### PR TITLE
Feature/goap goal onenter

### DIFF
--- a/Core/Goals/ApproachTargetGoal.cs
+++ b/Core/Goals/ApproachTargetGoal.cs
@@ -10,35 +10,34 @@ namespace Core.Goals
     {
         public override float CostOfPerformingAction { get => 8f; }
 
-        private ILogger logger;
+        private readonly ILogger logger;
         private readonly ConfigurableInput input;
 
         private readonly Wait wait;
         private readonly PlayerReader playerReader;
+        private readonly ClassConfiguration classConfig;
         private readonly StopMoving stopMoving;
-        private readonly StuckDetector stuckDetector;
 
-        private bool debug = false;
+        private readonly bool debug = false;
 
-        private Random random = new Random();
-        private DateTime LastJump = DateTime.Now;
+        private readonly Random random = new Random(DateTime.Now.Millisecond);
 
-        private bool NeedsToReset = true;
-        private bool playerWasInCombat = false;
+        private bool playerWasInCombat;
+        private double distance;
+        private WowPoint location;
+        private DateTime approachStart;
 
-        private DateTime lastFighting = DateTime.Now;
-
-        private int SecondsSinceLastFighting => (int)(DateTime.Now - this.lastFighting).TotalSeconds;
+        private int SecondsSinceApproachStarted => (int)(DateTime.Now - approachStart).TotalSeconds;
 
         private bool HasPickedUpAnAdd
         {
             get
             {
-                return this.playerReader.PlayerBitValues.PlayerInCombat && !this.playerReader.PlayerBitValues.TargetOfTargetIsPlayer;
+                return playerReader.PlayerBitValues.PlayerInCombat && !playerReader.PlayerBitValues.TargetOfTargetIsPlayer;
             }
         }
 
-        public ApproachTargetGoal(ILogger logger, ConfigurableInput input, Wait wait, PlayerReader playerReader, StopMoving stopMoving,  StuckDetector stuckDetector)
+        public ApproachTargetGoal(ILogger logger, ConfigurableInput input, Wait wait, PlayerReader playerReader, ClassConfiguration classConfig, StopMoving stopMoving)
         {
             this.logger = logger;
             this.input = input;
@@ -46,8 +45,11 @@ namespace Core.Goals
             this.wait = wait;
             this.playerReader = playerReader;
             this.stopMoving = stopMoving;
-            
-            this.stuckDetector = stuckDetector;
+
+            this.classConfig = classConfig;
+
+            distance = 0;
+            location = playerReader.PlayerLocation;
 
             AddPrecondition(GoapKey.hastarget, true);
             AddPrecondition(GoapKey.targetisalive, true);
@@ -56,19 +58,22 @@ namespace Core.Goals
             AddEffect(GoapKey.incombatrange, true);
         }
 
-        public override async Task PerformAction()
+        public override async Task OnEnter()
         {
+            await base.OnEnter();
+
             if (playerReader.PlayerBitValues.IsMounted)
             {
                 await input.TapDismount();
             }
 
-            if (NeedsToReset)
-            {
-                this.stuckDetector.ResetStuckParameters();
-            }
+            playerWasInCombat = playerReader.PlayerBitValues.PlayerInCombat;
+            approachStart = DateTime.Now;
+        }
 
-            var location = playerReader.PlayerLocation;
+        public override async Task PerformAction()
+        {
+            location = playerReader.PlayerLocation;
 
             if (!playerReader.PlayerBitValues.PlayerInCombat)
             {
@@ -80,79 +85,58 @@ namespace Core.Goals
                 if (!playerWasInCombat && HasPickedUpAnAdd)
                 {
                     logger.LogInformation("WARN Bodypull -- Looks like we have an add on approach");
-                    logger.LogInformation($"Combat={this.playerReader.PlayerBitValues.PlayerInCombat}, Is Target targetting me={this.playerReader.PlayerBitValues.TargetOfTargetIsPlayer}");
-                    
-                    await this.stopMoving.Stop();
-                    await input.TapClearTarget();
-                    await input.TapStopKey();
+                    logger.LogInformation($"Combat={playerReader.PlayerBitValues.PlayerInCombat}, Is Target targetting me={playerReader.PlayerBitValues.TargetOfTargetIsPlayer}");
 
-                    if(playerReader.PetHasTarget)
+                    await stopMoving.Stop();
+                    await input.TapClearTarget();
+
+                    if (playerReader.PetHasTarget)
                     {
-                        await this.input.TapTargetPet();
-                        await this.input.TapTargetOfTarget();
+                        await input.TapTargetPet();
+                        await input.TapTargetOfTarget();
+                        await wait.Update(1);
                     }
                 }
 
                 playerWasInCombat = true;
             }
 
-            await this.TapInteractKey("");
+            await input.TapInteractKey("");
             await wait.Update(1);
 
-            var newLocation = playerReader.PlayerLocation;
-            if ((location.X == newLocation.X && location.Y == newLocation.Y && SecondsSinceLastFighting > 5) ||
-                this.playerReader.LastUIErrorMessage == UI_ERROR.ERR_AUTOFOLLOW_TOO_FAR)
+            distance = WowPoint.DistanceTo(location, playerReader.PlayerLocation);
+
+            if (distance < 0.5 && playerReader.LastUIErrorMessage == UI_ERROR.ERR_AUTOFOLLOW_TOO_FAR)
             {
-                input.SetKeyState(ConsoleKey.UpArrow, true, false, $"{GetType().Name}: ");
-                await wait.InterruptTask(100, () => false);
-                await input.TapJump();
-                this.playerReader.LastUIErrorMessage = UI_ERROR.NONE;
+                playerReader.LastUIErrorMessage = UI_ERROR.NONE;
+
+                input.SetKeyState(ConsoleKey.UpArrow, true, false, $"{GetType().Name}: Too far, start moving forward!");
+                await wait.Update(1);
+            }
+
+            if (SecondsSinceApproachStarted > 1 && distance < 0.5)
+            {
+                await input.TapClearTarget("");
+                await wait.Update(1);
+                await input.KeyPress(random.Next(2) == 0 ? ConsoleKey.LeftArrow : ConsoleKey.RightArrow, 1000, "Seems stuck! Clear Target. Turn away.");
+            }
+
+            if (SecondsSinceApproachStarted > 10)
+            {
+                await input.TapClearTarget("");
+                await wait.Update(1);
+                await input.KeyPress(random.Next(2) == 0 ? ConsoleKey.LeftArrow : ConsoleKey.RightArrow, 1000, "Too long time. Clear Target. Turn away.");
             }
 
             await RandomJump();
-
-            //
-            int approachSeconds = (int)(this.stuckDetector.actionDurationSeconds);
-            if (approachSeconds > 20)
-            {
-                await this.stuckDetector.Unstick();
-                await this.TapInteractKey($"{GetType().Name}:  unstick");
-                await Task.Delay(250);
-            }
-        }
-
-        public override void OnActionEvent(object sender, ActionEventArgs e)
-        {
-            if (sender != this)
-            {
-                NeedsToReset = true;
-                playerWasInCombat = false;
-
-                if (e.Key == GoapKey.fighting)
-                {
-                    lastFighting = DateTime.Now;
-                }
-            }
         }
 
         private async Task RandomJump()
         {
-            if ((DateTime.Now - LastJump).TotalSeconds > 7)
+            if (classConfig.Jump.MillisecondsSinceLastClick > random.Next(5000, 7000))
             {
-                if (random.Next(1) == 0)
-                {
-                    await input.TapJump();
-                }
-                LastJump = DateTime.Now;
+                await input.TapJump();
             }
-        }
-
-
-        public async Task TapInteractKey(string source)
-        {
-            await input.TapInteractKey(source);
-            this.playerReader.LastUIErrorMessage = UI_ERROR.NONE;
-            await input.TapStopAttack();
         }
 
         private void Log(string text)

--- a/Core/Goals/GoalFactory.cs
+++ b/Core/Goals/GoalFactory.cs
@@ -108,7 +108,7 @@ namespace Core
                 {
                     var genericCombat = new CombatGoal(logger, input, wait, addonReader.PlayerReader, stopMoving, classConfig, castingHandler);
                     availableActions.Add(genericCombat);
-                    availableActions.Add(new PullTargetGoal(logger, input, wait, addonReader.PlayerReader, npcNameFinder, stopMoving, castingHandler, stuckDetector, classConfig));
+                    availableActions.Add(new PullTargetGoal(logger, input, wait, addonReader.PlayerReader, stopMoving, castingHandler, stuckDetector, classConfig));
 
                     availableActions.Add(new CreatureKilledGoal(logger, addonReader.PlayerReader, classConfig));
                     availableActions.Add(new ConsumeCorpse(logger, wait, addonReader.PlayerReader));

--- a/Core/Goals/GoalFactory.cs
+++ b/Core/Goals/GoalFactory.cs
@@ -80,7 +80,7 @@ namespace Core
                     availableActions.Add(walkToCorpseAction);
                 }
 
-                availableActions.Add(new ApproachTargetGoal(logger, input, wait, addonReader.PlayerReader, stopMoving,  stuckDetector));
+                availableActions.Add(new ApproachTargetGoal(logger, input, wait, addonReader.PlayerReader, classConfig, stopMoving));
 
                 if (classConfig.WrongZone.ZoneId > 0)
                 {

--- a/Core/Goals/GoalThread.cs
+++ b/Core/Goals/GoalThread.cs
@@ -49,8 +49,18 @@ namespace Core.Goals
                     {
                         this.currentGoal?.DoReset();
                         this.currentGoal = newGoal;
+
                         logger.LogInformation("---------------------------------");
                         logger.LogInformation($"New Plan= {newGoal.GetType().Name}");
+                        
+                        try
+                        {
+                            await this.currentGoal.OnEnter();
+                        }
+                        catch (Exception ex)
+                        {
+                            logger.LogError(ex, $"OnEnter on {newGoal.GetType().Name}");
+                        }
                     }
                     else if(!this.currentGoal.Repeatable)
                     {

--- a/Core/Goals/GoapGoal.cs
+++ b/Core/Goals/GoapGoal.cs
@@ -87,6 +87,11 @@ namespace Core.Goals
             return true;
         }
 
+        public virtual async Task OnEnter()
+        {
+            await Task.Delay(0);
+        }
+
         public abstract Task PerformAction();
 
         public virtual async Task Abort()


### PR DESCRIPTION
GoalGoal now has `OnEnter()` method. Which fires only once when the given `GoapGoal` gets selected by the planner, and transition happen from the old Goal to the new goal.

With that in mind its easier to Initialize or prepare the Goal for the main execution(`PerformAction`).

ex. if it takes too long time to reach a target in `ApproachTargetGoal` like above 10 seconds then something fishy going on. Similar logics implemented in `PullTargetGoal`

There was an issue before about it https://github.com/Xian55/WowClassicGrindBot/issues/98