### PR TITLE
Feature/target finder running in background

### DIFF
--- a/Core/BotController.cs
+++ b/Core/BotController.cs
@@ -1,4 +1,4 @@
-using Core.Goals;
+﻿using Core.Goals;
 using Core.GOAP;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -262,7 +262,7 @@ namespace Core
 
             Wait wait = new Wait(AddonReader.PlayerReader);
 
-            this.GoapAgent = new GoapAgent(logger, ConfigurableInput, AddonReader.PlayerReader, availableActions, blacklist, config, wait);
+            this.GoapAgent = new GoapAgent(logger, ConfigurableInput, AddonReader.PlayerReader, availableActions, blacklist, config);
 
             this.actionThread = new GoalThread(logger, ConfigurableInput, AddonReader.PlayerReader, GoapAgent);
 
@@ -315,8 +315,6 @@ namespace Core
             if (actionThread != null)
             {
                 actionThread.Active = false;
-                this.GoapAgent?.AvailableGoals.ToList().ForEach(goal => goal.OnActionEvent(this, new ActionEventArgs(GoapKey.abort, true)));
-
                 StatusChanged?.Invoke(this, actionThread.Active);
             }
         }

--- a/Core/BotController.cs
+++ b/Core/BotController.cs
@@ -1,4 +1,4 @@
-﻿using Core.Goals;
+using Core.Goals;
 using Core.GOAP;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -219,9 +219,10 @@ namespace Core
         {
             if (this.actionThread != null)
             {
+                actionThread.ResumeIfNeeded();
+
                 while (this.actionThread.Active && this.Enabled)
                 {
-
                     await actionThread.GoapPerformGoal();
                 }
             }

--- a/Core/GOAP/GoapAgent.cs
+++ b/Core/GOAP/GoapAgent.cs
@@ -25,9 +25,7 @@ namespace Core.GOAP
         public HashSet<KeyValuePair<GoapKey, object>> WorldState { get; private set; } = new HashSet<KeyValuePair<GoapKey, object>>();
         private IBlacklist blacklist;
 
-        private readonly Wait wait;
-
-        public GoapAgent(ILogger logger, ConfigurableInput input, PlayerReader playerReader, HashSet<GoapGoal> availableGoals, IBlacklist blacklist, ClassConfiguration classConfiguration, Wait wait)
+        public GoapAgent(ILogger logger, ConfigurableInput input, PlayerReader playerReader, HashSet<GoapGoal> availableGoals, IBlacklist blacklist, ClassConfiguration classConfiguration)
         {
             this.logger = logger;
             this.input = input;
@@ -41,8 +39,6 @@ namespace Core.GOAP
 
             this.planner = new GoapPlanner(logger);
             this.classConfiguration = classConfiguration;
-
-            this.wait = wait;
         }
 
         public void UpdateWorldState()

--- a/Core/GOAP/GoapKey.cs
+++ b/Core/GOAP/GoapKey.cs
@@ -19,6 +19,7 @@
         producedcorpse = 130,
         consumecorpse = 131,
         abort = 140,
+        resume = 141,
         shoulddrink = 150,
         classMount = 160,
         isalive=170,

--- a/Core/Goals/AdhocNPCGoal.cs
+++ b/Core/Goals/AdhocNPCGoal.cs
@@ -330,16 +330,6 @@ namespace Core.Goals
             return (DateTime.Now - LastActive).TotalSeconds < 2;
         }
 
-        public async Task Reset()
-        {
-            await this.stopMoving.Stop();
-        }
-
-        public override async Task Abort()
-        {
-            await this.stopMoving.Stop();
-        }
-
         public override string Name => this.Keys.Count == 0 ? base.Name : this.Keys[0].Name;
 
 

--- a/Core/Goals/ApproachTargetGoal.cs
+++ b/Core/Goals/ApproachTargetGoal.cs
@@ -185,6 +185,14 @@ namespace Core.Goals
             await RandomJump();
         }
 
+        public override void OnActionEvent(object sender, ActionEventArgs e)
+        {
+            if (e.Key == GoapKey.resume)
+            {
+                approachStart = DateTime.Now;
+            }
+        }
+
         private async Task RandomJump()
         {
             if (classConfig.Jump.MillisecondsSinceLastClick > random.Next(5000, 7000))

--- a/Core/Goals/CorpseRunGoal.cs
+++ b/Core/Goals/CorpseRunGoal.cs
@@ -177,10 +177,5 @@ namespace Core.Goals
             //logger.LogInformation($"distance:{x} {y} {distance.ToString()}");
             return distance;
         }
-
-        public override async Task Abort()
-        {
-            await this.stopMoving.Stop();
-        }
     }
 }

--- a/Core/Goals/FollowRouteGoal.cs
+++ b/Core/Goals/FollowRouteGoal.cs
@@ -502,16 +502,6 @@ namespace Core.Goals
             return false;
         }
 
-        public async Task Reset()
-        {
-            await this.stopMoving.Stop();
-        }
-
-        public override async Task Abort()
-        {
-            await this.stopMoving.Stop();
-        }
-
         public static Vector2 GetClosestPointOnLineSegment(Vector2 A, Vector2 B, Vector2 P)
         {
             Vector2 AP = P - A;       //Vector from A to P

--- a/Core/Goals/GoalFactory.cs
+++ b/Core/Goals/GoalFactory.cs
@@ -53,8 +53,10 @@ namespace Core
             var combatUtil = new CombatUtil(logger, input, wait, addonReader.PlayerReader);
             var mountHandler = new MountHandler(logger, input, classConfig, wait, addonReader.PlayerReader, stopMoving);
 
-            var followRouteAction = new FollowRouteGoal(logger, input, wait, addonReader.PlayerReader,  playerDirection, pathPoints, stopMoving, npcNameFinder, blacklist, stuckDetector, classConfig, pather, mountHandler);
-            var walkToCorpseAction = new WalkToCorpseGoal(logger, input, addonReader.PlayerReader,  playerDirection, spiritPath, pathPoints, stopMoving, stuckDetector, pather);
+            var targetFinder = new TargetFinder(logger, input, classConfig, wait, addonReader.PlayerReader, blacklist, npcNameFinder);
+
+            var followRouteAction = new FollowRouteGoal(logger, input, wait, addonReader.PlayerReader, playerDirection, pathPoints, stopMoving, npcNameFinder, stuckDetector, classConfig, pather, mountHandler, targetFinder);
+            var walkToCorpseAction = new WalkToCorpseGoal(logger, input, addonReader.PlayerReader, playerDirection, spiritPath, pathPoints, stopMoving, stuckDetector, pather);
 
             availableActions.Clear();
 

--- a/Core/Goals/GoalThread.cs
+++ b/Core/Goals/GoalThread.cs
@@ -1,4 +1,4 @@
-﻿using Core.GOAP;
+using Core.GOAP;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Threading;
@@ -93,6 +93,11 @@ namespace Core.Goals
                     Thread.Sleep(50);
                 }
             }
+        }
+
+        public void ResumeIfNeeded()
+        {
+            currentGoal?.OnActionEvent(this, new ActionEventArgs(GoapKey.resume, true));
         }
     }
 }

--- a/Core/Goals/GoalThread.cs
+++ b/Core/Goals/GoalThread.cs
@@ -1,6 +1,7 @@
-using Core.GOAP;
+﻿using Core.GOAP;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -15,7 +16,19 @@ namespace Core.Goals
         private readonly GoapAgent goapAgent;
 
         private GoapGoal? currentGoal;
-        public bool Active { get; set; }
+
+        private bool active;
+        public bool Active
+        {
+            get => active;
+            set
+            {
+                active = value;
+
+                if(!active)
+                    goapAgent?.AvailableGoals.ToList().ForEach(goal => goal.OnActionEvent(this, new ActionEventArgs(GoapKey.abort, true)));
+            }
+        }
 
         public GoalThread(ILogger logger, ConfigurableInput input, PlayerReader playerReader, GoapAgent goapAgent)
         {
@@ -27,14 +40,6 @@ namespace Core.Goals
 
         public void OnActionEvent(object sender, ActionEventArgs e)
         {
-            if (e.Key == GoapKey.abort)
-            {
-                logger.LogInformation($"Abort from: {sender.GetType().Name}");
-
-                var location = this.playerReader.PlayerLocation;
-                input?.TapHearthstone();
-                Active = false;
-            }
         }
 
         public async Task GoapPerformGoal()

--- a/Core/Goals/GoapGoal.cs
+++ b/Core/Goals/GoapGoal.cs
@@ -99,11 +99,6 @@ namespace Core.Goals
 
         public abstract Task PerformAction();
 
-        public virtual async Task Abort()
-        {
-            await Task.Delay(0);
-        }
-
         public void AddPrecondition(GoapKey key, object value)
         {
             var precondition = new GoapPreCondition(GoapKeyDescription.ToString(key, value), value);

--- a/Core/Goals/PullTargetGoal.cs
+++ b/Core/Goals/PullTargetGoal.cs
@@ -64,6 +64,14 @@ namespace Core.Goals
             pullStart = DateTime.Now;
         }
 
+        public override void OnActionEvent(object sender, ActionEventArgs e)
+        {
+            if (e.Key == GoapKey.resume)
+            {
+                pullStart = DateTime.Now;
+            }
+        }
+
         public override async Task PerformAction()
         {
             if (SecondsSincePullStarted > 7)

--- a/Core/Goals/TargetFinder.cs
+++ b/Core/Goals/TargetFinder.cs
@@ -1,0 +1,86 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Core.Goals
+{
+    public class TargetFinder
+    {
+        private readonly ILogger logger;
+        private readonly ConfigurableInput input;
+        private readonly ClassConfiguration classConfig;
+        private readonly Wait wait;
+        private readonly PlayerReader playerReader;
+
+        private readonly IBlacklist blacklist;
+        private readonly NpcNameFinder npcNameFinder;
+
+        private readonly Random random = new Random();
+
+        public TargetFinder(ILogger logger, ConfigurableInput input, ClassConfiguration classConfig, Wait wait, PlayerReader playerReader, IBlacklist blacklist, NpcNameFinder npcNameFinder)
+        {
+            this.logger = logger;
+            this.classConfig = classConfig;
+            this.input = input;
+            this.wait = wait;
+            this.playerReader = playerReader;
+
+            this.blacklist = blacklist;
+            this.npcNameFinder = npcNameFinder;
+        }
+
+        public async Task<bool> Search(string source, CancellationToken cancellationToken)
+        {
+            if (!cancellationToken.IsCancellationRequested && !playerReader.PlayerBitValues.PlayerInCombat
+                && classConfig.TargetNearestTarget.MillisecondsSinceLastClick > random.Next(1000, 1500))
+            {
+                if (await LookForTarget(source, cancellationToken))
+                {
+                    if (playerReader.HasTarget && !playerReader.PlayerBitValues.TargetIsDead)
+                    {
+                        logger.LogInformation($"{source}: Has target!");
+                        return true;
+                    }
+                    else
+                    {
+                        if (!cancellationToken.IsCancellationRequested)
+                            await input.TapClearTarget($"{source}: Target is dead!");
+
+                        if (!cancellationToken.IsCancellationRequested)
+                            await wait.Update(1);
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private async Task<bool> LookForTarget(string source, CancellationToken cancellationToken)
+        {
+            if (playerReader.HasTarget && !playerReader.PlayerBitValues.TargetIsDead && !blacklist.IsTargetBlacklisted())
+            {
+                return true;
+            }
+            else
+            {
+                if (!cancellationToken.IsCancellationRequested)
+                    await input.TapNearestTarget(source);
+
+                if (!playerReader.HasTarget && !cancellationToken.IsCancellationRequested)
+                {
+                    npcNameFinder.ChangeNpcType(NpcNameFinder.NPCType.Enemy);
+                    if (npcNameFinder.NpcCount > 0 && !cancellationToken.IsCancellationRequested)
+                    {
+                        await npcNameFinder.TargetingAndClickNpc(0, true, cancellationToken);
+
+                        if(!cancellationToken.IsCancellationRequested)
+                            await wait.Update(1);
+                    }
+                }
+            }
+
+            return !cancellationToken.IsCancellationRequested && playerReader.HasTarget && !blacklist.IsTargetBlacklisted();
+        }
+    }
+}

--- a/Core/Goals/WalkToCorpseGoal.cs
+++ b/Core/Goals/WalkToCorpseGoal.cs
@@ -360,11 +360,6 @@ namespace Core.Goals
             return distance;
         }
 
-        public override async Task Abort()
-        {
-            await this.stopMoving.Stop();
-        }
-
         public static Vector2 GetClosestPointOnLineSegment(Vector2 A, Vector2 B, Vector2 P)
         {
             Vector2 AP = P - A;       //Vector from A to P

--- a/Core/NpcFinder/NpcNameFinder.cs
+++ b/Core/NpcFinder/NpcNameFinder.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using SharedLib;
 using Game;
+using System.Threading;
 
 namespace Core
 {
@@ -114,7 +115,7 @@ namespace Core
             }
         }
 
-        public async Task TargetingAndClickNpc(int threshold, bool leftClick)
+        public async Task TargetingAndClickNpc(int threshold, bool leftClick, CancellationToken cancellationToken)
         {
             var npc = GetClosestNpc();
             if (npc != null)
@@ -123,6 +124,9 @@ namespace Core
                 {
                     foreach (var location in locTargetingAndClickNpc)
                     {
+                        if (cancellationToken.IsCancellationRequested)
+                            return;
+
                         var clickPostion = bitmapProvider.DirectBitmap.ToScreenCoordinates(npc.ClickPoint.X + location.X, npc.ClickPoint.Y + location.Y);
                         mouseInput.SetCursorPosition(clickPostion);
                         await Task.Delay(MOUSE_DELAY);
@@ -141,7 +145,7 @@ namespace Core
                 }
                 else
                 {
-                    logger.LogInformation($"{this.GetType().Name}.FindAndClickNpc: NPC found but below threshold {threshold}! Height={npc.Height}, width={npc.Width}");
+                    logger.LogInformation($"{this.GetType().Name}: NPC found but below threshold {threshold}! Height={npc.Height}, width={npc.Width}");
                 }
             }
             else


### PR DESCRIPTION
Added some new ways to interact with the Goals when toggling the application via the `Stop`/`Start` button.

- The behavior when first time starting it via `Start Bot` button does not changed!
- When the `Stop Bot` happening, an `abort` key will be broadcasted to every `availableGoal`. So they know they have to stop running their own background dependencies.
- Upon resuming it by pressing the `Start Bot` once again. There might be currently active GoapGoal, this goal needs to be notified to resume its dependencies.

This implemented in first hand in the `FollowRouteGoal` to utilize the `TargetFinder` component. which is running its on separate Task so it not needed to be awaited in the `FollowRouteGoal.PerformAction()`. However this introduces new challenges such as keeping track of the lifecycle of the `TargetFinder` which is the `FollowRouteGoal` responsibility.

`TargetFinder` is running in the background because it can be quite time consuming to find a target with the `NPCNameFinder` which has been enhanced with some really basic interrupt ability via `CancellationToken`

On the other hand, the `resume` event comes handy to reset internal timers and other things to avoid being stuck in the goal because of one of the timer has been expired.

This changes will setup a really nice ground up for future possibilities :)
