### PR TITLE
fix: 1440p resolution wrong estimation of possible required bitmap width

### DIFF
--- a/BlazorServer/Pages/FrameConfiguration.razor
+++ b/BlazorServer/Pages/FrameConfiguration.razor
@@ -229,11 +229,11 @@ else
 
                 if (dataFrameMeta != DataFrameMeta.Empty)
                 {
-                    var size = dataFrameMeta.EstimatedSize();
                     wowScreen.GetRectangle(out var rect);
+                    var size = dataFrameMeta.EstimatedSize(rect);
 
-                    if (size.Width < rect.Size.Width &&
-                        size.Height < rect.Size.Height && !size.IsEmpty)
+                    if (size.Width <= rect.Size.Width &&
+                    size.Height <= rect.Size.Height && !size.IsEmpty)
                     {
                         var screenshot = wowScreen.GetBitmap(size.Width, size.Height);
                         if (screenshot != null)
@@ -345,7 +345,10 @@ else
 
         meta = GetDataFrameMeta();
 
-        var size = meta.EstimatedSize();
+        if (wowScreen == null) return;
+        wowScreen.GetRectangle(out var rect);
+
+        var size = meta.EstimatedSize(rect);
         var screenshot = wowScreen?.GetBitmap(size.Width, size.Height);
         if (screenshot == null) return;
 
@@ -367,8 +370,6 @@ else
 
         await Wait();
 
-        if (wowScreen == null) return;
-        wowScreen.GetRectangle(out var rect);
         DataFrameConfiguration.SaveConfiguration(rect, version, meta, dataFrames);
         saved = true;
 

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -67,7 +67,8 @@ namespace Server
                 Log.Logger.Information("Enter Addon Configure mode!");
             }
 
-            var size = dataFrameMeta.EstimatedSize();
+            wowScreen.GetRectangle(out var rect);
+            var size = dataFrameMeta.EstimatedSize(rect);
             var screenshot = wowScreen.GetBitmap(size.Width, size.Height);
             var dataFrames = DataFrameConfiguration.CreateFrames(dataFrameMeta, screenshot);
 

--- a/SharedLib/DataFrameConfig/DataFrameMeta.cs
+++ b/SharedLib/DataFrameConfig/DataFrameMeta.cs
@@ -25,10 +25,9 @@ namespace SharedLib
 
         public int frames { private set; get; }
 
-        public Size EstimatedSize()
+        public Size EstimatedSize(Rectangle screenRect)
         {
-            var size = new SizeF(frames * (this.size + spacing), rows * (this.size + spacing));
-            size *= 1.3f; // error rate
+            SizeF size = new SizeF(screenRect.Width, rows * (this.size + spacing) * 2);
             return size.ToSize();
         }
 


### PR DESCRIPTION
At 1440p resolution estimating the required bitmap sample size was not correct.

with the given configuration:
- size: 1
- spacing: 1
- rows: 1

with the given formula under estimate the required width
```
            var size = new SizeF(frames * (this.size + spacing), rows * (this.size + spacing));
```

the possible bitmap width with 100 frames supposed to be around ~200px in width with 1:1 ratio. 

However given the fact how `uiScale` works, just rather avoid to calculate the required width.
