### PR TITLE
Feature: Expose `TargetTargetEnum`

### DIFF
--- a/Core/Requirement/RequirementFactory.cs
+++ b/Core/Requirement/RequirementFactory.cs
@@ -70,6 +70,9 @@ namespace Core
             {
                 // Target Based
                 { "TargetYieldXP", () => playerReader.TargetYieldXP },
+                { "TargetsMe", () => playerReader.TargetTarget == TargetTargetEnum.TargetIsTargettingMe },
+                { "TargetsPet", () => playerReader.TargetTarget == TargetTargetEnum.TargetIsTargettingPet },
+                { "TargetsNone", () => playerReader.TargetTarget == TargetTargetEnum.TargetHasNoTarget },
 
                 // Range
                 { "InMeleeRange", ()=> playerReader.IsInMeleeRange },

--- a/Json/class/Warlock_10.json
+++ b/Json/class/Warlock_10.json
@@ -64,7 +64,10 @@
         "Name": "Shadow Bolt",
         "Key": "2",
         "HasCastBar": true,
-        "Requirement": "TargetHealth% > DOT_MIN_HEALTH%",
+        "Requirements": [
+          "TargetHealth% > DOT_MIN_HEALTH%",
+          "!TargetsMe"
+        ],
         "MinMana": 25,
         "Cooldown": 8000
       },

--- a/Json/class/Warlock_20.json
+++ b/Json/class/Warlock_20.json
@@ -61,7 +61,8 @@
         "Key": "5",
         "Requirements": [
           "TargetHealth% > DOT_MIN_HEALTH%",
-          "!Immolate"
+          "!Immolate",
+          "!TargetsMe"
         ],
         "HasCastBar": true,
         "ResetOnNewTarget": true,
@@ -94,7 +95,10 @@
         "HasCastBar": true,
         "ResetOnNewTarget": true,
         "MinMana": 110,
-        "Requirement": "TargetHealth% > DOT_MIN_HEALTH%",
+        "Requirements": [
+          "TargetHealth% > DOT_MIN_HEALTH%",
+          "!TargetsMe"
+        ],
         "Cooldown": 8000
       },
       {

--- a/Json/class/Warlock_20_shard_farm.json
+++ b/Json/class/Warlock_20_shard_farm.json
@@ -58,7 +58,8 @@
         "Key": "5",
         "Requirements": [
           "TargetHealth% > DOT_MIN_HEALTH%",
-          "!Immolate"
+          "!Immolate",
+          "!TargetsMe"
         ],
         "HasCastBar": true,
         "ResetOnNewTarget": true,
@@ -95,7 +96,10 @@
         "HasCastBar": true,
         "ResetOnNewTarget": true,
         "MinMana": 110,
-        "Requirement": "TargetHealth% > DOT_MIN_HEALTH%",
+        "Requirements": [
+          "TargetHealth% > DOT_MIN_HEALTH%",
+          "!TargetsMe"
+        ],
         "Cooldown": 8000
       },
       {

--- a/Json/class/Warlock_26_Immunity.json
+++ b/Json/class/Warlock_26_Immunity.json
@@ -70,7 +70,7 @@
         "Requirements": [
           "TargetHealth% > DOT_MIN_HEALTH%",
           "!Immolate",
-          "!InMeleeRange"
+          "!TargetsMe"
         ],
         "ResetOnNewTarget": true,
         "MinMana": 90,
@@ -107,7 +107,7 @@
         "MinMana": 110,
         "Requirements": [
           "TargetHealth% > DOT_MIN_HEALTH%",
-          "!InMeleeRange"
+          "!TargetsMe"
         ],
         "School": "Shadow",
         "Cooldown": 8000

--- a/README.md
+++ b/README.md
@@ -937,6 +937,9 @@ Allow requirements about what buffs/debuffs you have or the target has or in gen
 | General boolean condition | Desciption |
 | --- | --- |
 | `"TargetYieldXP"` | The target yields experience upon death. (Grey Level) |
+| `"TargetsMe"` | The target currently targets the player |
+| `"TargetsPet"` | The target currently targets the player's pet |
+| `"TargetsNone"` | The target currently has not target |
 | `"TargetCastingSpell"` | Target casts any spell |
 | `"Swimming"` | The player is currently swimming. |
 | `"Falling"` | The player is currently falling down, not touching the ground. |


### PR DESCRIPTION
* Added `TargetsMe` condition
* Added `TargetsPet` condition
* Added `TargetsNone` condition
* Demonstrate `Targets*` condition in Warlock profiles. Only use `Shadow Bolt` when somebody else tanking the target.