### PR TITLE
Feature/addon config metadata

### DIFF
--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -54,9 +54,9 @@ local NUMBER_OF_FRAMES = 100
 -- Set number of pixel rows
 local FRAME_ROWS = 1
 -- Size of data squares in px. Varies based on rounding errors as well as dimension size. Use as a guideline, but not 100% accurate.
-local CELL_SIZE = 3
+local CELL_SIZE = 3 -- 1-9 
 -- Spacing in px between data squares.
-local CELL_SPACING = 0
+local CELL_SPACING = 0 -- 0 or 1
 -- Item slot trackers initialization
 local itemNum = 0
 local equipNum = 0
@@ -371,9 +371,6 @@ function DataToColor:CreateFrames(n)
         end
         -- Number of loops is based on the number of generated frames declared at beginning of script
         
-        for i = 0, 99 do
-            MakePixelSquareArr({63 / 255, 0, 63 / 255}, i)
-        end
         if not SETUP_SEQUENCE then
             MakePixelSquareArr(integerToColor(0), 0)
             -- The final data square, reserved for additional metadata.
@@ -497,7 +494,7 @@ function DataToColor:CreateFrames(n)
         end
         if SETUP_SEQUENCE then
             -- Emits meta data in data square index 0 concerning our estimated cell size, number of rows, and the numbers of frames
-            MakePixelSquareArr(integerToColor(CELL_SIZE * 100000 + 1000 * FRAME_ROWS + NUMBER_OF_FRAMES), 0)
+            MakePixelSquareArr(integerToColor(CELL_SPACING * 10000000 + CELL_SIZE * 100000 + 1000 * FRAME_ROWS + NUMBER_OF_FRAMES), 0)
             -- Assign pixel squares a value equivalent to their respective indices.
             for i = 1, NUMBER_OF_FRAMES - 1 do
                 MakePixelSquareArr(integerToColor(i), i)
@@ -521,6 +518,7 @@ function DataToColor:CreateFrames(n)
         f:SetWidth(CELL_SIZE) -- Change this to make white box wider
         setFramePixelBackdrop(f)
         f:SetFrameStrata("DIALOG")
+        f:SetBackdropColor(0, 0, 0, 1)
         return f
     end
     
@@ -534,6 +532,7 @@ function DataToColor:CreateFrames(n)
     backgroundframe:SetHeight(FRAME_ROWS * (CELL_SIZE + CELL_SPACING))
     backgroundframe:SetWidth(floor(n / FRAME_ROWS) * (CELL_SIZE + CELL_SPACING))
     backgroundframe:SetFrameStrata("HIGH")
+    backgroundframe:SetBackdropColor(0, 0, 0, 1)
     
     --local windowCheckFrame = CreateFrame("Frame", "frame_windowcheck", UIParent)
     --windowCheckFrame:SetPoint("TOPLEFT", 120, -200)

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: An addon that displays player position as color
-## Version: 1.0.1
+## Version: 1.0.2
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibDataBroker-1.1, LibCompress
 ## SavedVariables:

--- a/BlazorServer/AddonConfigurator.cs
+++ b/BlazorServer/AddonConfigurator.cs
@@ -34,9 +34,8 @@ namespace BlazorServer
         }
 
         public bool Installed()
-        {
-            var installed = GetVersion(FinalAddonPath, addonConfig.Title);
-            return installed != null;
+        {;
+            return GetInstalledVersion() != null;
         }
 
         public bool Validate()
@@ -313,27 +312,38 @@ namespace BlazorServer
             if (addonConfig.IsDefault())
                 return false;
 
+            Version? repo = GetRepoVerion();
+            Version? installed = GetInstalledVersion();
+
+            return installed != null && repo != null && repo > installed;
+        }
+
+        public Version? GetRepoVerion()
+        {
             Version? repo = null;
             try
             {
                 repo = GetVersion(Path.Join(AddonSourcePath, DefaultAddonName), DefaultAddonName);
             }
-            catch(Exception)
+            catch (Exception)
             {
                 // This only should be happen when running from IDE
                 string parentFolder = ".";
-                try { 
+                try
+                {
                     repo = GetVersion(Path.Join(parentFolder + AddonSourcePath, DefaultAddonName), DefaultAddonName);
                 }
-                catch(Exception e)
+                catch (Exception e)
                 {
                     logger.LogError(e.Message);
                 }
             }
+            return repo;
+        }
 
-            Version? installed = GetVersion(FinalAddonPath, addonConfig.Title);
-
-            return installed != null && repo != null && repo > installed;
+        public Version? GetInstalledVersion()
+        {
+            return GetVersion(FinalAddonPath, addonConfig.Title);
         }
 
         private static Version? GetVersion(string path, string fileName)

--- a/BlazorServer/Pages/FrameConfiguration.razor
+++ b/BlazorServer/Pages/FrameConfiguration.razor
@@ -3,9 +3,11 @@
 @inject Microsoft.Extensions.Hosting.IHostApplicationLifetime lifetime
 @inject NavigationManager NavigationManager
 @inject Libs.IBotController botController
+@implements IDisposable
 
 @using Libs
 @using Microsoft.AspNetCore.Html
+@using System.Threading;
 
 <style>
     h5 {
@@ -30,27 +32,67 @@ else
         <h1>Frame configuration not found !</h1>
     }
 
+    @if (addonNotVisible)
+    {
+        <hr />
+        <div class="row col-md-12">
+            <span class="row col-md-12">I saw @dataFrames.Count data frames. But its keep changing! The addon is not visible.</span>
+        </div>
+        <div class="row col-md-12">
+            <p class="h3 text-danger">Restart the game</p>
+        </div>
+        <div class="row col-md-12">
+            <p class="h3 text-danger">Enable the addon</p>
+        </div>
+        <div class="row col-md-12">
+            <p class="h3 text-danger">Make sure nothing obstruct</p>
+        </div>
+    }
+
     <hr />
-    <h4 class="row col-md-12">Use Auto config: It will automatically setup the necessary stuffs.</h4>
-    <hr />
+    <h5 class="row col-md-12">Your screen:</h5>
+    @if (@dataFrames.Count == dataFrameMeta.frames)
+    {
+        <span class="row col-md-12">I see @dataFrames.Count data frames. This is perfect, just click the Save button.</span>
+    }
+    else
+    {
+        <span class="row col-md-12">I see @dataFrames.Count data frames. I should see @dataFrameMeta.frames if you have typed <span class="ml-1"><b>&#47;@addonConfig?.Command</b></span></span>
+    }
 
     <div class="row col-md-12">
-        @if (@dataFrames.Count == 1)
+        @if (@dataFrames.Count != dataFrameMeta.frames)
         {
-            <span class="row col-md-12">I see @dataFrames.Count data frames. Most likely the addon is not visible. <p class="h1 text-danger">Restart the Game</p></span>
+            <img style="border:1px solid red; margin: 5px" src="data:image/png;base64, @image" alt="Red dot" />
+        }
+        else
+        {
+            <img style="border:1px solid green; margin: 5px" src="data:image/png;base64, @image" alt="Red dot" />
         }
     </div>
+
+    <span class="row col-md-12">@playerClass</span>
+
+    @if (Libs.DataFrameConfiguration.Exists())
+    {
+        <hr />
+        <h4 class="text-warning">Tinkering with the following fields are not recommend! Unless experinecing strange behaviours then repeat the Frame Configuration process!</h4>
+    }
+
     <hr />
-    <button class="row col-md-1 btn btn-sm btn-primary" @onclick="AutoConfigure">
+    <h4 class="row col-md-12"><b>Auto config</b>: It will automatically setup the necessary stuffs.</h4>
+    <hr />
+
+    <button class="row col-md-1 btn btn-sm btn-success" @onclick="AutoConfigure">
         <span>Auto Configure and Restart</span>
     </button>
 
     <hr />
-    <h4 class="row col-md-12">Manually:</h4>
-    <h5 class="row col-md-12">Step 1: Please ensure the addon <span class="ml-1"><b>&#47;@addonConfig?.Title</b></span> found in the addon folders is running. You should see the multi-coloured pixels at the top left of the screen.</h5>
+    <h4 class="row col-md-12"><b>Manually:</b></h4>
+    <h5 class="row col-md-12">Step 1: Please ensure the addon <span class="px-2"><b>@addonConfig?.Title</b></span> found in the addon folders is running. You should see the multi-coloured pixels at the top left of the screen.</h5>
 
     <div class="row col-md-12">
-        @if (@dataFrames.Count != 100)
+        @if (dataFrames.Count != dataFrameMeta.frames)
         {
             <img src="Addon_Normal.png" />
         }
@@ -58,65 +100,52 @@ else
 
     <h5 class="row col-md-12">Step 2: Now we are going to put the addon into configuration mode, this will change the addon colours displayed. In the wow chat window: type <span class="ml-1"><b>&#47;@addonConfig?.Command</b></span></h5>
 
-    @if (@dataFrames.Count != 100)
+    @if (dataFrames.Count != dataFrameMeta.frames)
     {
         <div class="row col-md-12" style="margin-top:10px">
             <img src="Addon_Config.png" />
         </div>
     }
 
-    @if (@dataFrames.Count > 70)
-    {
+    <h5 class="row col-md-12">Step 3: I see @dataFrames.Count data frames. Should see @dataFrameMeta.frames</h5>
 
-        <h5 class="row col-md-12">Step 3:  Click Save</h5>
-
-        <button class="row col-md-1 btn btn-sm btn-primary" @onclick="Configure">
-            <span>Save</span>
-        </button>
-    }
-    <hr />
-    <h5 class="row col-md-12">Your screen:</h5>
-    @if (@dataFrames.Count == 100)
+    @if (dataFrameMeta.frames != 0 && dataFrames.Count == dataFrameMeta.frames)
     {
-        <span class="row col-md-12">I see @dataFrames.Count data frames. This is perfect, just click the Save button.</span>
-    }
-    else
-    {
-        <span class="row col-md-12">I see @dataFrames.Count data frames. I should see 100 if you have typed <span class="ml-1"><b>&#47;@addonConfig?.Command</b></span></span>
-    }
+        <h5 class="row col-md-12">Step 4: Now return to normal mode, In the wow chat window: type <span class="ml-1"><b>&#47;@addonConfig?.Command</b></span></h5>
 
-    <div class="row col-md-12">
-        @if (@dataFrames.Count != 100)
+        @if (!playerClass.ToLower().Contains("unable to read player class"))
         {
-            <img style="border:5px solid red; margin: 5px" src="data:image/png;base64, @image" alt="Red dot" />
+            <h5 class="row col-md-12">Step 5:  Click Save</h5>
+            <button class="row col-md-1 btn btn-sm btn-primary" @onclick="Configure">
+                <span>Save</span>
+            </button>
         }
-        else
-        {
-            <img style="border:5px solid green; margin: 5px" src="data:image/png;base64, @image" alt="Red dot" />
-        }
-    </div>
-
-    <span class="row col-md-12">@playerClass</span>
+    }
 }
 @code {
 
+    private AddonConfig addonConfig = AddonConfig.Load();
+    private AddonConfigurator? addonConfigurator;
+
     private DataConfig? dataConfig;
+    private DataFrameMeta dataFrameMeta = DataFrameMeta.Empty;
     private DataFrameConfiguration? config;
     private List<DataFrame> dataFrames = new List<DataFrame>();
     private AddonReader? addonReader;
-
-    private int ConfigWidth = 800;
-    private int ConfigHeight = 200;
 
     private WowProcess? wowProcess;
     private WowScreen? wowScreen;
 
     private bool saved = false;
-    private string playerClass = "Unable to read player class";
+    private string playerClass = "";
+    private bool addonNotVisible = false;
 
     string image = "iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==";
 
-    private AddonConfig addonConfig = AddonConfig.Load();
+    private Thread? screenshotThread;
+    private const int interval = 1000;
+    private int counter = 0;
+    private CancellationTokenSource? cancellationTokenSource;
 
     protected override void OnInitialized()
     {
@@ -127,100 +156,211 @@ else
             config = new DataFrameConfiguration(wowScreen);
             dataConfig = DataConfig.Load();
 
-            var screenshotThread = new System.Threading.Thread(ScreenshotRefreshThread);
+            addonConfigurator = new AddonConfigurator(logger, addonConfig);
+
+            if (Libs.DataFrameConfiguration.Exists())
+            {
+                dataFrames = DataFrameConfiguration.LoadFrames();
+                dataFrameMeta = DataFrameConfiguration.LoadMeta();
+            }
+
+            cancellationTokenSource = new CancellationTokenSource();
+            screenshotThread = new System.Threading.Thread(ScreenshotRefreshThread);
             screenshotThread.Start();
         }
     }
 
+    public void Dispose()
+    {
+        cancellationTokenSource?.Cancel();
+    }
+
+    private DataFrameMeta GetDataFrameMeta()
+    {
+        if (config == null) return DataFrameMeta.Empty;
+
+        var screenshot = wowScreen?.GetBitmap(1, 1);
+        if (screenshot == null) return DataFrameMeta.Empty;
+
+        var meta = config.GetMeta(screenshot);
+        return meta;
+    }
+
     private void ScreenshotRefreshThread()
     {
-        while (true)
+        while (cancellationTokenSource != null && !cancellationTokenSource.Token.IsCancellationRequested)
         {
-            if (wowProcess == null) return;
-
-            var screenshot = wowScreen?.GetBitmap(ConfigWidth, ConfigHeight);
-            if (screenshot == null) return;
-            using (System.IO.MemoryStream ms = new System.IO.MemoryStream())
+            if (wowProcess != null && wowScreen != null && config != null && dataConfig != null)
             {
-                screenshot.Save(ms, System.Drawing.Imaging.ImageFormat.Jpeg);
-                byte[] byteImage = ms.ToArray();
-                this.image = Convert.ToBase64String(byteImage); // Get Base64
-
-                if (config != null && dataConfig != null)
+                if (dataFrameMeta == DataFrameMeta.Empty)
                 {
-                    dataFrames = config.CreateConfiguration(screenshot);
+                    addonNotVisible = false;
+                    dataFrameMeta = GetDataFrameMeta();
 
-                    if (dataFrames.Count == 100)
+                    InvokeAsync(() =>
                     {
-                        addonReader = new AddonReader(dataConfig, new WowScreen(wowProcess, logger), dataFrames, logger, null);
-                    }
+                        base.StateHasChanged();
+                    });
+                }
+                else
+                {
+                    var temp = GetDataFrameMeta();
+                    if (temp != DataFrameMeta.Empty && temp.rows != dataFrameMeta.rows)
+                    {
+                        addonNotVisible = true;
+                        dataFrameMeta = DataFrameMeta.Empty;
 
-                    if (addonReader != null && dataFrames.Count != 100)
-                    {
-                        addonReader.Refresh();
-                        if (Enum.GetValues(typeof(PlayerClassEnum)).Cast<PlayerClassEnum>().Contains(addonReader.PlayerReader.PlayerClass))
+                        InvokeAsync(() =>
                         {
-                            playerClass = "The class of the character is: " + addonReader.PlayerReader.PlayerClass.ToString();
-                        }
-                        else
-                        {
-                            playerClass = "Still unable to read player class";
-                        }
+                            base.StateHasChanged();
+                        });
                     }
                 }
 
-                InvokeAsync(() =>
+                if (dataFrameMeta != DataFrameMeta.Empty)
                 {
-                    base.StateHasChanged();
-                });
+                    var size = dataFrameMeta.EstimatedSize();
+                    wowScreen.GetRectangle(out var rect);
+
+                    if (size.Width < rect.Size.Width &&
+                        size.Height < rect.Size.Height)
+                    {
+                        var screenshot = wowScreen.GetBitmap(size.Width, size.Height);
+                        if (screenshot != null)
+                        {
+                            using (System.IO.MemoryStream ms = new System.IO.MemoryStream())
+                            {
+                                screenshot.Save(ms, System.Drawing.Imaging.ImageFormat.Jpeg);
+                                byte[] byteImage = ms.ToArray();
+                                this.image = Convert.ToBase64String(byteImage); // Get Base64
+
+                                if (dataFrameMeta == DataFrameMeta.Empty)
+                                {
+                                    dataFrameMeta = config.GetMeta(screenshot);
+                                }
+
+                                //if(dataFrames.Count == 0)
+                                if (dataFrames.Count != dataFrameMeta.frames)
+                                {
+                                    dataFrames = config.CreateFrames(dataFrameMeta, screenshot);
+                                }
+
+                                if (dataFrames.Count == dataFrameMeta.frames)
+                                {
+                                    addonReader = new AddonReader(dataConfig, new WowScreen(wowProcess, logger), dataFrames, logger, null);
+                                }
+
+                                if (addonReader != null) // && dataFrames.Count != dataFrameMeta.frames
+                                {
+                                    ResolveClass(addonReader);
+                                }
+
+                                InvokeAsync(() =>
+                                {
+                                    base.StateHasChanged();
+                                });
+                            }
+                        }
+                    }
+                    else
+                    {
+                        addonNotVisible = true;
+                        dataFrameMeta = DataFrameMeta.Empty;
+
+                        InvokeAsync(() =>
+                        {
+                            base.StateHasChanged();
+                        });
+                    }
+                }
             }
-            System.Threading.Thread.Sleep(1000);
+
+            System.Threading.Thread.Sleep(interval);
+            Interlocked.Increment(ref counter);
         }
     }
 
     private async Task Configure()
     {
-        var screenshot = wowScreen?.GetBitmap(ConfigWidth, ConfigHeight);
-        if (config != null && screenshot != null && wowProcess != null)
+        if (wowProcess == null) return;
+        if (config == null) return;
+
+        var version = addonConfigurator?.GetInstalledVersion();
+        if (version == null) return;
+
+        var size = dataFrameMeta.EstimatedSize();
+
+        var screenshot = wowScreen?.GetBitmap(size.Width, size.Height);
+        if (screenshot == null) return;
+
+        var dataFrames = config.CreateFrames(dataFrameMeta, screenshot);
+
+        wowProcess.GetWindowRect(out var rect);
+
+        DataFrameConfiguration.SaveConfiguration(rect, version, dataFrameMeta, dataFrames);
+        saved = true;
+
+        await InvokeAsync(() =>
         {
-            var dataFrames = config.CreateConfiguration(screenshot);
+            base.StateHasChanged();
+        });
 
-            wowProcess.GetWindowRect(out var rect);
+        await Wait();
 
-            DataFrameConfiguration.SaveConfiguration(rect, dataFrames);
-            saved = true;
-
-            await InvokeAsync(() =>
-            {
-                base.StateHasChanged();
-            });
-        }
+        await RestartServer();
     }
 
     private async Task AutoConfigure()
     {
-        await ToggleInGameConfiguration();
-        await Task.Delay(2000);
+        if (wowProcess == null) return;
+        if (config == null) return;
 
-        var screenshot = wowScreen?.GetBitmap(ConfigWidth, ConfigHeight);
-        if (config != null && screenshot != null && wowProcess != null)
+        var version = addonConfigurator?.GetInstalledVersion();
+        if (version == null) return;
+
+        var meta = GetDataFrameMeta();
+        if (meta == DataFrameMeta.Empty || meta.hash == 0)
         {
-            var dataFrames = config.CreateConfiguration(screenshot);
-
-            wowProcess.GetWindowRect(out var rect);
-
-            DataFrameConfiguration.SaveConfiguration(rect, dataFrames);
-            saved = true;
-
             await ToggleInGameConfiguration();
-
-            await InvokeAsync(() =>
-            {
-                base.StateHasChanged();
-            });
-
-            await RestartServer();
+            await Wait();
         }
+
+        meta = GetDataFrameMeta();
+
+        var size = meta.EstimatedSize();
+        var screenshot = wowScreen?.GetBitmap(size.Width, size.Height);
+        if (screenshot == null) return;
+
+        var dataFrames = config.CreateFrames(meta, screenshot);
+
+        if (dataFrames.Count != meta.frames)
+        {
+            return;
+        }
+
+        await Wait();
+
+        await ToggleInGameConfiguration();
+
+        if (addonReader != null && !ResolveClass(addonReader))
+        {
+            return;
+        }
+
+        await Wait();
+
+        wowProcess.GetWindowRect(out var rect);
+        DataFrameConfiguration.SaveConfiguration(rect, version, meta, dataFrames);
+        saved = true;
+
+        await InvokeAsync(() =>
+        {
+            base.StateHasChanged();
+        });
+
+        await Wait();
+
+        await RestartServer();
     }
 
     private async Task ToggleInGameConfiguration()
@@ -238,9 +378,36 @@ else
 
     private async Task RestartServer()
     {
+        cancellationTokenSource?.Cancel();
+
         this.botController.Shutdown();
         await Task.Delay(1000);
         NavigationManager.NavigateTo("/");
         lifetime.StopApplication();
+    }
+
+    private bool ResolveClass(AddonReader addonReader)
+    {
+        addonReader.Refresh();
+        if (Enum.GetValues(typeof(PlayerClassEnum)).Cast<PlayerClassEnum>().Contains(addonReader.PlayerReader.PlayerClass))
+        {
+            playerClass = "The class of the character is: " + addonReader.PlayerReader.PlayerClass.ToString();
+            return true;
+        }
+        else
+        {
+            playerClass = "Still unable to read player class";
+        }
+
+        return false;
+    }
+
+    private async Task Wait()
+    {
+        var temp = counter;
+        do
+        {
+            await Task.Delay(100);
+        } while (temp == counter);
     }
 }

--- a/BlazorServer/Pages/Index.razor
+++ b/BlazorServer/Pages/Index.razor
@@ -30,11 +30,11 @@
         }
         else if (!AddonConfig.Exists())
         {
-            <!--<AddonConfiguration />-->
+            <AddonConfiguration />
         }
         else if (!Libs.DataFrameConfiguration.Exists())
         {
-            <!--<FrameConfiguration />-->
+            <FrameConfiguration />
         }
     </div>
 </div>

--- a/BlazorServer/Startup.cs
+++ b/BlazorServer/Startup.cs
@@ -62,7 +62,8 @@ namespace BlazorServer
                 DataFrameConfiguration.RemoveConfiguration();
             }
 
-            if(DataFrameConfiguration.Exists() && !DataFrameConfiguration.IsValid(rect))
+            if(DataFrameConfiguration.Exists() && 
+                !DataFrameConfiguration.IsValid(rect, addonConfigurator.GetInstalledVersion()))
             {
                 // At this point the webpage never loads so fallback to configuration page
                 DataFrameConfiguration.RemoveConfiguration();

--- a/Libs/Addon/DataFrameConfiguration.cs
+++ b/Libs/Addon/DataFrameConfiguration.cs
@@ -6,11 +6,19 @@ using System.Linq;
 
 namespace Libs
 {
+    public static class DataFrameConfigurationVersion
+    {
+        public const int Version = 2;
+    }
+
     public class DataFrameConfiguration
     {
         private class DataFrameConfig
         {
+            public int Version = DataFrameConfigurationVersion.Version;
+            public System.Version? addonVersion;
             public Rectangle rect;
+            public DataFrameMeta meta;
             public List<DataFrame> frames = new List<DataFrame>();
         }
 
@@ -28,26 +36,42 @@ namespace Libs
             return File.Exists(ConfigurationFilename);
         }
 
-        public static bool IsValid(Rectangle rect)
+        public static bool IsValid(Rectangle rect, System.Version? addonVersion)
         {
             if (!Exists()) return false;
 
             var config = JsonConvert.DeserializeObject<DataFrameConfig>(File.ReadAllText(ConfigurationFilename));
+            var sameVersion = config.Version == DataFrameConfigurationVersion.Version;
+            var sameAddonVersion = addonVersion != null && addonVersion == config.addonVersion;
             var sameRect = config.rect.Width == rect.Width && config.rect.Height == rect.Height;
-            return sameRect && config.frames.Count > 1;
+            return sameAddonVersion && sameVersion && sameRect && config.frames.Count > 1;
         }
 
-        public static List<DataFrame> LoadConfiguration()
+        public static List<DataFrame> LoadFrames()
         {
             var config = JsonConvert.DeserializeObject<DataFrameConfig>(File.ReadAllText(ConfigurationFilename));
-            return config.frames;
+            if(config.Version == DataFrameConfigurationVersion.Version)
+                return config.frames;
+
+            return new List<DataFrame>();
         }
 
-        public static void SaveConfiguration(Rectangle rect, List<DataFrame> dataFrames)
+        public static DataFrameMeta LoadMeta()
+        {
+            var config = JsonConvert.DeserializeObject<DataFrameConfig>(File.ReadAllText(ConfigurationFilename));
+            if (config.Version == DataFrameConfigurationVersion.Version)
+                return config.meta;
+
+            return DataFrameMeta.Empty;
+        }
+
+        public static void SaveConfiguration(Rectangle rect, System.Version addonVersion, DataFrameMeta meta, List<DataFrame> dataFrames)
         {
             var config = new DataFrameConfig
             {
                 rect = rect,
+                addonVersion = addonVersion,
+                meta = meta,
                 frames = dataFrames
             };
             string output = JsonConvert.SerializeObject(config);
@@ -63,12 +87,36 @@ namespace Libs
             }
         }
 
-        public List<DataFrame> CreateConfiguration(Bitmap bmp)
+        public DataFrameMeta GetMeta(Bitmap bmp)
         {
-            var dataFrames = new List<DataFrame>() { new DataFrame(new Point(1, 1), 0) };
-            for (int dataframe = 1; dataframe < 400; dataframe++)
+            var color = colorReader.GetColorAt(new Point(0, 0), bmp);
+            int data, hash;
+            data = hash = color.R * 65536 + color.G * 256 + color.B;
+
+            if (hash == 0)
+                return DataFrameMeta.Empty;
+
+            // CELL_SPACING * 10000000 + CELL_SIZE * 100000 + 1000 * FRAME_ROWS + NUMBER_OF_FRAMES
+            int spacing = (int)(data / 10000000f);
+            data -= (10000000 * spacing);
+
+            int size = (int)(data / 100000f);
+            data -= (100000 * size);
+
+            int rows = (int)(data / 1000f);
+            data -= (1000 * rows);
+
+            int count = data;
+
+            return new DataFrameMeta(hash, spacing, size, rows, count);
+        }
+
+        public List<DataFrame> CreateFrames(DataFrameMeta meta, Bitmap bmp)
+        {
+            var dataFrames = new List<DataFrame>() { new DataFrame(new Point(0, 0), 0)};
+            for (int dataframe = 1; dataframe < meta.frames; dataframe++)
             {
-                var point = GetFramePoint(bmp, dataframe, dataFrames.Last().point.X);
+                var point = GetFramePoint(meta, bmp, dataframe, dataFrames.Last().point.X);
                 if (point == null)
                 {
                     break;
@@ -79,14 +127,15 @@ namespace Libs
             return dataFrames;
         }
 
-        private Point? GetFramePoint(Bitmap bmp, int dataframe, int startX)
+        private Point? GetFramePoint(DataFrameMeta meta, Bitmap bmp, int dataframe, int startX)
         {
             for (int x = startX; x < bmp.Width; x++)
             {
-                for (int y = 0; y < 2; y++)
+                for (int y = 0; y < meta.rows; y++)
                 {
                     var point = new Point(x, y);
-                    if (colorReader.GetColorAt(point, bmp).B == dataframe)
+                    var color = colorReader.GetColorAt(point, bmp);
+                    if (color.B == dataframe)
                     {
                         return point;
                     }

--- a/Libs/Addon/DataFrameMeta.cs
+++ b/Libs/Addon/DataFrameMeta.cs
@@ -1,0 +1,69 @@
+﻿using System.Drawing;
+using Newtonsoft.Json;
+
+namespace Libs
+{
+    public struct DataFrameMeta : System.IEquatable<object>, System.IEquatable<DataFrameMeta>
+    {
+        [JsonConstructor]
+        public DataFrameMeta(int hash, int spacing, int size, int rows, int frames)
+        {
+            this.hash = hash;
+            this.spacing = spacing;
+            this.size = size;
+            this.rows = rows;
+            this.frames = frames;
+        }
+
+        public int hash { private set; get; }
+
+        public int spacing { private set; get; }
+
+        public int size { private set; get; }
+
+        public int rows { private set; get; }
+
+        public int frames { private set; get; }
+
+        public Size EstimatedSize()
+        {
+            var size = new SizeF(frames * (this.size + spacing), rows * (this.size + spacing));
+            size *= 1.3f; // error rate
+            return size.ToSize();
+        }
+
+        private static readonly DataFrameMeta empty = new DataFrameMeta(-1, 0, 0, 0, 0);
+        [JsonIgnore]
+        public static DataFrameMeta Empty => empty;
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is DataFrameMeta other)) return false;
+            return Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return hash;
+        }
+
+        public static bool operator ==(DataFrameMeta left, DataFrameMeta right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(DataFrameMeta left, DataFrameMeta right)
+        {
+            return !(left == right);
+        }
+
+        public bool Equals(DataFrameMeta other)
+        {
+            return other.hash == hash &&
+                other.spacing == spacing &&
+                other.size == size &&
+                other.rows == rows &&
+                other.frames == frames;
+        }
+    }
+}

--- a/Libs/BotController.cs
+++ b/Libs/BotController.cs
@@ -64,9 +64,7 @@ namespace Libs
             wowProcess = new WowProcess(logger);
             WowScreen = new WowScreen(wowProcess, logger);
 
-            var frames = DataFrameConfiguration.Exists()
-                ? DataFrameConfiguration.LoadConfiguration()
-                : new List<DataFrame>();
+            var frames = DataFrameConfiguration.LoadFrames();
 
             AddonReader = new AddonReader(DataConfig, WowScreen, frames, logger, areaDb);
 


### PR DESCRIPTION
Goal:
- Make the `FrameConfiguration` page more useful upon creating the configuration files and when just opening up the page with normal use.
- Addon
--- Take advantage of the meta data what the addon provides during the `SETUP_SEQUENCE`
--- Use the meta data for validations such as the addon is visible/enabled
--- Found some unnecessary code which made the whole game sluggish. with the applied fix, feels more reliable and quicker to react!
--- fix - don't do this: each `OnUpdate` tick re-drawn with some purple/pinkish color then update the frames by the API
- DataFrameMeta: new class for `FrameConfig`
- Frontend: rearrange to be more useful
- Frontend logic: 
--- Get rid of the thread leaking when restarting the server!
--- most of the nested logic has been rewritten to be more clear
