### PR TITLE
Instead of 'incombat' GoapKey use 'dangercombat'

### DIFF
--- a/Core/Goals/CorpseConsumed.cs
+++ b/Core/Goals/CorpseConsumed.cs
@@ -17,7 +17,7 @@ namespace Core.Goals
             this.logger = logger;
             this.goapAgentState = goapAgentSate;
 
-            AddPrecondition(GoapKey.incombat, false);
+            AddPrecondition(GoapKey.dangercombat, false);
             AddPrecondition(GoapKey.consumecorpse, true);
 
             AddEffect(GoapKey.consumecorpse, false);

--- a/Core/Goals/FollowRouteGoal.cs
+++ b/Core/Goals/FollowRouteGoal.cs
@@ -93,7 +93,7 @@ namespace Core.Goals
 
             if (classConfiguration.Mode != Mode.AttendedGather)
             {
-                AddPrecondition(GoapKey.incombat, false);
+                AddPrecondition(GoapKey.dangercombat, false);
                 AddPrecondition(GoapKey.producedcorpse, false);
                 AddPrecondition(GoapKey.consumecorpse, false);
             }

--- a/Core/Goals/LootGoal.cs
+++ b/Core/Goals/LootGoal.cs
@@ -45,6 +45,7 @@ namespace Core.Goals
 
         public virtual void AddPreconditions()
         {
+            AddPrecondition(GoapKey.dangercombat, false);
             AddPrecondition(GoapKey.shouldloot, true);
             AddEffect(GoapKey.shouldloot, false);
         }
@@ -59,7 +60,7 @@ namespace Core.Goals
                 SendActionEvent(new ActionEventArgs(GoapKey.shouldloot, false));
             }
 
-            Log($"Search for {NpcNames.Corpse}");
+            Log($"OnEnter: Search for {NpcNames.Corpse}");
             npcNameTargeting.ChangeNpcType(NpcNames.Corpse);
         }
 

--- a/Core/Goals/SkinningGoal.cs
+++ b/Core/Goals/SkinningGoal.cs
@@ -38,7 +38,7 @@ namespace Core.Goals
             this.npcNameTargeting = npcNameTargeting;
             this.combatUtil = combatUtil;
 
-            AddPrecondition(GoapKey.incombat, false);
+            AddPrecondition(GoapKey.dangercombat, false);
             AddPrecondition(GoapKey.shouldskin, true);
 
             AddEffect(GoapKey.shouldskin, false);
@@ -66,6 +66,7 @@ namespace Core.Goals
                 SendActionEvent(new ActionEventArgs(GoapKey.shouldskin, false));
             }
 
+            Log($"OnEnter: Search for {NpcNames.Corpse}");
             npcNameTargeting.ChangeNpcType(NpcNames.Corpse);
         }
 


### PR DESCRIPTION
After killing a multiple or single mob during combat don't wait for losing combat because depending on the server backend and the client-server communication this could take up a lot of time doing nothing.