### PR TITLE
Feature/rework kill credit detection

### DIFF
--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -38,12 +38,17 @@ DataToColor.frames = nil
 DataToColor.r = 0
 
 DataToColor.uiErrorMessage = 0
-DataToColor.lastCombatDamageDealerCreature = 0
+
+DataToColor.lastCombatDamageTakenCreature = 0
+DataToColor.lastCombatDamageDoneCreature = 0
 DataToColor.lastCombatCreature = 0
 DataToColor.lastCombatCreatureDied = 0
 
 DataToColor.targetChanged = true
 DataToColor.updateActionBarCost = true
+
+DataToColor.playerGUID = UnitGUID(DataToColor.C.unitPlayer)
+DataToColor.petGUID = UnitGUID(DataToColor.C.unitPet)
 
 -- Update Queue
 stack = {}
@@ -229,6 +234,10 @@ function DataToColor:CreateFrames(n)
         end
 
         if not SETUP_SEQUENCE then
+
+            DataToColor.playerGUID = UnitGUID(DataToColor.C.unitPlayer)
+            DataToColor.petGUID = UnitGUID(DataToColor.C.unitPet)
+
             MakePixelSquareArrI(0, 0)
             -- The final data square, reserved for additional metadata.
             MakePixelSquareArrI(2000001, NUMBER_OF_FRAMES - 1)
@@ -394,8 +403,9 @@ function DataToColor:CreateFrames(n)
             -- 63 not used
             -- 64 not used
 
-            MakePixelSquareArrI(DataToColor.lastCombatCreature, 65) -- Combat message creature
-            MakePixelSquareArrI(DataToColor.lastCombatDamageDealerCreature, 66) -- Combat message last damage dealer creature
+            MakePixelSquareArrI(DataToColor.lastCombatCreature, 64) -- Combat message creature
+            MakePixelSquareArrI(DataToColor.lastCombatDamageDoneCreature, 65) -- Last Combat damage done
+            MakePixelSquareArrI(DataToColor.lastCombatDamageTakenCreature, 66) -- Last Combat Damage taken
             MakePixelSquareArrI(DataToColor.lastCombatCreatureDied, 67) -- Last Killed Unit
 
             MakePixelSquareArrI(DataToColor:getGuid(DataToColor.C.unitPet), 68) -- pet guid

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: An addon that displays player position as color
-## Version: 1.1.6
+## Version: 1.1.7
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibDataBroker-1.1, LibCompress, LibRangeCheck
 ## SavedVariables:

--- a/Addons/DataToColor/EventHandlers.lua
+++ b/Addons/DataToColor/EventHandlers.lua
@@ -77,17 +77,24 @@ function DataToColor:OnCombatEvent(event)
         DataToColor.lastCombatCreature=0;
     elseif string.find(sourceGUID, "Creature") then
         DataToColor.lastCombatCreature = DataToColor:getGuidFromUUID(sourceGUID);
-        DataToColor.lastCombatDamageDealerCreature = DataToColor.lastCombatCreature;
-        --print(sourceGUID.." "..lastCombatCreature);
+        DataToColor.lastCombatDamageTakenCreature = DataToColor.lastCombatCreature;
+        --print(sourceGUID.." "..DataToColor.lastCombatCreature);
+        --print(CombatLogGetCurrentEventInfo())
     else
         DataToColor.lastCombatCreature=0;
         --print("Other "..eventType);
     end
 
+    if string.find(eventType, "_DAMAGE") and ((sourceGUID == DataToColor.playerGUID) or (sourceGUID == DataToColor.petGUID)) then
+        --print(CombatLogGetCurrentEventInfo())
+        DataToColor.lastCombatDamageDoneCreature = DataToColor:getGuidFromUUID(destGUID);
+    end
+
     if eventType=="UNIT_DIED" then
         if string.find(destGUID, "Creature") then
+            --print(CombatLogGetCurrentEventInfo())
             DataToColor.lastCombatCreatureDied = DataToColor:getGuidFromUUID(destGUID);
-            --print("v_killing blow " .. destGUID .. " " .. lastCombatCreatureDied .. " " .. destName)
+            --print("v_killing blow " .. destGUID .. " " .. DataToColor.lastCombatCreatureDied .. " " .. destName)
         else
             --print("i_killing blow " .. destGUID .. " " .. destName)
         end

--- a/Core/Addon/CreatureHistory.cs
+++ b/Core/Addon/CreatureHistory.cs
@@ -4,18 +4,20 @@ using System.Collections.Generic;
 
 namespace Core
 {
-    public class CombatCreature
+    public class CreatureHistory
     {
         public int CreatureId { get; set; }
+
+        public float LastKnownHealthPercent { get; set; }
 
         public DateTime LastEvent { get; set; }
 
         public bool HasExpired()
         {
-            return (DateTime.Now - LastEvent).TotalSeconds > 3;
+            return (DateTime.Now - LastEvent).TotalSeconds > 60;
         }
 
-        public static void UpdateCombatCreatureCount(int creatureId, List<CombatCreature> CombatCreatures)
+        public static void Update(int creatureId, float healthPercent, List<CreatureHistory> CombatCreatures)
         {
             if (creatureId > 0)
             {
@@ -23,17 +25,23 @@ namespace Core
 
                 if (creature != null)
                 {
+                    creature.LastKnownHealthPercent = healthPercent;
                     creature.LastEvent = DateTime.Now;
                 }
                 else
                 {
-                    CombatCreatures.Add(new CombatCreature { CreatureId = creatureId, LastEvent = DateTime.Now });
+                    CombatCreatures.Add(new CreatureHistory { CreatureId = creatureId, LastKnownHealthPercent = healthPercent, LastEvent = DateTime.Now });
                 }
             }
 
             CombatCreatures.Where(c => c.HasExpired())
                 .ToList()
                 .ForEach(c => CombatCreatures.Remove(c));
+        }
+
+        public override string ToString()
+        {
+            return $"id: {CreatureId} | hp: {LastKnownHealthPercent}";
         }
     }
 }

--- a/Core/Addon/PlayerReader.cs
+++ b/Core/Addon/PlayerReader.cs
@@ -146,7 +146,7 @@ namespace Core
 
         public int LastCombatDamageDoneGuid => (int)reader.GetLongAtCell(65);
 
-        public int LastDamageTakenGuid => (int)reader.GetLongAtCell(66);
+        public int LastCombatDamageTakenGuid => (int)reader.GetLongAtCell(66);
 
         public int LastDeadGuid => (int)reader.GetLongAtCell(67);
 
@@ -175,7 +175,7 @@ namespace Core
         public void UpdateCreatureLists()
         {
             CreatureHistory.Update(LastCombatCreatureGuid, 100f, Creatures);
-            CreatureHistory.Update(LastDamageTakenGuid, 100f, DamageTaken);
+            CreatureHistory.Update(LastCombatDamageTakenGuid, 100f, DamageTaken);
             CreatureHistory.Update(LastCombatDamageDoneGuid, (int)TargetHealthPercentage, DamageDone);
 
             // set dead mob health everywhere

--- a/Core/Addon/PlayerReader.cs
+++ b/Core/Addon/PlayerReader.cs
@@ -20,8 +20,12 @@ namespace Core
         public double AvgUpdateLatency = 5;
 
         public int Sequence { get; private set; } = 0;
-        public List<CombatCreature> TargetHistory { get; } = new List<CombatCreature>();
-        public List<CombatCreature> CombatCreatures { get; } = new List<CombatCreature>();
+
+        public List<CreatureHistory> Creatures { get; } = new List<CreatureHistory>();
+        public List<CreatureHistory> Targets { get; } = new List<CreatureHistory>();
+        public List<CreatureHistory> DamageDone { get; } = new List<CreatureHistory>();
+        public List<CreatureHistory> DamageTaken { get; } = new List<CreatureHistory>();
+        public List<CreatureHistory> Deads { get; } = new List<CreatureHistory>();
 
         public WowPoint PlayerLocation => new WowPoint(XCoord, YCoord);
 
@@ -137,9 +141,15 @@ namespace Core
 
         public TargetTargetEnum TargetTarget => (TargetTargetEnum)reader.GetLongAtCell(59);
 
-        public int LastDamageDealerGuid => (int)reader.GetLongAtCell(66);
 
-        public int LastKilledGuid => (int)reader.GetLongAtCell(67);
+        public int LastCombatCreatureGuid => (int)reader.GetLongAtCell(64);
+
+        public int LastCombatDamageDoneGuid => (int)reader.GetLongAtCell(65);
+
+        public int LastDamageTakenGuid => (int)reader.GetLongAtCell(66);
+
+        public int LastDeadGuid => (int)reader.GetLongAtCell(67);
+
 
         public int PetGuid => (int)reader.GetLongAtCell(68);
         public int PetTargetGuid => (int)reader.GetLongAtCell(69);
@@ -160,12 +170,27 @@ namespace Core
 
 
         #region Combat Creatures
-        public int CombatCreatureCount => CombatCreatures.Count;
+        public int CombatCreatureCount => Creatures.Count;
 
         public void UpdateCreatureLists()
         {
-            CombatCreature.UpdateCombatCreatureCount((int)reader.GetLongAtCell(65), CombatCreatures);
-            CombatCreature.UpdateCombatCreatureCount((int)TargetGuid, TargetHistory);
+            CreatureHistory.Update(LastCombatCreatureGuid, 100f, Creatures);
+            CreatureHistory.Update(LastDamageTakenGuid, 100f, DamageTaken);
+            CreatureHistory.Update(LastCombatDamageDoneGuid, (int)TargetHealthPercentage, DamageDone);
+
+            // set dead mob health everywhere
+            CreatureHistory.Update(LastDeadGuid, 0, Deads);
+            CreatureHistory.Update(LastDeadGuid, 0, Creatures);
+            CreatureHistory.Update(LastDeadGuid, 0, DamageTaken);
+            CreatureHistory.Update(LastDeadGuid, 0, DamageDone);
+
+            CreatureHistory.Update((int)TargetGuid, (int)TargetHealthPercentage, Targets);
+
+            // Update last target health from LastDeadGuid
+            if (Targets.FindIndex(x => x.CreatureId == LastDeadGuid) != -1)
+            {
+                CreatureHistory.Update(LastDeadGuid, 0, Targets);
+            }
         }
 
         #endregion

--- a/Core/GOAP/GoapAgent.cs
+++ b/Core/GOAP/GoapAgent.cs
@@ -70,19 +70,12 @@ namespace Core.GOAP
             }
             else
             {
-                logger.LogInformation($"Target Health: {playerReader.TargetHealth}, max {playerReader.TargetMaxHealth}, dead {playerReader.PlayerBitValues.TargetIsDead}");
-
-                if (classConfiguration.Mode != Mode.AttendedGrind)
+                if (CurrentGoal != null && !CurrentGoal.Repeatable)
                 {
-                    await stopMoving.Stop();
+                    logger.LogInformation($"Plan= {CurrentGoal.GetType().Name} is not Repeatable!");
+                    CurrentGoal = null;
 
-                    await input.TapNearestTarget("GoapAgent");
-                    await wait.Update(1);
-                    if (playerReader.HasTarget && !playerReader.PlayerBitValues.TargetOfTargetIsPlayer)
-                    {
-                        await input.TapClearTarget("GoapAgent");
-                        await wait.Update(1);
-                    }
+                    await stopMoving.Stop();
                 }
             }
 

--- a/Core/Goals/CreatureKilledGoal.cs
+++ b/Core/Goals/CreatureKilledGoal.cs
@@ -53,7 +53,7 @@ namespace Core.Goals
                 SendActionEvent(new ActionEventArgs(GoapKey.shouldloot, true));
             }
 
-            await Task.Delay(10);
+            await Task.Delay(0);
         }
     }
 }

--- a/Core/Goals/GoalThread.cs
+++ b/Core/Goals/GoalThread.cs
@@ -47,25 +47,35 @@ namespace Core.Goals
                 {
                     if (newGoal != this.currentGoal)
                     {
+                        if (this.currentGoal != null)
+                        {
+                            try
+                            {
+                                await this.currentGoal.OnExit();
+                            }
+                            catch (Exception ex)
+                            {
+                                logger.LogError(ex, $"OnExit on {currentGoal.GetType().Name}");
+                            }
+                        }
+
                         this.currentGoal?.DoReset();
                         this.currentGoal = newGoal;
 
                         logger.LogInformation("---------------------------------");
                         logger.LogInformation($"New Plan= {newGoal.GetType().Name}");
                         
-                        try
+                        if (currentGoal != null)
                         {
-                            await this.currentGoal.OnEnter();
+                            try
+                            {
+                                await this.currentGoal.OnEnter();
+                            }
+                            catch (Exception ex)
+                            {
+                                logger.LogError(ex, $"OnEnter on {newGoal.GetType().Name}");
+                            }
                         }
-                        catch (Exception ex)
-                        {
-                            logger.LogError(ex, $"OnEnter on {newGoal.GetType().Name}");
-                        }
-                    }
-                    else if(!this.currentGoal.Repeatable)
-                    {
-                        logger.LogInformation($"Current Plan= {newGoal.GetType().Name} is not Repeatable!");
-                        return;
                     }
 
                     try

--- a/Core/Goals/GoapGoal.cs
+++ b/Core/Goals/GoapGoal.cs
@@ -92,6 +92,11 @@ namespace Core.Goals
             await Task.Delay(0);
         }
 
+        public virtual async Task OnExit()
+        {
+            await Task.Delay(0);
+        }
+
         public abstract Task PerformAction();
 
         public virtual async Task Abort()


### PR DESCRIPTION
In the past there were many issues detecting the kill credit, just by simply skipping it or causing unintended body pulls.

The new system should take account a lot more things to determine if the `player/players pet` killed a creature and should it be consumed. However detecting any possible threats after killing the current target.

`CombatCreature` has been renamed to `CreatureHistory` and includes the `LastKnownHealthPercent`. 
Of course only the player target health is known for sure and the Dead ones!

The addon is now keep tracks of the last
- `DamageDone creature` (from player or players pet)
- `DamageTaken creature` (a creature who caused damage to the player or players pet)
- `Dead creatures` (a creature died in general)
- `Target creature` (player target)

With these information available, we can make certain assumptions like. 
- Did we killed a creature?
- Is there any threat, possible body pull?
- How many units attacking me?
and many more!

Also `GoapAgent` no longer tries to find a target when entering `NO PLAN` it was quite misleading and it caused many issues like unintended pulls when the player was not ready to face a new enemy!

`GoapGoal` has OnExit() which is used in `CombatGoal` to have a double check for kill credit!

Also `GoapGoal.Repeatable=False` Goals will not be executed second time or more!
