### PR TITLE
Addon Fix: UnitCastingInfo and UnitChannelInfo different classic to tbcc

### DIFF
--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors
-## Version: 1.1.45
+## Version: 1.1.46
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck
 ## SavedVariables:

--- a/Addons/DataToColor/Query.lua
+++ b/Addons/DataToColor/Query.lua
@@ -116,7 +116,16 @@ function DataToColor:GetTargetName(partition)
 end
 
 function DataToColor:CastingInfoSpellId(unitId)
-    local _, _, _, _, startTime, _, _, spellID = UnitCastingInfo(unitId)
+
+    local startTime = nil
+    local spellID = nil
+
+    if DataToColor.C.IsClassic_BCC then
+        _, _, _, _, startTime, _, _, spellID = UnitCastingInfo(unitId)
+    elseif DataToColor.C.IsClassic then
+        _, _, _, _, startTime, _, _, _, spellID = UnitCastingInfo(unitId)
+    end
+
     if spellID ~= nil then
         if unitId == DataToColor.C.unitPlayer and startTime ~= DataToColor.lastCastStartTime then
             DataToColor.lastCastStartTime = startTime
@@ -124,7 +133,13 @@ function DataToColor:CastingInfoSpellId(unitId)
         end
         return spellID
     end
-    _, _, _, startTime, _, _, spellID = UnitChannelInfo(unitId)
+
+    if DataToColor.C.IsClassic_BCC then
+        _, _, _, startTime, _, _, spellID = UnitChannelInfo(unitId)
+    elseif DataToColor.C.IsClassic then
+        _, _, _, startTime, _, _, _, spellID = UnitChannelInfo(unitId)
+    end
+
     if spellID ~= nil then
         if unitId == DataToColor.C.unitPlayer and startTime ~= DataToColor.lastCastStartTime then
             DataToColor.lastCastStartTime = startTime


### PR DESCRIPTION
Goal: `UnitCastingInfo` and `UnitChannelInfo` used different version of the API. Missing `Interruptable` flag.