### PR TITLE
Feature/primary secondary resource

### DIFF
--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -287,7 +287,7 @@ function DataToColor:CreateFrames(n)
             MakePixelSquareArrI(DataToColor:getManaMax(DataToColor.C.unitPlayer), 12) --10 Represents maximum amount of mana
             MakePixelSquareArrI(DataToColor:getManaCurrent(DataToColor.C.unitPlayer), 13) --11 Represents current amount of mana
             -- 14 unused
-            MakePixelSquareArrI(DataToColor:getRange(), 15) -- 15 Represents if target is within 0-5 5-15 15-20, 20-30, 30-35, or greater than 35 yards
+            -- 15 unused
 
             if DataToColor.targetChanged then
                 MakePixelSquareArrI(DataToColor:GetTargetName(0), 16) -- Characters 1-3 of target's name
@@ -399,7 +399,7 @@ function DataToColor:CreateFrames(n)
             MakePixelSquareArrI(DataToColor.S.PlayerClass, 46) -- Returns player class as an integer
             MakePixelSquareArrI(DataToColor:isUnskinnable(), 47) -- Returns 1 if creature is unskinnable
             MakePixelSquareArrI(DataToColor:shapeshiftForm(), 48) -- Shapeshift id https://wowwiki.fandom.com/wiki/API_GetShapeshiftForm
-            -- 49 not used
+            MakePixelSquareArrI(DataToColor:getRange(), 49) -- 15 Represents if target is within 0-5 5-15 15-20, 20-30, 30-35, or greater than 35 yards
 
             MakePixelSquareArrI(DataToColor:getUnitXP(DataToColor.C.unitPlayer), 50) -- Player Xp
             MakePixelSquareArrI(DataToColor:getUnitXPMax(DataToColor.C.unitPlayer), 51) -- Player Level Xp

--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -284,10 +284,12 @@ function DataToColor:CreateFrames(n)
             -- Start combat/NPC related variables --
             MakePixelSquareArrI(DataToColor:getHealthMax(DataToColor.C.unitPlayer), 10) --8 Represents maximum amount of health
             MakePixelSquareArrI(DataToColor:getHealthCurrent(DataToColor.C.unitPlayer), 11) --9 Represents current amount of health
-            MakePixelSquareArrI(DataToColor:getManaMax(DataToColor.C.unitPlayer), 12) --10 Represents maximum amount of mana
-            MakePixelSquareArrI(DataToColor:getManaCurrent(DataToColor.C.unitPlayer), 13) --11 Represents current amount of mana
-            -- 14 unused
-            -- 15 unused
+
+            MakePixelSquareArrI(DataToColor:getPowerTypeMax(DataToColor.C.unitPlayer, nil), 12) --10 Represents maximum amount of primary resource(dynamic)
+            MakePixelSquareArrI(DataToColor:getPowerTypeCurrent(DataToColor.C.unitPlayer, nil), 13) --11 Represents current amount of primary resource(dynamic)
+
+            MakePixelSquareArrI(DataToColor:getPowerTypeMax(DataToColor.C.unitPlayer, Enum.PowerType.Mana), 14) --10 Represents maximum amount of mana
+            MakePixelSquareArrI(DataToColor:getPowerTypeCurrent(DataToColor.C.unitPlayer, Enum.PowerType.Mana), 15) --11 Represents current amount of mana
 
             if DataToColor.targetChanged then
                 MakePixelSquareArrI(DataToColor:GetTargetName(0), 16) -- Characters 1-3 of target's name

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: An addon that displays player position as color
-## Version: 1.1.18
+## Version: 1.1.19
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibDataBroker-1.1, LibCompress, LibRangeCheck
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: An addon that displays player position as color
-## Version: 1.1.19
+## Version: 1.1.20
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibDataBroker-1.1, LibCompress, LibRangeCheck
 ## SavedVariables:

--- a/Addons/DataToColor/Query.lua
+++ b/Addons/DataToColor/Query.lua
@@ -119,13 +119,13 @@ function DataToColor:getHealthCurrent(unit)
 end
 
 -- Finds maximum amount of mana a character can store
-function DataToColor:getManaMax(unit)
-    return UnitPowerMax(unit)
+function DataToColor:getPowerTypeMax(unit, type)
+    return UnitPowerMax(unit, type)
 end
 
 -- Finds exact amount of mana player is storing
-function DataToColor:getManaCurrent(unit)
-    return UnitPower(unit)
+function DataToColor:getPowerTypeCurrent(unit, type)
+    return UnitPower(unit, type)
 end
 
 -- Finds player current level

--- a/BlazorServer/Pages/BotHeader.razor
+++ b/BlazorServer/Pages/BotHeader.razor
@@ -23,7 +23,7 @@
                 </td>
                 <td>@addonReader.BagReader.BagItems.Count / @addonReader.BagReader.SlotCount</td>
                 <td>@playerReader.HealthPercent %</td>
-                <td>@playerReader.ManaCurrent (@playerReader.ManaPercentage %) </td>
+                <td>@playerReader.PTCurrent (@playerReader.PTPercentage %) </td>
                 <td>
                     @if (!string.IsNullOrEmpty(playerReader.Target))
                     {

--- a/Core/Addon/PlayerReader.cs
+++ b/Core/Addon/PlayerReader.cs
@@ -58,11 +58,8 @@ namespace Core
         public long ManaCurrent => reader.GetLongAtCell(13); // Current amount of mana
         public long ManaPercentage => ManaMax == 0 ? 0 : (ManaCurrent * 100) / ManaMax; // Mana in terms of a percentage
 
-        public bool IsInMeleeRange => MinRange == 0 && MaxRange == 5;
-        public bool IsInDeadZone => MinRange >= 5 && PlayerBitValues.IsInDeadZoneRange;
-
-        public long MinRange => (long)(reader.GetLongAtCell(15) / 100000f);
-        public long MaxRange => (long)((reader.GetLongAtCell(15)-(MinRange*100000f)) / 100f);
+        // 14
+        // 15
 
         public string Target
         {
@@ -115,8 +112,13 @@ namespace Core
         public bool Unskinnable => reader.GetLongAtCell(47) != 0; // Returns 1 if creature is unskinnable
 
         public Stance Stance => new Stance(reader.GetLongAtCell(48));
+        public Form Form => Stance.Get(this, PlayerClass);
 
-        public Form Form => Stance.Get(PlayerClass);
+        public long MinRange => (long)(reader.GetLongAtCell(49) / 100000f);
+        public long MaxRange => (long)((reader.GetLongAtCell(49) - (MinRange * 100000f)) / 100f);
+
+        public bool IsInMeleeRange => MinRange == 0 && (PlayerClass == PlayerClassEnum.Druid && PlayerLevel >= 10 ? MaxRange == 2 : MaxRange == 5);
+        public bool IsInDeadZone => MinRange >= 5 && PlayerBitValues.IsInDeadZoneRange;
 
         public long PlayerXp => reader.GetLongAtCell(50);
         public long PlayerMaxXp => reader.GetLongAtCell(51);

--- a/Core/Addon/PlayerReader.cs
+++ b/Core/Addon/PlayerReader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Core.Database;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
@@ -54,12 +54,14 @@ namespace Core
         public long HealthCurrent => reader.GetLongAtCell(11); // Current amount of health of player
         public long HealthPercent => HealthMax == 0 || HealthCurrent == 1 ? 0 : (HealthCurrent * 100) / HealthMax; // Health in terms of a percentage
 
-        public long ManaMax => reader.GetLongAtCell(12); // Maximum amount of mana
-        public long ManaCurrent => reader.GetLongAtCell(13); // Current amount of mana
-        public long ManaPercentage => ManaMax == 0 ? 0 : (ManaCurrent * 100) / ManaMax; // Mana in terms of a percentage
+        public long PTMax => reader.GetLongAtCell(12); // Maximum amount of Power Type (dynamic)
+        public long PTCurrent => reader.GetLongAtCell(13); // Current amount of Power Type (dynamic)
+        public long PTPercentage => PTMax == 0 ? 0 : (PTCurrent * 100) / PTMax; // Power Type (dynamic) in terms of a percentage
 
-        // 14
-        // 15
+
+        public long ManaMax => reader.GetLongAtCell(14); // Maximum amount of mana
+        public long ManaCurrent => reader.GetLongAtCell(15); // Current amount of mana
+        public long ManaPercentage => ManaMax == 0 ? 0 : (ManaCurrent * 100) / ManaMax; // Mana in terms of a percentage
 
         public string Target
         {

--- a/Core/Requirement/RequirementFactory.cs
+++ b/Core/Requirement/RequirementFactory.cs
@@ -91,11 +91,22 @@ namespace Core
         {
             if (value > 0)
             {
-                RequirementObjects.Add(new Requirement
+                if( type == "Mana")
                 {
-                    HasRequirement = () => playerReader.ManaCurrent >= value,
-                    LogMessage = () => $"{type} {playerReader.ManaCurrent} >= {value}"
-                });
+                    RequirementObjects.Add(new Requirement
+                    {
+                        HasRequirement = () => playerReader.ManaCurrent >= value,
+                        LogMessage = () => $"{type} {playerReader.ManaCurrent} >= {value}"
+                    });
+                }
+                else
+                {
+                    RequirementObjects.Add(new Requirement
+                    {
+                        HasRequirement = () => playerReader.PTCurrent >= value,
+                        LogMessage = () => $"{type} {playerReader.PTCurrent} >= {value}"
+                    });
+                }
             }
         }
 


### PR DESCRIPTION
Separate the primary currently active Player power from the mana.

The primary currently active power changes based on the currently active from/shapeshift the player is in. However for druid its mandatory to keep track of the mana usage as well.