### PR TITLE
Fix installed addon version check

### DIFF
--- a/BlazorServer/AddonConfigurator.cs
+++ b/BlazorServer/AddonConfigurator.cs
@@ -343,19 +343,17 @@ namespace BlazorServer
             try
             {
                 repo = GetVersion(Path.Join(AddonSourcePath, DefaultAddonName), DefaultAddonName);
-            }
-            catch (Exception)
-            {
-                // This only should be happen when running from IDE
-                string parentFolder = ".";
-                try
+
+                if (repo == null)
                 {
+                    string parentFolder = ".";
+
                     repo = GetVersion(Path.Join(parentFolder + AddonSourcePath, DefaultAddonName), DefaultAddonName);
                 }
-                catch (Exception e)
-                {
-                    logger.LogError(e.Message);
-                }
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e.Message);
             }
             return repo;
         }


### PR DESCRIPTION
Based on the documentation, the server gets started from the start.bat file, which changes the directory to "BlazorServer". (which is the same when it is running from VS)

In that case "./Addon/" folder is not valid, however the exception handling is basically useless because the GetVersion returns null, instead of an exception.

So the fix is basically solves the fallback branch of the version check.
