### PR TITLE
Fix: `UnitCastingInfo` and `UnitChannelInfo` for _classic_. Also for _classic_era_

### DIFF
--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors
-## Version: 1.1.51
+## Version: 1.1.52
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/Versions.lua
+++ b/Addons/DataToColor/Versions.lua
@@ -18,7 +18,9 @@ if DataToColor.IsClassic() then
   LibClassicCasterino = _G.LibStub("LibClassicCasterino")
 end
 
-if DataToColor.IsRetail() then
+local TBC253 = DataToColor.IsClassic_BCC() and select(4, GetBuildInfo()) >= 20503
+
+if DataToColor.IsRetail() or TBC253 then
     DataToColor.UnitCastingInfo = UnitCastingInfo
   elseif DataToColor.IsClassic_BCC() then
     DataToColor.UnitCastingInfo = function(unit)
@@ -28,7 +30,7 @@ if DataToColor.IsRetail() then
   else
     DataToColor.UnitCastingInfo = function(unit)
       if UnitIsUnit(unit, DataToColor.C.unitPlayer) then
-        return CastingInfo()
+        return UnitCastingInfo("player")
       else
         return LibClassicCasterino:UnitCastingInfo(unit)
       end
@@ -45,7 +47,7 @@ if DataToColor.IsRetail() then
   else
     DataToColor.UnitChannelInfo = function(unit)
       if UnitIsUnit(unit, DataToColor.C.unitPlayer) then
-        return ChannelInfo()
+        return UnitChannelInfo("player")
       else
         return LibClassicCasterino:UnitChannelInfo(unit)
       end


### PR DESCRIPTION
Tested on: 
* Classic TBC 2.5.3.41812
* Classic Era 1.14.2.41858