### PR TITLE
Feature/separate wait

### DIFF
--- a/Core/Addon/PlayerReader.cs
+++ b/Core/Addon/PlayerReader.cs
@@ -229,23 +229,5 @@ namespace Core
                 LastUIErrorMessage = (UI_ERROR)UIErrorMessage;
             }
         }
-
-        internal async Task WaitForUpdate()
-        {
-            var s = this.Sequence;
-            while (this.Sequence == s)
-            {
-                await Task.Delay(100);
-            }
-        }
-        public async Task WaitForNUpdate(int n)
-        {
-            var s = GlobalTime;
-            while (Math.Abs(s - GlobalTime) <= n)
-            {
-                await Task.Delay(2 * (int)AvgUpdateLatency);
-            }
-        }
-
     }
 }

--- a/Core/Goals/AdhocGoal.cs
+++ b/Core/Goals/AdhocGoal.cs
@@ -10,16 +10,18 @@ namespace Core.Goals
         private readonly ILogger logger;
         private readonly ConfigurableInput input;
 
+        private readonly Wait wait;
         private readonly StopMoving stopMoving;
         private readonly PlayerReader playerReader;
         
         private readonly KeyAction key;
         private readonly CastingHandler castingHandler;
 
-        public AdhocGoal(ILogger logger, ConfigurableInput input, KeyAction key, PlayerReader playerReader, StopMoving stopMoving, CastingHandler castingHandler)
+        public AdhocGoal(ILogger logger, ConfigurableInput input, Wait wait, KeyAction key, PlayerReader playerReader, StopMoving stopMoving, CastingHandler castingHandler)
         {
             this.logger = logger;
             this.input = input;
+            this.wait = wait;
             this.stopMoving = stopMoving;
             this.playerReader = playerReader;
             this.key = key;
@@ -55,7 +57,7 @@ namespace Core.Goals
                     //if (!await Wait(1000, () => playerReader.PlayerBitValues.PlayerInCombat)) return; // vanilla after dismout GCD
                 }
             }
-            await Wait(200, () => false);
+            await wait.InterruptTask(200, () => false);
 
             await castingHandler.CastIfReady(key, key.DelayBeforeCast);
 
@@ -68,7 +70,7 @@ namespace Core.Goals
             DateTime startTime = DateTime.Now;
             while ((playerReader.Buffs.Drinking || playerReader.Buffs.Eating || playerReader.IsCasting) && !playerReader.PlayerBitValues.PlayerInCombat)
             {
-                await playerReader.WaitForNUpdate(1);
+                await wait.Update(1);
 
                 if (playerReader.Buffs.Drinking)
                 {

--- a/Core/Goals/ApproachTargetGoal.cs
+++ b/Core/Goals/ApproachTargetGoal.cs
@@ -13,6 +13,7 @@ namespace Core.Goals
         private ILogger logger;
         private readonly ConfigurableInput input;
 
+        private readonly Wait wait;
         private readonly PlayerReader playerReader;
         private readonly StopMoving stopMoving;
         private readonly StuckDetector stuckDetector;
@@ -37,11 +38,12 @@ namespace Core.Goals
             }
         }
 
-        public ApproachTargetGoal(ILogger logger, ConfigurableInput input, PlayerReader playerReader, StopMoving stopMoving,  StuckDetector stuckDetector)
+        public ApproachTargetGoal(ILogger logger, ConfigurableInput input, Wait wait, PlayerReader playerReader, StopMoving stopMoving,  StuckDetector stuckDetector)
         {
             this.logger = logger;
             this.input = input;
 
+            this.wait = wait;
             this.playerReader = playerReader;
             this.stopMoving = stopMoving;
             
@@ -95,14 +97,14 @@ namespace Core.Goals
             }
 
             await this.TapInteractKey("");
-            await this.playerReader.WaitForNUpdate(1);
+            await wait.Update(1);
 
             var newLocation = playerReader.PlayerLocation;
             if ((location.X == newLocation.X && location.Y == newLocation.Y && SecondsSinceLastFighting > 5) ||
                 this.playerReader.LastUIErrorMessage == UI_ERROR.ERR_AUTOFOLLOW_TOO_FAR)
             {
                 input.SetKeyState(ConsoleKey.UpArrow, true, false, $"{GetType().Name}: ");
-                await Wait(100, () => false);
+                await wait.InterruptTask(100, () => false);
                 await input.TapJump();
                 this.playerReader.LastUIErrorMessage = UI_ERROR.NONE;
             }

--- a/Core/Goals/ConsumeCorpse.cs
+++ b/Core/Goals/ConsumeCorpse.cs
@@ -12,12 +12,14 @@ namespace Core.Goals
         public override float CostOfPerformingAction { get => 4.7f; }
 
         private readonly ILogger logger;
+        private readonly Wait wait;
         private readonly PlayerReader playerReader;
         private DateTime lastActive = DateTime.Now;
 
-        public ConsumeCorpse(ILogger logger, PlayerReader playerReader)
+        public ConsumeCorpse(ILogger logger, Wait wait, PlayerReader playerReader)
         {
             this.logger = logger;
+            this.wait = wait;
             this.playerReader = playerReader;
 
             AddPrecondition(GoapKey.incombat, false);
@@ -33,7 +35,9 @@ namespace Core.Goals
 
         public override async Task PerformAction()
         {
-            if((DateTime.Now - lastActive).TotalSeconds > 0.25f)
+            await wait.Update(1);
+
+            if ((DateTime.Now - lastActive).TotalSeconds > 0.25f)
             {
                 playerReader.DecrementKillCount();
                 logger.LogInformation("----- Consumed a corpse. Remaining:" + playerReader.LastCombatKillCount);
@@ -43,8 +47,6 @@ namespace Core.Goals
 
                 lastActive = DateTime.Now;
             }
-
-            await Task.Delay(0);
         }
     }
 }

--- a/Core/Goals/FollowRouteGoal.cs
+++ b/Core/Goals/FollowRouteGoal.cs
@@ -17,6 +17,7 @@ namespace Core.Goals
         private readonly ILogger logger;
         private readonly ConfigurableInput input;
 
+        private readonly Wait wait;
         private readonly PlayerReader playerReader;
         private readonly IPlayerDirection playerDirection;
         private readonly StopMoving stopMoving;
@@ -55,11 +56,12 @@ namespace Core.Goals
         private double avgDistance = 0;
         private bool firstLoad = true;
 
-        public FollowRouteGoal(ILogger logger, ConfigurableInput input, PlayerReader playerReader,  IPlayerDirection playerDirection, List<WowPoint> points, StopMoving stopMoving, NpcNameFinder npcNameFinder, IBlacklist blacklist, StuckDetector stuckDetector, ClassConfiguration classConfiguration, IPPather pather, MountHandler mountHandler)
+        public FollowRouteGoal(ILogger logger, ConfigurableInput input, Wait wait, PlayerReader playerReader,  IPlayerDirection playerDirection, List<WowPoint> points, StopMoving stopMoving, NpcNameFinder npcNameFinder, IBlacklist blacklist, StuckDetector stuckDetector, ClassConfiguration classConfiguration, IPPather pather, MountHandler mountHandler)
         {
             this.logger = logger;
             this.input = input;
 
+            this.wait = wait;
             this.playerReader = playerReader;
             this.playerDirection = playerDirection;
             this.stopMoving = stopMoving;
@@ -189,7 +191,7 @@ namespace Core.Goals
             {
                 // stuck so jump
                 input.SetKeyState(ConsoleKey.UpArrow, true, false, "FollowRouteAction 2");
-                await playerReader.WaitForNUpdate(1);
+                await wait.Update(1);
                 if (HasBeenActiveRecently())
                 {
                     await this.stuckDetector.Unstick();
@@ -197,7 +199,7 @@ namespace Core.Goals
                 }
                 else
                 {
-                    await playerReader.WaitForNUpdate(1);
+                    await wait.Update(1);
                     logger.LogInformation("Resuming movement");
                 }
             }

--- a/Core/Goals/GoalFactory.cs
+++ b/Core/Goals/GoalFactory.cs
@@ -42,16 +42,18 @@ namespace Core
             List<WowPoint> pathPoints, spiritPath;
             GetPaths(out pathPoints, out spiritPath, classConfig);
 
+            var wait = new Wait(addonReader.PlayerReader);
+
             var playerDirection = new PlayerDirection(logger, input, addonReader.PlayerReader);
             var stopMoving = new StopMoving(input, addonReader.PlayerReader);
 
-            var castingHandler = new CastingHandler(logger, input, addonReader.PlayerReader, classConfig, playerDirection, npcNameFinder, stopMoving);
+            var castingHandler = new CastingHandler(logger, input, wait, addonReader.PlayerReader, classConfig, playerDirection, npcNameFinder, stopMoving);
 
             var stuckDetector = new StuckDetector(logger, input, addonReader.PlayerReader, playerDirection, stopMoving);
-            var combatUtil = new CombatUtil(logger, input, addonReader.PlayerReader);
-            var mountHandler = new MountHandler(logger, input, classConfig, addonReader.PlayerReader, stopMoving);
+            var combatUtil = new CombatUtil(logger, input, wait, addonReader.PlayerReader);
+            var mountHandler = new MountHandler(logger, input, classConfig, wait, addonReader.PlayerReader, stopMoving);
 
-            var followRouteAction = new FollowRouteGoal(logger, input, addonReader.PlayerReader,  playerDirection, pathPoints, stopMoving, npcNameFinder, blacklist, stuckDetector, classConfig, pather, mountHandler);
+            var followRouteAction = new FollowRouteGoal(logger, input, wait, addonReader.PlayerReader,  playerDirection, pathPoints, stopMoving, npcNameFinder, blacklist, stuckDetector, classConfig, pather, mountHandler);
             var walkToCorpseAction = new WalkToCorpseGoal(logger, input, addonReader.PlayerReader,  playerDirection, spiritPath, pathPoints, stopMoving, stuckDetector, pather);
 
             availableActions.Clear();
@@ -78,7 +80,7 @@ namespace Core
                     availableActions.Add(walkToCorpseAction);
                 }
 
-                availableActions.Add(new ApproachTargetGoal(logger, input, addonReader.PlayerReader, stopMoving,  stuckDetector));
+                availableActions.Add(new ApproachTargetGoal(logger, input, wait, addonReader.PlayerReader, stopMoving,  stuckDetector));
 
                 if (classConfig.WrongZone.ZoneId > 0)
                 {
@@ -87,33 +89,33 @@ namespace Core
 
                 if (classConfig.Parallel.Sequence.Count > 0)
                 {
-                    availableActions.Add(new ParallelGoal(logger, input, addonReader.PlayerReader, stopMoving, classConfig.Parallel.Sequence, castingHandler));
+                    availableActions.Add(new ParallelGoal(logger, input, wait, addonReader.PlayerReader, stopMoving, classConfig.Parallel.Sequence, castingHandler));
                 }
 
                 if (classConfig.Loot)
                 {
-                    var lootAction = new LootGoal(logger, input, addonReader.PlayerReader, addonReader.BagReader, stopMoving, classConfig, npcNameFinder, combatUtil, areaDb);
+                    var lootAction = new LootGoal(logger, input, wait, addonReader.PlayerReader, addonReader.BagReader, stopMoving, classConfig, npcNameFinder, combatUtil, areaDb);
                     lootAction.AddPreconditions();
                     availableActions.Add(lootAction);
 
                     if (classConfig.Skin)
                     {
-                        availableActions.Add(new SkinningGoal(logger, input, addonReader.PlayerReader, addonReader.BagReader, addonReader.equipmentReader, stopMoving, npcNameFinder, combatUtil));
+                        availableActions.Add(new SkinningGoal(logger, input, wait, addonReader.PlayerReader, addonReader.BagReader, addonReader.equipmentReader, stopMoving, npcNameFinder, combatUtil));
                     }
                 }
 
                 try
                 {
-                    var genericCombat = new CombatGoal(logger, input, addonReader.PlayerReader, stopMoving, classConfig, castingHandler);
+                    var genericCombat = new CombatGoal(logger, input, wait, addonReader.PlayerReader, stopMoving, classConfig, castingHandler);
                     availableActions.Add(genericCombat);
-                    availableActions.Add(new PullTargetGoal(logger, input, addonReader.PlayerReader, npcNameFinder, stopMoving, castingHandler, stuckDetector, classConfig));
+                    availableActions.Add(new PullTargetGoal(logger, input, wait, addonReader.PlayerReader, npcNameFinder, stopMoving, castingHandler, stuckDetector, classConfig));
 
                     availableActions.Add(new CreatureKilledGoal(logger, addonReader.PlayerReader, classConfig));
-                    availableActions.Add(new ConsumeCorpse(logger, addonReader.PlayerReader));
+                    availableActions.Add(new ConsumeCorpse(logger, wait, addonReader.PlayerReader));
 
                     foreach (var item in classConfig.Adhoc.Sequence)
                     {
-                        availableActions.Add(new AdhocGoal(logger, input, item, addonReader.PlayerReader, stopMoving, castingHandler));
+                        availableActions.Add(new AdhocGoal(logger, input, wait, item, addonReader.PlayerReader, stopMoving, castingHandler));
                     }
                 }
                 catch (Exception ex)

--- a/Core/Goals/GoapGoal.cs
+++ b/Core/Goals/GoapGoal.cs
@@ -127,35 +127,5 @@ namespace Core.Goals
         {
             return $"{Name} " + (Keys.Count == 1 ? $"[{Keys.First().ConsoleKey}]" : "");
         }
-
-        public static async Task<bool> Wait(int durationMs, Func<bool> exit)
-        {
-            int elapsedMs = 0;
-            while (elapsedMs <= durationMs)
-            {
-                if (exit())
-                    return false;
-
-                await Task.Delay(50);
-                elapsedMs += 50;
-            }
-
-            return true;
-        }
-
-        public static async Task<bool> Wait(int durationMs, Task<bool> exit)
-        {
-            int elapsedMs = 0;
-            while (elapsedMs <= durationMs)
-            {
-                if (await exit)
-                    return false;
-
-                await Task.Delay(50);
-                elapsedMs += 50;
-            }
-
-            return true;
-        }
     }
 }

--- a/Core/Goals/LastTargetLoot.cs
+++ b/Core/Goals/LastTargetLoot.cs
@@ -11,14 +11,16 @@ namespace Core.Goals
         private readonly ConfigurableInput input;
 
         private readonly ClassConfiguration classConfiguration;
+        private readonly Wait wait;
         private readonly PlayerReader playerReader;
         
         public override float CostOfPerformingAction { get => 4.3f; }
 
-        public LastTargetLoot(ILogger logger, ConfigurableInput input, PlayerReader playerReader,  ClassConfiguration classConfiguration)
+        public LastTargetLoot(ILogger logger, ConfigurableInput input, Wait wait, PlayerReader playerReader,  ClassConfiguration classConfiguration)
         {
             this.logger = logger;
             this.input = input;
+            this.wait = wait;
             this.playerReader = playerReader;
             
             this.classConfiguration = classConfiguration;
@@ -42,14 +44,14 @@ namespace Core.Goals
             {
                 logger.LogInformation("wait till the player become stil!");
                 lastPosition = playerReader.PlayerLocation;
-                if (!await Wait(100, () => playerReader.HealthCurrent < lastHealth)) { return; }
+                if (!await wait.Interrupt(100, () => playerReader.HealthCurrent < lastHealth)) { return; }
             }
 
-            if (!await Wait(100, () => playerReader.HealthCurrent < lastHealth)) { return; }
+            if (!await wait.Interrupt(100, () => playerReader.HealthCurrent < lastHealth)) { return; }
             await input.TapInteractKey("Looting...");
 
             // wait grabbing the loot
-            if (!await Wait(200, () => playerReader.HealthCurrent < lastHealth)) { return; }
+            if (!await wait.Interrupt(200, () => playerReader.HealthCurrent < lastHealth)) { return; }
 
             logger.LogDebug("Loot was Successfull");
             SendActionEvent(new ActionEventArgs(GoapKey.shouldloot, false));

--- a/Core/Goals/LootGoal.cs
+++ b/Core/Goals/LootGoal.cs
@@ -16,6 +16,7 @@ namespace Core.Goals
         private ILogger logger;
         private readonly ConfigurableInput input;
 
+        private readonly Wait wait;
         private readonly PlayerReader playerReader;
         private readonly AreaDB areaDb;
         private readonly StopMoving stopMoving;
@@ -27,10 +28,11 @@ namespace Core.Goals
         private bool debug = true;
         private long lastLoot;
 
-        public LootGoal(ILogger logger, ConfigurableInput input, PlayerReader playerReader, BagReader bagReader, StopMoving stopMoving,  ClassConfiguration classConfiguration, NpcNameFinder npcNameFinder, CombatUtil combatUtil, AreaDB areaDb)
+        public LootGoal(ILogger logger, ConfigurableInput input, Wait wait, PlayerReader playerReader, BagReader bagReader, StopMoving stopMoving,  ClassConfiguration classConfiguration, NpcNameFinder npcNameFinder, CombatUtil combatUtil, AreaDB areaDb)
         {
             this.logger = logger;
             this.input = input;
+            this.wait = wait;
             this.playerReader = playerReader;
             this.areaDb = areaDb;
             this.stopMoving = stopMoving;
@@ -65,7 +67,7 @@ namespace Core.Goals
             if (foundCursor)
             {
                 Log("Found corpse - clicked");
-                await playerReader.WaitForNUpdate(8);
+                await wait.Update(1);
 
                 CheckForSkinning();
 
@@ -77,23 +79,24 @@ namespace Core.Goals
                     return;
                 }
 
-                if(moved) 
+                if (moved)
                 {
                     await input.TapInteractKey($"{GetType().Name}: Had to move so interact again");
+                    await wait.Update(1);
                 }
             }
             else
             {
                 await input.TapLastTargetKey($"{GetType().Name}: No corpse name found - check last dead target exists");
-                await playerReader.WaitForNUpdate(5);
-                if(playerReader.HasTarget)
+                await wait.Update(2);
+                if (playerReader.HasTarget)
                 {
                     if(playerReader.PlayerBitValues.TargetIsDead)
                     {
                         CheckForSkinning();
 
                         await input.TapInteractKey($"{GetType().Name}: Found last dead target");
-                        await playerReader.WaitForNUpdate(5);
+                        await wait.Update(1);
 
                         (bool foundTarget, bool moved) = await combatUtil.FoundTargetWhileMoved();
                         if (foundTarget)
@@ -137,7 +140,7 @@ namespace Core.Goals
 
         private async Task GoalExit()
         {
-            if(!await Wait(500, () => lastLoot != playerReader.LastLootTime))
+            if (!await wait.Interrupt(1000, () => lastLoot != playerReader.LastLootTime))
             {
                 Log($"Loot Successfull");
             }
@@ -153,13 +156,13 @@ namespace Core.Goals
             if (!classConfiguration.Skin)
             {
                 npcNameFinder.ChangeNpcType(NpcNameFinder.NPCType.Enemy);
-                await npcNameFinder.WaitForNUpdate(3);
+                await npcNameFinder.WaitForNUpdate(1);
             }
 
             if (playerReader.HasTarget && playerReader.PlayerBitValues.TargetIsDead)
             {
                 await input.TapClearTarget($"{GetType().Name}: Exit Goal");
-                await playerReader.WaitForNUpdate(5);
+                await wait.Update(1);
             }
         }
 

--- a/Core/Goals/MountHandler.cs
+++ b/Core/Goals/MountHandler.cs
@@ -11,17 +11,19 @@ namespace Core
         private readonly ILogger logger;
         private readonly ConfigurableInput input;
         private readonly ClassConfiguration classConfig;
+        private readonly Wait wait;
         private readonly PlayerReader playerReader;
         private readonly StopMoving stopMoving;
 
         private readonly int minLevelToMount = 30;
         private readonly int mountCastTimeMs = 3000;
 
-        public MountHandler(ILogger logger, ConfigurableInput input, ClassConfiguration classConfig, PlayerReader playerReader, StopMoving stopMoving)
+        public MountHandler(ILogger logger, ConfigurableInput input, ClassConfiguration classConfig, Wait wait, PlayerReader playerReader, StopMoving stopMoving)
         {
             this.logger = logger;
             this.classConfig = classConfig;
             this.input = input;
+            this.wait = wait;
             this.playerReader = playerReader;
             this.stopMoving = stopMoving;
         }
@@ -35,13 +37,14 @@ namespace Core
                     classConfig.ShapeshiftForm
                       .Where(s => s.ShapeShiftFormEnum == ShapeshiftForm.Druid_Travel)
                       .ToList()
-                      .ForEach(async k => await input.KeyPress(k.ConsoleKey, 325));
+                      .ForEach(async k => await input.KeyPress(k.ConsoleKey, 50));
                 }
                 else
                 {
                     await stopMoving.Stop();
-                    await Task.Delay(100);
-                    await input.TapMount(mountCastTimeMs, playerReader);
+                    await wait.Update(1);
+                    await input.TapMount();
+                    await wait.Interrupt(mountCastTimeMs, () => playerReader.PlayerBitValues.IsMounted);
                 }
             }
         }

--- a/Core/Goals/ParallelGoal.cs
+++ b/Core/Goals/ParallelGoal.cs
@@ -15,16 +15,18 @@ namespace Core.Goals
         private readonly ConfigurableInput input;
 
         private readonly StopMoving stopMoving;
+        private readonly Wait wait;
         private readonly PlayerReader playerReader;
         
         private readonly CastingHandler castingHandler;
 
-        public ParallelGoal(ILogger logger, ConfigurableInput input, PlayerReader playerReader, StopMoving stopMoving, List<KeyAction> keysConfig, CastingHandler castingHandler)
+        public ParallelGoal(ILogger logger, ConfigurableInput input, Wait wait, PlayerReader playerReader, StopMoving stopMoving, List<KeyAction> keysConfig, CastingHandler castingHandler)
         {
             this.logger = logger;
             this.input = input;
 
             this.stopMoving = stopMoving;
+            this.wait = wait;
             this.playerReader = playerReader;
             
             this.castingHandler = castingHandler;
@@ -52,7 +54,7 @@ namespace Core.Goals
                 }
             }
 
-            await Wait(200, () => false);
+            await wait.Interrupt(200, () => false);
 
             Keys.ForEach(async key =>
             {
@@ -68,7 +70,7 @@ namespace Core.Goals
             DateTime startTime = DateTime.Now;
             while ((playerReader.Buffs.Drinking || playerReader.Buffs.Eating || playerReader.IsCasting) && !playerReader.PlayerBitValues.PlayerInCombat)
             {
-                await playerReader.WaitForNUpdate(1);
+                await wait.Update(1);
 
                 if (playerReader.Buffs.Drinking && playerReader.Buffs.Eating)
                 {

--- a/Core/Goals/PostKillLootGoal.cs
+++ b/Core/Goals/PostKillLootGoal.cs
@@ -9,8 +9,8 @@ namespace Core.Goals
     {
         public override float CostOfPerformingAction { get => 4.5f; }
 
-        public PostKillLootGoal(ILogger logger, ConfigurableInput input, PlayerReader playerReader, BagReader bagReader, StopMoving stopMoving, ClassConfiguration classConfiguration, NpcNameFinder npcNameFinder, CombatUtil combatUtil, AreaDB areaDb)
-            : base(logger, input, playerReader, bagReader, stopMoving, classConfiguration, npcNameFinder, combatUtil, areaDb)
+        public PostKillLootGoal(ILogger logger, ConfigurableInput input, Wait wait, PlayerReader playerReader, BagReader bagReader, StopMoving stopMoving, ClassConfiguration classConfiguration, NpcNameFinder npcNameFinder, CombatUtil combatUtil, AreaDB areaDb)
+            : base(logger, input, wait, playerReader, bagReader, stopMoving, classConfiguration, npcNameFinder, combatUtil, areaDb)
         {
         }
 

--- a/Core/Goals/Wait.cs
+++ b/Core/Goals/Wait.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Core
+{
+    public class Wait
+    {
+        private readonly PlayerReader playerReader;
+
+        public Wait(PlayerReader playerReader)
+        {
+            this.playerReader = playerReader;
+        }
+
+        public async Task Update(int n)
+        {
+            var s = playerReader.GlobalTime;
+            while (Math.Abs(s - playerReader.GlobalTime) <= n)
+            {
+                await Task.Delay(2 * (int)playerReader.AvgUpdateLatency);
+            }
+        }
+
+
+        public async Task<bool> Interrupt(int durationMs, Func<bool> interrupt)
+        {
+            DateTime start = DateTime.Now;
+            while ((DateTime.Now - start).TotalMilliseconds < durationMs)
+            {
+                await Update(1);
+                if (interrupt())
+                    return false;
+            }
+
+            return true;
+        }
+
+        public async Task<Tuple<bool, double>> InterruptTask(int durationMs, Func<bool> interrupt)
+        {
+            DateTime start = DateTime.Now;
+            double elapsedMs;
+            while ((elapsedMs = (DateTime.Now - start).TotalMilliseconds) < durationMs)
+            {
+                await Update(1);
+                if (interrupt())
+                    return Tuple.Create(false, elapsedMs);
+            }
+
+            return Tuple.Create(true, elapsedMs);
+        }
+
+        public async Task<bool> Interrupt(int durationMs, Task<bool> exit)
+        {
+            DateTime start = DateTime.Now;
+            double elapsedMs;
+            while ((elapsedMs = (DateTime.Now - start).TotalMilliseconds) < durationMs)
+            {
+                await Update(1);
+                if (await exit)
+                    return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/Core/Input/ConfigurableInput.cs
+++ b/Core/Input/ConfigurableInput.cs
@@ -86,17 +86,10 @@ namespace Core
             await KeyPress(ConsoleKey.I, defaultKeyPress, "TapHearthstone");
         }
 
-        public async Task TapMount(int castTimeMs, PlayerReader playerReader)
+        public async Task TapMount()
         {
             await KeyPress(classConfig.Mount.ConsoleKey, defaultKeyPress, "TapMount");
             this.classConfig.Mount.SetClicked();
-
-            for (int i = 0; i < (castTimeMs / 100); i++)
-            {
-                if (playerReader.PlayerBitValues.IsMounted) { return; }
-                if (playerReader.PlayerBitValues.PlayerInCombat) { return; }
-                await playerReader.WaitForNUpdate(1);
-            }
         }
 
         public async Task TapDismount()


### PR DESCRIPTION
In the past couple of days been tinkering with the internal delay and timing, as a result some of the Goals were not behave as expected or sometimes they get out of sync with the addon state and executing the sequences too quickly. 

To mitigate the issue created a helper class `Wait` which has a few ways to wait in the given `Task`. 

Example `Interrupt`, by passing in a maximum timeout and an interrupt condition we can check if the given keypress successfully executed and also can measure how many milliseconds does it took to complete or fail the task.

During testing, in the past days noticed quite a few times failing the `LootGoal` and `SkinningGoal` because of the internal timing significantly reduced. In the past When `playerReader.WaitForNUpdate(1)` was called the task waited at least baked 50ms ore more. However with the previously mentioned `Interrupt` logic this polling can be done much faster depending on the addon `OnUpdate` time.

On the other hand noticed `ClassConfiguration.Combat` rotations were much more snappier and reacting way more quickly. 
Example. as a paladin you can execute. `Seal of the crusader -> Judgement -> Seal or Righteousness` opener and the when the player initiates the first melee hit he will already have the `Seal or Righteousness` benefiting the holy damage. 💯 