### PR TITLE
Feature/improved loot goal

### DIFF
--- a/Libs/Addon/PlayerReader.cs
+++ b/Libs/Addon/PlayerReader.cs
@@ -90,6 +90,14 @@ namespace Libs
                 await Task.Delay(100);
             }
         }
+        public async Task WaitForNUpdate(int n)
+        {
+            var s = this.Sequence;
+            while (this.Sequence <= s + n)
+            {
+                await Task.Delay(100);
+            }
+        }
 
         // 32 - 33
         public long Gold => reader.GetLongAtCell(32) + reader.GetLongAtCell(33) * 1000000;

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ You are welcome to create pull requests. Some ideas of things that could be impr
 
 * Runtime Profile picker
 * Frontend Dark mode
+* Fast Loot for single target combat
 
 # Issues and Ideas
 


### PR DESCRIPTION
**Goal**
Fast Loot - Speed up the looting process after leaving single target combat. To achieve this using an already implemented feature, just reevaluated the process.

As soon as the target dies, making roughly 1 second(10 internal tick) time window to check if we leave combat. if the player leaves combat in that time window that means no other NPCs took part of the combat. At this point the player will lose target, but there's a way to target the corpse by pressing the keybind of `Target Last target` or from macro `/targetlasttarget`. Then using the `Interact` keybind makes the player to run towards to the target and loot it. The described situation showed in video.

**video**
https://user-images.githubusercontent.com/367101/105780643-37f9e800-5f71-11eb-91ad-27d185135db9.mp4


