### PR TITLE
Feature/addon update time dictates the waitforupdate

### DIFF
--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -102,8 +102,8 @@ function DataToColor:OnInitialize()
     DataToColor:RegisterEvent('MERCHANT_SHOW','OnMerchantShow')
     DataToColor:RegisterEvent('PLAYER_TARGET_CHANGED', 'OnPlayerTargetChanged')
 
-    DataToColor:Update()
-    
+    DataToColor:UpdateTimer()
+
     local version = GetAddOnMetadata('DataToColor', 'Version')
     DataToColor:Print("Welcome. Using "..version)
 end
@@ -117,22 +117,26 @@ function DataToColor:SetupRequirements()
 	SetCVar('Gamma',1,'[]')
 end
 
-local UpdateFuncCache={};
 function DataToColor:Update()
-	DataToColor.globalTime = DataToColor.globalTime + 1
+    DataToColor.globalTime = DataToColor.globalTime + 1
     if DataToColor.globalTime > (256 * 256 * 256 - 1) then
         DataToColor.globalTime = 0
     end
-
     --DataToColor:Print(DataToColor.globalTime)
- 
+end
+
+local UpdateFuncCache={};
+function DataToColor:UpdateTimer()
+    DataToColor:Update()
+
     local func = UpdateFuncCache[self]
     if not func then
-        func = function() DataToColor:Update(); end;
+        func = function() DataToColor:UpdateTimer(); end;
         UpdateFuncCache[self] = func;
     end
     C_Timer.After(DataToColor.timeUpdateSec, func);
 end
+
 
 function DataToColor:FushState()
     DataToColor.targetChanged = true
@@ -357,6 +361,8 @@ function DataToColor:CreateFrames(n)
             DataToColor:ConsumeChanges()
 
             DataToColor:HandlePlayerInteractionEvents()
+
+            DataToColor:Update()
         end
 
         if SETUP_SEQUENCE then

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: An addon that displays player position as color
-## Version: 1.0.32
+## Version: 1.0.33
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibDataBroker-1.1, LibCompress, LibRangeCheck
 ## SavedVariables:

--- a/BlazorServer/Pages/GoalsComponent.razor
+++ b/BlazorServer/Pages/GoalsComponent.razor
@@ -5,6 +5,7 @@
 <div class="card" style="margin-top: 10px">
     <div class="card-header">
         Goals -> @addonReader.PlayerReader.MinRange - @addonReader.PlayerReader.MaxRange
+        <span class="float-right">Update: @addonReader.PlayerReader.AvgUpdateLatency.ToString("0.00") ms</span>
     </div>
     @if (ShowGoals)
     {

--- a/Core/Addon/PlayerReader.cs
+++ b/Core/Addon/PlayerReader.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Core.Database;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
@@ -243,7 +243,7 @@ namespace Core
             var s = GlobalTime;
             while (Math.Abs(s - GlobalTime) <= n)
             {
-                await Task.Delay(50);
+                await Task.Delay(2 * (int)AvgUpdateLatency);
             }
         }
 

--- a/Core/Addon/PlayerReader.cs
+++ b/Core/Addon/PlayerReader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Core.Database;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
@@ -16,6 +16,8 @@ namespace Core
             this.reader = reader;
             this.creatureDb = creatureDb;
         }
+
+        public double AvgUpdateLatency = 0;
 
         public int Sequence { get; private set; } = 0;
         public List<CombatCreature> TargetHistory { get; } = new List<CombatCreature>();

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -28,6 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Cyotek.CircularBuffer" Version="1.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Html.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.6">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Addon side instead of using a hard coded `100ms` time to increment the `DataToColor.globalTime` use the `OnUpdate` call which runs as soon as possible.

Before this PR, there were
+ `100ms` addon side Update tick
+ `100ms` backend side wait time each `WaitForNUpdate`
which means worst case scenario 200ms downtime doing nothing / waiting for something to happen in game.

Downtime is significantly reduced. Example if the game is running with 60fps per second. That means  the addon can run the OnUpdate every `16.6ms` + some overhead.