### PR TITLE
Feature/runtime profile picker

### DIFF
--- a/BlazorServer/Pages/Index.razor
+++ b/BlazorServer/Pages/Index.razor
@@ -23,6 +23,7 @@
             <div class="col-sm" style="margin-left:10px">
                 <BotHeader ShowActiveGoal="false" />
 
+                <ProfileSelectorComponent />
                 <GoalsComponent />
             </div>
         }

--- a/BlazorServer/Pages/ProfileSelectorComponent.razor
+++ b/BlazorServer/Pages/ProfileSelectorComponent.razor
@@ -1,0 +1,58 @@
+﻿@using Libs
+@inject Libs.IBotController botController
+@inject Libs.IAddonReader addonReader
+
+<div class="card" style="margin-top: 10px">
+    <div class="card-header">
+        Profile
+
+        <select name="listbox" id="listbox" @onchange="OnChange" runat="server">
+            @foreach (var item in botController.FileList())
+            {
+                <option value="@item">
+                    @item
+                </option>
+            }
+        </select>
+
+        <button class="btn btn-sm btn-primary float-right" @onclick="LoadClassProfile">
+            <span>Load Profile</span>
+        </button>
+    </div>
+</div>
+
+@code {
+
+    string selectedProfile = String.Empty;
+
+    protected override void OnInitialized()
+    {
+        if (Libs.DataFrameConfiguration.ConfigurationExists())
+        {
+
+            ((Libs.AddonReader)addonReader).AddonDataChanged += (o, e) =>
+            {
+                base.InvokeAsync(() =>
+                {
+                    try
+                    {
+                        StateHasChanged();
+                    }
+                    catch { }
+                });
+            };
+        }
+    }
+
+    private void LoadClassProfile()
+    {
+        if(!string.IsNullOrEmpty(selectedProfile))
+            botController.LoadClassProfile(selectedProfile);
+    }
+
+    private void OnChange(ChangeEventArgs changeEventArgs)
+    {
+        selectedProfile = (string)changeEventArgs.Value;
+    }
+
+}

--- a/BlazorServer/Pages/RouteComponent.razor
+++ b/BlazorServer/Pages/RouteComponent.razor
@@ -10,6 +10,11 @@
             <tr>
                 <td>Route</td>
                 <td>
+                    <button class="btn btn-sm btn-primary" @onclick="ReInitialize">
+                        <span>Reload</span>
+                    </button>
+                </td>
+                <td>
                     <div class="float-right">
                         Player at @addonReader.PlayerReader.XCoord.ToString("0.0") , @addonReader.PlayerReader.YCoord.ToString("0.0") on map @addonReader.PlayerReader.ZoneId
                     </div>
@@ -176,5 +181,10 @@
         {
             await JSRuntime.InvokeAsync<string>("draw");
         }
+    }
+
+    private void ReInitialize()
+    {
+        CanvasInitialised = false;
     }
 }

--- a/BlazorServer/Startup.cs
+++ b/BlazorServer/Startup.cs
@@ -55,7 +55,6 @@ namespace BlazorServer
                 var botController = new BotController(logger, pather);
                 services.AddSingleton<IBotController>(botController);
                 services.AddSingleton<IAddonReader>(botController.AddonReader);
-                botController.InitialiseBot();
             }
             else
             {

--- a/Libs/BotController.cs
+++ b/Libs/BotController.cs
@@ -160,9 +160,9 @@ namespace Libs
             logger.LogInformation("Stopped!");
         }
 
-        public void InitialiseBot()
+        public void InitialiseBot(string profile)
         {
-            ClassConfig = ReadClassConfiguration();
+            ClassConfig = ReadClassConfiguration(profile);
 
             var blacklist = this.ClassConfig.Mode != Mode.Grind ? new NoBlacklist() : (IBlacklist)new Blacklist(AddonReader.PlayerReader, ClassConfig.NPCMaxLevels_Above, ClassConfig.NPCMaxLevels_Below, ClassConfig.Blacklist, logger);
 
@@ -191,12 +191,18 @@ namespace Libs
             });
         }
 
-        private ClassConfiguration ReadClassConfiguration()
+        private ClassConfiguration ReadClassConfiguration(string profile)
         {
             ClassConfiguration classConfig;
             var requirementFactory = new RequirementFactory(AddonReader.PlayerReader, AddonReader.BagReader, logger);
 
-            var classFilename = $"../json/class/{AddonReader.PlayerReader.PlayerClass.ToString()}.json";
+            if(!profile.ToLower().Contains(AddonReader.PlayerReader.PlayerClass.ToString().ToLower()))
+            {
+                throw new ArgumentOutOfRangeException($"Not allowed to load other classes profile." + 
+                    "As you are a {AddonReader.PlayerReader.PlayerClass.ToString()}");
+            }
+
+            var classFilename = $"../json/class/{profile}";
             if (File.Exists(classFilename))
             {
                 classConfig = JsonConvert.DeserializeObject<ClassConfiguration>(File.ReadAllText(classFilename));
@@ -224,6 +230,18 @@ namespace Libs
         public void Shutdown()
         {
             this.Enabled = false;
+        }
+
+        public void LoadClassProfile(string profile)
+        {
+            StopBot();
+            InitialiseBot(profile);
+        }
+
+        public List<string> FileList()
+        {
+            DirectoryInfo directory = new DirectoryInfo("../Json/class/");
+            return directory.GetFiles().Select(i => i.Name).ToList();
         }
     }
 }

--- a/Libs/ConfigBotController.cs
+++ b/Libs/ConfigBotController.cs
@@ -1,5 +1,6 @@
 ﻿using Libs.GOAP;
 using System;
+using System.Collections.Generic;
 using System.Threading;
 
 namespace Libs
@@ -31,6 +32,16 @@ namespace Libs
         }
 
         public void ToggleBotStatus()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void LoadClassProfile(string profile)
+        {
+            throw new NotImplementedException();
+        }
+
+        public List<string> FileList()
         {
             throw new NotImplementedException();
         }

--- a/Libs/IBotController.cs
+++ b/Libs/IBotController.cs
@@ -1,4 +1,5 @@
 ﻿using Libs.GOAP;
+using System.Collections.Generic;
 using System.Threading;
 
 namespace Libs
@@ -22,5 +23,9 @@ namespace Libs
         void Shutdown();
 
         bool IsBotActive { get; }
+
+        List<string> FileList();
+
+        void LoadClassProfile(string profile);
     }
 }


### PR DESCRIPTION
**Goal**
Ability to load specific profiles during runtime without stopping the server.

**Screenshot**
![2021-01-24 033247](https://user-images.githubusercontent.com/367101/105619663-44f1cc80-5df5-11eb-8f44-751e32734036.png)

**Tests**
During manual testing found two issues with the approach.

**Resolved issues**
- `RoutesComponent` are not being updated after second time loading any profile. For the first profile load it works completely fine. However after the second its not getting updated. Solved the issue by marking the `CanvasInitialised` flag to false. Accessed by `Reload` button from the frontend.
- The other issue is more severe, since the class based profile loading restriction has been lifted. It is possible to load other classes profile beside the currently played character. To detect this issue, the profile file name has to contain the class name so ex. `Mage1to4.json` is valid for Mage class, but not for Warlock player during runtime. When this case happens an Exception will be thrown. 

