### PR TITLE
Backend relies on the in game onUpdate tick when it comes to WaitForNUpdate

### DIFF
--- a/Core/Addon/PlayerReader.cs
+++ b/Core/Addon/PlayerReader.cs
@@ -1,4 +1,5 @@
-﻿using Core.Database;
+﻿using System;
+using Core.Database;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -237,8 +238,8 @@ namespace Core
         }
         public async Task WaitForNUpdate(int n)
         {
-            var s = this.Sequence;
-            while (this.Sequence <= s + n)
+            var s = GlobalTime;
+            while (Math.Abs(s - GlobalTime) <= n)
             {
                 await Task.Delay(100);
             }


### PR DESCRIPTION
Issue:
Either on low(<30) or high(>100) framerate, the loot and skinning Goals failing when the player has to move to the corpse in prior to start the actions.

The problem, no sync between the in-game and backend update loop, and many times things not happened in the right order or some of the placed `WaitForNUpdate` not waited for an in-game redraw(`onUpdate`) as intended.

Example:
In-Game:
> Mob dies
> npc name found and right click happened
> the player starts moving in the game

Backend:
> based on the playerReader, the player stays still, by prematurely evaluating `CombatUtil.IsPlayerMoving` => false

Note: `GlobalTime` max value is 2^24. so it can overflow with the current setup every 7.8 hours. To mitigate the issue using a different way to calculate time frame differences in `WaitForNUpdate`