### PR TITLE
Add support for gossip based vendoring

### DIFF
--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -25,6 +25,8 @@ local globalCounter = 0
 local ITEM_ITERATION_FRAME_CHANGE_RATE = 5
 -- How often the actionbar frames change
 local ACTION_BAR_ITERATION_FRAME_CHANGE_RATE = 5
+-- How often the gossip frames change
+local GOSSIP_ITERATION_FRAME_CHANGE_RATE = 5
 
 -- Action bar configuration for which spells are tracked
 local MAX_ACTIONBAR_SLOT = 108
@@ -62,20 +64,32 @@ function stack:push(t, item)
 end
 
 function stack:pop(t)
-    local key, value = next(t)
+    local key, value = minKey(t)
     if key ~= nil then
+        value = t[key]
         t[key] = nil
+        return key, value
     end
-    return key, value
+end
+
+function minKey(t)
+    local k
+    for i, v in pairs(t) do
+      k = k or i
+      if v < t[k] then k = i end
+    end
+    return k
 end
 
 DataToColor.equipmentQueue = {}
 DataToColor.bagQueue = {}
 DataToColor.inventoryQueue = {}
+DataToColor.gossipQueue = {}
 
 local equipmentSlot = nil
 local bagNum = nil
 local bagSlotNum = nil
+local gossipNum = nil
 
 -- Note: Coordinates where player is standing (max: 10, min: -10)
 -- Note: Player direction is in radians (360 degrees = 2π radians)
@@ -361,7 +375,12 @@ function DataToColor:CreateFrames(n)
 
             MakePixelSquareArrI(DataToColor:actionbarCost(actionNum), 36)
 
-            -- 37 not used
+            if DataToColor:Modulo(globalCounter, GOSSIP_ITERATION_FRAME_CHANGE_RATE) == 0 then
+                gossipNum = DataToColor.stack:pop(DataToColor.gossipQueue)
+                if gossipNum then
+                    MakePixelSquareArrI(gossipNum, 37)
+                end
+            end
 
             MakePixelSquareArrI(DataToColor:getHealthMax(DataToColor.C.unitPet), 38)
             MakePixelSquareArrI(DataToColor:getHealthCurrent(DataToColor.C.unitPet), 39)

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: An addon that displays player position as color
-## Version: 1.1.12
+## Version: 1.1.13
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibDataBroker-1.1, LibCompress, LibRangeCheck
 ## SavedVariables:

--- a/Addons/DataToColor/EventHandlers.lua
+++ b/Addons/DataToColor/EventHandlers.lua
@@ -31,8 +31,10 @@ function DataToColor:RegisterEvents()
     DataToColor:RegisterEvent('BAG_UPDATE','OnBagUpdate')
     DataToColor:RegisterEvent('BAG_CLOSED','OnBagUpdate')
     DataToColor:RegisterEvent('MERCHANT_SHOW','OnMerchantShow')
+    DataToColor:RegisterEvent('MERCHANT_CLOSED','OnMerchantClosed')
     DataToColor:RegisterEvent('PLAYER_TARGET_CHANGED', 'OnPlayerTargetChanged')
     DataToColor:RegisterEvent('PLAYER_EQUIPMENT_CHANGED', 'OnPlayerEquipmentChanged')
+    DataToColor:RegisterEvent('GOSSIP_SHOW', 'OnGossipShow')
 end
 
 function DataToColor:OnUIErrorMessage(event, messageType, message)
@@ -137,6 +139,7 @@ end
 
 function DataToColor:OnMerchantShow(event)
     
+    DataToColor.stack:push(DataToColor.gossipQueue, 9999999)
     TotalPrice = 0
     for myBags = 0,4 do
         for bagSlots = 1, GetContainerNumSlots(myBags) do
@@ -159,6 +162,10 @@ function DataToColor:OnMerchantShow(event)
     end
 end
 
+function DataToColor:OnMerchantClosed(event)
+    DataToColor.stack:push(DataToColor.gossipQueue, 9999998)
+end
+
 function DataToColor:OnPlayerTargetChanged(event)
     DataToColor.targetChanged = true
 end
@@ -167,6 +174,27 @@ function DataToColor:OnPlayerEquipmentChanged(event, equipmentSlot, hasCurrent)
     DataToColor.stack:push(DataToColor.equipmentQueue, equipmentSlot)
     --local c = hasCurrent and 1 or 0
     --DataToColor:Print("OnPlayerEquipmentChanged "..equipmentSlot.." -> "..c)
+end
+
+function DataToColor:OnGossipShow(event)
+    local options = GetGossipOptions()
+    if not options then
+        return
+    end
+
+    DataToColor.stack:push(DataToColor.gossipQueue, 0)
+    
+    -- returns variable string - format of one entry
+    -- [1] localized name
+    -- [2] gossip_type
+    local GossipOptions = { GetGossipOptions() }
+    local count = table.getn(GossipOptions) / 2
+    for k, v in pairs(GossipOptions) do
+        -- do something
+        if k % 2 == 0 then
+            DataToColor.stack:push(DataToColor.gossipQueue, 10000 * count + 100 * (k/2) + DataToColor.S.Gossip[v])
+        end
+    end
 end
 
 DataToColor.playerInteractIterator = 0

--- a/Addons/DataToColor/Storage.lua
+++ b/Addons/DataToColor/Storage.lua
@@ -7,6 +7,20 @@ DataToColor.S.spellInRangeList = {}
 DataToColor.S.playerBuffs = {}
 DataToColor.S.targetDebuffs = {}
 
+DataToColor.S.Gossip = {
+    ["banker"] = 0,
+    ["battlemaster"] = 1,
+    ["binder"] = 2,
+    ["gossip"] = 3,
+    ["healer"] = 4,
+    ["petition"] = 5,
+    ["tabard"] = 6,
+    ["taxi"] = 7,
+    ["trainer"] = 8,
+    ["unlearn"] = 9,
+    ["vendor"] = 10,
+}
+
 function DataToColor:InitStorage()
     CreatePlayerClass()
     CreateSpellInRangeList()

--- a/Core/Addon/AddonReader.cs
+++ b/Core/Addon/AddonReader.cs
@@ -18,6 +18,9 @@ namespace Core
         public EquipmentReader equipmentReader { get; set; }
 
         public ActionBarCostReader ActionBarCostReader { get; set; }
+
+        public GossipReader GossipReader { get; set; }
+
         public LevelTracker LevelTracker { get; set; }
 
         public event EventHandler? AddonDataChanged;
@@ -50,8 +53,11 @@ namespace Core
 
             this.equipmentReader = new EquipmentReader(squareReader, 24, 25);
             this.BagReader = new BagReader(squareReader, itemDb, equipmentReader, 20, 21, 22, 23);
-            
+
             this.ActionBarCostReader = new ActionBarCostReader(squareReader, 36);
+
+            this.GossipReader = new GossipReader(squareReader, 37);
+
             this.PlayerReader = new PlayerReader(squareReader, creatureDb);
             this.LevelTracker = new LevelTracker(PlayerReader);
 
@@ -68,14 +74,12 @@ namespace Core
             if(seq == 0 || uiMapId != PlayerReader.UIMapId)
                 ZoneChanged?.Invoke(this, EventArgs.Empty);
 
-            // 20 - 29
             BagReader.Read();
-
-            // 30 - 31
             equipmentReader.Read();
 
-            // 44
             ActionBarCostReader.Read();
+
+            GossipReader.Read();
 
             LevelTracker.Update();
 

--- a/Core/BotController.cs
+++ b/Core/BotController.cs
@@ -261,7 +261,7 @@ namespace Core
 
             var blacklist = config.Mode != Mode.Grind ? new NoBlacklist() : (IBlacklist)new Blacklist(AddonReader.PlayerReader, config.NPCMaxLevels_Above, config.NPCMaxLevels_Below, config.CheckTargetGivesExp, config.Blacklist, logger);
 
-            var actionFactory = new GoalFactory(logger, AddonReader, ConfigurableInput, DataConfig, npcNameFinder, npcNameTargeting, pather, areaDb);
+            var actionFactory = new GoalFactory(logger, AddonReader, ConfigurableInput, DataConfig, npcNameFinder, npcNameTargeting, pather, areaDb, ExecGameCommand);
             var availableActions = actionFactory.CreateGoals(config, blacklist);
             RouteInfo = actionFactory.RouteInfo;
 

--- a/Core/Goals/GoalFactory.cs
+++ b/Core/Goals/GoalFactory.cs
@@ -24,9 +24,11 @@ namespace Core
 
         private readonly AreaDB areaDb;
 
+        private readonly ExecGameCommand exec;
+
         public RouteInfo? RouteInfo { get; private set; }
 
-        public GoalFactory(ILogger logger, AddonReader addonReader, ConfigurableInput input, DataConfig dataConfig, NpcNameFinder npcNameFinder, NpcNameTargeting npcNameTargeting, IPPather pather, AreaDB areaDb)
+        public GoalFactory(ILogger logger, AddonReader addonReader, ConfigurableInput input, DataConfig dataConfig, NpcNameFinder npcNameFinder, NpcNameTargeting npcNameTargeting, IPPather pather, AreaDB areaDb, ExecGameCommand execGameCommand)
         {
             this.logger = logger;
             this.addonReader = addonReader;
@@ -36,6 +38,7 @@ namespace Core
             this.npcNameTargeting = npcNameTargeting;
             this.pather = pather;
             this.areaDb = areaDb;
+            this.exec = execGameCommand;
         }
 
         public HashSet<GoapGoal> CreateGoals(ClassConfiguration classConfig, IBlacklist blacklist)
@@ -56,7 +59,7 @@ namespace Core
             var combatUtil = new CombatUtil(logger, input, wait, addonReader.PlayerReader);
             var mountHandler = new MountHandler(logger, input, classConfig, wait, addonReader.PlayerReader, stopMoving);
 
-            var targetFinder = new TargetFinder(logger, input, classConfig, wait, addonReader.PlayerReader, blacklist, npcNameFinder, npcNameTargeting);
+            var targetFinder = new TargetFinder(logger, input, classConfig, wait, addonReader.PlayerReader, blacklist, npcNameTargeting);
 
             var followRouteAction = new FollowRouteGoal(logger, input, wait, addonReader.PlayerReader, playerDirection, pathPoints, stopMoving, npcNameFinder, stuckDetector, classConfig, pather, mountHandler, targetFinder);
             var walkToCorpseAction = new WalkToCorpseGoal(logger, input, addonReader.PlayerReader, playerDirection, spiritPath, pathPoints, stopMoving, stuckDetector, pather);
@@ -131,7 +134,7 @@ namespace Core
 
                 foreach (var item in classConfig.NPC.Sequence)
                 {
-                    availableActions.Add(new AdhocNPCGoal(logger, input, addonReader.PlayerReader, playerDirection, stopMoving, npcNameTargeting, stuckDetector, classConfig, pather, item, blacklist, mountHandler));
+                    availableActions.Add(new AdhocNPCGoal(logger, input, addonReader.PlayerReader, playerDirection, stopMoving, npcNameTargeting, stuckDetector, classConfig, pather, item, blacklist, mountHandler, wait, exec, addonReader.GossipReader));
                     item.Path.AddRange(ReadPath(item.Name, item.PathFilename));
                 }
 

--- a/Core/Gossip/GossipReader.cs
+++ b/Core/Gossip/GossipReader.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Core
+{
+    public enum Gossip
+    {
+        Banker,
+        Battlemaster,
+        Binder,
+        Gossip,
+        Healer,
+        Petition,
+        Tabard,
+        Taxi,
+        Trainer,
+        Unlearn,
+        Vendor
+    }
+
+    public class GossipReader
+    {
+        private readonly int cGossip;
+
+        private readonly ISquareReader reader;
+
+        private DateTime lastEvent = DateTime.Now;
+
+        public int Count { private set; get; } = 0;
+        public Dictionary<Gossip, int> Gossips { get; private set; } = new Dictionary<Gossip, int>();
+
+        private int data;
+
+        public bool Ready => Gossips.Count == Count;
+
+        public bool MerchantWindowOpened => data == 9999999;
+
+        public bool MerchantWindowClosed => data == 9999998;
+
+        public GossipReader(ISquareReader reader, int cGossip)
+        {
+            this.reader = reader;
+            this.cGossip = cGossip;
+        }
+
+        public void Read()
+        {
+            data = (int)reader.GetLongAtCell(cGossip);
+
+            // used for merchant window open state
+            if (data == 9999999 || data == 9999998)
+                return;
+
+            if (data == 0)
+            {
+                Count = 0;
+                Gossips.Clear();
+                lastEvent = DateTime.Now;
+
+                return;
+            }
+
+            // formula
+            // 10000 * count + 100 * index + value
+            int count = (int)(data / 10000f);
+            data -= 10000 * count;
+
+            int order = (int)(data / 100f);
+            data -= 100 * order;
+
+            Count = count;
+
+            if (!Gossips.ContainsKey((Gossip)data))
+            {
+                Gossips.Add((Gossip)data, order);
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
Added support for obtaining the available Gossip options upon interacting with an NPC. Which opens up the possibility to handle other types of gossip options.

`AdhocNPCGoal`: incase the merchant option is gated behind a gossip option pick that and start the selling process.

On the other hand Addon is now picking the lowest key from the `stack` to have some order. It's required for the `GossipReader` to work properly.