### PR TITLE
Feature: PPather less exception and logging

### DIFF
--- a/PathingAPI/PPather/Triangles/MPQTriangleSupplier.cs
+++ b/PathingAPI/PPather/Triangles/MPQTriangleSupplier.cs
@@ -110,7 +110,8 @@ namespace WowTriangles
                     TotalName = Name + ":" + ParentName;
                 try
                 {
-                    zoneToMapId.Add(TotalName, WorldID);
+                    if (!zoneToMapId.ContainsKey(TotalName))
+                        zoneToMapId.Add(TotalName, WorldID);
                     //logger.WriteLine(TotalName + " => " + WorldID);
                 }
                 catch
@@ -127,46 +128,9 @@ namespace WowTriangles
 
         public static string[] GetArchiveNames(DataConfig dataConfig, Action<string> log)
         {
-            string[] archiveNames = {
-                    "patch.MPQ",
-                    "enUS\\patch-enUS.MPQ",
-                    "enGB\\patch-enGB.MPQ",
-                    "lichking.MPQ",
-                    "common-2.MPQ",
-                    "common.MPQ",
-                    "expansion.MPQ",
-                    "enUS\\lichking-locale-enUS.MPQ", "enUS\\locale-enUS.MPQ", "enUS\\expansion-locale-enUS.MPQ",
-                    "enGB\\lichking-locale-enGB.MPQ", "enGB\\locale-enGB.MPQ", "enGB\\expansion-locale-enGB.MPQ",
-                    "enUS\\base-enUS.MPQ",
-                    "enGB\\base-enGB.MPQ",
-                    "enUS\\backup-enUS.MPQ",
-                    "enGB\\backup-enGB.MPQ",
-                    "expansion1.MPQ",
-                    "expansion2.MPQ",
-                    "OldWorld.MPQ",
-                    "world.MPQ",
-                    "enGB\\expansion1-locale-enGB.MPQ",
-                    "enGB\\expansion2-locale-enGB.MPQ",
-                    "enGB\\locale-enGB.MPQ",
-                    "enGB\\locale-enGB.MPQ",
+            //log("MPQ dir is " + dataConfig.MPQ);
 
-                    "wow-update-13164.MPQ",
-                    "wow-update-oldworld-13154.MPQ",
-                    "Cache\\patch-base-oldworld-13154.MPQ",
-                    "Cache\\enGB\\patch-enGB-oldworld-13154.MPQ",
-                    "expansion2.MPQ","expansion1.MPQ",
-                    "world.MPQ",
-                    "sound.MPQ",
-                    "art.MPQ",
-                    "enGB\\expansion2-locale-enGB.MPQ",
-                    "enGB\\expansion1-locale-enGB.MPQ",
-                    "enGB\\locale-enGB.MPQ",
-                    "enGB\\base-enGB.MPQ"
-                                    };
-
-            string regGameDir = dataConfig.MPQ;
-            log("MPQ dir is " + regGameDir);
-            return archiveNames.Select(a => Path.Join(regGameDir, a)).ToArray();
+            return Directory.GetFiles(dataConfig.MPQ);
         }
 
         public void SetContinent(string continent)
@@ -307,7 +271,7 @@ namespace WowTriangles
                     }
                 }
 
-                logger.WriteLine("wee");
+                //logger.WriteLine("wee");
                 /*logger.WriteLine(
 					String.Format(" Triangles - Map: {0,6} Objects: {1,6} Models: {2,6}",
 								  map_triangles.GetNumberOfTriangles(),
@@ -315,7 +279,7 @@ namespace WowTriangles
 								  model_triangles.GetNumberOfTriangles()));
 				*/
             }
-            logger.WriteLine(" done");
+            //logger.WriteLine(" done");
             wdt.maptiles[chunk_x, chunk_y] = null; // clear it atain
                                                    //myChunk.triangles.ClearVertexMatrix(); // not needed anymore
                                                    //return myChunk;
@@ -450,7 +414,7 @@ namespace WowTriangles
             float dir_y = wi.dir.y - 90;
             float dir_z = -wi.dir.x;
 
-            logger.WriteLine("modeli: " + dir_x + " " + dir_y + " " + dir_z);
+            //logger.WriteLine("modeli: " + dir_x + " " + dir_y + " " + dir_z);
             WMO wmo = wi.wmo;
 
             foreach (WMOGroup g in wmo.groups)
@@ -496,7 +460,7 @@ namespace WowTriangles
                     if (finalz > maxz) { maxz = finalx; }
                 }
 
-                logger.WriteLine("AddTriangles: x(" + minx + " - " + maxx + ") y(" + miny + " - " + maxy + ") z(" + minz + " - " + maxz + ")");
+                //logger.WriteLine("AddTriangles: x(" + minx + " - " + maxx + ") y(" + miny + " - " + maxy + ") z(" + minz + " - " + maxz + ")");
 
                 for (int i = 0; i < g.nTriangles; i++)
                 {

--- a/PathingAPI/PPather/Triangles/StormDll.cs
+++ b/PathingAPI/PPather/Triangles/StormDll.cs
@@ -175,7 +175,7 @@ int   WINAPI SFileAddListFile(HANDLE hMpq, const char * szListFile);
             {
                 if (a.HasFile(from))
                 {
-                    logger.Debug("Extract " + from + " from " + a.FileName);
+                    //logger.Debug("Extract " + from + " from " + a.FileName);
                     bool ok = a.ExtractFile(from, to);
                     if (!ok)
                     {

--- a/PathingAPI/PPather/Triangles/WmoFile.cs
+++ b/PathingAPI/PPather/Triangles/WmoFile.cs
@@ -750,31 +750,31 @@ namespace Wmo
         private Logger logger;
         private DataConfig dataConfig;
 
-        //Alterac Valley> ZonePath :” world\\maps\\PVPZone01\\PVPZone01”
+        //Alterac Valley> ZonePath :ï¿½ world\\maps\\PVPZone01\\PVPZone01ï¿½
 
         // 238.
-        //  Warsong Gulch> ZonePath : world\\maps\\PVPZone03\\PVPZone03”
+        //  Warsong Gulch> ZonePath : world\\maps\\PVPZone03\\PVPZone03ï¿½
 
         // 239.
-        //  Arathi Basin> ZonePath : “world\\mapsPVPZone04\\PVPZone04”
+        //  Arathi Basin> ZonePath : ï¿½world\\mapsPVPZone04\\PVPZone04ï¿½
 
         // 240.
-        //  Eye of the Storm> ZonePath : “world\\maps\\NetherstormBG\\NetherstormBG”
+        //  Eye of the Storm> ZonePath : ï¿½world\\maps\\NetherstormBG\\NetherstormBGï¿½
 
         // 241.
-        //  Strand of the Ancients> ZonePath : "world\\maps\\NorthrendBG\\NorthrendBG”
+        //  Strand of the Ancients> ZonePath : "world\\maps\\NorthrendBG\\NorthrendBGï¿½
 
         // 242.
-        //  Isle of Conquest> ZonePath : “world\\maps\\IsleofConquest\\IsleofConquest”
+        //  Isle of Conquest> ZonePath : ï¿½world\\maps\\IsleofConquest\\IsleofConquestï¿½
 
         // 243.
-        //  Twin Peaks> ZonePath : “world\\maps\\CataclysmCTF\\CataclysmCTF”
+        //  Twin Peaks> ZonePath : ï¿½world\\maps\\CataclysmCTF\\CataclysmCTFï¿½
 
         // 244.
-        //  Tol Barad> ZonePath : “world\\maps\\TolBarad\\TolBarad”
+        //  Tol Barad> ZonePath : ï¿½world\\maps\\TolBarad\\TolBaradï¿½
 
         // 245.
-        //  The Battle for Gilneas > ZonePath : “world\\maps\\Gilneas_BG_2\\Gilneas_BG_2”*/
+        //  The Battle for Gilneas > ZonePath : ï¿½world\\maps\\Gilneas_BG_2\\Gilneas_BG_2ï¿½*/
 
         //        1.
         //Azeroth
@@ -989,7 +989,7 @@ namespace Wmo
                     else if (type == ChunkReader.MAIN)
                     {
                         int cnt = HandleMAIN(size);
-                        logger.WriteLine("Map Tiles available in " + wdtfile + " = " + cnt);
+                        //logger.WriteLine("Map Tiles available in " + wdtfile + " = " + cnt);
                     }
                     else
                     {
@@ -1002,7 +1002,7 @@ namespace Wmo
                 {
                     done = true;
                 }
-            } while (!done);
+            } while (!done && file.BaseStream.Position != file.BaseStream.Length);
 
             file.Close();
             stream.Close();
@@ -1128,7 +1128,7 @@ namespace Wmo
                 {
                     done = true;
                 }
-            } while (!done);
+            } while (!done && file.BaseStream.Position != file.BaseStream.Length);
 
             file.Close();
             stream.Close();
@@ -1297,7 +1297,7 @@ namespace Wmo
                 {
                     done = true;
                 }
-            } while (!done);
+            } while (!done && file.BaseStream.Position != file.BaseStream.Length);
 
             for (int j = 0; j < 16; j++)
             {
@@ -1646,7 +1646,7 @@ namespace Wmo
                 {
                     done = true;
                 }
-            } while (!done);
+            } while (!done && file.BaseStream.Position != file.BaseStream.Length);
         }
 
         private static void HandleChunkMCNR(MapChunk chunk, uint size)
@@ -1799,7 +1799,7 @@ namespace Wmo
                 {
                     done = true;
                 }
-            } while (!done);
+            } while (!done && file.BaseStream.Position != file.BaseStream.Length);
             file.Close();
             stream.Close();
         }
@@ -2018,7 +2018,7 @@ namespace Wmo
                 {
                     done = true;
                 }
-            } while (!done);
+            } while (!done && file.BaseStream.Position != file.BaseStream.Length);
 
             file.Close();
             stream.Close();


### PR DESCRIPTION
* Don't use exceptions for EOF :dense:
* Don't try to parse that long MPQ file list, just read the `DataConfig.MPQ` dictionary to see what exists
* Log less about PPather pathfinding and asset loading process
