### PR TITLE
Feature/addon/rework equipments handle on change

### DIFF
--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -268,15 +268,12 @@ function DataToColor:CreateFrames(n)
                     itemNum = itemNum + 1
                 end
 
-                local equipNum = DataToColor.stack:pop(DataToColor.equipmentQueue)
-                if equipNum then
-                    local equipName = DataToColor:equipName(equipNum)
-                    -- Equipment ID
-                    MakePixelSquareArrI(equipName, 30)
-                    -- Equipment slot
-                    MakePixelSquareArrI(equipNum, 31)
-
-                    --DataToColor:Print("equipmentQueue "..equipNum.." -> "..equipName)
+                local equipmentSlot = DataToColor.stack:pop(DataToColor.equipmentQueue)
+                if equipmentSlot then
+                    local itemId = DataToColor:equipName(equipmentSlot)
+                    MakePixelSquareArrI(itemId, 30)
+                    MakePixelSquareArrI(equipmentSlot, 31)
+                    --DataToColor:Print("equipmentQueue "..equipmentSlot.." -> "..itemId)
                 end
 
                 local bagNum = DataToColor.stack:pop(DataToColor.bagQueue)

--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -18,12 +18,11 @@ local CELL_SIZE = 1 -- 1-9
 -- Spacing in px between data squares.
 local CELL_SPACING = 1 -- 0 or 1
 -- Item slot trackers initialization
-local itemNum = 0
 local actionNum = 1
 local globalCounter = 0
 
 -- How often item frames change
-local ITEM_ITERATION_FRAME_CHANGE_RATE = 10
+local ITEM_ITERATION_FRAME_CHANGE_RATE = 5
 -- How often the actionbar frames change
 local ACTION_BAR_ITERATION_FRAME_CHANGE_RATE = 5
 
@@ -47,8 +46,6 @@ DataToColor.lastCombatCreature = 0
 DataToColor.lastCombatCreatureDied = 0
 
 DataToColor.targetChanged = true
-DataToColor.inventoryChanged = true
-
 DataToColor.updateActionBarCost = true
 
 -- Update Queue
@@ -56,7 +53,7 @@ stack = {}
 DataToColor.stack = stack
 
 function stack:push(t, item)
-    if item ~= stack:peek(t) then
+    if not t[item] then
         table.insert(t, item)
     end
 end
@@ -65,12 +62,13 @@ function stack:pop(t)
     return table.remove(t)
 end
 
-function stack:peek(t)
-    return t[#t]
-end
-
 DataToColor.equipmentQueue = {}
 DataToColor.bagQueue = {}
+DataToColor.inventoryQueue = {}
+
+local equipmentSlot = nil
+local bagNum = nil
+local bagSlotNum = nil
 
 -- Note: Coordinates where player is standing (max: 10, min: -10)
 -- Note: Player direction is in radians (360 degrees = 2π radians)
@@ -155,11 +153,16 @@ end
 
 function DataToColor:FushState()
     DataToColor.targetChanged = true
-    DataToColor.inventoryChanged = true
     DataToColor.updateActionBarCost = true
 
     DataToColor:InitEquipmentQueue()
     DataToColor:InitBagQueue()
+
+    DataToColor:InitInventoryQueue(4)
+    DataToColor:InitInventoryQueue(3)
+    DataToColor:InitInventoryQueue(2)
+    DataToColor:InitInventoryQueue(1)
+    DataToColor:InitInventoryQueue(0)
 
     DataToColor:Print('Flush State')
 end
@@ -172,8 +175,9 @@ end
 
 function DataToColor:InitUpdateQueues()
     DataToColor:InitEquipmentQueue()
-    -- login or /reload -> DataToColor.bagQueue will be populated by BAG_UPDATE
-    -- DataToColor:InitBagQueue()
+
+    DataToColor:InitBagQueue(0, 0)
+    DataToColor:InitInventoryQueue(0)
 end
 
 function DataToColor:InitEquipmentQueue()
@@ -182,9 +186,19 @@ function DataToColor:InitEquipmentQueue()
     end
 end
 
-function DataToColor:InitBagQueue()
-    for bagNum = 0, 5 do
-        DataToColor.stack:push(DataToColor.bagQueue, bagNum)
+function DataToColor:InitInventoryQueue(containerID)
+    if containerID >= 0 and containerID <= 4 then
+        for i = 1, 21 do
+            DataToColor.stack:push(DataToColor.inventoryQueue, containerID * 1000 + i)
+        end
+    end
+end
+
+function DataToColor:InitBagQueue(min, max)
+    min = min or 0
+    max = max or 4
+    for bag = min, max do
+        DataToColor.stack:push(DataToColor.bagQueue, bag)
     end
 end
 
@@ -242,6 +256,8 @@ function DataToColor:CreateFrames(n)
             -- Boolean variables --
             MakePixelSquareArrI(DataToColor:Base2Converter(), 8)
 
+            -- 9 not used
+
             -- Start combat/NPC related variables --
             MakePixelSquareArrI(DataToColor:getHealthMax(DataToColor.C.unitPlayer), 10) --8 Represents maximum amount of health
             MakePixelSquareArrI(DataToColor:getHealthCurrent(DataToColor.C.unitPlayer), 11) --9 Represents current amount of health
@@ -259,42 +275,58 @@ function DataToColor:CreateFrames(n)
 
             MakePixelSquareArrI(DataToColor:getHealthCurrent(DataToColor.C.unitTarget), 19) -- Returns the current amount of health the target currently has
 
-            -- Begin Items section --
-            -- there are 5 item slots: main backpack and 4 pouches
-            -- Indexes one slot from each bag each frame. SlotN (1-16) and bag (0-4) calculated here:
             if DataToColor:Modulo(globalCounter, ITEM_ITERATION_FRAME_CHANGE_RATE) == 0 then
 
-                if DataToColor.inventoryChanged then
-                    itemNum = itemNum + 1
+                -- 20 21 22
+                bagSlotNum = DataToColor.stack:pop(DataToColor.inventoryQueue)
+                if bagSlotNum then
+
+                    bagNum = math.floor(bagSlotNum / 1000)
+                    bagSlotNum = bagSlotNum - (bagNum * 1000)
+
+                    local _, itemCount, _, _, _, _, 
+                    _, _, _, itemID = GetContainerItemInfo(bagNum, bagSlotNum)
+
+                    if not itemCount then
+                        itemCount = 0
+                        itemID = 0
+                    end
+
+                    --DataToColor:Print("inventoryQueue: "..bagNum.. " "..bagSlotNum.." -> id:"..itemID.." c:"..itemCount)
+
+                    local soulbound = 0
+                    if itemCount > 0 then
+                        soulbound = C_Item.IsBound(ItemLocation:CreateFromBagAndSlot(bagNum, bagSlotNum)) and 1 or 0
+                    end
+
+                    -- 20 -- 0-4 bagNum + 1-21 itenNum + 1-1000 quantity
+                    MakePixelSquareArrI(bagNum * 1000000 + bagSlotNum * 10000 + itemCount, 20)
+
+                    -- 21 -- itemId 1-999999
+                    MakePixelSquareArrI(itemID, 21)
+
+                    -- 22 -- item bits
+                    MakePixelSquareArrI(soulbound, 22)
                 end
 
-                local equipmentSlot = DataToColor.stack:pop(DataToColor.equipmentQueue)
+                -- 30 31
+                equipmentSlot = DataToColor.stack:pop(DataToColor.equipmentQueue)
                 if equipmentSlot then
-                    local itemId = DataToColor:equipSlotItemId(equipmentSlot)
-                    MakePixelSquareArrI(itemId, 30)
+                    MakePixelSquareArrI(DataToColor:equipSlotItemId(equipmentSlot), 30)
                     MakePixelSquareArrI(equipmentSlot, 31)
                     --DataToColor:Print("equipmentQueue "..equipmentSlot.." -> "..itemId)
                 end
 
-                local bagNum = DataToColor.stack:pop(DataToColor.bagQueue)
+                -- 37
+                bagNum = DataToColor.stack:pop(DataToColor.bagQueue)
                 if bagNum then
                     local freeSlots, bagType = GetContainerNumFreeSlots(bagNum)
-                    if bagType == nil then
+                    if not bagType then
                         bagType = 0
                     end
                     MakePixelSquareArrI(bagType * 1000000 + bagNum * 100000 + freeSlots * 1000 + DataToColor:bagSlots(bagNum), 37) -- BagType + Index + FreeSpace + BagSlots
 
                     --DataToColor:Print("bagQueue "..bagType.." -> "..bagNum.." -> "..freeSlots.." -> "..DataToColor:bagSlots(bagNum))
-                end
-
-                if itemNum >= 21 then
-                    itemNum = 1
-                    DataToColor.inventoryChanged = false
-                end
-
-                -- Reseting global counter to prevent integer overflow
-                if globalCounter > 10000 then
-                    globalCounter = 1000
                 end
             end
 
@@ -310,16 +342,18 @@ function DataToColor:CreateFrames(n)
             -- Controls rate at which item frames change.
             globalCounter = globalCounter + 1
 
-            if DataToColor.inventoryChanged then
-                -- Bag contents - Uses data pixel positions 20-29
-                for bagNo = 0, 4 do
-                    -- Returns item ID and quantity
-                    MakePixelSquareArrI(DataToColor:itemName(bagNo, itemNum), 20 + bagNo * 2) -- 20,22,24,26,28
-                    -- Return item slot number
-                    MakePixelSquareArrI(bagNo * 20 + itemNum, 21 + bagNo * 2) -- 21,23,25,27,29
-                    MakePixelSquareArrI(DataToColor:itemInfo(bagNo, itemNum), 60 + bagNo) -- 60,61,62,63,64
-                end
+            -- Reseting global counter to prevent integer overflow
+            if globalCounter > 10000 then
+                globalCounter = 1000
             end
+
+            -- 23 not used
+            -- 24 not used
+            -- 25 not used
+            -- 26 not used
+            -- 27 not used
+            -- 28 not used
+            -- 29 not used
 
             -- Amount of money in coppers
             MakePixelSquareArrI(DataToColor:Modulo(DataToColor:getMoneyTotal(), 1000000), 32) -- 13 Represents amount of money held (in copper)
@@ -333,7 +367,8 @@ function DataToColor:CreateFrames(n)
 
             MakePixelSquareArrI(DataToColor:getHealthMax(DataToColor.C.unitPet), 38)
             MakePixelSquareArrI(DataToColor:getHealthCurrent(DataToColor.C.unitPet), 39)
-            -- 40
+
+            -- 40 not used
 
             -- Profession levels:
             -- tracks our skinning level
@@ -346,6 +381,7 @@ function DataToColor:CreateFrames(n)
             MakePixelSquareArrI(DataToColor:getTargetLevel(), 43)
 
             MakePixelSquareArrI(DataToColor:actionbarCost(actionNum), 44)
+            -- 45 not used
             --MakePixelSquareArrI(DataToColor:GetGossipIcons(), 45) -- Returns which gossip icons are on display in dialogue box
 
             MakePixelSquareArrI(DataToColor.S.PlayerClass, 46) -- Returns player class as an integer
@@ -370,7 +406,11 @@ function DataToColor:CreateFrames(n)
             MakePixelSquareArrI(DataToColor:GetBestMap(),58) -- MapId
 
             MakePixelSquareArrI(DataToColor:IsTargetOfTargetPlayerAsNumber(),59) -- IsTargetOfTargetPlayerAsNumber
-            -- 60-64 = Bag item info
+            -- 60 not used
+            -- 61 not used
+            -- 62 not used
+            -- 63 not used
+            -- 64 not used
             MakePixelSquareArrI(DataToColor.lastCombatCreature,65) -- Combat message creature
             MakePixelSquareArrI(DataToColor.lastCombatDamageDealerCreature,66) -- Combat message last damage dealer creature
             MakePixelSquareArrI(DataToColor.lastCombatCreatureDied,67) -- Last Killed Unit

--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -270,7 +270,7 @@ function DataToColor:CreateFrames(n)
 
                 local equipmentSlot = DataToColor.stack:pop(DataToColor.equipmentQueue)
                 if equipmentSlot then
-                    local itemId = DataToColor:equipName(equipmentSlot)
+                    local itemId = DataToColor:equipSlotItemId(equipmentSlot)
                     MakePixelSquareArrI(itemId, 30)
                     MakePixelSquareArrI(equipmentSlot, 31)
                     --DataToColor:Print("equipmentQueue "..equipmentSlot.." -> "..itemId)

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: An addon that displays player position as color
-## Version: 1.1.0
+## Version: 1.1.1
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibDataBroker-1.1, LibCompress, LibRangeCheck
 ## SavedVariables:

--- a/Addons/DataToColor/EventHandlers.lua
+++ b/Addons/DataToColor/EventHandlers.lua
@@ -102,6 +102,9 @@ end
 
 function DataToColor:OnBagUpdate(event, containerID)
     DataToColor.inventoryChanged = true
+    if containerID >= 0 then
+        DataToColor.stack:push(DataToColor.bagQueue, containerID)
+    end
     --DataToColor:Print("OnBagUpdate "..containerID)
 end
 
@@ -134,7 +137,9 @@ function DataToColor:OnPlayerTargetChanged(event)
 end
 
 function DataToColor:OnPlayerEquipmentChanged(event, equipmentSlot, hasCurrent)
-    DataToColor.equipmentChanged = true
+    DataToColor.stack:push(DataToColor.equipmentQueue, equipmentSlot)
+    --local c = hasCurrent and 1 or 0
+    --DataToColor:Print("OnPlayerEquipmentChanged "..equipmentSlot.." -> "..c)
 end
 
 DataToColor.playerInteractIterator = 0

--- a/Addons/DataToColor/EventHandlers.lua
+++ b/Addons/DataToColor/EventHandlers.lua
@@ -31,6 +31,7 @@ function DataToColor:RegisterEvents()
     DataToColor:RegisterEvent('BAG_UPDATE','OnBagUpdate')
     DataToColor:RegisterEvent('MERCHANT_SHOW','OnMerchantShow')
     DataToColor:RegisterEvent('PLAYER_TARGET_CHANGED', 'OnPlayerTargetChanged')
+    DataToColor:RegisterEvent('PLAYER_EQUIPMENT_CHANGED', 'OnPlayerEquipmentChanged')
 end
 
 function DataToColor:OnUIErrorMessage(event, messageType, message)
@@ -130,6 +131,10 @@ end
 
 function DataToColor:OnPlayerTargetChanged(event)
     DataToColor.targetChanged = true
+end
+
+function DataToColor:OnPlayerEquipmentChanged(event, equipmentSlot, hasCurrent)
+    DataToColor.equipmentChanged = true
 end
 
 DataToColor.playerInteractIterator = 0

--- a/Addons/DataToColor/EventHandlers.lua
+++ b/Addons/DataToColor/EventHandlers.lua
@@ -96,14 +96,13 @@ end
 
 function DataToColor:OnLootClosed(event)
     DataToColor.lastLoot = DataToColor.globalTime
-    DataToColor.inventoryChanged = true
     --DataToColor:Print("OnLootClosed:"..DataToColor.lastLoot)
 end
 
 function DataToColor:OnBagUpdate(event, containerID)
-    DataToColor.inventoryChanged = true
-    if containerID >= 0 then
+    if containerID >= 0 and containerID <=4 then
         DataToColor.stack:push(DataToColor.bagQueue, containerID)
+        DataToColor:InitInventoryQueue(containerID)
     end
     --DataToColor:Print("OnBagUpdate "..containerID)
 end

--- a/Addons/DataToColor/Query.lua
+++ b/Addons/DataToColor/Query.lua
@@ -301,17 +301,14 @@ end
 
 
 
-function DataToColor:equipName(slot)
+function DataToColor:equipSlotItemId(slot)
     local equip
     if GetInventoryItemLink(DataToColor.C.unitPlayer, slot) == nil then
         equip = 0
     else _, _, equip = string.find(GetInventoryItemLink(DataToColor.C.unitPlayer, slot), DataToColor.C.ItemPattern)
         equip = string.gsub(equip, 'm:', '')
     end
-    if equip == nil then
-        equip = 0
-    end
-    return tonumber(equip)
+    return tonumber(equip or 0)
 end
 -- -- Function to tell if a spell is on cooldown and if the specified slot has a spell assigned to it
 -- -- Slot ID information can be found on WoW Wiki. Slots we are using: 1-12 (main action bar), Bottom Right Action Bar maybe(49-60), and  Bottom Left (61-72)

--- a/Addons/DataToColor/Query.lua
+++ b/Addons/DataToColor/Query.lua
@@ -2,11 +2,6 @@ local Load = select(2, ...)
 local DataToColor = unpack(Load)
 local Range = DataToColor.Libs.RangeCheck
 
--- Global table of all items player has
-local items = {}
-local itemsPlaceholderComparison = {}
-local enchantedItemsList = {}
-
 -- Discover player's direction in radians (360 degrees = 2π radians)
 function DataToColor:GetPlayerFacing()
     return GetPlayerFacing() or 0
@@ -251,55 +246,6 @@ function DataToColor:actionbarCost(slot)
     end
     return DataToColor.C.MAX_ACTION_IDX * slot
 end
-
--- A function used to check which items we have.
--- Find item IDs on wowhead in the url: e.g: http://www.wowhead.com/item=5571/small-black-pouch. Best to confirm ingame if possible, though.
-function DataToColor:itemName(bag, slot)
-    local item
-    local itemCount
-    _, itemCount, _, _, _, _, _ = GetContainerItemInfo(bag, slot)
-    -- If no item in the slot, returns nil. We assign this as zero for sake of pixel reading.
-    if GetContainerItemLink(bag, slot) == nil then
-        item = 0
-        -- Formatting to isolate the ID in the ItemLink
-    else _, _, item = string.find(GetContainerItemLink(bag, slot), DataToColor.C.ItemPattern)
-        item = string.gsub(item, 'm:', '')
-    end
-    if item == nil then item = 0
-    end
-    if(itemCount ~= nil and itemCount > 0) then 
-        if (itemCount>100) then itemCount=100 end
-        item = item + itemCount * 100000
-    end
-    -- Sets global variable to current list of items
-    items[(bag * 16) + slot] = item
-    return tonumber(item)
-end
-
-function DataToColor:itemInfo(bag, slot)
-    local itemCount
-    _, itemCount, _, _, _, _, _ = GetContainerItemInfo(bag, slot)
-    local value=0
-    if itemCount ~= nil and itemCount > 0 then 
-        local isSoulBound = C_Item.IsBound(ItemLocation:CreateFromBagAndSlot(bag,slot))
-        if isSoulBound == true then value=1 end
-    else
-        value=2
-    end
-    return value
-end
-
--- Returns item id from specific index in global items table
-function DataToColor:returnItemFromIndex(index)
-    return items[index]
-end
-
-function DataToColor:enchantedItems()
-    if DataToColor:ValuesAreEqual(items, itemsPlaceholderComparison) then
-    end
-end
-
-
 
 function DataToColor:equipSlotItemId(slot)
     local equip


### PR DESCRIPTION
Rework how the equipment's, inventory and bags being processed both addon and backend side.

The goal was to reduce the total amount of processing. only update those values which were changed. This can be easily achieved with the equipments and the equipped bags.

On the other hand the inventory only can be reduced to per bag. So sadly still have to run a full loop with the bag items(22).

However the runtime response should be way better.

- Freed up quite a bit of cells, the inventory used quite a lot!
- `PLAYER_EQUIPMENT_CHANGED` is handled!
- Updated some of the API calls
- cleanup