### PR TITLE
CoreTest: Npc name finder. seperate targeting and looting/skinning tests

### DIFF
--- a/Core/NpcFinder/NpcNameFinder.cs
+++ b/Core/NpcFinder/NpcNameFinder.cs
@@ -57,7 +57,7 @@ namespace Core
         private float scaleToRefHeight = 1;
 
         public List<Point> locTargetingAndClickNpc { get; private set; }
-        private readonly List<Point> locFindByCursorType;
+        public List<Point> locFindByCursorType { get; private set; }
 
         public List<NpcPosition> Npcs { get; private set; } = new List<NpcPosition>();
         public int NpcCount => npcs.Count;
@@ -80,10 +80,10 @@ namespace Core
             locFindByCursorType = new List<Point>
             {
                 new Point(0, 0),
-                new Point(0, 20).Scale(scaleToRefWidth, scaleToRefHeight),
-                new Point(0, 60).Scale(scaleToRefWidth, scaleToRefHeight),
-                new Point(-10, 45).Scale(scaleToRefWidth, scaleToRefHeight),
-                new Point(10, 45).Scale(scaleToRefWidth, scaleToRefHeight),
+                new Point(0, 25).Scale(scaleToRefWidth, scaleToRefHeight),
+                new Point(0, 90).Scale(scaleToRefWidth, scaleToRefHeight),
+                new Point(-10, 50).Scale(scaleToRefWidth, scaleToRefHeight),
+                new Point(10, 50).Scale(scaleToRefWidth, scaleToRefHeight),
             };
         }
 

--- a/CoreTests/NpcNameFinder/Test_NpcNameFinderLoot.cs
+++ b/CoreTests/NpcNameFinder/Test_NpcNameFinderLoot.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using Core;
+using Microsoft.Extensions.Logging;
+using SharedLib;
+
+namespace CoreTests
+{
+    public class Test_NpcNameFinderLoot
+    {
+        private readonly ILogger logger;
+        private readonly NpcNameFinder npcNameFinder;
+        private readonly RectProvider rectProvider;
+        private readonly DirectBitmapCapturer capturer;
+
+        public Test_NpcNameFinderLoot(ILogger logger)
+        {
+            this.logger = logger;
+
+            MockWoWProcess mockWoWProcess = new MockWoWProcess();
+            rectProvider = new RectProvider();
+            rectProvider.GetRectangle(out var rect);
+            capturer = new DirectBitmapCapturer(rect);
+
+            npcNameFinder = new NpcNameFinder(logger, capturer, mockWoWProcess);
+        }
+
+        public void Execute()
+        {
+            npcNameFinder.ChangeNpcType(NpcNameFinder.NPCType.Corpse);
+
+            capturer.Capture();
+
+            System.Diagnostics.Stopwatch stopwatch = new System.Diagnostics.Stopwatch();
+            stopwatch.Start();
+            this.npcNameFinder.Update();
+            stopwatch.Stop();
+            logger.LogInformation($"Update: {stopwatch.ElapsedMilliseconds}ms");
+
+            var bitmap = capturer.GetBitmap(capturer.Rect.Width, capturer.Rect.Height);
+
+            using (var gr = Graphics.FromImage(bitmap))
+            {
+                Font drawFont = new Font("Arial", 10);
+                SolidBrush drawBrush = new SolidBrush(Color.White);
+
+                if (npcNameFinder.Npcs.Count > 0)
+                {
+                    using (var whitePen = new Pen(Color.White, 1))
+                    {
+                        gr.DrawRectangle(whitePen, npcNameFinder.Area);
+
+                        npcNameFinder.Npcs.ForEach(n =>
+                        {
+                            npcNameFinder.locFindByCursorType.ForEach(l =>
+                            {
+                                gr.DrawEllipse(whitePen, l.X + n.ClickPoint.X, l.Y + n.ClickPoint.Y, 5, 5);
+                            });
+                        });
+
+
+                        npcNameFinder.Npcs.ForEach(n => gr.DrawRectangle(whitePen, new Rectangle(n.Min, new Size(n.Width, n.Height))));
+                        npcNameFinder.Npcs.ForEach(n => gr.DrawString(npcNameFinder.Npcs.IndexOf(n).ToString(), drawFont, drawBrush, new PointF(n.Min.X - 20f, n.Min.Y)));
+                    }
+                }
+            }
+
+            npcNameFinder.Npcs.ForEach(n =>
+            {
+                logger.LogInformation($"{npcNameFinder.Npcs.IndexOf(n),2} -> rect={new Rectangle(n.Min.X, n.Min.Y, n.Width, n.Height)} ClickPoint={{{n.ClickPoint.X,4},{n.ClickPoint.Y,4}}}");
+            });
+
+            logger.LogInformation("\n");
+
+            bitmap.Save("loot_names.png");
+        }
+    }
+}

--- a/CoreTests/NpcNameFinder/Test_NpcNameFinderTarget.cs
+++ b/CoreTests/NpcNameFinder/Test_NpcNameFinderTarget.cs
@@ -1,21 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Text;
+﻿using System.Drawing;
 using Core;
 using Microsoft.Extensions.Logging;
 using SharedLib;
 
 namespace CoreTests
 {
-    public class Test_NpcNameFinder
+    public class Test_NpcNameFinderTarget
     {
         private readonly ILogger logger;
         private readonly NpcNameFinder npcNameFinder;
         private readonly RectProvider rectProvider;
         private readonly DirectBitmapCapturer capturer;
 
-        public Test_NpcNameFinder(ILogger logger)
+        public Test_NpcNameFinderTarget(ILogger logger)
         {
             this.logger = logger;
 
@@ -74,7 +71,7 @@ namespace CoreTests
 
             logger.LogInformation("\n");
 
-            bitmap.Save("names.png");
+            bitmap.Save("target_names.png");
         }
     }
 }

--- a/CoreTests/Program.cs
+++ b/CoreTests/Program.cs
@@ -21,7 +21,8 @@ namespace CoreTests
         {
             CreateLogger();
 
-            var test = new Test_NpcNameFinder(logger);
+            //var test = new Test_NpcNameFinderTarget(logger);
+            var test = new Test_NpcNameFinderLoot(logger);
             test.Execute();
         }
     }


### PR DESCRIPTION
make a separate testing suite for the looting/skinning trying to adjust the offset values to make suitable for big hitbox targets such as nagas, yetis, hippos