### PR TITLE
Feature: Swagger overhaul

### DIFF
--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -312,7 +312,7 @@ end
 
 function DataToColor:InitInventoryQueue(containerID)
     if containerID >= 0 and containerID <= 4 then
-        for i = 1, 21 do
+        for i = 1, GetContainerNumSlots(containerID) do
             DataToColor.stack:push(DataToColor.inventoryQueue, containerID * 1000 + i)
         end
     end

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors
-## Version: 1.1.54
+## Version: 1.1.55
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/EventHandlers.lua
+++ b/Addons/DataToColor/EventHandlers.lua
@@ -207,6 +207,10 @@ function DataToColor:OnBagUpdate(event, containerID)
     if containerID >= 0 and containerID <=4 then
         DataToColor.stack:push(DataToColor.bagQueue, containerID)
         DataToColor:InitInventoryQueue(containerID)
+
+        if containerID >= 1 then
+            DataToColor.stack:push(DataToColor.equipmentQueue, 19 + containerID) -- from tabard
+        end
     end
     --DataToColor:Print("OnBagUpdate "..containerID)
 end

--- a/BlazorServer/Pages/BagItemComponent.razor
+++ b/BlazorServer/Pages/BagItemComponent.razor
@@ -1,26 +1,33 @@
-@using SharedLib
-@using Core 
+﻿@using SharedLib
+@using Core
+@using System.Xml
+
 @if (BagItem != null)
 {
     <a href="@($"{WApi.ItemId}{BagItem.ItemId}")" target="_blank" data-wowhead="item=@BagItem.ItemId" class="small" style="text-decoration:none">
         <b>
-            <span style="color:@BagItemColour(BagItem.Item)">
-            @if (BagItem.WasRecentlyUpdated)
-            {
-                <span class="badge badge-info">@BagItem.LastChangeDescription</span>
-            }
+            <span style="color:@BagItemColour(BagItem.Item);font-weight:normal">
             @if (BagItem.Count > 1)
             {
                 @BagItem.Count<span>&nbsp;</span>
+            }
+
+            @if(iconName != string.Empty)
+            {
+                <img src="@imgLink"/>
             }
             @BagItem.Item.Name
             @if (BagItem.IsSoulbound)
             {
                 <span>(S)</span>
             }
-            @if (BagItem.Item.SellPrice > 0)
+            @if (ShowPrice && BagItem.Item.SellPrice > 0)
             {
                 <Money Value="GetItemPrice(BagItem)" />
+            }
+            @if (BagItem.WasRecentlyUpdated)
+            {
+                <span class="float-right badge badge-info">@BagItem.LastChangeDescription</span>
             }
             </span>
         </b>
@@ -34,15 +41,58 @@
     [Parameter]
     public bool ShowChangesPrice { get; set; } = false;
 
-    List<string> itemColour = new List<string> { "grey", "white", "green", "blue", "purple", "yellow", "yellow", "yellow" };
+    [Parameter]
+    public bool ShowPrice { get; set; } = false;
+
+    [Parameter]
+    public bool ShowIcon { get; set; }
+
+    private string iconName { get; set; } = string.Empty;
+
+    private static List<string> colors = new List<string> { "#9d9d9d", "#fff", "#1eff00", "#0070dd", "#9345ff", "#ff8000", "#e5cc80", "#e5cc80" };
+    private static List<string> itemBadge = new List<string> { "badge-secondary", "badge-dark", "badge-success", "badge-primary", "badge-warning", "badge-warning", "badge-warning", "badge-warning" };
+
+    private static Dictionary<int, string> icons = new();
+
+    private string imgLink => string.Format(WApi.IconUrl, iconName);
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (ShowIcon && BagItem != null && BagItem.ItemId != 0)
+        {
+            if (icons.TryGetValue(BagItem.ItemId, out var icon))
+            {
+                iconName = icon;
+                return;
+            }
+
+            try
+            {
+                XmlReader reader = XmlReader.Create($"{WApi.ItemId}{BagItem.ItemId}&xml", new XmlReaderSettings { Async = true, LineNumberOffset = 14 });
+                while (await reader.ReadAsync())
+                {
+                    if ((reader.NodeType == XmlNodeType.Element) && (reader.Name.Contains("icon")))
+                    {
+                        await reader.ReadAsync();
+                        iconName = reader.Value;
+
+                        icons.TryAdd(BagItem.ItemId, iconName);
+                        break;
+                    }
+                }
+            }
+            catch
+            {
+                
+            }
+        }
+    }
 
     protected string BagItemColour(Item item)
     {
         if (item.Quality < 0 || item.Quality > 7) { return "black"; }
-        return itemColour[item.Quality];
+        return colors[item.Quality];
     }
-
-    List<string> itemBadge = new List<string> { "badge-secondary", "badge-dark", "badge-success", "badge-primary", "badge-warning", "badge-warning", "badge-warning", "badge-warning" };
 
     protected string BagItemBadge(Item item)
     {

--- a/BlazorServer/Pages/BagItemComponent.razor
+++ b/BlazorServer/Pages/BagItemComponent.razor
@@ -1,8 +1,8 @@
-﻿@using SharedLib
+@using SharedLib
 @using Core 
 @if (BagItem != null)
 {
-    <a href="https://tbc.wowhead.com/item=@BagItem.ItemId" target="_blank" data-wowhead="item=@BagItem.ItemId" class="small" style="text-decoration:none">
+    <a href="@($"{WApi.ItemId}{BagItem.ItemId}")" target="_blank" data-wowhead="item=@BagItem.ItemId" class="small" style="text-decoration:none">
         <b>
             <span style="color:@BagItemColour(BagItem.Item)">
             @if (BagItem.WasRecentlyUpdated)

--- a/BlazorServer/Pages/BotHeader.razor
+++ b/BlazorServer/Pages/BotHeader.razor
@@ -29,7 +29,7 @@
                 <td>
                     @if (addonReader.PlayerReader.Bits.HasTarget)
                     {
-                        <a href="https://tbc.wowhead.com/npc=@playerReader.TargetId" target="_blank">
+                        <a href="@($"{WApi.NpcId}{playerReader.TargetId}")" target="_blank">
                             <div>
                                 @addonReader.TargetName<br />
                                 (@playerReader.TargetLevel) @((int)playerReader.TargetHealthPercentage) %<br />

--- a/BlazorServer/Pages/Money.razor
+++ b/BlazorServer/Pages/Money.razor
@@ -14,6 +14,5 @@
     [Parameter]
     public int[] Value { get; set; } = new int[3] { 0, 0, 0 };
 
-    List<string> images = new List<string> { "money-gold.png", "money-silver.png", "money-copper.png" };
-
+    private static List<string> images = new List<string> { "money-gold.png", "money-silver.png", "money-copper.png" };
 }

--- a/BlazorServer/Pages/Swag.razor
+++ b/BlazorServer/Pages/Swag.razor
@@ -3,7 +3,8 @@
 @inject Core.IAddonReader addonReader
 @inject Core.IBotController botController
 @inject IJSRuntime JSRuntime;
-@using SharedLib 
+@using Core
+@using SharedLib
 
 <BotHeader />
 
@@ -15,27 +16,27 @@
         </div>
     </div>
     <div class="card-body" style="padding-bottom: 0">
-
         <table class="table table-sm table-striped table-no-border">
             <thead class="thead-dark">
                 <tr>
-                    <th>Bag 1</th>
-                    <th>Bag 2</th>
-                    <th>Bag 3</th>
-                    <th>Bag 4</th>
-                    <th>Bag 5</th>
+                    @foreach(var bag in bagReader.Bags.Reverse())
+                    {
+                        <th>
+                            <a href="@($"{WApi.ItemId}{bag.ItemId}")" target="_blank">@bag.Name</a>
+                        </th>
+                    }
                 </tr>
             </thead>
-            @for (int bagIndex = 0; bagIndex < 20; bagIndex++)
+            @for (int bagIndex = 0; bagIndex < maxSlot; bagIndex++)
             {
                 <tr>
-                    @for (int bag = 0; bag < 5; bag++)
+                    @for (int bag = 4; bag >= 0; bag--)
                     {
                         <td width="20%">
-                            @{ var bagItem = addonReader.BagReader.BagItems.Where(i => i.Bag == bag).Where(i => i.BagIndex == bagIndex).FirstOrDefault();}
+                            @{ var bagItem = bagReader.BagItems.Where(i => i.Bag == bag).Where(i => i.BagIndex == bagIndex).FirstOrDefault();}
                             @if (bagItem != null)
                             {
-                                <BagItemComponent BagItem="bagItem" />
+                                <BagItemComponent BagItem="bagItem" ShowIcon="true" />
                             }
                         </td>
                     }
@@ -45,17 +46,34 @@
     </div>
 </div>
 
+<div class="card">
+    <div class="card-header">
+        Equipments
+    </div>
+    <div class="card-body" style="padding-bottom: 0">
+        @for (int index = 0; index <= (int)InventorySlotId.Bag_3; index++)
+        {
+            <a href="@($"{WApi.ItemId}{addonReader.EquipmentReader.GetId(index)}")" target="_blank">@((InventorySlotId)index)</a><br/>
+        }
+    </div>
+</div>
+
 <div id="tooltip" display="none" style="position: absolute; display: none;"></div>
 
 @code {
 
     int[] vendMoney = new int[0];
 
+    private BagReader bagReader = null!;
+
+    private int maxSlot => bagReader.Bags.Max(b => b.SlotCount);
+
     protected override void OnInitialized()
     {
-        addonReader.BagReader.DataChanged += (o, e) =>
+        bagReader = addonReader.BagReader;
+        bagReader.DataChanged += (o, e) =>
         {
-            vendMoney = Item.ToSellPrice(addonReader.BagReader.BagItems.Sum(s => s.Item.SellPrice * s.Count));
+            vendMoney = Item.ToSellPrice(bagReader.BagItems.Sum(s => s.Item.SellPrice * s.Count));
 
             base.InvokeAsync(() => { try { StateHasChanged(); } catch { } });
         };

--- a/BlazorServer/WApi.cs
+++ b/BlazorServer/WApi.cs
@@ -1,0 +1,11 @@
+﻿namespace BlazorServer
+{
+    public static class WApi
+    {
+        public const string Version = "tbc";
+
+        public const string NpcId = $"https://{Version}.wowhead.com/npc=";
+        public const string ItemId = $"https://{Version}.wowhead.com/item=";
+        public const string IconUrl = "https://wow.zamimg.com/images/wow/icons/tiny/{0}.gif";
+    }
+}

--- a/Core/Addon/EquipmentReader.cs
+++ b/Core/Addon/EquipmentReader.cs
@@ -1,4 +1,6 @@
-﻿namespace Core
+﻿using System;
+
+namespace Core
 {
     public enum InventorySlotId
     {
@@ -38,6 +40,8 @@
 
         private readonly int[] equipment = new int[MAX_EQUIPMENT_COUNT];
 
+        public event EventHandler<(int, int)>? OnEquipmentChanged;
+
         public EquipmentReader(ISquareReader reader, int cSlotNum, int cItemId)
         {
             this.reader = reader;
@@ -52,8 +56,12 @@
             if (index < MAX_EQUIPMENT_COUNT && index >= 0)
             {
                 int itemId = reader.GetIntAtCell(cItemId);
-                if(itemId > 0)
-                    equipment[index] = itemId;
+                bool changed = equipment[index] != itemId;
+
+                equipment[index] = itemId;
+
+                if (changed)
+                    OnEquipmentChanged?.Invoke(this, (index, itemId));
             }
         }
 

--- a/Core/Bag/Bag.cs
+++ b/Core/Bag/Bag.cs
@@ -1,14 +1,13 @@
-﻿using System;
+﻿using SharedLib;
 
 namespace Core
 {
-#pragma warning disable CA1815 // Override equals and operator equals on value types
-    public struct Bag
-#pragma warning restore CA1815 // Override equals and operator equals on value types
+    public class Bag
     {
         public int ItemId { get; set; }
         public BagType BagType { get; set; }
         public int SlotCount { get; set; }
         public int FreeSlot { get; set; }
+        public string Name { get; set; } = string.Empty;
     }
 }

--- a/Core/Bag/BagItem.cs
+++ b/Core/Bag/BagItem.cs
@@ -1,5 +1,4 @@
-﻿using Core.Addon;
-using System;
+﻿using System;
 using SharedLib;
 
 namespace Core

--- a/Core/Bag/BagReader.cs
+++ b/Core/Bag/BagReader.cs
@@ -99,7 +99,8 @@ namespace Core
                 bag.SlotCount = slotCount;
                 bag.FreeSlot = freeSlots;
 
-                bags[index] = bag;
+                BagItems.RemoveAll(b => b.Bag == index && b.BagIndex > bag.SlotCount);
+
                 changed = true;
             }
         }

--- a/Core/Bag/BagReader.cs
+++ b/Core/Bag/BagReader.cs
@@ -1,4 +1,4 @@
-using SharedLib;
+﻿using SharedLib;
 using Core.Database;
 using System;
 using System.Collections.Generic;


### PR DESCRIPTION
# Features
* Addon: Listen for swap/equip/unequip bags
* Addon: instead of using a baked `21` bagslot count use the related api
* Frontend: Added a `WApi` class to hold wowhead related endpoints
* Frontend: `BagReader` listen for equipmentchange and so be aware of the bag related changes.
* Frontend: BagItemComp: has the ability to show the item icon also using better name colors.
* Frontend: Swag: Container names shows up. Change the order of bag and inventory display. Temporary the equipments shows up here.

# Fixes
* Core: `BagReader`: Fix an issue when swapping bags which has less amount of BagSlots then the prior one.

# Media
![image](https://user-images.githubusercontent.com/367101/151193933-afd62add-04bf-4bb4-8f14-f3c5baa899c9.png)

![image](https://user-images.githubusercontent.com/367101/151193984-1346a0fa-a801-484a-9c9f-aa6991627cef.png)
