### PR TITLE
Feature/reduce input delay

### DIFF
--- a/Core/Addon/PlayerReader.cs
+++ b/Core/Addon/PlayerReader.cs
@@ -241,7 +241,7 @@ namespace Core
             var s = GlobalTime;
             while (Math.Abs(s - GlobalTime) <= n)
             {
-                await Task.Delay(100);
+                await Task.Delay(50);
             }
         }
 

--- a/Core/Goals/FollowRouteGoal.cs
+++ b/Core/Goals/FollowRouteGoal.cs
@@ -189,7 +189,7 @@ namespace Core.Goals
             {
                 // stuck so jump
                 input.SetKeyState(ConsoleKey.UpArrow, true, false, "FollowRouteAction 2");
-                await Task.Delay(100);
+                await playerReader.WaitForNUpdate(1);
                 if (HasBeenActiveRecently())
                 {
                     await this.stuckDetector.Unstick();
@@ -197,7 +197,7 @@ namespace Core.Goals
                 }
                 else
                 {
-                    await Task.Delay(100);
+                    await playerReader.WaitForNUpdate(1);
                     logger.LogInformation("Resuming movement");
                 }
             }

--- a/Core/NpcFinder/NpcNameFinder.cs
+++ b/Core/NpcFinder/NpcNameFinder.cs
@@ -14,6 +14,8 @@ namespace Core
 {
     public class NpcNameFinder
     {
+        private const int MOUSE_DELAY = 35;
+
         public enum NPCType
         {
             Enemy,
@@ -119,7 +121,7 @@ namespace Core
                     {
                         var clickPostion = bitmapProvider.DirectBitmap.ToScreenCoordinates(npc.ClickPoint.X + location.X, npc.ClickPoint.Y + location.Y);
                         mouseInput.SetCursorPosition(clickPostion);
-                        await Task.Delay(100);
+                        await Task.Delay(MOUSE_DELAY);
                         CursorClassifier.Classify(out var cls).Dispose();
                         if (cls == CursorClassification.Kill)
                         {
@@ -152,7 +154,7 @@ namespace Core
                 {
                     var clickPostion = bitmapProvider.DirectBitmap.ToScreenCoordinates(npc.ClickPoint.X + location.X, npc.ClickPoint.Y + location.Y);
                     mouseInput.SetCursorPosition(clickPostion);
-                    await Task.Delay(75);
+                    await Task.Delay(MOUSE_DELAY);
                     CursorClassifier.Classify(out var cls).Dispose();
                     if (cursor.Contains(cls))
                     {

--- a/Game/Input/InputSimulator.cs
+++ b/Game/Input/InputSimulator.cs
@@ -11,16 +11,20 @@ namespace Game
 {
     public class InputSimulator : IInput
     {
-        private const int MAX_DELAY = 200;
-        private const int MAX_MOUSE_DELAY = 75;
+        private readonly int MIN_DELAY;
+        private readonly int MAX_DELAY;
 
         private readonly Random random = new Random();
         private readonly GregsStack.InputSimulatorStandard.InputSimulator simulator;
         private readonly Process process;
 
-        public InputSimulator(Process process)
+        public InputSimulator(Process process, int minDelay, int maxDelay)
         {
             this.process = process;
+
+            MIN_DELAY = minDelay;
+            MAX_DELAY = maxDelay;
+
             simulator = new GregsStack.InputSimulatorStandard.InputSimulator();
         }
 
@@ -62,18 +66,17 @@ namespace Game
         public async Task LeftClickMouse(Point p)
         {
             SetCursorPosition(p);
-            await Delay(MAX_MOUSE_DELAY);
+            await Delay(MIN_DELAY);
             simulator.Mouse.LeftButtonDown();
-            await Delay(MAX_MOUSE_DELAY);
+            await Delay(MIN_DELAY);
             simulator.Mouse.LeftButtonUp();
-            await Delay(MAX_MOUSE_DELAY);
         }
 
         public async Task RightClickMouse(Point p)
         {
             SetCursorPosition(p);
             simulator.Mouse.RightButtonDown();
-            await Delay(MAX_MOUSE_DELAY);
+            await Delay(MIN_DELAY);
             simulator.Mouse.RightButtonUp();
         }
 

--- a/Game/Input/InputWindowsNative.cs
+++ b/Game/Input/InputWindowsNative.cs
@@ -11,17 +11,20 @@ namespace Game
 {
     public class InputWindowsNative : IInput
     {
-        private const int MAX_DELAY = 180;
-        private const int MIN_MOUSE_DELAY = 10;
+        private readonly int MIN_DELAY;
+        private readonly int MAX_DELAY;
 
         private readonly Process process;
         private readonly Random random = new Random();
 
         private readonly IEnumerable<ConsoleKey> consoleKeys = (IEnumerable<ConsoleKey>)Enum.GetValues(typeof(ConsoleKey));
 
-        public InputWindowsNative(Process process)
+        public InputWindowsNative(Process process, int minDelay, int maxDelay)
         {
             this.process = process;
+
+            MIN_DELAY = minDelay;
+            MAX_DELAY = maxDelay;
         }
 
         private async Task Delay(int milliseconds)
@@ -64,7 +67,7 @@ namespace Game
             int lparam = NativeMethods.MakeLParam(pp.x, pp.y);
 
             NativeMethods.PostMessage(process.MainWindowHandle, NativeMethods.WM_LBUTTONDOWN, NativeMethods.VK_LBUTTON, lparam);
-            await Delay(MIN_MOUSE_DELAY);
+            await Delay(MIN_DELAY);
             NativeMethods.PostMessage(process.MainWindowHandle, NativeMethods.WM_LBUTTONUP, 0, lparam);
         }
 
@@ -79,7 +82,7 @@ namespace Game
             int lparam = NativeMethods.MakeLParam(pp.x, pp.y);
 
             NativeMethods.PostMessage(process.MainWindowHandle, NativeMethods.WM_RBUTTONDOWN, NativeMethods.VK_RBUTTON, lparam);
-            await Delay(MIN_MOUSE_DELAY);
+            await Delay(MIN_DELAY);
             NativeMethods.PostMessage(process.MainWindowHandle, NativeMethods.WM_RBUTTONUP, 0, lparam);
         }
 

--- a/Game/Input/WowProcessInput.cs
+++ b/Game/Input/WowProcessInput.cs
@@ -10,6 +10,9 @@ namespace Game
 {
     public class WowProcessInput : IMouseInput
     {
+        private const int MIN_DELAY = 20;
+        private const int MAX_DELAY = 70;
+
         private readonly ILogger logger;
         private readonly WowProcess wowProcess;
         private readonly IInput nativeInput;
@@ -24,8 +27,8 @@ namespace Game
             this.logger = logger;
             this.wowProcess = wowProcess;
 
-            this.nativeInput = new InputWindowsNative(wowProcess.WarcraftProcess);
-            this.simulatorInput = new InputSimulator(wowProcess.WarcraftProcess);
+            this.nativeInput = new InputWindowsNative(wowProcess.WarcraftProcess, MIN_DELAY, MAX_DELAY);
+            this.simulatorInput = new InputSimulator(wowProcess.WarcraftProcess, MIN_DELAY, MAX_DELAY);
         }
 
         private void KeyDown(ConsoleKey key, string description = "")


### PR DESCRIPTION
Improve input responsiveness by reducing the unnecessarily high delay values such as >200ms.

Goal was to fix an isssue: 
- When the target dies, and the LootGoal tries to find the corpse hitbox correctly, however the hitbox is dynamic, and can change when the mobs dying animation is finished. So many times when the Rightclick mouse up event fired(+50 - +200ms later) the click position were not valid. Instead of interacting with the corpse, the player started moving via `Click to move`.

- Also made some improvement with the frame rate independence in the `FollowRouteGoal`
