### PR TITLE
Feature/goals waiting - casting handler rewrite main logics

### DIFF
--- a/Core/Addon/BuffStatus.cs
+++ b/Core/Addon/BuffStatus.cs
@@ -2,22 +2,22 @@
 {
     public class BuffStatus
     {
-        private long value;
+        public long Value { get; private set; }
 
         public BuffStatus(string name)
         {
             this.name = name;
-            this.value = 0;
+            this.Value = 0;
         }
 
         public BuffStatus(long value)
         {
-            this.value = value;
+            this.Value = value;
         }
 
         public bool IsBitSet(int pos)
         {
-            return (value & (1 << pos)) != 0;
+            return (Value & (1 << pos)) != 0;
         }
 
         public string name { get; set; } = string.Empty;

--- a/Core/ClassConfig/KeyAction.cs
+++ b/Core/ClassConfig/KeyAction.cs
@@ -37,6 +37,9 @@ namespace Core
 
         public bool Log { get; set; } = true;
         public int DelayAfterCast { get; set; } = 1450; // GCD 1500 - but spell queue window 400 ms
+
+        public bool AfterCastWaitBuff = false;
+
         public bool DelayUntilCombat { get; set; } = false;
         public int DelayBeforeCast { get; set; } = 0;
         public float Cost { get; set; } = 18;

--- a/Core/Goals/CombatGoal.cs
+++ b/Core/Goals/CombatGoal.cs
@@ -21,6 +21,8 @@ namespace Core.Goals
         private readonly ClassConfiguration classConfiguration;
         private DateTime lastPulled = DateTime.Now;
 
+        private readonly KeyAction defaultKeyAction = new KeyAction();
+
         private int lastKilledGuid;
 
         public CombatGoal(ILogger logger, ConfigurableInput input, PlayerReader playerReader, StopMoving stopMoving,  ClassConfiguration classConfiguration, CastingHandler castingHandler)
@@ -71,7 +73,7 @@ namespace Core.Goals
                     continue;
                 }
 
-                pressed = await this.castingHandler.CastIfReady(item);
+                pressed = await this.castingHandler.CastIfReady(item, item.DelayBeforeCast);
                 if (pressed)
                 {
                     break;
@@ -79,7 +81,7 @@ namespace Core.Goals
             }
             if (!pressed)
             {
-                await Task.Delay(20);
+                await Task.Delay(defaultKeyAction.PressDuration);
             }
 
             this.lastActive = DateTime.Now;
@@ -168,7 +170,7 @@ namespace Core.Goals
                     logger.LogInformation("Exit CombatGoal!!!");
                 }
             }
-            await Task.Delay(0);
+            await playerReader.WaitForNUpdate(2);
         }
 
         private bool DidKilledACreature()
@@ -211,7 +213,7 @@ namespace Core.Goals
 
             // check for targets attacking me
             await input.TapNearestTarget();
-            await playerReader.WaitForNUpdate(1);
+            await playerReader.WaitForNUpdate(2);
             if (this.playerReader.HasTarget && playerReader.PlayerBitValues.TargetInCombat)
             {
                 if (this.playerReader.PlayerBitValues.TargetOfTargetIsPlayer)

--- a/Core/Goals/ParallelGoal.cs
+++ b/Core/Goals/ParallelGoal.cs
@@ -1,5 +1,6 @@
 ﻿using Core.GOAP;
 using Microsoft.Extensions.Logging;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -30,68 +31,68 @@ namespace Core.Goals
 
             AddPrecondition(GoapKey.incombat, false);
 
-            keysConfig.ForEach(key => this.Keys.Add(key));
+            keysConfig.ForEach(key => Keys.Add(key));
         }
 
         public override bool CheckIfActionCanRun()
         {
-            return this.Keys.Any(key => key.CanRun());
+            return Keys.Any(key => key.CanRun());
         }
 
         public override async Task PerformAction()
         {
-            if (this.Keys.Any(k => k.StopBeforeCast))
+            if (Keys.Any(k => k.StopBeforeCast))
             {
-                await this.stopMoving.Stop();
+                await stopMoving.Stop();
 
                 if (playerReader.PlayerBitValues.IsMounted)
                 {
                     await input.TapDismount();
+                    //if (!await Wait(1000, () => playerReader.PlayerBitValues.PlayerInCombat)) return; // vanilla after dismout GCD
                 }
-                if (!await Wait(1000, () => playerReader.PlayerBitValues.PlayerInCombat)) return;
             }
 
-            this.Keys.ForEach(async key =>
+            await Wait(200, () => false);
+
+            Keys.ForEach(async key =>
             {
-                var pressed = await this.castingHandler.CastIfReady(key);
+                var pressed = await castingHandler.CastIfReady(key, key.DelayBeforeCast);
                 key.ResetCooldown();
                 key.SetClicked();
             });
 
-            if (!await Wait(400, () => playerReader.PlayerBitValues.PlayerInCombat)) return;
+            bool wasDrinkingOrEating = playerReader.Buffs.Drinking || playerReader.Buffs.Eating;
 
-            bool wasDrinkingOrEating = this.playerReader.Buffs.Drinking || this.playerReader.Buffs.Eating;
-            int ticks = 0;
+            logger.LogInformation($"Waiting for {Name}");
 
-            this.logger.LogInformation($"Waiting for {Name}");
-            while ((this.playerReader.Buffs.Drinking || this.playerReader.Buffs.Eating || this.playerReader.IsCasting) && !this.playerReader.PlayerBitValues.PlayerInCombat)
+            DateTime startTime = DateTime.Now;
+            while ((playerReader.Buffs.Drinking || playerReader.Buffs.Eating || playerReader.IsCasting) && !playerReader.PlayerBitValues.PlayerInCombat)
             {
-                if (!await Wait(100, () => playerReader.PlayerBitValues.PlayerInCombat)) return;
-                ticks++;
+                await playerReader.WaitForNUpdate(1);
 
-                if (this.playerReader.Buffs.Drinking && this.playerReader.Buffs.Eating)
+                if (playerReader.Buffs.Drinking && playerReader.Buffs.Eating)
                 {
-                    if (this.playerReader.ManaPercentage > 98 && this.playerReader.HealthPercent > 98) { break; }
+                    if (playerReader.ManaPercentage > 98 && playerReader.HealthPercent > 98) { break; }
                 }
-                else if (this.playerReader.Buffs.Drinking)
+                else if (playerReader.Buffs.Drinking)
                 {
-                    if (this.playerReader.ManaPercentage > 98) { break; }
+                    if (playerReader.ManaPercentage > 98) { break; }
                 }
-                else if (this.playerReader.Buffs.Eating)
+                else if (playerReader.Buffs.Eating)
                 {
-                    if (this.playerReader.HealthPercent > 98) { break; }
+                    if (playerReader.HealthPercent > 98) { break; }
                 }
 
-                if (ticks > 250)
+                if ((DateTime.Now - startTime).TotalSeconds >= 25)
                 {
-                    this.logger.LogInformation($"Waited long enough for {Name}");
+                    logger.LogInformation($"Waited (25s) long enough for {Name}");
                     break;
                 }
             }
 
             if (wasDrinkingOrEating)
             {
-                await input.TapStandUpKey(); // stand up
+                await input.TapStandUpKey();
             }
         }
     }

--- a/Json/class/Druid_1.json
+++ b/Json/class/Druid_1.json
@@ -40,8 +40,9 @@
       {
         "Name": "Water",
         "Key": "-",
-        "HasCastBar": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Requirement": "Mana%<30",
         "Cooldown": 10
       }

--- a/Json/class/Druid_4.json
+++ b/Json/class/Druid_4.json
@@ -40,8 +40,9 @@
       {
         "Name": "Water",
         "Key": "-",
-        "HasCastBar": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Requirement": "Mana%<30",
         "Cooldown": 10
       },

--- a/Json/class/Hunter_10.json
+++ b/Json/class/Hunter_10.json
@@ -103,6 +103,8 @@
       {
         "Name": "Food",
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "6",
         "Requirement": "Health%<40",
         "Cooldown": 10,
@@ -111,6 +113,8 @@
       {
         "Name": "Water",
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "7",
         "Requirement": "Mana%<40",
         "Cooldown": 10,

--- a/Json/class/Hunter_18.json
+++ b/Json/class/Hunter_18.json
@@ -102,6 +102,8 @@
       {
         "Name": "Food",
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "6",
         "Requirement": "Health%<40",
         "Cooldown": 10,
@@ -110,6 +112,8 @@
       {
         "Name": "Water",
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "7",
         "Requirement": "Mana%<40",
         "Cooldown": 10,

--- a/Json/class/Hunter_26.json
+++ b/Json/class/Hunter_26.json
@@ -111,6 +111,8 @@
       {
         "Name": "Food",
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "6",
         "Requirement": "Health%<40",
         "Cooldown": 10,
@@ -119,6 +121,8 @@
       {
         "Name": "Water",
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "7",
         "Requirement": "Mana%<40",
         "Cooldown": 10,

--- a/Json/class/Hunter_30.json
+++ b/Json/class/Hunter_30.json
@@ -118,6 +118,8 @@
       {
         "Name": "Food",
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "6",
         "Requirement": "Health%<40",
         "Cooldown": 10,
@@ -126,6 +128,8 @@
       {
         "Name": "Water",
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "7",
         "Requirement": "Mana%<40",
         "Cooldown": 10,

--- a/Json/class/Hunter_4.json
+++ b/Json/class/Hunter_4.json
@@ -64,18 +64,20 @@
       {
         "Name": "Food",
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "6",
         "Requirement": "Health%<30",
-        "Cooldown": 10,
-        "Log": false
+        "Cooldown": 10
       },
       {
         "Name": "Water",
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "7",
         "Requirement": "Mana%<30",
-        "Cooldown": 10,
-        "Log": false
+        "Cooldown": 10
       }
     ]
   },

--- a/Json/class/Hunter_58.json
+++ b/Json/class/Hunter_58.json
@@ -142,6 +142,8 @@
       {
         "Name": "Food",
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "N1",
         "Requirement": "Health%<45",
         "Cooldown": 10,
@@ -150,6 +152,8 @@
       {
         "Name": "Water",
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "N2",
         "Requirement": "Mana%<45",
         "Cooldown": 10,

--- a/Json/class/Hunter_6.json
+++ b/Json/class/Hunter_6.json
@@ -64,6 +64,8 @@
       {
         "Name": "Food",
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "6",
         "Requirement": "Health%<30",
         "Cooldown": 10,
@@ -72,6 +74,8 @@
       {
         "Name": "Water",
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "7",
         "Requirement": "Mana%<30",
         "Cooldown": 10,

--- a/Json/class/Mage54.json
+++ b/Json/class/Mage54.json
@@ -74,8 +74,9 @@
     "Sequence": [
       {
         "Name": "Food",
-        "HasCastBar": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "N1",
         "Requirement": "Health%<60",
         "Cooldown": 10,
@@ -83,8 +84,9 @@
       },
       {
         "Name": "Water",
-        "HasCastBar": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "N2",
         "Requirement": "Mana%<60",
         "Cooldown": 10,

--- a/Json/class/Mage_1.json
+++ b/Json/class/Mage_1.json
@@ -53,18 +53,20 @@
       },
       {
         "Name": "Food",
-        "HasCastBar": true,
         "StopBeforeCast": true,
-        "Key": "-",
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
+        "Key": "=",
         "Requirement": "Health%<30",
         "Cooldown": 15,
         "Log": false
       },
       {
         "Name": "Water",
-        "HasCastBar": true,
         "StopBeforeCast": true,
-        "Key": "0",
+        "DelayAfterCast": 0,
+        "AfterCastWaitBuff": true,
+        "Key": "-",
         "Requirement": "Mana%<30",
         "Cooldown": 15,
         "Log": false

--- a/Json/class/Mage_10.json
+++ b/Json/class/Mage_10.json
@@ -61,8 +61,9 @@
     "Sequence": [
       {
         "Name": "Food",
-        "HasCastBar": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "N1",
         "Requirement": "Health%<60",
         "Cooldown": 10,
@@ -70,8 +71,9 @@
       },
       {
         "Name": "Water",
-        "HasCastBar": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "N2",
         "Requirement": "Mana%<60",
         "Cooldown": 10,

--- a/Json/class/Mage_12.json
+++ b/Json/class/Mage_12.json
@@ -61,8 +61,9 @@
     "Sequence": [
       {
         "Name": "Food",
-        "HasCastBar": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "N1",
         "Requirement": "Health%<60",
         "Cooldown": 10,
@@ -70,8 +71,9 @@
       },
       {
         "Name": "Water",
-        "HasCastBar": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "N2",
         "Requirement": "Mana%<60",
         "Cooldown": 10,

--- a/Json/class/Mage_14_Arcane_Frost.json
+++ b/Json/class/Mage_14_Arcane_Frost.json
@@ -62,8 +62,9 @@
     "Sequence": [
       {
         "Name": "Food",
-        "HasCastBar": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "N1",
         "Requirement": "Health%<60",
         "Cooldown": 10,
@@ -71,8 +72,9 @@
       },
       {
         "Name": "Water",
-        "HasCastBar": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "N2",
         "Requirement": "Mana%<60",
         "Cooldown": 10,

--- a/Json/class/Mage_4.json
+++ b/Json/class/Mage_4.json
@@ -46,8 +46,9 @@
     "Sequence": [
       {
         "Name": "Food",
-        "HasCastBar": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "6",
         "Requirement": "Health%<30",
         "Cooldown": 10,
@@ -55,8 +56,9 @@
       },
       {
         "Name": "Water",
-        "HasCastBar": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "7",
         "Requirement": "Mana%<30",
         "Cooldown": 10,

--- a/Json/class/Mage_54_Frost_Arcane.json
+++ b/Json/class/Mage_54_Frost_Arcane.json
@@ -90,8 +90,9 @@
     "Sequence": [
       {
         "Name": "Food",
-        "HasCastBar": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "N1",
         "Requirement": "Health%<50",
         "Cooldown": 5,
@@ -99,8 +100,9 @@
       },
       {
         "Name": "Water",
-        "HasCastBar": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "N2",
         "Requirement": "Mana%<50",
         "Cooldown": 5,

--- a/Json/class/Mage_6.json
+++ b/Json/class/Mage_6.json
@@ -53,8 +53,9 @@
       "Sequence": [
         {
           "Name": "Food",
-          "HasCastBar": true,
           "StopBeforeCast": true,
+          "AfterCastWaitBuff": true,
+          "DelayAfterCast": 0,
           "Key": "6",
           "Requirement": "Health%<50",
           "Cooldown": 10,
@@ -62,8 +63,9 @@
         },
         {
           "Name": "Water",
-          "HasCastBar": true,
           "StopBeforeCast": true,
+          "AfterCastWaitBuff": true,
+          "DelayAfterCast": 0,
           "Key": "7",
           "Requirement": "Mana%<50",
           "Cooldown": 10,

--- a/Json/class/Rogue_1.json
+++ b/Json/class/Rogue_1.json
@@ -24,8 +24,9 @@
     "Sequence": [
       {
         "Name": "Food",
-        "HasCastBar": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "N1",
         "Requirement": "Health%<30",
         "Cooldown": 15,

--- a/Json/class/Rogue_10.json
+++ b/Json/class/Rogue_10.json
@@ -38,8 +38,9 @@
     "Sequence": [
       {
         "Name": "Food",
-        "HasCastBar": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "N1",
         "Requirement": "Health%<30",
         "Cooldown": 15,

--- a/Json/class/Shaman_1.json
+++ b/Json/class/Shaman_1.json
@@ -45,8 +45,9 @@
     "Sequence": [
       {
         "Name": "Food",
-        "HasCastBar": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "6",
         "Requirement": "Health%<30",
         "Cooldown": 10,
@@ -54,8 +55,9 @@
       },
       {
         "Name": "Water",
-        "HasCastBar": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "7",
         "Requirement": "Mana%<30",
         "Cooldown": 10,

--- a/Json/class/Shaman_15.json
+++ b/Json/class/Shaman_15.json
@@ -90,8 +90,9 @@
     "Sequence": [
       {
         "Name": "Food",
-        "HasCastBar": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "8",
         "Requirement": "Health%<40",
         "Cooldown": 6,
@@ -99,8 +100,9 @@
       },
       {
         "Name": "Water",
-        "HasCastBar": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "9",
         "Requirement": "Mana%<40",
         "Cooldown": 6,

--- a/Json/class/Shaman_2.json
+++ b/Json/class/Shaman_2.json
@@ -56,8 +56,9 @@
     "Sequence": [
       {
         "Name": "Food",
-        "HasCastBar": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "6",
         "Requirement": "Health%<30",
         "Cooldown": 10,
@@ -65,8 +66,9 @@
       },
       {
         "Name": "Water",
-        "HasCastBar": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "7",
         "Requirement": "Mana%<30",
         "Cooldown": 10,

--- a/Json/class/Shaman_22.json
+++ b/Json/class/Shaman_22.json
@@ -109,8 +109,9 @@
       },
       {
         "Name": "Food",
-        "HasCastBar": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "8",
         "Requirement": "Health%<40",
         "Cooldown": 6,
@@ -118,8 +119,9 @@
       },
       {
         "Name": "Water",
-        "HasCastBar": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "9",
         "Requirement": "Mana%<40",
         "Cooldown": 6,

--- a/Json/class/Warlock.json
+++ b/Json/class/Warlock.json
@@ -122,6 +122,8 @@
       {
         "Name": "Food",
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "N1",
         "Requirement": "Health%<50",
         "Cooldown": 20,
@@ -130,6 +132,8 @@
       {
         "Name": "Water",
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "N2",
         "Requirement": "Mana%<50",
         "Cooldown": 20,

--- a/Json/class/Warlock_1.json
+++ b/Json/class/Warlock_1.json
@@ -52,16 +52,18 @@
       },
       {
         "Name": "Food",
-        "HasCastBar": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "N1",
         "Requirement": "Health%<50",
         "Cooldown": 60
       },
       {
         "Name": "Water",
-        "HasCastBar": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "N2",
         "Requirement": "Mana%<50",
         "Cooldown": 60

--- a/Json/class/Warlock_10.json
+++ b/Json/class/Warlock_10.json
@@ -87,6 +87,8 @@
       {
         "Name": "Food",
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "N1",
         "Requirement": "Health%<50",
         "Cooldown": 20,
@@ -95,6 +97,8 @@
       {
         "Name": "Water",
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "N2",
         "Requirement": "Mana%<40",
         "Cooldown": 20,

--- a/Json/class/Warlock_20.json
+++ b/Json/class/Warlock_20.json
@@ -112,6 +112,8 @@
       {
         "Name": "Food",
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "N1",
         "Requirement": "Health%<50",
         "Cooldown": 20,
@@ -120,6 +122,8 @@
       {
         "Name": "Water",
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "N2",
         "Requirement": "Mana%<40",
         "Cooldown": 20,

--- a/Json/class/Warlock_20_shard_farm.json
+++ b/Json/class/Warlock_20_shard_farm.json
@@ -115,6 +115,8 @@
       {
         "Name": "Food",
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "N1",
         "Requirement": "Health%<50",
         "Cooldown": 20,
@@ -123,6 +125,8 @@
       {
         "Name": "Water",
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "N2",
         "Requirement": "Mana%<40",
         "Cooldown": 20,

--- a/Json/class/Warlock_26_Immunity.json
+++ b/Json/class/Warlock_26_Immunity.json
@@ -125,6 +125,8 @@
       {
         "Name": "Food",
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "N1",
         "Requirement": "Health%<50",
         "Cooldown": 20,
@@ -133,6 +135,8 @@
       {
         "Name": "Water",
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "N2",
         "Requirement": "Mana%<40",
         "Cooldown": 20,

--- a/Json/class/Warlock_4.json
+++ b/Json/class/Warlock_4.json
@@ -80,16 +80,18 @@
       },
       {
         "Name": "Food",
-        "HasCastBar": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "N1",
         "Requirement": "Health%<50",
         "Cooldown": 60
       },
       {
         "Name": "Water",
-        "HasCastBar": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "N2",
         "Requirement": "Mana%<50",
         "Cooldown": 60

--- a/Json/class/Warlock_8.json
+++ b/Json/class/Warlock_8.json
@@ -73,6 +73,8 @@
       {
         "Name": "Food",
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "N1",
         "Requirement": "Health%<50",
         "Cooldown": 20,
@@ -81,6 +83,8 @@
       {
         "Name": "Water",
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "DelayAfterCast": 0,
         "Key": "N2",
         "Requirement": "Mana%<40",
         "Cooldown": 20,

--- a/README.md
+++ b/README.md
@@ -282,8 +282,9 @@ Commands have the following parameters, only a subset will be used by each comma
 | WaitForWithinMelleRange| Wait after casting for the mob to be in melee range | false |
 | ResetOnNewTarget | Reset the cooldown if the target changes | false |
 | Log | Write to the log when this key is evaluated | true |
-| DelayAfterCast | The delay in milliseconds after the spell is cast | 1450 |
 | DelayBeforeCast | A delay in milliseconds before this spell is cast | 0 |
+| DelayAfterCast | The delay in milliseconds after the spell is cast | 1450 |
+| AfterCastWaitBuff | After the cast happened, should wait until player buffs changed | false |
 | Cost | For Adhoc goals the priority | 18 |
 | InCombat | Can it be cast in combat | false |
 | StepBackAfterCast | Hero will go back for X milliseconds after casting this spell , usable for spells like Mage Frost Nova | 0 |


### PR DESCRIPTION
Since the addon timing has been rewritten and as a result the polling delay reduced. Have to accommodate the changes backend side.

Fixing an issue about ParallelGoal and AdhocGoal not properly waiting for `Food` and `Water` actions by introducing `AfterCastWaitBuff`. It is a generally way to tell the `CastingHandler` to wait until the player buffs changed, in backend side this way preventing immaturely fast code execution backend side. Also updated all the profiles which used the `HasCastbar` flag.

Fixed a bug about `DelayBeforeCast` was not treated evenly among the codebase when interacting with the `CastingHandler`

`PullTargetGoal`: From now on individually checks if the given steps requires `StopBeforeCast`. Also `WaitForWithinMeleeRange` has been rewritten.

`CastingHandler`: rewritten, many of the parameters now using `Wait()` method, which allows to set a maximum time for the execution and check the result. Also changed the interrupting condition for checking if the target is dead after the cast.

All the mentioned changes should yield a much more responsive experience.
