### PR TITLE
Core: LootGoal: Take advantage of the known corpse locations when no npcname was visible.

### DIFF
--- a/Core/Goals/GoalFactory.cs
+++ b/Core/Goals/GoalFactory.cs
@@ -107,7 +107,7 @@ namespace Core
                     }
                     else
                     {
-                        var lootAction = new LootGoal(logger, input, wait, addonReader, stopMoving, classConfig, npcNameTargeting, combatUtil);
+                        var lootAction = new LootGoal(logger, input, wait, addonReader, stopMoving, classConfig, npcNameTargeting, combatUtil, playerDirection);
                         lootAction.AddPreconditions();
                         availableActions.Add(lootAction);
                     }

--- a/Core/Goals/PostKillLootGoal.cs
+++ b/Core/Goals/PostKillLootGoal.cs
@@ -8,8 +8,8 @@ namespace Core.Goals
     {
         public override float CostOfPerformingAction { get => 4.5f; }
 
-        public PostKillLootGoal(ILogger logger, ConfigurableInput input, Wait wait, AddonReader addonReader, StopMoving stopMoving, ClassConfiguration classConfiguration, NpcNameTargeting npcNameTargeting, CombatUtil combatUtil)
-            : base(logger, input, wait, addonReader, stopMoving, classConfiguration, npcNameTargeting, combatUtil)
+        public PostKillLootGoal(ILogger logger, ConfigurableInput input, Wait wait, AddonReader addonReader, StopMoving stopMoving, ClassConfiguration classConfiguration, NpcNameTargeting npcNameTargeting, CombatUtil combatUtil, IPlayerDirection playerDirection)
+            : base(logger, input, wait, addonReader, stopMoving, classConfiguration, npcNameTargeting, combatUtil, playerDirection)
         {
         }
 


### PR DESCRIPTION
**Issue:** Sometimes when pulling multiple mobs in a combat the character keep facing to the latest enemy. And therefor the previously killed mobs getting out of player vision.

**Solution:** Take advantage of the approximated kill locations. When no npcname is visible, turn the closest one and try to find again.

