### PR TITLE
Feature/runtime profile picker

### DIFF
--- a/BlazorServer/Pages/RouteComponent.razor
+++ b/BlazorServer/Pages/RouteComponent.razor
@@ -10,11 +10,6 @@
             <tr>
                 <td>Route</td>
                 <td>
-                    <button class="btn btn-sm btn-primary" @onclick="ReInitialize">
-                        <span>Reload</span>
-                    </button>
-                </td>
-                <td>
                     <div class="float-right">
                         Player at @addonReader.PlayerReader.XCoord.ToString("0.0") , @addonReader.PlayerReader.YCoord.ToString("0.0") on map @addonReader.PlayerReader.ZoneId
                     </div>
@@ -105,6 +100,9 @@
 
     protected override void OnInitialized()
     {
+        botController.ProfileLoaded -= OnProfileLoaded;
+        botController.ProfileLoaded += OnProfileLoaded;
+
         ((Libs.AddonReader)addonReader).AddonDataChanged += (o, e) =>
         {
             base.InvokeAsync(() =>
@@ -183,7 +181,7 @@
         }
     }
 
-    private void ReInitialize()
+    private void OnProfileLoaded(object? sender, EventArgs e)
     {
         CanvasInitialised = false;
     }

--- a/Libs/BotController.cs
+++ b/Libs/BotController.cs
@@ -39,6 +39,8 @@ namespace Libs
 
         private bool Enabled = true;
 
+        public event EventHandler? ProfileLoaded;
+
         public BotController(ILogger logger, IPPather pather)
         {
             updatePlayerPostion.Start();
@@ -236,6 +238,8 @@ namespace Libs
         {
             StopBot();
             InitialiseBot(profile);
+
+            ProfileLoaded?.Invoke(this, EventArgs.Empty);
         }
 
         public List<string> FileList()

--- a/Libs/ConfigBotController.cs
+++ b/Libs/ConfigBotController.cs
@@ -21,6 +21,8 @@ namespace Libs
         public IImageProvider? MinimapImageFinder { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public ClassConfiguration? ClassConfig { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
+        public event EventHandler? ProfileLoaded;
+
         public void Shutdown()
         {
             throw new NotImplementedException();
@@ -38,6 +40,7 @@ namespace Libs
 
         public void LoadClassProfile(string profile)
         {
+            ProfileLoaded?.Invoke(this, EventArgs.Empty);
             throw new NotImplementedException();
         }
 

--- a/Libs/IBotController.cs
+++ b/Libs/IBotController.cs
@@ -17,6 +17,8 @@ namespace Libs
         ClassConfiguration? ClassConfig { get; set; }
         IImageProvider? MinimapImageFinder { get; set; }
 
+        event System.EventHandler? ProfileLoaded;
+
         void ToggleBotStatus();
         void StopBot();
 


### PR DESCRIPTION
Remove the Reload button from the `RouteComponent` its unnecessary. 

With this updated approach there are fewer risk of stuck in an old internal sate.