### PR TITLE
Feature/key action charges

### DIFF
--- a/Core/Goals/CastingHandler.cs
+++ b/Core/Goals/CastingHandler.cs
@@ -174,6 +174,8 @@ namespace Core.Goals
             {
                 await this.input.KeyPress(ConsoleKey.DownArrow, item.StepBackAfterCast , $"Step back for {item.StepBackAfterCast}ms");
             }
+
+            item.ConsumeCharge();
             return true;
         }
 

--- a/Core/Goals/CombatGoal.cs
+++ b/Core/Goals/CombatGoal.cs
@@ -109,6 +109,7 @@ namespace Core.Goals
             {
                 logger.LogInformation($"Reset cooldown on {item.Name}");
                 item.ResetCooldown();
+                item.ResetChanges();
             });
         }
 

--- a/Core/Requirement/RequirementFactory.cs
+++ b/Core/Requirement/RequirementFactory.cs
@@ -34,6 +34,7 @@ namespace Core
             CreateMinRequirement(item.RequirementObjects, "Energy", item.MinEnergy);
             CreateMinComboPointsRequirement(item.RequirementObjects, item);
             item.CreateCooldownRequirement();
+            item.CreateChargeRequirement();
         }
 
         private void CreateMinRequirement(List<Requirement> RequirementObjects, string type, int value)

--- a/Json/class/Warlock_10.json
+++ b/Json/class/Warlock_10.json
@@ -95,7 +95,7 @@
         "Name": "Water",
         "StopBeforeCast": true,
         "Key": "N2",
-        "Requirement": "Mana%<50",
+        "Requirement": "Mana%<40",
         "Cooldown": 20,
         "Log": false
       }
@@ -123,14 +123,8 @@
       {
         "Name": "Life Tap",
         "Key": "8",
+        "Charge": 2,
         "Requirements": ["Health%>70","Mana%<60"],
-        "Cooldown": 0,
-        "Log": false
-      },
-      {
-        "Name": "Life Tap 2",
-        "Key": "8",
-        "Requirements": ["Health%>80","Mana%<80"],
         "Cooldown": 0,
         "Log": false
       }

--- a/Json/class/Warlock_20.json
+++ b/Json/class/Warlock_20.json
@@ -113,7 +113,7 @@
         "Name": "Water",
         "StopBeforeCast": true,
         "Key": "N2",
-        "Requirement": "Mana%<50",
+        "Requirement": "Mana%<40",
         "Cooldown": 20,
         "Log": false
       }
@@ -141,14 +141,8 @@
       {
         "Name": "Life Tap",
         "Key": "8",
+        "Charge": 2,
         "Requirements": ["Health%>70","Mana%<60"],
-        "Cooldown": 0,
-        "Log": false
-      },
-      {
-        "Name": "Life Tap 2",
-        "Key": "8",
-        "Requirements": ["Health%>80","Mana%<80"],
         "Cooldown": 0,
         "Log": false
       },

--- a/Json/class/Warlock_20_shard_farm.json
+++ b/Json/class/Warlock_20_shard_farm.json
@@ -116,7 +116,7 @@
         "Name": "Water",
         "StopBeforeCast": true,
         "Key": "N2",
-        "Requirement": "Mana%<50",
+        "Requirement": "Mana%<40",
         "Cooldown": 20,
         "Log": false
       }
@@ -144,14 +144,8 @@
       {
         "Name": "Life Tap",
         "Key": "8",
+        "Charge": 2,
         "Requirements": ["Health%>70","Mana%<60"],
-        "Cooldown": 0,
-        "Log": false
-      },
-      {
-        "Name": "Life Tap 2",
-        "Key": "8",
-        "Requirements": ["Health%>80","Mana%<80"],
         "Cooldown": 0,
         "Log": false
       }

--- a/Json/class/Warlock_26_Immunity.json
+++ b/Json/class/Warlock_26_Immunity.json
@@ -85,6 +85,7 @@
       {
         "Name": "Shadow Bolt",
         "Key": "2",
+        "Charge": 2,
         "HasCastBar": true,
         "StopBeforeCast": true,
         "ResetOnNewTarget": true,
@@ -122,7 +123,7 @@
         "Name": "Water",
         "StopBeforeCast": true,
         "Key": "N2",
-        "Requirement": "Mana%<50",
+        "Requirement": "Mana%<40",
         "Cooldown": 20,
         "Log": false
       }
@@ -150,14 +151,8 @@
       {
         "Name": "Life Tap",
         "Key": "8",
+        "Charge": 2,
         "Requirements": ["Health%>70","Mana%<60"],
-        "Cooldown": 0,
-        "Log": false
-      },
-      {
-        "Name": "Life Tap 2",
-        "Key": "8",
-        "Requirements": ["Health%>80","Mana%<80"],
         "Cooldown": 0,
         "Log": false
       },

--- a/Json/class/Warlock_8.json
+++ b/Json/class/Warlock_8.json
@@ -81,7 +81,7 @@
         "Name": "Water",
         "StopBeforeCast": true,
         "Key": "N2",
-        "Requirement": "Mana%<50",
+        "Requirement": "Mana%<40",
         "Cooldown": 20,
         "Log": false
       }
@@ -109,15 +109,8 @@
         "Name": "Life Tap",
         "StopBeforeCast": true,
         "Key": "8",
+        "Charge": 2,
         "Requirements": ["Health%>70","Mana%<60"],
-        "Cooldown": 0,
-        "Log": false
-      },
-      {
-        "Name": "Life Tap 2",
-        "StopBeforeCast": true,
-        "Key": "8",
-        "Requirements": ["Health%>80","Mana%<80"],
         "Cooldown": 0,
         "Log": false
       }

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Commands have the following parameters, only a subset will be used by each comma
 | PressDuration | How many milliseconds to press the key for |  250 |
 | ShapeShiftForm | For druids the shapeshift form to be in to cast this spell | None |
 | CastIfAddsVisible | If the bot can "See" any adds | false |
+| Charge | How many times shoud this Command be used in sequence and ignore its Cooldown | 1 |
 | Cooldown | The cooldown in seconds until the command can be done again | 0 |
 | MinMana | The minimum Mana required to cast the spell | 0 |
 | MinRage | The minimum Rage required to cast the spell | 0 |


### PR DESCRIPTION
Goal:
- Some later levels when the mob Health is increased a bit more starting from level 20. It is not necessary to copy and paste once more the main damage dealer ability (for example warlock shadow bolt) just enough to increase its `Charge`. from 1 -> 2. 

One other example is the warlock life tap, upon having max hp and around 60% mana by doing two life tap ending up 70% mana and hp as well without needed to drink and eat.