### PR TITLE
Upgrade: every poject to `dotnet6.0`

### DIFF
--- a/AddonConfig/AddonConfig.csproj
+++ b/AddonConfig/AddonConfig.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
 

--- a/Game/Input/InputWindowsNative.cs
+++ b/Game/Input/InputWindowsNative.cs
@@ -36,34 +36,34 @@ namespace Game
 
         public void KeyDown(int key)
         {
-            NativeMethods.PostMessage(process.MainWindowHandle, NativeMethods.WM_KEYDOWN, (int)key, 0);
+            NativeMethods.PostMessage(process.MainWindowHandle, NativeMethods.WM_KEYDOWN, key, 0);
         }
 
         public void KeyUp(int key)
         {
-            NativeMethods.PostMessage(process.MainWindowHandle, NativeMethods.WM_KEYUP, (int)key, 0);
+            NativeMethods.PostMessage(process.MainWindowHandle, NativeMethods.WM_KEYUP, key, 0);
         }
 
         public async ValueTask<int> KeyPress(int key, int milliseconds)
         {
-            NativeMethods.PostMessage(process.MainWindowHandle, NativeMethods.WM_KEYDOWN, (int)key, 0);
+            NativeMethods.PostMessage(process.MainWindowHandle, NativeMethods.WM_KEYDOWN, key, 0);
             int delay = await Delay(milliseconds);
-            NativeMethods.PostMessage(process.MainWindowHandle, NativeMethods.WM_KEYUP, (int)key, 0);
+            NativeMethods.PostMessage(process.MainWindowHandle, NativeMethods.WM_KEYUP, key, 0);
             return delay;
         }
 
         public async ValueTask KeyPressNoDelay(int key, int milliseconds)
         {
-            NativeMethods.PostMessage(process.MainWindowHandle, NativeMethods.WM_KEYDOWN, (int)key, 0);
+            NativeMethods.PostMessage(process.MainWindowHandle, NativeMethods.WM_KEYDOWN, key, 0);
             await Task.Delay(milliseconds);
-            NativeMethods.PostMessage(process.MainWindowHandle, NativeMethods.WM_KEYUP, (int)key, 0);
+            NativeMethods.PostMessage(process.MainWindowHandle, NativeMethods.WM_KEYUP, key, 0);
         }
 
         public void KeyPressSleep(int key, int milliseconds)
         {
-            NativeMethods.PostMessage(process.MainWindowHandle, NativeMethods.WM_KEYDOWN, (int)key, 0);
+            NativeMethods.PostMessage(process.MainWindowHandle, NativeMethods.WM_KEYDOWN, key, 0);
             Thread.Sleep(milliseconds);
-            NativeMethods.PostMessage(process.MainWindowHandle, NativeMethods.WM_KEYUP, (int)key, 0);
+            NativeMethods.PostMessage(process.MainWindowHandle, NativeMethods.WM_KEYUP, key, 0);
         }
 
         public async ValueTask LeftClickMouse(Point p)

--- a/MasterOfPuppets.sln
+++ b/MasterOfPuppets.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29728.190
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32112.339
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Core", "Core\Core.csproj", "{277C93F8-DF2B-49B8-8A1C-1A64EB347B90}"
 EndProject
@@ -52,7 +52,6 @@ Global
 		{1FCAB55D-8AA5-4E68-9502-6C27D9BEF252}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1FCAB55D-8AA5-4E68-9502-6C27D9BEF252}.Release|Any CPU.Build.0 = Release|Any CPU
 		{36189519-32D6-4650-87CC-A525D99A0363}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{36189519-32D6-4650-87CC-A525D99A0363}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{36189519-32D6-4650-87CC-A525D99A0363}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{841D6DAD-AB21-47CF-98C2-F1DE3CABF59A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{841D6DAD-AB21-47CF-98C2-F1DE3CABF59A}.Debug|Any CPU.Build.0 = Debug|Any CPU
@@ -83,7 +82,6 @@ Global
 		{2DD51B2A-AA1A-493C-9370-72B52B74E350}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2DD51B2A-AA1A-493C-9370-72B52B74E350}.Release|Any CPU.Build.0 = Release|Any CPU
 		{8F340D60-AF40-4000-B7B6-98507A9C95A3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{8F340D60-AF40-4000-B7B6-98507A9C95A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8F340D60-AF40-4000-B7B6-98507A9C95A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution

--- a/SharedLib/Data/Creature.cs
+++ b/SharedLib/Data/Creature.cs
@@ -1,8 +1,8 @@
 ﻿namespace SharedLib
 {
-    public struct Creature
+    public readonly struct Creature
     {
-        public int Entry { get; set; }
-        public string Name { get; set; }
+        public int Entry { get; init; }
+        public string Name { get; init; }
     }
 }

--- a/SharedLib/Data/EntityId.cs
+++ b/SharedLib/Data/EntityId.cs
@@ -1,7 +1,7 @@
 ﻿namespace SharedLib
 {
-    public struct EntityId
+    public readonly struct EntityId
     {
-        public int Id { get; set; }
+        public int Id { get; init; }
     }
 }

--- a/SharedLib/Data/Item.cs
+++ b/SharedLib/Data/Item.cs
@@ -2,12 +2,12 @@
 
 namespace SharedLib
 {
-    public struct Item
+    public readonly struct Item
     {
-        public int Entry { get; set; }
-        public string Name { get; set; }
-        public int Quality { get; set; }
-        public int SellPrice { get; set; }
+        public int Entry { get; init; }
+        public string Name { get; init; }
+        public int Quality { get; init; }
+        public int SellPrice { get; init; }
 
         public static int[] ToSellPrice(int sellPrice)
         {

--- a/SharedLib/Data/Spell.cs
+++ b/SharedLib/Data/Spell.cs
@@ -1,11 +1,9 @@
 ﻿namespace SharedLib
 {
-#pragma warning disable CA1815 // Override equals and operator equals on value types
-    public struct Spell
-#pragma warning restore CA1815 // Override equals and operator equals on value types
+    public readonly struct Spell
     {
-        public int Id { set; get; }
-        public string Name { set; get; }
-        public int Level { set; get; }
+        public int Id { get; init; }
+        public string Name { get; init; }
+        public int Level { get; init; }
     }
 }

--- a/SharedLib/Data/TalentTab.cs
+++ b/SharedLib/Data/TalentTab.cs
@@ -1,12 +1,10 @@
 ﻿namespace SharedLib
 {
-#pragma warning disable CA1815 // Override equals and operator equals on value types
-    public struct TalentTab
-#pragma warning restore CA1815 // Override equals and operator equals on value types
+    public readonly struct TalentTab
     {
-        public int Id { set; get; }
-        public string Name { set; get; }
-        public string BackgroundFile { set; get; }
-        public int OrderIndex { set; get; }
+        public int Id { get; init; }
+        public string Name { get; init; }
+        public string BackgroundFile { get; init; }
+        public int OrderIndex { get; init; }
     }
 }

--- a/SharedLib/Data/TalentTreeElement.cs
+++ b/SharedLib/Data/TalentTreeElement.cs
@@ -2,13 +2,11 @@
 
 namespace SharedLib
 {
-#pragma warning disable CA1815 // Override equals and operator equals on value types
-    public struct TalentTreeElement
-#pragma warning restore CA1815 // Override equals and operator equals on value types
+    public readonly struct TalentTreeElement
     {
-        public int TierID { set; get; }
-        public int ColumnIndex { set; get; }
-        public int TabID { set; get; }
-        public List<int> SpellIds { set; get; }
+        public int TierID { get; init; }
+        public int ColumnIndex { get; init; }
+        public int TabID { get; init; }
+        public List<int> SpellIds { get; init; }
     }
 }

--- a/SharedLib/Data/WorldMapArea.cs
+++ b/SharedLib/Data/WorldMapArea.cs
@@ -1,16 +1,16 @@
 ﻿namespace SharedLib
 {
-    public struct WorldMapArea
+    public readonly struct WorldMapArea
     {
-        public int MapID { get; set; }
-        public int AreaID { get; set; }
-        public string AreaName { get; set; }
-        public float LocLeft { get; set; }
-        public float LocRight { get; set; }
-        public float LocTop { get; set; }
-        public float LocBottom { get; set; }
-        public int UIMapId { get; set; }
-        public string Continent { get; set; }
+        public int MapID { get; init; }
+        public int AreaID { get; init; }
+        public string AreaName { get; init; }
+        public float LocLeft { get; init; }
+        public float LocRight { get; init; }
+        public float LocTop { get; init; }
+        public float LocBottom { get; init; }
+        public int UIMapId { get; init; }
+        public string Continent { get; init; }
 
 
         public float ToWorldX(float value)

--- a/Utilities/ImageFilter/ImageFilter/ImageFilter.csproj
+++ b/Utilities/ImageFilter/ImageFilter/ImageFilter.csproj
@@ -2,15 +2,15 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
-    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
+    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Utilities/ImageFilter/ImageFilter/MainWindow.xaml.cs
+++ b/Utilities/ImageFilter/ImageFilter/MainWindow.xaml.cs
@@ -122,7 +122,7 @@ namespace ImageFilter
         }
 
 
-        public BitmapImage ToBitmapImage(Bitmap Bitmap)
+        public static BitmapImage ToBitmapImage(Bitmap Bitmap)
         {
             using (var memory = new MemoryStream())
             {
@@ -144,7 +144,7 @@ namespace ImageFilter
 
         #region Cursor Input 
 
-        public void SetCursorPosition(System.Drawing.Point position)
+        public static void SetCursorPosition(System.Drawing.Point position)
         {
             //SetCursorPos(position.X, position.Y);
         }

--- a/Utilities/PathMaker/PathMaker/PathMaker.csproj
+++ b/Utilities/PathMaker/PathMaker/PathMaker.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Utilities/ReadDBC_CSV/ConsumablesExtractor.cs
+++ b/Utilities/ReadDBC_CSV/ConsumablesExtractor.cs
@@ -48,7 +48,7 @@ namespace ReadDBC_CSV
             File.WriteAllText(Path.Join(path, "waters.json"), JsonConvert.SerializeObject(waterIds));
         }
 
-        private List<EntityId> ExtractSpells(string path, string descLang)
+        private static List<EntityId> ExtractSpells(string path, string descLang)
         {
             int entryIndex = -1;
             int descIndex = -1;
@@ -79,7 +79,7 @@ namespace ReadDBC_CSV
             return items;
         }
 
-        private List<EntityId> ExtractItem(string path, List<EntityId> spells)
+        private static List<EntityId> ExtractItem(string path, List<EntityId> spells)
         {
             int entryIndex = -1;
             int spellIdIndex = -1;

--- a/Utilities/ReadDBC_CSV/Extractor/CSVExtractor.cs
+++ b/Utilities/ReadDBC_CSV/Extractor/CSVExtractor.cs
@@ -41,7 +41,7 @@ namespace ReadDBC_CSV
             throw new ArgumentOutOfRangeException(v);
         }
 
-        public string[] SplitQuotes(string csvText)
+        public static string[] SplitQuotes(string csvText)
         {
             List<string> tokens = new List<string>();
 

--- a/Utilities/ReadDBC_CSV/ItemExtractor.cs
+++ b/Utilities/ReadDBC_CSV/ItemExtractor.cs
@@ -31,7 +31,7 @@ namespace ReadDBC_CSV
 
         }
 
-        private List<Item> ExtractItems(string path)
+        private static List<Item> ExtractItems(string path)
         {
             int idIndex = -1;
             int nameIndex = -1;
@@ -51,8 +51,8 @@ namespace ReadDBC_CSV
             Action<string> extractLine = line =>
             {
                 string[] values = line.Split(",");
-                if (line.Contains("\""))
-                    values = extractor.SplitQuotes(line);
+                if (line.Contains('\"'))
+                    values = CSVExtractor.SplitQuotes(line);
                 else
                     values = line.Split(",");
 

--- a/Utilities/ReadDBC_CSV/ReadDBC_CSV.csproj
+++ b/Utilities/ReadDBC_CSV/ReadDBC_CSV.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <Reference Include="SharedLib">
-      <HintPath>..\..\SharedLib\bin\Debug\netstandard2.1\SharedLib.dll</HintPath>
+      <HintPath>..\..\SharedLib\bin\Debug\net6.0\SharedLib.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/Utilities/ReadDBC_CSV/SpellExtractor.cs
+++ b/Utilities/ReadDBC_CSV/SpellExtractor.cs
@@ -34,7 +34,7 @@ namespace ReadDBC_CSV
             File.WriteAllText(Path.Join(path, "spells.json"), JsonConvert.SerializeObject(spells));
         }
 
-        private List<Spell> ExtractNames(string path)
+        private static List<Spell> ExtractNames(string path)
         {
             int entryIndex = -1;
             int nameIndex = -1;
@@ -65,7 +65,7 @@ namespace ReadDBC_CSV
             return spells;
         }
 
-        private void ExtractLevels(string path, List<Spell> spells)
+        private static void ExtractLevels(string path, List<Spell> spells)
         {
             int entryIndex = -1;
             int spellIdIndex = -1;
@@ -92,9 +92,12 @@ namespace ReadDBC_CSV
                         int index = spells.FindIndex(0, x => x.Id == spellId);
                         if (index > -1)
                         {
-                            Spell spell = spells[index];
-                            spell.Level = level;
-                            spells[index] = spell;
+                            spells[index] = new Spell
+                            {
+                                Id = spellId,
+                                Level = level,
+                                Name = spells[index].Name,
+                            };
                         }
                     }
                 }

--- a/Utilities/ReadDBC_CSV/TalentExtractor.cs
+++ b/Utilities/ReadDBC_CSV/TalentExtractor.cs
@@ -34,7 +34,7 @@ namespace ReadDBC_CSV
             File.WriteAllText(Path.Join(path, "talent.json"), JsonConvert.SerializeObject(talents));
         }
 
-        private List<TalentTab> ExtractTalentTabs(string path)
+        private static List<TalentTab> ExtractTalentTabs(string path)
         {
             int idIndex = -1;
             int NameIndex = -1;

--- a/Utilities/ReadDBC_CSV/WorldMapAreaExtractor.cs
+++ b/Utilities/ReadDBC_CSV/WorldMapAreaExtractor.cs
@@ -42,7 +42,7 @@ namespace ReadDBC_CSV
             File.WriteAllText(Path.Join(path, "WorldMapArea.json"), JsonConvert.SerializeObject(wmas, Formatting.Indented));
         }
 
-        private List<WorldMapArea> ExtractUIMap(string path)
+        private static List<WorldMapArea> ExtractUIMap(string path)
         {
             int idIndex = -1;
             int nameIndex = -1;
@@ -74,7 +74,7 @@ namespace ReadDBC_CSV
             return items;
         }
 
-        private void ExtractBoundaries(string path, List<WorldMapArea> wmas)
+        private static void ExtractBoundaries(string path, List<WorldMapArea> wmas)
         {
             int uiMapIdIndex = -1;
             int mapIdIndex = -1;
@@ -123,17 +123,22 @@ namespace ReadDBC_CSV
                     if (index > -1)
                     {
                         var wma = wmas[index];
+                        wmas[index] = new WorldMapArea
+                        {
+                            MapID = int.Parse(values[mapIdIndex]),
+                            AreaID = int.Parse(values[areaIdIndex]),
 
-                        wma.MapID = int.Parse(values[mapIdIndex]);
-                        wma.AreaID = int.Parse(values[areaIdIndex]);
+                            AreaName = wma.AreaName,
 
-                        wma.LocBottom = float.Parse(values[region0Index]);
-                        wma.LocRight = float.Parse(values[region1Index]);
+                            LocBottom = float.Parse(values[region0Index]),
+                            LocRight = float.Parse(values[region1Index]),
 
-                        wma.LocTop = float.Parse(values[region3Index]);
-                        wma.LocLeft = float.Parse(values[region4Index]);
+                            LocTop = float.Parse(values[region3Index]),
+                            LocLeft = float.Parse(values[region4Index]),
 
-                        wmas[index] = wma;
+                            UIMapId = wma.UIMapId,
+                            Continent = wma.Continent,
+                        };
                     }
                 }
             };
@@ -141,7 +146,7 @@ namespace ReadDBC_CSV
             extractor.ExtractTemplate(path, extractLine);
         }
 
-        private void ExtractContinent(string path, List<WorldMapArea> wmas)
+        private static void ExtractContinent(string path, List<WorldMapArea> wmas)
         {
             int mapIdIndex = -1;
             int directoryIndex = -1;
@@ -156,8 +161,8 @@ namespace ReadDBC_CSV
             Action<string> extractLine = line =>
             {
                 string[] values;
-                if (line.Contains("\""))
-                    values = extractor.SplitQuotes(line);
+                if (line.Contains('\"'))
+                    values = CSVExtractor.SplitQuotes(line);
                 else
                     values = line.Split(",");
 
@@ -167,11 +172,25 @@ namespace ReadDBC_CSV
                     int mapId = int.Parse(values[mapIdIndex]);
 
                     var list = wmas.FindAll(x => x.MapID == mapId);
-                    for(int i = 0; i < list.Count; i++)
+                    for (int i = 0; i < list.Count; i++)
                     {
                         var wma = list[i];
-                        wma.Continent = values[directoryIndex];
-                        list[i] = wma;
+                        list[i] = new WorldMapArea
+                        {
+                            MapID = wma.MapID,
+                            AreaID = wma.AreaID,
+
+                            AreaName = wma.AreaName,
+
+                            LocBottom = wma.LocBottom,
+                            LocRight = wma.LocRight,
+
+                            LocTop = wma.LocTop,
+                            LocLeft = wma.LocLeft,
+
+                            UIMapId = wma.UIMapId,
+                            Continent = values[directoryIndex]
+                        };
                     }
                 }
             };
@@ -179,7 +198,7 @@ namespace ReadDBC_CSV
             extractor.ExtractTemplate(path, extractLine);
         }
 
-        private void ClearEmptyBound(List<WorldMapArea> wmas)
+        private static void ClearEmptyBound(List<WorldMapArea> wmas)
         {
             for (int i = wmas.Count - 1; i >= 0; i--)
             {

--- a/Utilities/ReadItems/ConsoleApp10/ReadWowDb.csproj
+++ b/Utilities/ReadItems/ConsoleApp10/ReadWowDb.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Utilities/WowheadDB_Extractor/PerZoneSkinnable.cs
+++ b/Utilities/WowheadDB_Extractor/PerZoneSkinnable.cs
@@ -10,14 +10,11 @@ namespace WowheadDB_Extractor
 {
     public class PerZoneSkinnable
     {
-        private int zoneId;
         private Area area;
-
         private string url;
 
         public PerZoneSkinnable(int zoneId, Area area)
         {
-            this.zoneId = zoneId;
             this.area = area;
             url = $"https://tbc.wowhead.com/npcs?filter=6:10;{zoneId}:1;0:0";
         }
@@ -40,7 +37,6 @@ namespace WowheadDB_Extractor
                     area.skinnable.Sort();
                 }
             }
-
             catch (Exception e)
             {
                 Console.WriteLine($" - PerZoneSkinnable\n {e}");
@@ -55,7 +51,7 @@ namespace WowheadDB_Extractor
             return await response.Content.ReadAsStringAsync();
         }
 
-        string GetPayloadFromWebpage(string content)
+        static string GetPayloadFromWebpage(string content)
         {
             string beginPat = "new Listview(";
             string endPat = "</script>";

--- a/Utilities/WowheadDB_Extractor/WowheadDB_Extractor.csproj
+++ b/Utilities/WowheadDB_Extractor/WowheadDB_Extractor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <Reference Include="WowheadDB">
-      <HintPath>..\..\WowheadDB\bin\Debug\netstandard2.1\WowheadDB.dll</HintPath>
+      <HintPath>..\..\WowheadDB\bin\Debug\net6.0\WowheadDB.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/Utilities/WowheadDB_Extractor/ZoneExtractor.cs
+++ b/Utilities/WowheadDB_Extractor/ZoneExtractor.cs
@@ -15,12 +15,12 @@ namespace WowheadDB_Extractor
         private const string ZONE_CLASSIC_URL = "https://classic.wowhead.com/zone=";
         private const string ZONE_TBC_URL = "https://tbc.wowhead.com/zone=";
 
-        public async Task Run()
+        public static async Task Run()
         {
             await ExtractZones();
         }
 
-        async Task ExtractZones()
+        static async Task ExtractZones()
         {
             foreach (KeyValuePair<string, int> entry in Areas.List)
             {
@@ -47,7 +47,7 @@ namespace WowheadDB_Extractor
             }
         }
 
-        async Task<string> LoadPage(int zoneId)
+        static async Task<string> LoadPage(int zoneId)
         {
             var url = ZONE_TBC_URL + zoneId;
 
@@ -56,7 +56,7 @@ namespace WowheadDB_Extractor
             return await response.Content.ReadAsStringAsync();
         }
 
-        string GetPayloadFromWebpage(string content)
+        static string GetPayloadFromWebpage(string content)
         {
             string beginPat = "new ShowOnMap(";
             string endPat = ");</script>";
@@ -67,12 +67,12 @@ namespace WowheadDB_Extractor
             return content.Substring(beginPos + beginPat.Length, endPos - beginPos - beginPat.Length);
         }
 
-        Area ZoneFromJson(string content)
+        static Area ZoneFromJson(string content)
         {
             return JsonConvert.DeserializeObject<Area>(content);
         }
 
-        void SaveZone(Area zone, string name)
+        static void SaveZone(Area zone, string name)
         {
             var output = JsonConvert.SerializeObject(zone);
             var file = Path.Join(outputPath, name + ".json");
@@ -83,14 +83,14 @@ namespace WowheadDB_Extractor
 
         #region local tests
 
-        void SerializeTest()
+        static void SerializeTest()
         {
             int zoneId = 40;
             var file = Path.Join(outputPath, zoneId + ".json");
             var zone = ZoneFromJson(File.ReadAllText(file));
         }
 
-        void ExtractFromFileTest()
+        static void ExtractFromFileTest()
         {
             var file = Path.Join(outputPath, "a.html");
             var html = File.ReadAllText(file);


### PR DESCRIPTION
### Changes
* Every project is converted either from `dotnetstandard2.1` or `dotnet3.1` or `dotnet5.0` to `dotnet6.0`
* Removed every reference of the old `dotnetstandard2.1` builds
* Utility projects are also upgraded
* The main solution requires Visual Studio 2022 from now on
* `SharedLib` based data structures are `readonly struct`s
* Some places replaced logging with the `LoggerMessage` generated version. Console output colorful 🤸‍♂️ 

### Result
* Build times significantly faster
* Runtime memory usage significantly reduced. From around ~150mb can go below 100mb