### PR TITLE
Fix: TargetPetTarget goal use `dangercombat` key instead of pure `incombat`. 

### DIFF
--- a/Core/Goals/TargetPetTarget.cs
+++ b/Core/Goals/TargetPetTarget.cs
@@ -16,7 +16,7 @@ namespace Core.Goals
             this.input = input;
             this.playerReader = playerReader;
 
-            AddPrecondition(GoapKey.incombat, true);
+            AddPrecondition(GoapKey.dangercombat, true);
             AddPrecondition(GoapKey.hastarget, false);
             AddPrecondition(GoapKey.pethastarget, true);
 


### PR DESCRIPTION
### Fix
* `TargetPetTarget`: Gives much better result. Increase the chance to loot the corpse. Only triggers if multiple enemies appears in the combat.