### PR TITLE
Fix: Druid moonfire pull + typo

### DIFF
--- a/Json/class/Druid_20_cat_bear.json
+++ b/Json/class/Druid_20_cat_bear.json
@@ -40,7 +40,7 @@
         "Key": "5",
         "AfterCastWaitBuff": true,
         "CastIfAddsVisible": true,
-        "Requirements": ["SpellInRange:0", "not InMeleeRange", "not Moonfire", "Mana%>40"],
+        "Requirements": ["SpellInRange:0", "MinRange > 10", "not Moonfire", "Mana%>40"],
         "StopBeforeCast": true,
         "Form": "None"
       },

--- a/Json/class/Druid_24_cat_bear.json
+++ b/Json/class/Druid_24_cat_bear.json
@@ -50,7 +50,7 @@
         "CastIfAddsVisible": true,
         "StopBeforeCast": true,
         "AfterCastWaitBuff": true,
-        "Requirements": ["SpellInRange:0", "not InMeleeRange", "not Moonfire"],
+        "Requirements": ["SpellInRange:0", "MinRange > 10", "not Moonfire"],
         "Cooldown": 10000,
         "Form": "None"
       },

--- a/Json/class/Druid_30_cat_bear.json
+++ b/Json/class/Druid_30_cat_bear.json
@@ -3,7 +3,7 @@
   "Loot": true,
   "PathFilename": "24-30 Duskwood wolf ravager.json",
   "PathReduceSteps": true,
-  "PathThere/obtainerflushAndBack": false,
+  "PathThereAndBack": false,
   "CheckTargetGivesExp": true,
   "Form": [
     {
@@ -57,7 +57,7 @@
         "CastIfAddsVisible": true,
         "StopBeforeCast": true,
         "AfterCastWaitBuff": true,
-        "Requirements": ["SpellInRange:0", "!InMeleeRange", "!Moonfire"],
+        "Requirements": ["SpellInRange:0", "MinRange > 10", "!Moonfire"],
         "Cooldown": 10000,
         "Form": "None"
       },


### PR DESCRIPTION
### Fix
* Fixed an issue with moonfire pull while closing the gap from the target in the very last moment shifts out from cat and does a moonfire.
* Fixed a typo in `Json/class/Druid_30_cat_bear.json`