### PR TITLE
Refactor/loot combat detect

### DIFF
--- a/Core/Goals/CombatGoal.cs
+++ b/Core/Goals/CombatGoal.cs
@@ -219,10 +219,15 @@ namespace Core.Goals
                 {
                     ResetCooldowns();
 
-                    logger.LogWarning("---- Somebody is attacking me or my pet!");
+                    logger.LogWarning("---- Somebody is attacking me!");
                     await input.TapInteractKey("Found new target to attack");
                     return true;
                 }
+            }
+
+            if (await Wait(200, () => playerReader.HasTarget))
+            {
+                return true;
             }
 
             await input.TapClearTarget();

--- a/Core/Goals/CombatUtil.cs
+++ b/Core/Goals/CombatUtil.cs
@@ -1,0 +1,173 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+
+namespace Core
+{
+    public class CombatUtil
+    {
+        private readonly ILogger logger;
+        private readonly PlayerReader playerReader;
+        private readonly ConfigurableInput input;
+
+        private bool debug = true;
+
+        private bool outOfCombat;
+        private WowPoint lastPosition;
+
+        public CombatUtil(ILogger logger, ConfigurableInput input, PlayerReader playerReader)
+        {
+            this.logger = logger;
+            this.input = input;
+            this.playerReader = playerReader;
+
+            outOfCombat = !playerReader.PlayerBitValues.PlayerInCombat;
+            lastPosition = playerReader.PlayerLocation;
+        }
+
+        public void UpdateLastPosition()
+        {
+            lastPosition = playerReader.PlayerLocation;
+        }
+
+        public async Task<bool> EnteredCombat()
+        {
+            await Task.Delay(1);
+            if (!outOfCombat && !playerReader.PlayerBitValues.PlayerInCombat)
+            {
+                Log("Combat Leave");
+                outOfCombat = true;
+                return false;
+            }
+
+            if (outOfCombat && playerReader.PlayerBitValues.PlayerInCombat)
+            {
+                Log("Combat Enter");
+                outOfCombat = false;
+                return true;
+            }
+
+            return false;
+        }
+
+        public async Task<bool> AquiredTarget()
+        {
+            if (this.playerReader.PlayerBitValues.PlayerInCombat)
+            {
+                if (this.playerReader.PetHasTarget)
+                {
+                    await input.TapTargetPet();
+                    Log($"Pets target {this.playerReader.TargetTarget}");
+                    if (this.playerReader.TargetTarget == TargetTargetEnum.PetHasATarget)
+                    {
+                        Log("Found target by pet");
+                        await input.TapTargetOfTarget();
+                        //SendActionEvent(new ActionEventArgs(GoapKey.shouldloot, false));
+                        //SendActionEvent(new ActionEventArgs(GoapKey.newtarget, true));
+                        //SendActionEvent(new ActionEventArgs(GoapKey.hastarget, true));
+                        return true;
+                    }
+                }
+
+                await input.TapNearestTarget();
+                await playerReader.WaitForNUpdate(1);
+                if (this.playerReader.HasTarget && playerReader.PlayerBitValues.TargetInCombat &&
+                    playerReader.PlayerBitValues.TargetOfTargetIsPlayer)
+                {
+                    Log("Found from nearest target");
+                    //SendActionEvent(new ActionEventArgs(GoapKey.shouldloot, false));
+                    //SendActionEvent(new ActionEventArgs(GoapKey.newtarget, true));
+                    //SendActionEvent(new ActionEventArgs(GoapKey.hastarget, true));
+                    return true;
+                }
+
+                if (await Wait(200, () => playerReader.HasTarget))
+                {
+                    return true;
+                }
+
+                await input.TapClearTarget();
+                await playerReader.WaitForNUpdate(1);
+                Log("No target found");
+            }
+            return false;
+        }
+
+        public bool IsPlayerMoving(WowPoint lastPos)
+        {
+            var distance = WowPoint.DistanceTo(lastPos, playerReader.PlayerLocation);
+            return distance > 0.5f;
+        }
+
+        public async Task<Tuple<bool, bool>> FoundTargetWhileMoved()
+        {
+            bool hadToMove = false;
+            if (IsPlayerMoving(lastPosition))
+            {
+                hadToMove = true;
+                Log("Goto corpse - Wait till player become stil!");
+            }
+
+            while (IsPlayerMoving(lastPosition))
+            {
+                lastPosition = playerReader.PlayerLocation;
+                if (!await Wait(200, EnteredCombat()))
+                {
+                    if (await AquiredTarget())
+                        return Tuple.Create(true, hadToMove);
+                }
+            }
+
+            if (hadToMove)
+            {
+                if (!await Wait(200, EnteredCombat()))
+                {
+                    if (await AquiredTarget())
+                        return Tuple.Create(true, hadToMove);
+                }
+            }
+
+            return Tuple.Create(false, hadToMove);
+        }
+
+
+        public static async Task<bool> Wait(int durationMs, Func<bool> exit)
+        {
+            int elapsedMs = 0;
+            while (elapsedMs <= durationMs)
+            {
+                if (exit())
+                    return false;
+
+                await Task.Delay(50);
+                elapsedMs += 50;
+            }
+
+            return true;
+        }
+
+        public static async Task<bool> Wait(int durationMs, Task<bool> exit)
+        {
+            int elapsedMs = 0;
+            while (elapsedMs <= durationMs)
+            {
+                if (await exit)
+                    return false;
+
+                await Task.Delay(50);
+                elapsedMs += 50;
+            }
+
+            return true;
+        }
+
+
+        private void Log(string text)
+        {
+            if (debug)
+            {
+                logger.LogInformation($"{this.GetType().Name}: {text}");
+            }
+        }
+    }
+}

--- a/Core/Goals/CombatUtil.cs
+++ b/Core/Goals/CombatUtil.cs
@@ -25,8 +25,10 @@ namespace Core
             lastPosition = playerReader.PlayerLocation;
         }
 
-        public void UpdateLastPosition()
+        public void Update()
         {
+            // TODO: have to find a better way to reset outOfCombat
+            outOfCombat = false;
             lastPosition = playerReader.PlayerLocation;
         }
 
@@ -43,7 +45,6 @@ namespace Core
             if (outOfCombat && playerReader.PlayerBitValues.PlayerInCombat)
             {
                 Log("Combat Enter");
-                outOfCombat = false;
                 return true;
             }
 

--- a/Core/Goals/CombatUtil.cs
+++ b/Core/Goals/CombatUtil.cs
@@ -63,9 +63,6 @@ namespace Core
                     {
                         Log("Found target by pet");
                         await input.TapTargetOfTarget();
-                        //SendActionEvent(new ActionEventArgs(GoapKey.shouldloot, false));
-                        //SendActionEvent(new ActionEventArgs(GoapKey.newtarget, true));
-                        //SendActionEvent(new ActionEventArgs(GoapKey.hastarget, true));
                         return true;
                     }
                 }
@@ -76,9 +73,6 @@ namespace Core
                     playerReader.PlayerBitValues.TargetOfTargetIsPlayer)
                 {
                     Log("Found from nearest target");
-                    //SendActionEvent(new ActionEventArgs(GoapKey.shouldloot, false));
-                    //SendActionEvent(new ActionEventArgs(GoapKey.newtarget, true));
-                    //SendActionEvent(new ActionEventArgs(GoapKey.hastarget, true));
                     return true;
                 }
 

--- a/Core/Goals/GoalFactory.cs
+++ b/Core/Goals/GoalFactory.cs
@@ -44,6 +44,7 @@ namespace Core
             var castingHandler = new CastingHandler(logger, input, addonReader.PlayerReader, classConfig, playerDirection, npcNameFinder);
 
             var stuckDetector = new StuckDetector(logger, input, addonReader.PlayerReader, playerDirection, stopMoving);
+            var combatUtil = new CombatUtil(logger, input, addonReader.PlayerReader);
             var followRouteAction = new FollowRouteGoal(logger, input, addonReader.PlayerReader,  playerDirection, pathPoints, stopMoving, npcNameFinder, blacklist, stuckDetector, classConfig, pather);
             var walkToCorpseAction = new WalkToCorpseGoal(logger, input, addonReader.PlayerReader,  playerDirection, spiritPath, pathPoints, stopMoving, stuckDetector, pather);
 
@@ -86,13 +87,13 @@ namespace Core
 
                 if (classConfig.Loot)
                 {
-                    var lootAction = new LootGoal(logger, input, addonReader.PlayerReader, addonReader.BagReader, stopMoving, classConfig, npcNameFinder);
+                    var lootAction = new LootGoal(logger, input, addonReader.PlayerReader, addonReader.BagReader, stopMoving, classConfig, npcNameFinder, combatUtil);
                     lootAction.AddPreconditions();
                     availableActions.Add(lootAction);
 
                     if (classConfig.Skin)
                     {
-                        availableActions.Add(new SkinningGoal(logger, input, addonReader.PlayerReader, addonReader.BagReader, addonReader.equipmentReader, stopMoving, classConfig, npcNameFinder));
+                        availableActions.Add(new SkinningGoal(logger, input, addonReader.PlayerReader, addonReader.BagReader, addonReader.equipmentReader, stopMoving, npcNameFinder, combatUtil));
                     }
                 }
 

--- a/Core/Goals/GoapGoal.cs
+++ b/Core/Goals/GoapGoal.cs
@@ -38,8 +38,6 @@ namespace Core.Goals
 
         public List<KeyAction> Keys { get; private set; } = new List<KeyAction>();
 
-        public bool InRangeOfTarget { get; set; }
-
         public abstract float CostOfPerformingAction { get; }
 
         public void DoReset()

--- a/Core/Goals/LastTargetLoot.cs
+++ b/Core/Goals/LastTargetLoot.cs
@@ -59,11 +59,6 @@ namespace Core.Goals
             await input.TapClearTarget();
         }
 
-        public override void ResetBeforePlanning()
-        {
-            base.ResetBeforePlanning();
-        }
-
         private bool IsPlayerMoving(WowPoint lastPos)
         {
             var distance = WowPoint.DistanceTo(lastPos, playerReader.PlayerLocation);

--- a/Core/Goals/LootGoal.cs
+++ b/Core/Goals/LootGoal.cs
@@ -19,11 +19,12 @@ namespace Core.Goals
         private readonly BagReader bagReader;
         private readonly ClassConfiguration classConfiguration;
         private readonly NpcNameFinder npcNameFinder;
+        private readonly CombatUtil combatUtil;
 
         private bool debug = true;
-        private bool outOfCombat = false;
+        private long LastLoot;
 
-        public LootGoal(ILogger logger, ConfigurableInput input, PlayerReader playerReader, BagReader bagReader, StopMoving stopMoving,  ClassConfiguration classConfiguration, NpcNameFinder npcNameFinder)
+        public LootGoal(ILogger logger, ConfigurableInput input, PlayerReader playerReader, BagReader bagReader, StopMoving stopMoving,  ClassConfiguration classConfiguration, NpcNameFinder npcNameFinder, CombatUtil combatUtil)
         {
             this.logger = logger;
             this.input = input;
@@ -33,13 +34,15 @@ namespace Core.Goals
             
             this.classConfiguration = classConfiguration;
             this.npcNameFinder = npcNameFinder;
+            this.combatUtil = combatUtil;
 
-            outOfCombat = playerReader.PlayerBitValues.PlayerInCombat;
+            LastLoot = playerReader.LastLootTime;
         }
 
         public virtual void AddPreconditions()
         {
             AddPrecondition(GoapKey.shouldloot, true);
+            AddEffect(GoapKey.shouldloot, false);
         }
 
         public override bool CheckIfActionCanRun()
@@ -49,13 +52,12 @@ namespace Core.Goals
 
         public override void ResetBeforePlanning()
         {
-            outOfCombat = playerReader.PlayerBitValues.PlayerInCombat;
             base.ResetBeforePlanning();
         }
 
         public override async Task PerformAction()
         {
-            WowPoint lastPosition = playerReader.PlayerLocation;
+            combatUtil.UpdateLastPosition();
 
             Log("Search for corpse");
             npcNameFinder.ChangeNpcType(NpcNameFinder.NPCType.Corpse);
@@ -63,179 +65,96 @@ namespace Core.Goals
             await stopMoving.Stop();
             await npcNameFinder.WaitForNUpdate(1);
 
-            bool lootSuccess = await npcNameFinder.FindByCursorType(Cursor.CursorClassification.Loot);
-            if (lootSuccess)
+            bool foundCursor = await npcNameFinder.FindByCursorType(Cursor.CursorClassification.Loot);
+            if (foundCursor)
             {
                 Log("Found corpse - interact with it");
                 await playerReader.WaitForNUpdate(1);
 
-                if (classConfiguration.Skin)
-                {
-                    var targetSkinnable = !playerReader.Unskinnable;
-                    AddEffect(GoapKey.shouldskin, targetSkinnable);
-                    Log($"Should skin ? {targetSkinnable}");
-                    SendActionEvent(new ActionEventArgs(GoapKey.shouldskin, targetSkinnable));
-                }
+                CheckForSkinning();
 
-                bool hadToMove = false;
-                if (IsPlayerMoving(lastPosition))
+                (bool foundTarget, bool moved) = await combatUtil.FoundTargetWhileMoved();
+                if (foundTarget)
                 {
-                    hadToMove = true;
-                    Log("Goto corpse - Wait till player become stil!");
-                }
-
-                while (IsPlayerMoving(lastPosition))
-                {
-                    lastPosition = playerReader.PlayerLocation;
-                    if (!await Wait(100, DiDEnteredCombat()))
-                    {
-                        await AquireTarget();
-                        return;
-                    }
-                }
-
-                // TODO: damn spell batching
-                // arriving to the corpse min distance to interact location
-                // and says you are too far away
-                // so have to wait and retry the action
-                // at this point the player have a target
-                // might be a good idea to check the last error message :shrug:
-                if (hadToMove)
-                {
-                    if (!await Wait(200, DiDEnteredCombat()))
-                    {
-                        await AquireTarget();
-                        return;
-                    }
-                }
-                    
-
-                await input.TapInteractKey("Approach corpse");
-
-                // TODO: find a better way to get notified about the successful loot
-                // challlange:
-                // - the mob might have no loot at all so cant check inventory change
-                // - loot window could be checked
-                /*
-                if (!await Wait(400, DiDEnteredCombat()))
-                {
-                    await AquireTarget();
+                    Log("Goal interrupted!");
                     return;
                 }
-                */
-                Log("Loot Successfull");
 
-                await GoalExit();
+                if(moved) 
+                {
+                    Log("had to move so interact again");
+                    await input.TapInteractKey("");
+                }
             }
             else
             {
-                Log($"No corpse found - Npc Count: {npcNameFinder.NpcCount}");
+                Log($"No corpse name found - check last dead target exists");
 
-                await input.TapLastTargetKey("loot second attempt by last target");
+                await input.TapLastTargetKey("");
                 await playerReader.WaitForNUpdate(1);
                 if(playerReader.HasTarget)
                 {
                     if(playerReader.PlayerBitValues.TargetIsDead)
                     {
-                        await input.TapInteractKey("loot dead corpse by last target");
+                        Log("Found last dead target");
+
+                        CheckForSkinning();
+
+                        await input.TapInteractKey("");
+                        await playerReader.WaitForNUpdate(1);
+
+                        (bool foundTarget, bool moved) = await combatUtil.FoundTargetWhileMoved();
+                        if (foundTarget)
+                        {
+                            Log("Goal interrupted!");
+                            return;
+                        }
+
+                        if (moved)
+                        {
+                            Log("Last dead target double");
+                            await input.TapInteractKey("");
+                        }
                     }
                     else
                     {
-                        await input.TapClearTarget("dont attack");
+                        Log("Dont attak the target!");
+                        await input.TapClearTarget("");
                     }
                 }
-
-                if (!await Wait(100, DiDEnteredCombat()))
-                {
-                    await AquireTarget();
-                }
-                else
-                {
-                    await GoalExit();
-                }
             }
+
+            await GoalExit();
         }
 
-        public override void OnActionEvent(object sender, ActionEventArgs e)
+        private void CheckForSkinning()
         {
-            if (sender != this)
+            if (classConfiguration.Skin)
             {
-                outOfCombat = true;
+                var targetSkinnable = !playerReader.Unskinnable;
+                Log($"Should skin ? {targetSkinnable}");
+                AddEffect(GoapKey.shouldskin, targetSkinnable);
+                SendActionEvent(new ActionEventArgs(GoapKey.shouldskin, targetSkinnable));
             }
         }
-
-        public async Task<bool> DiDEnteredCombat()
-        {
-            await Task.Delay(0);
-            if (!outOfCombat && !playerReader.PlayerBitValues.PlayerInCombat)
-            {
-                Log("Combat Leave");
-                outOfCombat = true;
-                return false;
-            }
-
-            if (outOfCombat && playerReader.PlayerBitValues.PlayerInCombat)
-            {
-                Log("Combat Enter");
-                return true;
-            }
-
-            return false;
-        }
-
-        private async Task AquireTarget()
-        {
-            if (this.playerReader.PlayerBitValues.PlayerInCombat && this.playerReader.PetHasTarget)
-            {
-                await input.TapTargetPet();
-                Log($"Pets target {this.playerReader.TargetTarget}");
-                if (this.playerReader.TargetTarget == TargetTargetEnum.PetHasATarget)
-                {
-                    Log("Found target by pet");
-                    await input.TapTargetOfTarget();
-                    SendActionEvent(new ActionEventArgs(GoapKey.shouldloot, false));
-                    SendActionEvent(new ActionEventArgs(GoapKey.newtarget, true));
-                    SendActionEvent(new ActionEventArgs(GoapKey.hastarget, true));
-                    return;
-                }
-
-                await input.TapNearestTarget();
-                await playerReader.WaitForNUpdate(1);
-                if (this.playerReader.HasTarget && playerReader.PlayerBitValues.TargetInCombat)
-                {
-                    if (playerReader.PlayerBitValues.TargetOfTargetIsPlayer)
-                    {
-                        Log("Found from nearest target");
-                        SendActionEvent(new ActionEventArgs(GoapKey.shouldloot, false));
-                        SendActionEvent(new ActionEventArgs(GoapKey.newtarget, true));
-                        SendActionEvent(new ActionEventArgs(GoapKey.hastarget, true));
-                        return;
-                    }
-                }
-
-                await input.TapClearTarget();
-                Log("No target found");
-            }
-        }
-
-        private bool IsPlayerMoving(WowPoint lastPos)
-        {
-            var distance = WowPoint.DistanceTo(lastPos, playerReader.PlayerLocation);
-            return distance > 0.5f;
-        }
-
 
         private async Task GoalExit()
         {
-            AddEffect(GoapKey.shouldloot, false);
+            LastLoot = playerReader.LastLootTime;
+            Log($"Loot Finished! LastLoot = {LastLoot}");
+
             SendActionEvent(new ActionEventArgs(GoapKey.shouldloot, false));
+            await Task.Delay(1);
 
             if (!classConfiguration.Skin)
             {
                 npcNameFinder.ChangeNpcType(NpcNameFinder.NPCType.Enemy);
             }
 
-            await input.TapClearTarget();
+            if (playerReader.HasTarget && playerReader.PlayerBitValues.TargetIsDead)
+            {
+                await input.TapClearTarget();
+            }
         }
 
         private void Log(string text)

--- a/Core/Goals/LootGoal.cs
+++ b/Core/Goals/LootGoal.cs
@@ -50,11 +50,6 @@ namespace Core.Goals
             return !bagReader.BagsFull && playerReader.ShouldConsumeCorpse;
         }
 
-        public override void ResetBeforePlanning()
-        {
-            base.ResetBeforePlanning();
-        }
-
         public override async Task PerformAction()
         {
             combatUtil.Update();
@@ -77,6 +72,10 @@ namespace Core.Goals
                 if (foundTarget)
                 {
                     Log("Goal interrupted!");
+                    SendActionEvent(new ActionEventArgs(GoapKey.shouldloot, false));
+                    SendActionEvent(new ActionEventArgs(GoapKey.newtarget, true));
+                    SendActionEvent(new ActionEventArgs(GoapKey.hastarget, true));
+                    SendActionEvent(new ActionEventArgs(GoapKey.pulled, true));
                     return;
                 }
 
@@ -107,6 +106,10 @@ namespace Core.Goals
                         if (foundTarget)
                         {
                             Log("Goal interrupted!");
+                            SendActionEvent(new ActionEventArgs(GoapKey.shouldloot, false));
+                            SendActionEvent(new ActionEventArgs(GoapKey.newtarget, true));
+                            SendActionEvent(new ActionEventArgs(GoapKey.hastarget, true));
+                            SendActionEvent(new ActionEventArgs(GoapKey.pulled, true));
                             return;
                         }
 

--- a/Core/Goals/LootGoal.cs
+++ b/Core/Goals/LootGoal.cs
@@ -57,7 +57,7 @@ namespace Core.Goals
 
         public override async Task PerformAction()
         {
-            combatUtil.UpdateLastPosition();
+            combatUtil.Update();
 
             Log("Search for corpse");
             npcNameFinder.ChangeNpcType(NpcNameFinder.NPCType.Corpse);

--- a/Core/Goals/PostKillLootGoal.cs
+++ b/Core/Goals/PostKillLootGoal.cs
@@ -8,8 +8,8 @@ namespace Core.Goals
     {
         public override float CostOfPerformingAction { get => 4.5f; }
 
-        public PostKillLootGoal(ILogger logger, ConfigurableInput input, PlayerReader playerReader, BagReader bagReader, StopMoving stopMoving, ClassConfiguration classConfiguration, NpcNameFinder npcNameFinder)
-            : base(logger, input, playerReader, bagReader, stopMoving, classConfiguration, npcNameFinder)
+        public PostKillLootGoal(ILogger logger, ConfigurableInput input, PlayerReader playerReader, BagReader bagReader, StopMoving stopMoving, ClassConfiguration classConfiguration, NpcNameFinder npcNameFinder, CombatUtil combatUtil)
+            : base(logger, input, playerReader, bagReader, stopMoving, classConfiguration, npcNameFinder, combatUtil)
         {
         }
 

--- a/Core/Goals/SkinningGoal.cs
+++ b/Core/Goals/SkinningGoal.cs
@@ -63,9 +63,6 @@ namespace Core.Goals
             npcNameFinder.ChangeNpcType(NpcNameFinder.NPCType.Corpse);
 
             await stopMoving.Stop();
-
-            // TODO: have to wait for the cursor to switch from loot -> skinning
-            // sometimes takes a lot of time
             await npcNameFinder.WaitForNUpdate(1);
 
             if (await combatUtil.EnteredCombat())

--- a/Core/Goals/SkinningGoal.cs
+++ b/Core/Goals/SkinningGoal.cs
@@ -57,7 +57,7 @@ namespace Core.Goals
 
         public override async Task PerformAction()
         {
-            combatUtil.UpdateLastPosition();
+            combatUtil.Update();
 
             Log("Try to find Corpse");
             npcNameFinder.ChangeNpcType(NpcNameFinder.NPCType.Corpse);

--- a/Core/Goals/SkinningGoal.cs
+++ b/Core/Goals/SkinningGoal.cs
@@ -18,13 +18,10 @@ namespace Core.Goals
         private readonly StopMoving stopMoving;
         private readonly BagReader bagReader;
         private readonly EquipmentReader equipmentReader;
-        private readonly ClassConfiguration classConfiguration;
         private readonly NpcNameFinder npcNameFinder;
-        
+        private readonly CombatUtil combatUtil;
 
-        private bool outOfCombat = false;
-
-        public SkinningGoal(ILogger logger, ConfigurableInput input, PlayerReader playerReader, BagReader bagReader, EquipmentReader equipmentReader, StopMoving stopMoving,  ClassConfiguration classConfiguration, NpcNameFinder npcNameFinder)
+        public SkinningGoal(ILogger logger, ConfigurableInput input, PlayerReader playerReader, BagReader bagReader, EquipmentReader equipmentReader, StopMoving stopMoving,  NpcNameFinder npcNameFinder, CombatUtil combatUtil)
         {
             this.logger = logger;
             this.input = input;
@@ -34,16 +31,13 @@ namespace Core.Goals
             this.bagReader = bagReader;
             this.equipmentReader = equipmentReader;
 
-
-            this.classConfiguration = classConfiguration;
             this.npcNameFinder = npcNameFinder;
+            this.combatUtil = combatUtil;
 
             AddPrecondition(GoapKey.incombat, false);
             AddPrecondition(GoapKey.shouldskin, true);
 
             AddEffect(GoapKey.shouldskin, false);
-
-            outOfCombat = playerReader.PlayerBitValues.PlayerInCombat;
         }
 
         public override bool CheckIfActionCanRun()
@@ -63,6 +57,8 @@ namespace Core.Goals
 
         public override async Task PerformAction()
         {
+            combatUtil.UpdateLastPosition();
+
             Log("Try to find Corpse");
             npcNameFinder.ChangeNpcType(NpcNameFinder.NPCType.Corpse);
 
@@ -71,38 +67,40 @@ namespace Core.Goals
             // TODO: have to wait for the cursor to switch from loot -> skinning
             // sometimes takes a lot of time
             await npcNameFinder.WaitForNUpdate(1);
-            if (await DiDEnteredCombat())
+
+            if (await combatUtil.EnteredCombat())
             {
-                await AquireTarget();
+                await combatUtil.AquiredTarget();
                 return;
             }
 
             Log("Found corpses: " + npcNameFinder.NpcCount);
-            WowPoint lastPosition = playerReader.PlayerLocation;
+
             bool skinSuccess = await npcNameFinder.FindByCursorType(Cursor.CursorClassification.Skin);
             if (skinSuccess)
             {
-                await Wait(100, () => false);
-                if (IsPlayerMoving(lastPosition)) 
-                    Log("Goto corpse - Wait till the player become stil!");
+                Log("Found corpse - interact with it");
+                await playerReader.WaitForNUpdate(1);
 
-                while (IsPlayerMoving(lastPosition))
+                (bool foundTarget, bool moved) = await combatUtil.FoundTargetWhileMoved();
+                if (foundTarget)
                 {
-                    lastPosition = playerReader.PlayerLocation;
-                    if (!await Wait(100, DiDEnteredCombat()))
-                    {
-                        await AquireTarget();
-                        return;
-                    }
+                    Log("Goal interrupted!");
+                    return;
                 }
-                
-                await input.TapInteractKey("Skinning Attempt...");
+
+                if (moved)
+                {
+                    Log("had to move so interact again");
+                    await input.TapInteractKey("");
+                }
+
                 do
                 {
                     await playerReader.WaitForNUpdate(1);
-                    if (await DiDEnteredCombat())
+                    if (await combatUtil.EnteredCombat())
                     {
-                        await AquireTarget();
+                        await combatUtil.AquiredTarget();
                         return;
                     }
                 } while (playerReader.IsCasting);
@@ -128,77 +126,16 @@ namespace Core.Goals
             }
         }
 
-        public override void OnActionEvent(object sender, ActionEventArgs e)
-        {
-            if (sender != this)
-            {
-                outOfCombat = true;
-            }
-        }
-
         async Task GoalExit()
         {
             SendActionEvent(new ActionEventArgs(GoapKey.shouldskin, false));
 
             npcNameFinder.ChangeNpcType(NpcNameFinder.NPCType.Enemy);
 
-            await input.TapClearTarget();
-        }
-
-        public async Task<bool> DiDEnteredCombat()
-        {
-            await Task.Delay(0);
-            if (!outOfCombat && !playerReader.PlayerBitValues.PlayerInCombat)
+            if (playerReader.HasTarget && playerReader.PlayerBitValues.TargetIsDead)
             {
-                Log("Combat Leave");
-                outOfCombat = true;
-            }
-
-            if (outOfCombat && playerReader.PlayerBitValues.PlayerInCombat)
-            {
-                Log("Combat detected");
-                return true;
-            }
-
-            return false;
-        }
-
-        private async Task AquireTarget()
-        {
-            if (this.playerReader.PlayerBitValues.PlayerInCombat && this.playerReader.PetHasTarget)
-            {
-                await input.TapTargetPet();
-                Log($"Pets target {this.playerReader.TargetTarget}");
-                if (this.playerReader.TargetTarget == TargetTargetEnum.PetHasATarget)
-                {
-                    Log("Found target by pet");
-                    await input.TapTargetOfTarget();
-                    SendActionEvent(new ActionEventArgs(GoapKey.newtarget, true));
-                    return;
-                }
-
-                await input.TapNearestTarget();
-                await playerReader.WaitForNUpdate(1);
-                if (this.playerReader.HasTarget && playerReader.PlayerBitValues.TargetInCombat)
-                {
-                    if (playerReader.PlayerBitValues.TargetOfTargetIsPlayer)
-                    {
-                        Log("Found from nearest target");
-                        SendActionEvent(new ActionEventArgs(GoapKey.newtarget, true));
-                        return;
-                    }
-                }
-
                 await input.TapClearTarget();
-                Log("No target found");
             }
-        }
-
-
-
-        public override void ResetBeforePlanning()
-        {
-            base.ResetBeforePlanning();
         }
 
         private void Log(string text)
@@ -206,10 +143,5 @@ namespace Core.Goals
             logger.LogInformation($"{this.GetType().Name}: {text}");
         }
 
-        private bool IsPlayerMoving(WowPoint lastPos)
-        {
-            var distance = WowPoint.DistanceTo(lastPos, playerReader.PlayerLocation);
-            return distance > 0.5f;
-        }
     }
 }

--- a/Core/NpcFinder/NpcNameFinder.cs
+++ b/Core/NpcFinder/NpcNameFinder.cs
@@ -108,6 +108,7 @@ namespace Core
             if(_NPCType != type)
             {
                 _NPCType = type;
+                logger.LogInformation($"ChangeNpcType = {type}");
             }
         }
 


### PR DESCRIPTION
Goal:
- Reduce the downtime after loot and the next pull
- have a common component `CombatUtil` which can handle combat stuffs outside of `CombatGoal`
- fixed non pet based classes body pull
- try not to stuck in `LootGoal` or `SkinningGoal` upon body pull