### PR TITLE
Feature/addon/delay after reset

### DIFF
--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -20,6 +20,7 @@ local CELL_SPACING = 1 -- 0 or 1
 
 -- Item slot trackers initialization
 local globalCounter = 0
+local initPhase = 10
 
 -- How often item frames change
 local ITEM_ITERATION_FRAME_CHANGE_RATE = 5
@@ -41,7 +42,6 @@ DataToColor.globalTime = 0
 DataToColor.lastLoot = 0
 
 DataToColor.frames = nil
-DataToColor.r = 0
 
 DataToColor.uiErrorMessage = 0
 
@@ -236,6 +236,8 @@ function DataToColor:Reset()
     playerBuffCount = 0
     targetDebuffCount = 0
     targetBuffCount = 0
+
+    globalCounter = 0
 end
 
 function DataToColor:Update()
@@ -386,7 +388,11 @@ function DataToColor:CreateFrames(n)
             end
         end
 
-        if not SETUP_SEQUENCE then
+        function UpdateGlobalTime(slot)
+            MakePixelSquareArrI(DataToColor.globalTime, slot)
+        end
+
+        if not SETUP_SEQUENCE and globalCounter >= initPhase then
 
             DataToColor.playerGUID = UnitGUID(DataToColor.C.unitPlayer)
             DataToColor.petGUID = UnitGUID(DataToColor.C.unitPet)
@@ -488,6 +494,9 @@ function DataToColor:CreateFrames(n)
                     MakePixelSquareArrI(equipmentSlot, 24)
                     MakePixelSquareArrI(DataToColor:equipSlotItemId(equipmentSlot), 25)
                     --DataToColor:Print("equipmentQueue "..equipmentSlot.." -> "..itemId)
+                else
+                    MakePixelSquareArrI(0, 24)
+                    MakePixelSquareArrI(0, 25)
                 end
             end
 
@@ -508,6 +517,8 @@ function DataToColor:CreateFrames(n)
                 actionCostNum = DataToColor.stack:pop(DataToColor.actionBarCostQueue)
                 if actionCostNum then
                     MakePixelSquareArrI(DataToColor:actionbarCost(actionCostNum), 36)
+                else
+                    MakePixelSquareArrI(0, 36)
                 end
 
                 actionCooldownKey, actionCooldownValue = DataToColor.struct:get(DataToColor.actionBarCooldownQueue)
@@ -598,6 +609,8 @@ function DataToColor:CreateFrames(n)
                 spellId = DataToColor.stack:pop(DataToColor.spellBookQueue)
                 if spellId then
                     MakePixelSquareArrI(spellId, 71)
+                else
+                    MakePixelSquareArrI(0, 71)
                 end
             end
 
@@ -605,6 +618,8 @@ function DataToColor:CreateFrames(n)
                 talentNum = DataToColor.stack:pop(DataToColor.talentQueue)
                 if talentNum then
                     MakePixelSquareArrI(talentNum, 72)
+                else
+                    MakePixelSquareArrI(0, 72)
                 end
             end
 
@@ -619,16 +634,21 @@ function DataToColor:CreateFrames(n)
 
             -- Timers
             MakePixelSquareArrI(DataToColor.lastLoot, 97)
-            MakePixelSquareArrI(DataToColor.globalTime, 98)
-
+            UpdateGlobalTime(98)
             -- 99 Reserved
-            globalCounter = globalCounter + 1
 
             DataToColor:ConsumeChanges()
 
             DataToColor:HandlePlayerInteractionEvents()
 
             DataToColor:Update()
+        elseif not SETUP_SEQUENCE then
+            if globalCounter < initPhase then
+                for i = 1, NUMBER_OF_FRAMES - 1 do
+                    MakePixelSquareArrI(0, i)
+                end
+            end
+            UpdateGlobalTime(98)
         end
 
         if SETUP_SEQUENCE then
@@ -639,6 +659,8 @@ function DataToColor:CreateFrames(n)
                 MakePixelSquareArrI(i, i)
             end
         end
+
+        globalCounter = globalCounter + 1
     end
     -- Function used to generate a single frame
     local function setFramePixelBackdrop(f)

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors
-## Version: 1.1.41
+## Version: 1.1.42
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck
 ## SavedVariables:

--- a/Core/Actionbar/ActionBarCostReader.cs
+++ b/Core/Actionbar/ActionBarCostReader.cs
@@ -47,6 +47,7 @@ namespace Core
             // formula
             // MAX_POWER_TYPE * type + MAX_ACTION_IDX * slot + cost
             int data = reader.GetIntAtCell(cActionbarNum);
+            if (data == 0) return;
 
             int type = (int)(data / MAX_POWER_TYPE);
             data -= (int)MAX_POWER_TYPE * type;

--- a/Core/Addon/EquipmentReader.cs
+++ b/Core/Addon/EquipmentReader.cs
@@ -53,7 +53,9 @@ namespace Core
             int index = reader.GetIntAtCell(cSlotNum);
             if (index < MAX_EQUIPMENT_COUNT && index >= 0)
             {
-                equipment[index] = reader.GetIntAtCell(cItemId);
+                int itemId = reader.GetIntAtCell(cItemId);
+                if(itemId > 0)
+                    equipment[index] = itemId;
             }
         }
 

--- a/Core/Addon/SpellBookReader.cs
+++ b/Core/Addon/SpellBookReader.cs
@@ -23,6 +23,7 @@ namespace Core
         public void Read()
         {
             int spellId = reader.GetIntAtCell(cSpellId);
+            if (spellId == 0) return;
             if (!Spells.ContainsKey(spellId) && SpellDB.Spells.TryGetValue(spellId, out Spell spell))
             {
                 Spells.Add(spellId, spell);

--- a/Core/Bag/BagReader.cs
+++ b/Core/Bag/BagReader.cs
@@ -126,13 +126,13 @@ namespace Core
 
                 if (addItem)
                 {
-                    var item = new Item { Name = "Unknown" };
                     if (itemDb.Items.ContainsKey(itemId))
                     {
+                        var item = new Item { Name = "Unknown" };
                         item = itemDb.Items[itemId];
+                        BagItems.Add(new BagItem(bag, slot, itemId, itemCount, item, isSoulbound));
+                        hasChanged = true;
                     }
-                    BagItems.Add(new BagItem(bag, slot, itemId, itemCount, item, isSoulbound));
-                    hasChanged = true;
                 }
             }
             else


### PR DESCRIPTION
Goal: Introduce an `init phase` in the addon in order to **preserve all** the cells. During `init phase` all the cells are `0/black/empty` except the `GlobalTime` cell. This way can avoid leaking state from other characters after login. Regarding this, there was an issue when the early values from the addon got discarded at the backend after login / `/reload` / Init State button press.

Upon addon queue is empty, now its going to show black cell instead of keeping the previously set value. At the backend some readers are checking if the cell is `0/empty/full black` that case don't even try to process the cell value.

Whenever a `BagReader` can't find an item in the database just won't register at the backend. This should give more precise `Bag Full` condition.