### PR TITLE
Rework casting handler and react to LastUIErrorMessage

### DIFF
--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: An addon that displays player position as color
-## Version: 1.0.37
+## Version: 1.0.38
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibDataBroker-1.1, LibCompress, LibRangeCheck
 ## SavedVariables:

--- a/Addons/DataToColor/EventHandlers.lua
+++ b/Addons/DataToColor/EventHandlers.lua
@@ -16,11 +16,12 @@ local ignoreErrorList = {
 }
 
 local errorList = {
-    "ERR_BADATTACKFACING", --1
-    "ERR_SPELL_FAILED_S", --2
-    "ERR_SPELL_OUT_OF_RANGE", --3
-    "ERR_BADATTACKPOS", --4
-    "ERR_AUTOFOLLOW_TOO_FAR", --5
+    "ERR_BADATTACKFACING", --1 "You are facing the wrong way!";
+    "ERR_SPELL_FAILED_S", --2 -- like a printf 
+    "ERR_SPELL_OUT_OF_RANGE", --3 "Out of range.";
+    "ERR_BADATTACKPOS", --4 "You are too far away!";
+    "ERR_AUTOFOLLOW_TOO_FAR", --5 "Target is too far away.";
+    "SPELL_FAILED_MOVING", --6 "Can't do that while moving";
 };
 
 function DataToColor:RegisterEvents()
@@ -47,6 +48,16 @@ function DataToColor:OnUIErrorMessage(event, messageType, message)
         for i = 1, table.getn(errorList), 1 do
             if errorList[i]==errorName then
                 DataToColor.uiErrorMessage = i;
+
+                if errorName==errorList[2] then -- ERR_SPELL_FAILED_S
+                    if message==SPELL_FAILED_UNIT_NOT_INFRONT then
+                        DataToColor.uiErrorMessage = 1
+                        message = message.." ("..ERR_BADATTACKFACING..")"
+                    elseif message==SPELL_FAILED_MOVING then
+                        DataToColor.uiErrorMessage = 6
+                    end
+                end
+                
                 foundMessage=true;
                 UIErrorsFrame:AddMessage(message, 0, 1, 0) -- show as green messasge
             end

--- a/Core/Addon/UI_ERROR.cs
+++ b/Core/Addon/UI_ERROR.cs
@@ -8,5 +8,6 @@
         ERR_SPELL_OUT_OF_RANGE = 3,
         ERR_BADATTACKPOS = 4,
         ERR_AUTOFOLLOW_TOO_FAR = 5,
+        SPELL_FAILED_MOVING = 6
     }
 }

--- a/Core/Goals/CombatGoal.cs
+++ b/Core/Goals/CombatGoal.cs
@@ -156,7 +156,7 @@ namespace Core.Goals
 
             SendActionEvent(new ActionEventArgs(GoapKey.fighting, true));
 
-            await this.castingHandler.InteractOnUIError();
+            //await castingHandler.ReactToLastUIErrorMessage($"{GetType().Name}-PerformAction: ");
 
             await Fight();
             await KillCheck();

--- a/Core/Goals/PullTargetGoal.cs
+++ b/Core/Goals/PullTargetGoal.cs
@@ -124,7 +124,7 @@ namespace Core.Goals
                 await input.TapInteractKey($"{GetType().Name} {source}");
                 await wait.Update(1);
 
-                await castingHandler.InteractOnUIError($"{GetType().Name}-Interact: ");
+                await castingHandler.ReactToLastUIErrorMessage($"{GetType().Name}-Interact: ");
             }
         }
 


### PR DESCRIPTION
Addon: Some of the important casting error were hidden behind the `ERR_SPELL_FAILED_S`.
To be useful, now the addon will show `ERR_BADATTACKFACING` and one new error after keypress.
- "SPELL_FAILED_MOVING", --6 "Can't do that while moving";

With that in mind reworked the `CastingHandler`.
before setting a KeyAction, resetting the `playerReader.LastUIErrorMessage` so after the keypress can check immediately if there was an issue by checking `playerReader.LastUIErrorMessage`. and given the known issues can react to put the player character back in action.

Also with verbose logging made more clear, what reaction going to be executed.