### PR TITLE
AddonDataProvider: Make sure to only grab the data

### DIFF
--- a/Core/Addon/AddonDataProvider/AddonDataProvider.cs
+++ b/Core/Addon/AddonDataProvider/AddonDataProvider.cs
@@ -19,6 +19,9 @@ namespace Core
         private readonly DirectBitmapCapturer capturer;
         private Rectangle rectangle;
 
+        private readonly Color firstColor = Color.FromArgb(255, 0, 0, 0);
+        private readonly Color lastColor = Color.FromArgb(255, 30, 132, 129);
+
         public AddonDataProvider(IWowScreen wowScreen, List<DataFrame> frames)
         {
             this.wowScreen = wowScreen;
@@ -43,12 +46,19 @@ namespace Core
             rectangle.Y = p.Y;
             capturer.Capture(rectangle);
 
+            if (!Visible()) return;
+
             for (int i = 0; i < frames.Length; i++)
             {
                 FrameColor[frames[i].index] = capturer.GetColorAt(frames[i].point);
             }
         }
 
+        private bool Visible()
+        {
+            return capturer.GetColorAt(frames[0].point) == firstColor &&
+                capturer.GetColorAt(frames[frames.Length-1].point) == lastColor;
+        }
 
         public Color GetColor(int index)
         {


### PR DESCRIPTION
when the meta colors(begin and end) is exists.
Possibly filtering out some of the strange cases when the target guid or
id is not reported properly.