### PR TITLE
Fix: macro which contains items shows up always usable even when the item dosen't exists in inventory

### DIFF
--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors
-## Version: 1.1.53
+## Version: 1.1.54
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/Query.lua
+++ b/Addons/DataToColor/Query.lua
@@ -313,7 +313,8 @@ function DataToColor:isActionUseable(min,max)
     for i = min, max do
         local start, duration, enabled = GetActionCooldown(i)
         isUsable, notEnough = IsUsableAction(i)
-        if start == 0 and isUsable == true and notEnough == false then
+
+        if start == 0 and isUsable == true and notEnough == false and GetActionTexture(i) ~= 134400 then -- red question mark texture
             isUsableBits = isUsableBits + (2 ^ (i - min))
         end
 


### PR DESCRIPTION
### The issue 

Having macro like this which requires an item in inventory and have to use it on a weapon and maybe have to accept a prompt.

```lua
#showtooltip
/use Solid Sharpening Stone
/use 16
/click StaticPopup1Button1
```

The macro always show up as `Usable` even if the mentioned item `Solid Sharpening Stone` is missing from inventory. 

### Solution

![image](https://user-images.githubusercontent.com/367101/150773386-5820d00f-053e-4425-bc63-dacbba005955.png)
Incase the Actionbarslot icon is show up as red question mark that means the macro item is missing from the inventory or the macro has no assigned icon. 

That means all macros required to have any icon beside the default. This can be solved by adding the `#showtooltip` in the first line.


