### PR TITLE
Fix: Damage taken guid was unable to expire due `LastEvent` kept renewing

### DIFF
--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -28,10 +28,12 @@ local ITEM_ITERATION_FRAME_CHANGE_RATE = 5
 local ACTION_BAR_ITERATION_FRAME_CHANGE_RATE = 5
 -- How often the gossip frames change
 local GOSSIP_ITERATION_FRAME_CHANGE_RATE = 5
--- How ofthen the spellbook frames change
+-- How often the spellbook frames change
 local SPELLBOOK_ITERATION_FRAME_CHANGE_RATE = 5
--- How ofthen the spellbook frames change
+-- How often the spellbook frames change
 local TALENT_ITERATION_FRAME_CHANGE_RATE = 5
+-- How often the spellbook frames change
+local COMBAT_LOG_ITERATION_FRAME_CHANGE_RATE = 5
 
 -- Action bar configuration for which spells are tracked
 local MAX_ACTIONBAR_SLOT = 108
@@ -45,7 +47,6 @@ DataToColor.frames = nil
 
 DataToColor.uiErrorMessage = 0
 
-DataToColor.lastCombatDamageTakenCreature = 0
 DataToColor.lastCombatDamageDoneCreature = 0
 DataToColor.lastCombatCreature = 0
 DataToColor.lastCombatCreatureDied = 0
@@ -135,6 +136,7 @@ DataToColor.actionBarCostQueue = {}
 DataToColor.actionBarCooldownQueue = {}
 DataToColor.spellBookQueue = {}
 DataToColor.talentQueue = {}
+DataToColor.CombatDamageTakenQueue = {}
 
 local equipmentSlot = nil
 local bagNum = nil
@@ -219,7 +221,6 @@ function DataToColor:Reset()
     DataToColor.lastLoot = 0
     DataToColor.uiErrorMessage = 0
 
-    DataToColor.lastCombatDamageTakenCreature = 0
     DataToColor.lastCombatDamageDoneCreature = 0
     DataToColor.lastCombatCreature = 0
     DataToColor.lastCombatCreatureDied = 0
@@ -604,7 +605,11 @@ function DataToColor:CreateFrames(n)
 
             MakePixelSquareArrI(DataToColor.lastCombatCreature, 64) -- Combat message creature
             MakePixelSquareArrI(DataToColor.lastCombatDamageDoneCreature, 65) -- Last Combat damage done
-            MakePixelSquareArrI(DataToColor.lastCombatDamageTakenCreature, 66) -- Last Combat Damage taken
+
+            if DataToColor:Modulo(globalCounter, COMBAT_LOG_ITERATION_FRAME_CHANGE_RATE) == 0 then
+                MakePixelSquareArrI(DataToColor.stack:pop(DataToColor.CombatDamageTakenQueue) or 0, 66) -- Last Combat Damage taken
+            end
+
             MakePixelSquareArrI(DataToColor.lastCombatCreatureDied, 67) -- Last Killed Unit
 
             MakePixelSquareArrI(DataToColor:getGuid(DataToColor.C.unitPet), 68) -- pet guid

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors
-## Version: 1.1.46
+## Version: 1.1.47
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck
 ## SavedVariables:

--- a/Addons/DataToColor/EventHandlers.lua
+++ b/Addons/DataToColor/EventHandlers.lua
@@ -137,7 +137,7 @@ function DataToColor:OnCombatEvent(...)
     end
 
     if string.find(sourceGUID, "Creature") and (destGUID == DataToColor.playerGUID or destGUID == DataToColor.petGUID) then
-        DataToColor.lastCombatDamageTakenCreature = DataToColor:getGuidFromUUID(sourceGUID);
+        DataToColor.stack:push(DataToColor.CombatDamageTakenQueue, DataToColor:getGuidFromUUID(sourceGUID))
     end
 
     if sourceGUID == DataToColor.playerGUID then

--- a/Core/AddonComponent/CreatureHistory.cs
+++ b/Core/AddonComponent/CreatureHistory.cs
@@ -102,30 +102,29 @@ namespace Core
 
         private static void Update(int creatureId, float healthPercent, List<CreatureRecord> CombatCreatures)
         {
-            if (creatureId > 0)
+            if (creatureId <= 0) return;
+
+            int index = CombatCreatures.FindIndex(c => c.Guid == creatureId);
+            if (index > -1)
             {
-                int index = CombatCreatures.FindIndex(c => c.Guid == creatureId);
-                if (index > -1)
+                if (healthPercent < CombatCreatures[index].HealthPercent)
                 {
                     CreatureRecord creature = CombatCreatures[index];
 
-                    if (creature.HealthPercent > healthPercent)
-                    {
-                        creature.HealthPercent = healthPercent;
-                    }
+                    creature.HealthPercent = healthPercent;
                     creature.LastEvent = DateTime.Now;
 
                     CombatCreatures[index] = creature;
                 }
-                else
+            }
+            else
+            {
+                CombatCreatures.Add(new CreatureRecord
                 {
-                    CombatCreatures.Add(new CreatureRecord
-                    {
-                        Guid = creatureId,
-                        HealthPercent = healthPercent,
-                        LastEvent = DateTime.Now
-                    });
-                }
+                    Guid = creatureId,
+                    HealthPercent = healthPercent,
+                    LastEvent = DateTime.Now
+                });
             }
         }
 


### PR DESCRIPTION
Bump Addon version to `1.1.47`