### PR TITLE
Refactor: `KeyAction.CastIfAddsVisible` replaced with `AddsVisible`. Requirement `CD==0` replaced by `WhenUsable`

### DIFF
--- a/Core/BotController.cs
+++ b/Core/BotController.cs
@@ -310,7 +310,7 @@ namespace Core
             if (File.Exists(classFilePath))
             {
                 ClassConfiguration classConfig = JsonConvert.DeserializeObject<ClassConfiguration>(File.ReadAllText(classFilePath));
-                var requirementFactory = new RequirementFactory(logger, AddonReader);
+                var requirementFactory = new RequirementFactory(logger, AddonReader, npcNameFinder);
                 classConfig.Initialise(DataConfig, AddonReader, requirementFactory, logger, pathFilename);
 
                 logger.LogInformation($"[{nameof(BotController)}] Profile Loaded `{classFilename}` with `{classConfig.PathFilename}`.");

--- a/Core/ClassConfig/KeyAction.cs
+++ b/Core/ClassConfig/KeyAction.cs
@@ -17,7 +17,6 @@ namespace Core
         public int PressDuration { get; set; } = 50;
         public string Form { get; set; } = string.Empty;
         public Form FormEnum { get; set; } = Core.Form.None;
-        public string CastIfAddsVisible { get; set; } = "";
         public float Cooldown { get; set; }
 
         private int _charge;

--- a/Core/Goals/CastingHandler.cs
+++ b/Core/Goals/CastingHandler.cs
@@ -48,20 +48,6 @@ namespace Core.Goals
 
         public bool CanRun(KeyAction item)
         {
-            if (!string.IsNullOrEmpty(item.CastIfAddsVisible))
-            {
-                var needAdds = bool.Parse(item.CastIfAddsVisible);
-                if (needAdds != npcNameFinder.PotentialAddsExist)
-                {
-                    item.LogInformation($"Only cast if adds exist = {item.CastIfAddsVisible} and it is {npcNameFinder.PotentialAddsExist} - Targets:{npcNameFinder.TargetCount} - Adds:{npcNameFinder.AddCount}");
-                    return false;
-                }
-                else
-                {
-                    item.LogInformation($"Only cast if adds exist = {item.CastIfAddsVisible} and it is {npcNameFinder.PotentialAddsExist} - Targets:{npcNameFinder.TargetCount} - Adds:{npcNameFinder.AddCount}");
-                }
-            }
-
             if (item.School != SchoolMask.None &&
                 classConfig.ImmunityBlacklist.TryGetValue(playerReader.TargetId, out var list) &&
                 list.Contains(item.School))

--- a/Core/Requirement/RequirementFactory.cs
+++ b/Core/Requirement/RequirementFactory.cs
@@ -314,6 +314,7 @@ namespace Core
             if (item.WhenUsable && !string.IsNullOrEmpty(item.Key))
             {
                 item.RequirementObjects.Add(CreateActionUsableRequirement(item));
+                item.RequirementObjects.Add(CreateActionNotInGameCooldown(item));
             }
 
             CreateCooldownRequirement(item.RequirementObjects, item);
@@ -433,6 +434,18 @@ namespace Core
                     !item.HasFormRequirement() ? $"Usable" : // {playerReader.UsableAction.Num(item)}
                     (playerReader.Form != item.FormEnum && item.CanDoFormChangeAndHaveMinimumMana()) ? $"Usable after Form change" : // {playerReader.UsableAction.Num(item)}
                     (playerReader.Form == item.FormEnum && addonReader.UsableAction.Is(item)) ? $"Usable current Form" : $"not Usable current Form" // {playerReader.UsableAction.Num(item)}
+            };
+        }
+
+        private Requirement CreateActionNotInGameCooldown(KeyAction item)
+        {
+            string key = $"CD_{item.Name}";
+            return new Requirement
+            {
+                HasRequirement = () => valueDictionary[key]() == 0,
+                VisibleIfHasRequirement = false,
+                LogMessage = () =>
+                    $"CD {valueDictionary[key]() / 1000:F1}"
             };
         }
 

--- a/Core/Requirement/RequirementFactory.cs
+++ b/Core/Requirement/RequirementFactory.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Core.Database;
 using SharedLib;
+using SharedLib.NpcFinder;
 
 namespace Core
 {
@@ -33,7 +34,7 @@ namespace Core
            "!"
         };
 
-        public RequirementFactory(ILogger logger, AddonReader addonReader)
+        public RequirementFactory(ILogger logger, AddonReader addonReader, NpcNameFinder npcNameFinder)
         {
             this.logger = logger;
             this.addonReader = addonReader;
@@ -73,6 +74,8 @@ namespace Core
                 { "TargetsMe", () => playerReader.TargetTarget == TargetTargetEnum.TargetIsTargettingMe },
                 { "TargetsPet", () => playerReader.TargetTarget == TargetTargetEnum.TargetIsTargettingPet },
                 { "TargetsNone", () => playerReader.TargetTarget == TargetTargetEnum.TargetHasNoTarget },
+
+                { "AddVisible", () => npcNameFinder.PotentialAddsExist },
 
                 // Range
                 { "InMeleeRange", ()=> playerReader.IsInMeleeRange },

--- a/Json/class/Druid_1.json
+++ b/Json/class/Druid_1.json
@@ -18,18 +18,18 @@
         "Name": "Healing Touch",
         "Key": "3",
         "HasCastBar": true,
-        "Requirement": "Health%<50",
-        "Cooldown": 5000
+        "WhenUsable": true,
+        "Requirement": "Health% < 50"
       },
       {
         "Name": "Wrath",
         "Key": "2",
-        "Requirement": "TargetHealth%>50",
-        "HasCastBar": true
+        "HasCastBar": true,
+        "Requirement": "TargetHealth% > 50"
       },
       {
         "Name": "AutoAttack",
-        "Requirement": "not AutoAttacking"
+        "Requirement": "!AutoAttacking"
       },
       {
         "Name": "Approach",
@@ -42,25 +42,28 @@
       {
         "Name": "Water",
         "Key": "-",
-        "Requirement": "Mana%<30"
+        "Requirement": "Mana% < 30"
       }
     ]
   },
   "NPC": {
     "Sequence": [
       {
+        "Cost": 6,
         "Name": "Repair",
         "Key": "C",
         "Requirement": "Items Broken",
-        "PathFilename": "1_NightElf_Vendor.json",
-        "Cost": 6
+        "PathFilename": "1_NightElf_Vendor.json"
       },
       {
+        "Cost": 6,
         "Name": "Sell",
         "Key": "C",
-        "Requirements": ["BagFull", "BagGreyItem"],
-        "PathFilename": "1_NightElf_Vendor.json",
-        "Cost": 6
+        "Requirements": [
+          "BagFull",
+          "BagGreyItem"
+        ],
+        "PathFilename": "1_NightElf_Vendor.json"
       }
     ]
   }

--- a/Json/class/Druid_10_bear.json
+++ b/Json/class/Druid_10_bear.json
@@ -4,7 +4,6 @@
   "PathFilename": "_pack\\1-20\\Night elf\\09-11_Teldrassil_Near Lake Al'Ameth.json",
   "PathReduceSteps": true,
   "CheckTargetGivesExp": true,
-
   "Form": [
     {
       //macro: /cancelform
@@ -23,23 +22,32 @@
       {
         "Name": "Moonfire",
         "Key": "5",
-        "AfterCastWaitBuff": true,
-        "CastIfAddsVisible": true,
-        "Requirements": ["SpellInRange:0", "not InMeleeRange", "not Moonfire", "Mana%>50"],
-        "WaitForWithinMeleeRange": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "Requirements": [
+          "!Moonfire",
+          "AddVisible",
+          "SpellInRange:0",
+          "MinRange > 10"
+        ],
         "Form": "None"
       },
       {
         "Name": "Bear Form",
         "Key": "F2",
         "WaitForWithinMeleeRange": true,
-        "Requirements": ["Moonfire", "not Form:Druid_Bear"]
+        "Requirements": [
+          "Moonfire",
+          "!Form:Druid_Bear"
+        ]
       },
       {
         "Name": "Bear Form",
         "Key": "F2",
-        "Requirements": ["not Form:Druid_Bear"]
+        "Requirements": [
+          "SpellInRange:0",
+          "!Form:Druid_Bear"
+        ]
       }
     ]
   },
@@ -49,16 +57,18 @@
         "Name": "Healing Touch",
         "Key": "3",
         "HasCastBar": true,
-        "Requirement": "Health%<25",
-        "Cooldown": 5000,
+        "WhenUsable": true,
+        "Requirement": "Health% < 25",
         "Form": "None"
       },
       {
         "Name": "Rejuvenation",
         "Key": "6",
-        "AfterCastWaitBuff": true,
-        "Requirements": ["Health%<55", "not Rejuvenation"],
-        "Cooldown": 5000,
+        "WhenUsable": true,
+        "Requirements": [
+          "Health% < 55",
+          "!Rejuvenation"
+        ],
         "Form": "None"
       },
       {
@@ -66,20 +76,28 @@
         "Key": "3",
         "MinRage": 10,
         "WhenUsable": true,
-        "Requirements": ["InMeleeRange", "not Demoralizing Roar", "Form:Druid_Bear"],
+        "Requirements": [
+          "InMeleeRange",
+          "!Demoralizing Roar",
+          "Form:Druid_Bear"
+        ],
         "Form": "Druid_Bear"
       },
       {
         "Name": "Maul",
         "Key": "2",
         "MinRage": 15,
-        "Requirements": ["InMeleeRange", "LastMainHandMs>2100", "Form:Druid_Bear"], // bear swing speed fixed at 2.5
+        "Requirements": [
+          "InMeleeRange",
+          "LastMainHandMs > 2100",
+          "Form:Druid_Bear"
+        ], // bear swing speed fixed at 2.5
         "AfterCastWaitNextSwing": true,
         "Form": "Druid_Bear"
       },
       {
         "Name": "AutoAttack",
-        "Requirement": "not AutoAttacking"
+        "Requirement": "!AutoAttacking"
       },
       {
         "Name": "Approach",
@@ -92,23 +110,19 @@
       {
         "Name": "Mark of the Wild",
         "Key": "4",
-        "AfterCastWaitBuff": true,
-        "DelayAfterCast": 0,
-        "Requirement": "not Mark of the Wild",
+        "Requirement": "!Mark of the Wild",
         "Form": "None"
       },
       {
         "Name": "Thorns",
         "Key": "7",
-        "AfterCastWaitBuff": true,
-        "DelayAfterCast": 0,
-        "Requirement": "not Thorns",
+        "Requirement": "!Thorns",
         "Form": "None"
       },
       {
         "Name": "Water",
         "Key": "-",
-        "Requirement": "Mana%<40",
+        "Requirement": "Mana% < 40",
         "Form": "None"
       }
     ]
@@ -116,20 +130,23 @@
   "NPC": {
     "Sequence": [
       {
+        "Cost": 19,
         "Name": "Repair",
         "Key": "C",
         "Form": "None",
         "Requirement": "Items Broken",
-        "PathFilename": "5_NightElf_Vendor.json",
-        "Cost": 19
+        "PathFilename": "5_NightElf_Vendor.json"
       },
       {
+        "Cost": 19,
         "Name": "Sell",
         "Key": "C",
         "Form": "None",
-        "Requirements": ["BagFull", "BagGreyItem"],
-        "PathFilename": "5_NightElf_Vendor.json",
-        "Cost": 19
+        "Requirements": [
+          "BagFull",
+          "BagGreyItem"
+        ],
+        "PathFilename": "5_NightElf_Vendor.json"
       }
     ]
   }

--- a/Json/class/Druid_12_bear.json
+++ b/Json/class/Druid_12_bear.json
@@ -4,7 +4,6 @@
   "PathFilename": "_pack\\1-20\\Night elf\\10-12_Darkshore_Crawlers.json",
   "PathReduceSteps": true,
   "CheckTargetGivesExp": true,
-
   "Form": [
     {
       //macro: /cancelform
@@ -25,30 +24,41 @@
         "Name": "Rejuvenation",
         "Key": "6",
         "AfterCastWaitBuff": true,
-        "Requirements": ["Health%<75", "not Rejuvenation"],
-        "Cooldown": 5000,
+        "WhenUsable": true,
+        "Requirements": [
+          "Health% < 75",
+          "!Rejuvenation"
+        ],
         "Form": "None"
       },
       {
         "Name": "Moonfire",
         "Key": "5",
-        "AfterCastWaitBuff": true,
-        "CastIfAddsVisible": true,
-        "Requirements": ["SpellInRange:0", "not InMeleeRange", "not Moonfire", "Mana%>50"],
-        "WaitForWithinMeleeRange": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "Requirements": [
+          "!Moonfire",
+          "AddVisible",
+          "SpellInRange:0",
+          "MinRange > 10"
+        ],
         "Form": "None"
       },
       {
         "Name": "Bear Form",
         "Key": "F2",
         "WaitForWithinMeleeRange": true,
-        "Requirements": ["Moonfire", "not Form:Druid_Bear"]
+        "Requirements": [
+          "Moonfire",
+          "!Form:Druid_Bear"
+        ]
       },
       {
         "Name": "Bear Form",
         "Key": "F2",
-        "Requirements": ["not Form:Druid_Bear"]
+        "Requirements": [
+          "!Form:Druid_Bear"
+        ]
       }
     ]
   },
@@ -58,15 +68,15 @@
         "Name": "Healing Touch",
         "Key": "3",
         "HasCastBar": true,
-        "Requirement": "Health%<30",
-        "Cooldown": 5000,
+        "WhenUsable": true,
+        "Requirement": "Health% < 30",
         "Form": "None"
       },
       {
         "Name": "Enrage",
         "Key": "4",
         "WhenUsable": true,
-        "Requirement": "TargetHealth%>40",
+        "Requirement": "TargetHealth% > 40",
         "Form": "Druid_Bear"
       },
       {
@@ -74,20 +84,28 @@
         "Key": "3",
         "MinRage": 10,
         "WhenUsable": true,
-        "Requirements": ["InMeleeRange", "not Demoralizing Roar", "Form:Druid_Bear"],
+        "Requirements": [
+          "InMeleeRange",
+          "!Demoralizing Roar",
+          "Form:Druid_Bear"
+        ],
         "Form": "Druid_Bear"
       },
       {
         "Name": "Maul",
         "Key": "2",
         "MinRage": 15,
-        "Requirements": ["InMeleeRange", "LastMainHandMs>2100", "Form:Druid_Bear"], // bear swing speed fixed at 2.5
+        "Requirements": [
+          "InMeleeRange",
+          "LastMainHandMs > 2100",
+          "Form:Druid_Bear"
+        ], // bear swing speed fixed at 2.5
         "AfterCastWaitNextSwing": true,
         "Form": "Druid_Bear"
       },
       {
         "Name": "AutoAttack",
-        "Requirement": "not AutoAttacking"
+        "Requirement": "!AutoAttacking"
       },
       {
         "Name": "Approach",
@@ -107,23 +125,19 @@
       {
         "Name": "Mark of the Wild",
         "Key": "4",
-        "AfterCastWaitBuff": true,
-        "DelayAfterCast": 0,
-        "Requirement": "not Mark of the Wild",
+        "Requirement": "!Mark of the Wild",
         "Form": "None"
       },
       {
         "Name": "Thorns",
         "Key": "7",
-        "AfterCastWaitBuff": true,
-        "DelayAfterCast": 0,
-        "Requirement": "not Thorns",
+        "Requirement": "!Thorns",
         "Form": "None"
       },
       {
         "Name": "Water",
         "Key": "-",
-        "Requirement": "Mana%<40",
+        "Requirement": "Mana% < 40",
         "Form": "None"
       }
     ]
@@ -131,20 +145,23 @@
   "NPC": {
     "Sequence": [
       {
+        "Cost": 19,
         "Name": "Repair",
         "Key": "C",
         "Form": "None",
         "Requirement": "Items Broken",
-        "PathFilename": "10_NightElf_Vendor.json",
-        "Cost": 19
+        "PathFilename": "10_NightElf_Vendor.json"
       },
       {
+        "Cost": 19,
         "Name": "Sell",
         "Key": "C",
         "Form": "None",
-        "Requirements": ["BagFull", "BagGreyItem"],
-        "PathFilename": "10_NightElf_Vendor.json",
-        "Cost": 19
+        "Requirements": [
+          "BagFull",
+          "BagGreyItem"
+        ],
+        "PathFilename": "10_NightElf_Vendor.json"
       }
     ]
   }

--- a/Json/class/Druid_14_bear.json
+++ b/Json/class/Druid_14_bear.json
@@ -4,7 +4,6 @@
   "PathFilename": "_pack\\1-20\\Night elf\\11-14_Darkshore_Ameth'Aran Ruins.json",
   "PathReduceSteps": true,
   "CheckTargetGivesExp": true,
-
   "Form": [
     {
       //macro: /cancelform
@@ -25,30 +24,40 @@
         "Name": "Rejuvenation",
         "Key": "6",
         "AfterCastWaitBuff": true,
-        "Requirements": ["Health%<75", "not Rejuvenation"],
-        "Cooldown": 5000,
+        "Requirements": [
+          "Health% < 75",
+          "!Rejuvenation"
+        ],
         "Form": "None"
       },
       {
         "Name": "Moonfire",
         "Key": "5",
-        "AfterCastWaitBuff": true,
-        "CastIfAddsVisible": true,
-        "Requirements": ["SpellInRange:0", "not InMeleeRange", "not Moonfire", "Mana%>50"],
-        "WaitForWithinMeleeRange": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "Requirements": [
+          "!Moonfire",
+          "AddVisible",
+          "SpellInRange:0",
+          "MinRange > 10"
+        ],
         "Form": "None"
       },
       {
         "Name": "Bear Form",
         "Key": "F2",
         "WaitForWithinMeleeRange": true,
-        "Requirements": ["Moonfire", "not Form:Druid_Bear"]
+        "Requirements": [
+          "Moonfire",
+          "!Form:Druid_Bear"
+        ]
       },
       {
         "Name": "Bear Form",
         "Key": "F2",
-        "Requirements": ["not Form:Druid_Bear"]
+        "Requirements": [
+          "!Form:Druid_Bear"
+        ]
       }
     ]
   },
@@ -58,15 +67,15 @@
         "Name": "Healing Touch",
         "Key": "3",
         "HasCastBar": true,
-        "Requirement": "Health%<30",
-        "Cooldown": 5000,
+        "WhenUsable": true,
+        "Requirement": "Health% < 30",
         "Form": "None"
       },
       {
         "Name": "Enrage",
         "Key": "4",
         "WhenUsable": true,
-        "Requirement": "TargetHealth%>40",
+        "Requirement": "TargetHealth% > 40",
         "Form": "Druid_Bear"
       },
       {
@@ -74,7 +83,10 @@
         "Key": "5",
         "WhenUsable": true,
         "MinRage": 10,
-        "Requirements": ["SpellInRange:1", "CD == 0", "TargetCastingSpell || Health%<38"],
+        "Requirements": [
+          "SpellInRange:1",
+          "TargetCastingSpell || Health% < 38"
+        ],
         "Form": "Druid_Bear"
       },
       {
@@ -82,20 +94,28 @@
         "Key": "3",
         "MinRage": 10,
         "WhenUsable": true,
-        "Requirements": ["InMeleeRange", "not Demoralizing Roar", "Form:Druid_Bear"],
+        "Requirements": [
+          "InMeleeRange",
+          "!Demoralizing Roar",
+          "Form:Druid_Bear"
+        ],
         "Form": "Druid_Bear"
       },
       {
         "Name": "Maul",
         "Key": "2",
         "MinRage": 15,
-        "Requirements": ["InMeleeRange", "LastMainHandMs>2100", "Form:Druid_Bear"], // bear swing speed fixed at 2.5
+        "Requirements": [
+          "InMeleeRange",
+          "LastMainHandMs > 2100",
+          "Form:Druid_Bear"
+        ], // bear swing speed fixed at 2.5
         "AfterCastWaitNextSwing": true,
         "Form": "Druid_Bear"
       },
       {
         "Name": "AutoAttack",
-        "Requirement": "not AutoAttacking"
+        "Requirement": "!AutoAttacking"
       },
       {
         "Name": "Approach",
@@ -115,23 +135,19 @@
       {
         "Name": "Mark of the Wild",
         "Key": "4",
-        "AfterCastWaitBuff": true,
-        "DelayAfterCast": 0,
-        "Requirement": "not Mark of the Wild",
+        "Requirement": "!Mark of the Wild",
         "Form": "None"
       },
       {
         "Name": "Thorns",
         "Key": "7",
-        "AfterCastWaitBuff": true,
-        "DelayAfterCast": 0,
-        "Requirement": "not Thorns",
+        "Requirement": "!Thorns",
         "Form": "None"
       },
       {
         "Name": "Water",
         "Key": "-",
-        "Requirement": "Mana%<40",
+        "Requirement": "Mana% < 40",
         "Form": "None"
       }
     ]
@@ -139,20 +155,23 @@
   "NPC": {
     "Sequence": [
       {
+        "Cost": 19,
         "Name": "Repair",
         "Key": "C",
         "Form": "None",
         "Requirement": "Items Broken",
-        "PathFilename": "10_NightElf_Vendor.json",
-        "Cost": 19
+        "PathFilename": "10_NightElf_Vendor.json"
       },
       {
+        "Cost": 19,
         "Name": "Sell",
         "Key": "C",
         "Form": "None",
-        "Requirements": ["BagFull", "BagGreyItem"],
-        "PathFilename": "10_NightElf_Vendor.json",
-        "Cost": 19
+        "Requirements": [
+          "BagFull",
+          "BagGreyItem"
+        ],
+        "PathFilename": "10_NightElf_Vendor.json"
       }
     ]
   }

--- a/Json/class/Druid_16_bear.json
+++ b/Json/class/Druid_16_bear.json
@@ -4,8 +4,6 @@
   "PathFilename": "_pack\\1-20\\Night elf\\15-18_Darkshore_Twilight Vale - Blackwood.json",
   "PathReduceSteps": true,
   "CheckTargetGivesExp": true,
-  "NPCMaxLevels_Below": 10,
-
   "Form": [
     {
       //macro: /cancelform
@@ -26,30 +24,40 @@
         "Name": "Rejuvenation",
         "Key": "6",
         "AfterCastWaitBuff": true,
-        "Requirements": ["Health%<75", "not Rejuvenation"],
-        "Cooldown": 5000,
+        "Requirements": [
+          "Health% < 75",
+          "!Rejuvenation"
+        ],
         "Form": "None"
       },
       {
         "Name": "Moonfire",
         "Key": "5",
-        "AfterCastWaitBuff": true,
-        "CastIfAddsVisible": true,
-        "Requirements": ["SpellInRange:0", "not InMeleeRange", "not Moonfire", "Mana%>50"],
-        "WaitForWithinMeleeRange": true,
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "Requirements": [
+          "!Moonfire",
+          "AddVisible",
+          "SpellInRange:0",
+          "MinRange > 10"
+        ],
         "Form": "None"
       },
       {
         "Name": "Bear Form",
         "Key": "F2",
         "WaitForWithinMeleeRange": true,
-        "Requirements": ["Moonfire", "not Form:Druid_Bear"]
+        "Requirements": [
+          "Moonfire",
+          "!Form:Druid_Bear"
+        ]
       },
       {
         "Name": "Bear Form",
         "Key": "F2",
-        "Requirements": ["not Form:Druid_Bear"]
+        "Requirements": [
+          "!Form:Druid_Bear"
+        ]
       }
     ]
   },
@@ -59,21 +67,24 @@
         "Name": "Healing Touch",
         "Key": "3",
         "HasCastBar": true,
-        "Requirement": "Health%<30",
-        "Cooldown": 5000,
+        "WhenUsable": true,
+        "Requirement": "Health% < 30",
         "Form": "None"
       },
       {
         "Name": "Enrage",
         "Key": "4",
         "WhenUsable": true,
-        "Requirement": "TargetHealth%>40",
+        "Requirement": "TargetHealth% > 40",
         "Form": "Druid_Bear"
       },
       {
         "Name": "Bash",
         "Key": "5",
-        "Requirements": ["SpellInRange:1", "CD == 0", "TargetCastingSpell || Health%<38"],
+        "Requirements": [
+          "SpellInRange:1",
+          "TargetCastingSpell || Health% < 38"
+        ],
         "WhenUsable": true,
         "MinRage": 10,
         "Form": "Druid_Bear"
@@ -83,7 +94,11 @@
         "Key": "3",
         "MinRage": 10,
         "WhenUsable": true,
-        "Requirements": ["InMeleeRange", "not Demoralizing Roar", "Form:Druid_Bear"],
+        "Requirements": [
+          "InMeleeRange",
+          "!Demoralizing Roar",
+          "Form:Druid_Bear"
+        ],
         "Form": "Druid_Bear"
       },
       {
@@ -91,20 +106,29 @@
         "Key": "6",
         "MinRage": 20,
         "WhenUsable": true,
-        "Requirements": ["InMeleeRange", "MobCount>1", "Form:Druid_Bear"],
+        "Requirements": [
+          "InMeleeRange",
+          "MobCount > 1",
+          "Form:Druid_Bear"
+        ],
         "Form": "Druid_Bear"
       },
       {
         "Name": "Maul",
         "Key": "2",
         "MinRage": 15,
-        "Requirements": ["InMeleeRange", "MobCount<2", "LastMainHandMs>2100", "Form:Druid_Bear"], // bear swing speed fixed at 2.5
+        "Requirements": [
+          "InMeleeRange",
+          "MobCount < 2",
+          "LastMainHandMs > 2100",
+          "Form:Druid_Bear"
+        ], // bear swing speed fixed at 2.5
         "AfterCastWaitNextSwing": true,
         "Form": "Druid_Bear"
       },
       {
         "Name": "AutoAttack",
-        "Requirement": "not AutoAttacking"
+        "Requirement": "!AutoAttacking"
       },
       {
         "Name": "Approach",
@@ -117,23 +141,19 @@
       {
         "Name": "Mark of the Wild",
         "Key": "4",
-        "AfterCastWaitBuff": true,
-        "DelayAfterCast": 0,
-        "Requirement": "not Mark of the Wild",
+        "Requirement": "!Mark of the Wild",
         "Form": "None"
       },
       {
         "Name": "Thorns",
         "Key": "7",
-        "AfterCastWaitBuff": true,
-        "DelayAfterCast": 0,
-        "Requirement": "not Thorns",
+        "Requirement": "!Thorns",
         "Form": "None"
       },
       {
         "Name": "Water",
         "Key": "-",
-        "Requirement": "Mana%<40",
+        "Requirement": "Mana% < 40",
         "Form": "None"
       }
     ]
@@ -141,20 +161,23 @@
   "NPC": {
     "Sequence": [
       {
+        "Cost": 19,
         "Name": "Repair",
         "Key": "C",
         "Form": "None",
         "Requirement": "Items Broken",
-        "PathFilename": "10_NightElf_Vendor.json",
-        "Cost": 19
+        "PathFilename": "10_NightElf_Vendor.json"
       },
       {
+        "Cost": 19,
         "Name": "Sell",
         "Key": "C",
         "Form": "None",
-        "Requirements": ["BagFull", "BagGreyItem"],
-        "PathFilename": "10_NightElf_Vendor.json",
-        "Cost": 19
+        "Requirements": [
+          "BagFull",
+          "BagGreyItem"
+        ],
+        "PathFilename": "10_NightElf_Vendor.json"
       }
     ]
   }

--- a/Json/class/Druid_20_cat_bear.json
+++ b/Json/class/Druid_20_cat_bear.json
@@ -31,29 +31,40 @@
         "Key": "6",
         "StopBeforeCast": true,
         "AfterCastWaitBuff": true,
-        "Requirements": ["Health%<75", "not Rejuvenation"],
-        "Cooldown": 5000,
+        "Requirements": [
+          "Health% < 75",
+          "!Rejuvenation"
+        ],
         "Form": "None"
       },
       {
         "Name": "Moonfire",
         "Key": "5",
-        "AfterCastWaitBuff": true,
-        "CastIfAddsVisible": true,
-        "Requirements": ["SpellInRange:0", "MinRange > 10", "not Moonfire", "Mana%>40"],
         "StopBeforeCast": true,
+        "AfterCastWaitBuff": true,
+        "Requirements": [
+          "!Moonfire",
+          "AddVisible",
+          "SpellInRange:0",
+          "MinRange > 10"
+        ],
         "Form": "None"
       },
       {
         "Name": "Cat Form",
         "Key": "F3",
         "WaitForWithinMeleeRange": true,
-        "Requirements": ["Moonfire", "not Form:Druid_Cat"]
+        "Requirements": [
+          "Moonfire",
+          "!Form:Druid_Cat"
+        ]
       },
       {
         "Name": "Cat Form",
         "Key": "F3",
-        "Requirements": ["not Form:Druid_Cat"]
+        "Requirements": [
+          "!Form:Druid_Cat"
+        ]
       }
     ]
   },
@@ -64,8 +75,7 @@
         "Key": "0",
         "HasCastBar": true,
         "WhenUsable": true,
-        "Requirement": "Health%<30",
-        "Cooldown": 8000,
+        "Requirement": "Health% < 30",
         "Form": "None"
       },
       {
@@ -74,7 +84,12 @@
         "MinEnergy": 30,
         "MinComboPoints": 1,
         "WhenUsable": true,
-        "Requirements": ["SpellInRange:2", "not Rip", "MobCount<2", "Form:Druid_Cat"],
+        "Requirements": [
+          "SpellInRange:2",
+          "!Rip",
+          "MobCount < 2",
+          "Form:Druid_Cat"
+        ],
         "Form": "Druid_Cat"
       },
       {
@@ -82,18 +97,28 @@
         "Key": "2",
         "MinEnergy": 40,
         "WhenUsable": true,
-        "Requirements": ["SpellInRange:2", "MobCount<2", "Form:Druid_Cat"],
+        "Requirements": [
+          "SpellInRange:2",
+          "MobCount < 2",
+          "Form:Druid_Cat"
+        ],
         "Form": "Druid_Cat"
       },
       {
         "Name": "Bear Form",
         "Key": "F2",
-        "Requirements": ["not Form:Druid_Bear", "Health%<50||MobCount>1"]
+        "Requirements": [
+          "!Form:Druid_Bear",
+          "Health% < 50||MobCount > 1"
+        ]
       },
       {
         "Name": "Bash",
         "Key": "5",
-        "Requirements": ["SpellInRange:1", "CD == 0", "TargetCastingSpell||Health%<38"],
+        "Requirements": [
+          "SpellInRange:1",
+          "TargetCastingSpell || Health% < 38"
+        ],
         "WhenUsable": true,
         "MinRage": 10,
         "Form": "Druid_Bear"
@@ -110,7 +135,12 @@
         "Key": "3",
         "MinRage": 10,
         "WhenUsable": true,
-        "Requirements": ["InMeleeRange", "not Demoralizing Roar", "MobCount>1", "Form:Druid_Bear"],
+        "Requirements": [
+          "InMeleeRange",
+          "!Demoralizing Roar",
+          "MobCount > 1",
+          "Form:Druid_Bear"
+        ],
         "Form": "Druid_Bear"
       },
       {
@@ -118,25 +148,38 @@
         "Key": "6",
         "MinRage": 20,
         "WhenUsable": true,
-        "Requirements": ["InMeleeRange", "MobCount>1", "Form:Druid_Bear"],
+        "Requirements": [
+          "InMeleeRange",
+          "MobCount > 1",
+          "Form:Druid_Bear"
+        ],
         "Form": "Druid_Bear"
       },
       {
         "Name": "Maul",
         "Key": "2",
         "MinRage": 15,
-        "Requirements": ["InMeleeRange", "MobCount<2", "LastMainHandMs>2100", "Form:Druid_Bear"], // bear swing speed fixed at 2.5
+        "Requirements": [
+          "InMeleeRange",
+          "MobCount < 2",
+          "LastMainHandMs > 2100",
+          "Form:Druid_Bear"
+        ], // bear swing speed fixed at 2.5
         "AfterCastWaitNextSwing": true,
         "Form": "Druid_Bear"
       },
       {
         "Name": "Cat Form",
         "Key": "F3",
-        "Requirements": ["not Form:Druid_Cat", "Health%>60", "MobCount<2"]
+        "Requirements": [
+          "!Form:Druid_Cat",
+          "Health% > 60",
+          "MobCount < 2"
+        ]
       },
       {
         "Name": "AutoAttack",
-        "Requirement": "not AutoAttacking"
+        "Requirement": "!AutoAttacking"
       },
       {
         "Name": "Approach",
@@ -149,23 +192,19 @@
       {
         "Name": "Mark of the Wild",
         "Key": "4",
-        "AfterCastWaitBuff": true,
-        "DelayAfterCast": 0,
-        "Requirement": "not Mark of the Wild",
+        "Requirement": "!Mark of the Wild",
         "Form": "None"
       },
       {
         "Name": "Thorns",
         "Key": "7",
-        "AfterCastWaitBuff": true,
-        "DelayAfterCast": 0,
-        "Requirement": "not Thorns",
+        "Requirement": "!Thorns",
         "Form": "None"
       },
       {
         "Name": "Water",
         "Key": "-",
-        "Requirement": "Mana%<30",
+        "Requirement": "Mana% < 30",
         "Form": "None"
       }
     ]
@@ -173,18 +212,21 @@
   "NPC": {
     "Sequence": [
       {
+        "Cost": 6,
         "Name": "Repair",
         "Key": "C",
         "Requirement": "Items Broken",
-        "PathFilename": "20_Westfall_Vendor.json",
-        "Cost": 6
+        "PathFilename": "20_Westfall_Vendor.json"
       },
       {
+        "Cost": 6,
         "Name": "Sell",
         "Key": "C",
-        "Requirements": ["BagFull", "BagGreyItem"],
-        "PathFilename": "20_Westfall_Vendor.json",
-        "Cost": 6
+        "Requirements": [
+          "BagFull",
+          "BagGreyItem"
+        ],
+        "PathFilename": "20_Westfall_Vendor.json"
       }
     ]
   }

--- a/Json/class/Druid_24_cat_bear.json
+++ b/Json/class/Druid_24_cat_bear.json
@@ -31,8 +31,7 @@
         "Key": "0",
         "HasCastBar": true,
         "WhenUsable": true,
-        "Requirements": ["Health%<50", "CD==0"],
-        "Cooldown": 8000,
+        "Requirement": "Health% < 50",
         "Form": "None"
       },
       {
@@ -40,42 +39,51 @@
         "Key": "6",
         "StopBeforeCast": true,
         "AfterCastWaitBuff": true,
-        "Requirements": ["Health%<75", "not Rejuvenation"],
-        "Cooldown": 5000,
+        "Requirements": [
+          "Health% < 75",
+          "!Rejuvenation"
+        ],
         "Form": "None"
       },
       {
         "Name": "Moonfire",
         "Key": "5",
-        "CastIfAddsVisible": true,
         "StopBeforeCast": true,
         "AfterCastWaitBuff": true,
-        "Requirements": ["SpellInRange:0", "MinRange > 10", "not Moonfire"],
-        "Cooldown": 10000,
+        "Requirements": [
+          "!Moonfire",
+          "AddVisible",
+          "SpellInRange:0",
+          "MinRange > 10"
+        ],
         "Form": "None"
       },
       {
         "Name": "Cat Form",
         "Key": "F3",
         "WaitForWithinMeleeRange": true,
-        "Requirements": ["Moonfire", "not Form:Druid_Cat", "Health%>50"]
+        "Requirements": [
+          "Moonfire",
+          "!Form:Druid_Cat"
+        ]
       },
       {
         "Name": "Cat Form",
         "Key": "F3",
-        "Requirements": ["not Form:Druid_Cat", "Health%>50"]
+        "Requirements": [
+          "!Form:Druid_Cat"
+        ]
       },
       {
         "Name": "Tiger's Fury",
         "Key": "5",
         "WhenUsable": true,
         "MinEnergy": 30,
-        "Requirements": ["Form:Druid_Cat", "not TigersFury", "InMeleeRange"]
-      },
-      {
-        "Name": "Bear Form",
-        "Key": "F2",
-        "Requirements": ["not Form:Druid_Bear", "Health%<50"]
+        "Requirements": [
+          "Form:Druid_Cat",
+          "!TigersFury",
+          "InMeleeRange"
+        ]
       }
     ]
   },
@@ -86,8 +94,7 @@
         "Key": "0",
         "HasCastBar": true,
         "WhenUsable": true,
-        "Requirements": ["Health%<30", "CD==0"],
-        "Cooldown": 8000,
+        "Requirement": "Health% < 30",
         "Form": "None"
       },
       {
@@ -95,8 +102,13 @@
         "Key": "5",
         "WhenUsable": true,
         "MinEnergy": 30,
-        "Cooldown": 5000,
-        "Requirements": ["Form:Druid_Cat", "not TigersFury", "Rip", "Rake", "InMeleeRange"],
+        "Requirements": [
+          "Form:Druid_Cat",
+          "!TigersFury",
+          "Rip",
+          "Rake",
+          "InMeleeRange"
+        ],
         "Form": "Druid_Cat"
       },
       {
@@ -105,7 +117,13 @@
         "MinEnergy": 30,
         "MinComboPoints": 1,
         "WhenUsable": true,
-        "Requirements": ["SpellInRange:2", "not Rip", "MobCount<2", "Form:Druid_Cat", "TargetHealth%>20"],
+        "Requirements": [
+          "SpellInRange:2",
+          "!Rip",
+          "MobCount < 2",
+          "Form:Druid_Cat",
+          "TargetHealth% > 20"
+        ],
         "Form": "Druid_Cat"
       },
       {
@@ -113,7 +131,13 @@
         "Key": "4",
         "MinEnergy": 35,
         "WhenUsable": true,
-        "Requirements": ["SpellInRange:2", "not Rake", "MobCount<2", "Form:Druid_Cat", "TargetHealth%>20"],
+        "Requirements": [
+          "SpellInRange:2",
+          "!Rake",
+          "MobCount < 2",
+          "Form:Druid_Cat",
+          "TargetHealth% > 20"
+        ],
         "Form": "Druid_Cat"
       },
       {
@@ -121,18 +145,28 @@
         "Key": "2",
         "MinEnergy": 40,
         "WhenUsable": true,
-        "Requirements": ["SpellInRange:2", "MobCount<2", "Form:Druid_Cat"],
+        "Requirements": [
+          "SpellInRange:2",
+          "MobCount < 2",
+          "Form:Druid_Cat"
+        ],
         "Form": "Druid_Cat"
       },
       {
         "Name": "Bear Form",
         "Key": "F2",
-        "Requirements": ["not Form:Druid_Bear", "Health%<50||MobCount>1"]
+        "Requirements": [
+          "!Form:Druid_Bear",
+          "Health% < 50||MobCount > 1"
+        ]
       },
       {
         "Name": "Bash",
         "Key": "5",
-        "Requirements": ["SpellInRange:1", "CD == 0", "TargetCastingSpell || Health%<38"],
+        "Requirements": [
+          "SpellInRange:1",
+          "TargetCastingSpell || Health% < 38"
+        ],
         "WhenUsable": true,
         "MinRage": 10,
         "Form": "Druid_Bear"
@@ -149,7 +183,12 @@
         "Key": "3",
         "MinRage": 10,
         "WhenUsable": true,
-        "Requirements": ["InMeleeRange", "not Demoralizing Roar", "MobCount>1", "Form:Druid_Bear"],
+        "Requirements": [
+          "InMeleeRange",
+          "!Demoralizing Roar",
+          "MobCount > 1",
+          "Form:Druid_Bear"
+        ],
         "Form": "Druid_Bear"
       },
       {
@@ -157,25 +196,38 @@
         "Key": "6",
         "MinRage": 20,
         "WhenUsable": true,
-        "Requirements": ["InMeleeRange", "MobCount>1", "Form:Druid_Bear"],
+        "Requirements": [
+          "InMeleeRange",
+          "MobCount > 1",
+          "Form:Druid_Bear"
+        ],
         "Form": "Druid_Bear"
       },
       {
         "Name": "Maul",
         "Key": "2",
         "MinRage": 15,
-        "Requirements": ["InMeleeRange", "MobCount<2", "LastMainHandMs>2100", "Form:Druid_Bear"], // bear swing speed fixed at 2.5
+        "Requirements": [
+          "InMeleeRange",
+          "MobCount < 2",
+          "LastMainHandMs > 2100",
+          "Form:Druid_Bear"
+        ], // bear swing speed fixed at 2.5
         "AfterCastWaitNextSwing": true,
         "Form": "Druid_Bear"
       },
       {
         "Name": "Cat Form",
         "Key": "F3",
-        "Requirements": ["not Form:Druid_Cat", "Health%>60", "MobCount<2"]
+        "Requirements": [
+          "!Form:Druid_Cat",
+          "Health% > 60",
+          "MobCount < 2"
+        ]
       },
       {
         "Name": "AutoAttack",
-        "Requirement": "not AutoAttacking"
+        "Requirement": "!AutoAttacking"
       },
       {
         "Name": "Approach",
@@ -188,17 +240,13 @@
       {
         "Name": "Mark of the Wild",
         "Key": "4",
-        "AfterCastWaitBuff": true,
-        "DelayAfterCast": 0,
-        "Requirement": "not Mark of the Wild",
+        "Requirement": "!Mark of the Wild",
         "Form": "None"
       },
       {
         "Name": "Thorns",
         "Key": "7",
-        "AfterCastWaitBuff": true,
-        "DelayAfterCast": 0,
-        "Requirement": "not Thorns",
+        "Requirement": "!Thorns",
         "Form": "None"
       }
     ]
@@ -208,13 +256,13 @@
       {
         "Name": "Food",
         "Key": "=",
-        "Requirement": "Health%<50",
+        "Requirement": "Health% < 50",
         "Form": "None"
       },
       {
         "Name": "Water",
         "Key": "-",
-        "Requirement": "Mana%<40",
+        "Requirement": "Mana% < 40",
         "Form": "None"
       }
     ]
@@ -222,18 +270,21 @@
   "NPC": {
     "Sequence": [
       {
+        "Cost": 6,
         "Name": "Repair",
         "Key": "C",
         "Requirement": "Items Broken",
-        "PathFilename": "23_Duskwood_Vendor.json",
-        "Cost": 6
+        "PathFilename": "23_Duskwood_Vendor.json"
       },
       {
+        "Cost": 6,
         "Name": "Sell",
         "Key": "C",
-        "Requirements": ["BagFull", "BagGreyItem"],
-        "PathFilename": "23_Duskwood_Vendor.json",
-        "Cost": 6
+        "Requirements": [
+          "BagFull",
+          "BagGreyItem"
+        ],
+        "PathFilename": "23_Duskwood_Vendor.json"
       }
     ]
   }

--- a/Json/class/Druid_32_cat_bear.json
+++ b/Json/class/Druid_32_cat_bear.json
@@ -1,10 +1,13 @@
 {
   "ClassName": "Druid",
   "Loot": true,
-  "PathFilename": "24-30 Duskwood wolf ravager.json",
+  "PathFilename": "_pack\\30-40\\Alterac Mountains\\32-36 Yettis-Ogers.json",
   "PathReduceSteps": true,
   "PathThereAndBack": false,
   "CheckTargetGivesExp": true,
+  "IntVariables": {
+    "MIN_TARGET_HP_DOT%": 20
+  },
   "Form": [
     {
       //macro: /cancelform
@@ -38,13 +41,16 @@
         "Key": "0",
         "HasCastBar": true,
         "WhenUsable": true,
-        "Requirement": "Health% < 65",
+        "Requirements": [
+          "Health% < 65"
+        ],
         "Form": "None"
       },
       {
         "Name": "Rejuvenation",
         "Key": "6",
         "StopBeforeCast": true,
+        "HasCastBar": true,
         "AfterCastWaitBuff": true,
         "Requirements": [
           "Health% < 75",
@@ -71,6 +77,7 @@
         "WaitForWithinMeleeRange": true,
         "Requirements": [
           "Moonfire",
+          "SpellInRange:0",
           "!Form:Druid_Cat"
         ]
       },
@@ -78,6 +85,7 @@
         "Name": "Cat Form",
         "Key": "F3",
         "Requirements": [
+          "SpellInRange:0",
           "!Form:Druid_Cat"
         ]
       },
@@ -101,7 +109,9 @@
         "Key": "0",
         "HasCastBar": true,
         "WhenUsable": true,
-        "Requirement": "Health% < 30",
+        "Requirements": [
+          "Health% < 30"
+        ],
         "Form": "None"
       },
       {
@@ -114,7 +124,8 @@
           "!TigersFury",
           "Rip",
           "Rake",
-          "InMeleeRange"
+          "InMeleeRange",
+          "TargetHealth% > MIN_TARGET_HP_DOT%"
         ],
         "Form": "Druid_Cat"
       },
@@ -129,7 +140,7 @@
           "!Rip",
           "MobCount < 2",
           "Form:Druid_Cat",
-          "TargetHealth%  > 20"
+          "TargetHealth% > MIN_TARGET_HP_DOT%"
         ],
         "Form": "Druid_Cat"
       },
@@ -143,7 +154,20 @@
           "!Rake",
           "MobCount < 2",
           "Form:Druid_Cat",
-          "TargetHealth%  > 20"
+          "TargetHealth% > MIN_TARGET_HP_DOT%"
+        ],
+        "Form": "Druid_Cat"
+      },
+      {
+        "Name": "Ferocious Bite",
+        "Key": "6",
+        "MinEnergy": 35,
+        "WhenUsable": true,
+        "Requirements": [
+          "SpellInRange:2",
+          "MobCount < 2",
+          "Form:Druid_Cat",
+          "TargetHealth% <= MIN_TARGET_HP_DOT%"
         ],
         "Form": "Druid_Cat"
       },
@@ -164,17 +188,17 @@
         "Key": "F2",
         "Requirements": [
           "!Form:Druid_Bear",
-          "Health% < 50 || MobCount  >  1"
+          "Health% < 50 || MobCount > 1"
         ]
       },
       {
         "Name": "Bash",
         "Key": "5",
+        "WhenUsable": true,
         "Requirements": [
           "SpellInRange:1",
-          "TargetCastingSpell || Health% < 38"
+          "TargetCastingSpell || Health% < 33"
         ],
-        "WhenUsable": true,
         "MinRage": 10,
         "Form": "Druid_Bear"
       },
@@ -228,7 +252,7 @@
         "Key": "F3",
         "Requirements": [
           "!Form:Druid_Cat",
-          "Health% > 60",
+          "Health% > 50",
           "MobCount < 2"
         ]
       },
@@ -273,27 +297,6 @@
         "Key": "-",
         "Requirement": "Mana% < 40",
         "Form": "None"
-      }
-    ]
-  },
-  "NPC": {
-    "Sequence": [
-      {
-        "Cost": 6,
-        "Name": "Repair",
-        "Key": "C",
-        "Requirement": "Items Broken",
-        "PathFilename": "23_Duskwood_Vendor.json"
-      },
-      {
-        "Cost": 6,
-        "Name": "Sell",
-        "Key": "C",
-        "Requirements": [
-          "BagFull",
-          "BagGreyItem"
-        ],
-        "PathFilename": "23_Duskwood_Vendor.json"
       }
     ]
   }

--- a/Json/class/Druid_4.json
+++ b/Json/class/Druid_4.json
@@ -18,8 +18,8 @@
         "Name": "Healing Touch",
         "Key": "3",
         "HasCastBar": true,
-        "Requirement": "Health%<50",
-        "Cooldown": 5000
+        "WhenUsable": true,
+        "Requirement": "Health% < 50"
       },
       {
         "Name": "Wrath",
@@ -37,31 +37,33 @@
       {
         "Name": "Water",
         "Key": "-",
-        "Requirement": "Mana%<30"
+        "Requirement": "Mana% < 30"
       },
       {
         "Name": "Mark of the Wild",
         "Key": "4",
-        "Requirement": "not Mark of the Wild",
-        "Cooldown": 10000
+        "Requirement": "!Mark of the Wild"
       }
     ]
   },
   "NPC": {
     "Sequence": [
       {
+        "Cost": 6,
         "Name": "Repair",
         "Key": "C",
         "Requirement": "Items Broken",
-        "PathFilename": "1_NightElf_Vendor.json",
-        "Cost": 6
+        "PathFilename": "1_NightElf_Vendor.json"
       },
       {
+        "Cost": 6,
         "Name": "Sell",
         "Key": "C",
-        "Requirements": ["BagFull", "BagGreyItem"],
-        "PathFilename": "1_NightElf_Vendor.json",
-        "Cost": 6
+        "Requirements": [
+          "BagFull",
+          "BagGreyItem"
+        ],
+        "PathFilename": "1_NightElf_Vendor.json"
       }
     ]
   }

--- a/Json/class/Druid_6.json
+++ b/Json/class/Druid_6.json
@@ -19,30 +19,35 @@
         "Name": "Healing Touch",
         "Key": "3",
         "HasCastBar": true,
-        "Requirement": "Health%<25",
-        "Cooldown": 5000
+        "WhenUsable": true,
+        "Requirement": "Health% < 25"
       },
       {
         "Name": "Rejuvenation",
         "Key": "6",
-        "AfterCastWaitBuff": true,
-        "Requirements": ["Health%<55", "not Rejuvenation"],
-        "Cooldown": 5000
+        "WhenUsable": true,
+        "Requirements": [
+          "Health% < 55",
+          "!Rejuvenation"
+        ]
       },
       {
         "Name": "Moonfire",
-        "Requirements": ["not Moonfire", "TargetHealth%>25"],
-        "Key": "5"
+        "Key": "5",
+        "Requirements": [
+          "!Moonfire",
+          "TargetHealth% > 25"
+        ]
       },
       {
         "Name": "Wrath",
         "Key": "2",
-        "Requirement": "TargetHealth%>50",
-        "HasCastBar": true
+        "HasCastBar": true,
+        "Requirement": "TargetHealth% > 50"
       },
       {
         "Name": "AutoAttack",
-        "Requirement": "not AutoAttacking"
+        "Requirement": "!AutoAttacking"
       },
       {
         "Name": "Approach",
@@ -55,39 +60,38 @@
       {
         "Name": "Mark of the Wild",
         "Key": "4",
-        "AfterCastWaitBuff": true,
-        "DelayAfterCast": 0,
-        "Requirement": "not Mark of the Wild"
+        "Requirement": "!Mark of the Wild"
       },
       {
         "Name": "Thorns",
         "Key": "7",
-        "AfterCastWaitBuff": true,
-        "DelayAfterCast": 0,
-        "Requirement": "not Thorns"
+        "Requirement": "!Thorns"
       },
       {
         "Name": "Water",
         "Key": "-",
-        "Requirement": "Mana%<30"
+        "Requirement": "Mana% < 30"
       }
     ]
   },
   "NPC": {
     "Sequence": [
       {
+        "Cost": 19,
         "Name": "Repair",
         "Key": "C",
         "Requirement": "Items Broken",
-        "PathFilename": "5_NightElf_Vendor.json",
-        "Cost": 19
+        "PathFilename": "5_NightElf_Vendor.json"
       },
       {
+        "Cost": 19,
         "Name": "Sell",
         "Key": "C",
-        "Requirements": ["BagFull", "BagGreyItem"],
-        "PathFilename": "5_NightElf_Vendor.json",
-        "Cost": 19
+        "Requirements": [
+          "BagFull",
+          "BagGreyItem"
+        ],
+        "PathFilename": "5_NightElf_Vendor.json"
       }
     ]
   }

--- a/Json/class/Druid_bear.json
+++ b/Json/class/Druid_bear.json
@@ -44,7 +44,10 @@
         "Name": "Rejuvenation",
         "Key": "1",
         "AfterCastWaitBuff": true,
-        "Requirements": ["Health%<70", "not Rejuvenation"],
+        "Requirements": [
+          "Health% < 70",
+          "!Rejuvenation"
+        ],
         "Form": "None"
       },
       {
@@ -58,7 +61,10 @@
         "Name": "Moonfire",
         "Key": "8",
         "Form": "None",
-        "Requirements": ["not Moonfire", "SpellInRange:0"],
+        "Requirements": [
+          "!Moonfire",
+          "SpellInRange:0"
+        ],
         "MinMana": 235
       },
       {
@@ -82,9 +88,9 @@
       {
         "Name": "Healing Touch",
         "Key": "6",
-        "Requirement": "Health%<50",
-        "Cooldown": 10000,
         "HasCastBar": true,
+        "WhenUsable": true,
+        "Requirement": "Health% < 50",        
         "Form": "None"
       },
       {
@@ -95,16 +101,17 @@
       },
       {
         "Name": "Faerie Fire",
-        "Requirement": "not Faerie Fire",
         "Key": "7",
         "MinRage": 10,
-        "Cooldown": 10000,
-        "Form": "Druid_Bear",
-        "ResetOnNewTarget": true
+        "Requirement": "!Faerie Fire",
+        "Form": "Druid_Bear"
       },
       {
         "Name": "Roar",
-        "Requirements": ["InMeleeRange", "not Demoralizing Roar"],
+        "Requirements": [
+          "InMeleeRange",
+          "!Demoralizing Roar"
+        ],
         "Key": "5",
         "MinRage": 6,
         "Cooldown": 10000,
@@ -113,8 +120,8 @@
       {
         "Name": "Bash",
         "Key": "4",
+        "WhenUsable": true,
         "MinRage": 10,
-        "Cooldown": 31000,
         "Form": "Druid_Bear"
       },
       {
@@ -122,7 +129,10 @@
         "Key": "N1",
         "MinRage": 20,
         "WhenUsable": true,
-        "Requirements": ["InMeleeRange", "MobCount>1"],
+        "Requirements": [
+          "InMeleeRange",
+          "MobCount > 1"
+        ],
         "Form": "Druid_Bear"
       },
       {
@@ -130,12 +140,16 @@
         "Key": "2",
         "MinRage": 10,
         "AfterCastWaitNextSwing": true,
-        "Requirements": ["InMeleeRange", "MobCount<2", "LastMainHandMs>2100"], // bear swing speed fixed at 2.5
+        "Requirements": [
+          "InMeleeRange",
+          "MobCount < 2",
+          "LastMainHandMs > 2100"
+        ], // bear swing speed fixed at 2.5
         "Form": "Druid_Bear"
       },
       {
         "Name": "AutoAttack",
-        "Requirement": "not AutoAttacking"
+        "Requirement": "!AutoAttacking"
       },
       {
         "Name": "Approach",
@@ -148,7 +162,7 @@
       {
         "Name": "Healing Potion",
         "Key": "-",
-        "Requirement": "Health%<8",
+        "Requirement": "Health% < 8",
         "Cooldown": 60000,
         "Form": "None",
         "InCombat": "true",
@@ -157,7 +171,7 @@
       {
         "Name": "Heal",
         "Key": "6",
-        "Requirement": "Health%<60",
+        "Requirement": "Health% < 60",
         "Cooldown": 10000,
         "HasCastBar": true,
         "Form": "None",
@@ -167,14 +181,14 @@
         "Name": "Well Fed",
         "StopBeforeCast": false,
         "Key": "9",
-        "Requirement": "not Well Fed",
+        "Requirement": "!Well Fed",
         "Cooldown": 120000,
         "Form": "None"
       },
       {
         "Name": "Water",
         "Key": "0",
-        "Requirement": "Mana%<40",
+        "Requirement": "Mana% < 40",
         "Form": "None",
         "Cost": 3
       },
@@ -182,14 +196,14 @@
         "Name": "Thorns",
         "Key": "3",
         "Cooldown": 10000,
-        "Requirement": "not Thorns",
+        "Requirement": "!Thorns",
         "Form": "None"
       },
       {
         "Name": "Mark of the Wild",
         "Key": "4",
         "Cooldown": 10000,
-        "Requirement": "not Mark of the Wild",
+        "Requirement": "!Mark of the Wild",
         "Form": "None"
       },
       {

--- a/Json/class/Druid_cat.json
+++ b/Json/class/Druid_cat.json
@@ -51,7 +51,10 @@
         "Name": "Rejuvenation",
         "Key": "1",
         "AfterCastWaitBuff": true,
-        "Requirements": ["Health%<70", "not Rejuvenation"],
+        "Requirements": [
+          "Health% < 70",
+          "!Rejuvenation"
+        ],
         "Form": "None"
       },
       {
@@ -65,7 +68,10 @@
         "Name": "Moonfire",
         "Key": "8",
         "Form": "None",
-        "Requirements": ["SpellInRange:0", "not Moonfire"],
+        "Requirements": [
+          "SpellInRange:0",
+          "!Moonfire"
+        ],
         "MinMana": 235
       },
       {
@@ -85,7 +91,7 @@
       {
         "Name": "Healing Touch",
         "Key": "6",
-        "Requirement": "Health%<40",
+        "Requirement": "Health% < 40",
         "Cooldown": 10000,
         "HasCastBar": true,
         "Form": "None"
@@ -97,13 +103,13 @@
       {
         "Name": "Healing Potion",
         "Key": "-",
-        "Requirement": "Health%<50",
+        "Requirement": "Health% < 50",
         "Cooldown": 10000,
         "Form": "None"
       },
       {
         "Name": "Tigers Fury",
-        "Requirement": "not TigersFury",
+        "Requirement": "!TigersFury",
         "Key": "3",
         "MinEnergy": 30,
         "Cooldown": 6000,
@@ -112,7 +118,7 @@
       },
       {
         "Name": "Faerie Fire",
-        "Requirement": "not Faerie Fire",
+        "Requirement": "!Faerie Fire",
         "Key": "7",
         "MinRage": 10,
         "Cooldown": 10000,
@@ -121,7 +127,7 @@
       },
       {
         "Name": "Rip",
-        "Requirement": "not Rip",
+        "Requirement": "!Rip",
         "Key": "2",
         "MinEnergy": 30,
         "MinComboPoints": 3,
@@ -137,7 +143,7 @@
       },
       {
         "Name": "AutoAttack",
-        "Requirement": "not AutoAttacking"
+        "Requirement": "!AutoAttacking"
       },
       {
         "Name": "Approach",
@@ -150,7 +156,7 @@
       {
         "Name": "Healing Potion",
         "Key": "-",
-        "Requirement": "Health%<8",
+        "Requirement": "Health% < 8",
         "Cooldown": 60000,
         "Form": "None",
         "InCombat": "true",
@@ -159,7 +165,7 @@
       {
         "Name": "Healing Touch",
         "Key": "6",
-        "Requirement": "Health%<80",
+        "Requirement": "Health% < 80",
         "Cooldown": 10000,
         "HasCastBar": true,
         "Form": "None",
@@ -168,14 +174,14 @@
       {
         "Name": "Well Fed",
         "Key": "9",
-        "Requirement": "not Well Fed",
+        "Requirement": "!Well Fed",
         "Cooldown": 120000,
         "Form": "None"
       },
       {
         "Name": "Water",
         "Key": "0",
-        "Requirement": "Mana%<40",
+        "Requirement": "Mana% < 40",
         "Form": "None",
         "Cost": 3
       },
@@ -184,7 +190,7 @@
         "Key": "3",
         "AfterCastWaitBuff": true,
         "DelayAfterCast": 0,
-        "Requirement": "not Thorns",
+        "Requirement": "!Thorns",
         "Form": "None"
       },
       {
@@ -192,7 +198,7 @@
         "Key": "4",
         "AfterCastWaitBuff": true,
         "DelayAfterCast": 0,
-        "Requirement": "not Mark of the Wild",
+        "Requirement": "!Mark of the Wild",
         "Form": "None"
       },
       {

--- a/Json/class/Paladin_10.json
+++ b/Json/class/Paladin_10.json
@@ -66,8 +66,7 @@
         "HasCastBar": true,
         "WhenUsable": true,
         "Requirements": [
-          "(Blessing of Protection || Divine Protection && Health% < 60) || (!Blessing of Protection && CD_Blessing of Protection > 0 && !Divine Protection && CD_Divine Protection > 0 && Health% < 50 && TargetHealth%>20 && LastMainHandMs <= 1000)",
-          "CD==0"
+          "(Blessing of Protection || Divine Protection && Health% < 60) || (!Blessing of Protection && CD_Blessing of Protection > 0 && !Divine Protection && CD_Divine Protection > 0 && Health% < 50 && TargetHealth%>20 && LastMainHandMs <= 1000)"
         ]
       },
       {

--- a/Json/class/Paladin_16.json
+++ b/Json/class/Paladin_16.json
@@ -66,8 +66,7 @@
         "HasCastBar": true,
         "WhenUsable": true,
         "Requirements": [
-          "(Blessing of Protection || Divine Protection && Health% < 60) || (!Blessing of Protection && CD_Blessing of Protection > 0 && !Divine Protection && CD_Divine Protection > 0 && Health% < 50 && TargetHealth%>20 && LastMainHandMs <= 1000)",
-          "CD==0"
+          "(Blessing of Protection || Divine Protection && Health% < 60) || (!Blessing of Protection && CD_Blessing of Protection > 0 && !Divine Protection && CD_Divine Protection > 0 && Health% < 50 && TargetHealth%>20 && LastMainHandMs <= 1000)"
         ]
       },
       {

--- a/Json/class/Paladin_20.json
+++ b/Json/class/Paladin_20.json
@@ -72,8 +72,7 @@
         "WhenUsable": true,
         "Requirements": [
           "Health% < 75",
-          "(Blessing of Protection || Divine Protection)",
-          "CD == 0"
+          "(Blessing of Protection || Divine Protection)"
         ]
       },
       {
@@ -84,7 +83,6 @@
         "Requirements": [
           "Health% < 60",
           "!Blessing of Protection && CD_Blessing of Protection > 0 && !Divine Protection && CD_Divine Protection > 0",
-          "CD == 0",
           "MobCount < 2",
           "LastMainHandMs <= 1000"
         ],
@@ -96,7 +94,6 @@
         "WhenUsable": true,
         "Requirements": [
           "Mana% > 50",
-          "CD == 0",
           "MobCount > 1"
         ]
       },

--- a/Json/class/Paladin_30.json
+++ b/Json/class/Paladin_30.json
@@ -75,8 +75,7 @@
         "WhenUsable": true,
         "Requirements": [
           "Health% < 75",
-          "(Blessing of Protection || Divine Protection)",
-          "CD == 0"
+          "(Blessing of Protection || Divine Protection)"
         ]
       },
       {
@@ -87,7 +86,6 @@
         "Requirements": [
           "Health% < 60",
           "!Blessing of Protection && CD_Blessing of Protection > 0 && !Divine Protection && CD_Divine Protection > 0",
-          "CD == 0",
           "MobCount < 2",
           "LastMainHandMs <= 1000"
         ],
@@ -99,7 +97,6 @@
         "WhenUsable": true,
         "Requirements": [
           "Mana% > 50",
-          "CD == 0",
           "MobCount > 1"
         ]
       },

--- a/Json/class/Paladin_4.json
+++ b/Json/class/Paladin_4.json
@@ -8,7 +8,7 @@
         "Key": "3",
         "HasCastBar": true,
         "WhenUsable": true,
-        "Requirements": ["Health%<60", "TargetHealth%>20", "CD==0", "LastMainHandMs <= 1000"],
+        "Requirements": ["Health%<60", "TargetHealth%>20", "LastMainHandMs <= 1000"],
         "Cooldown": 5000
       },
       {

--- a/Json/class/Paladin_6.json
+++ b/Json/class/Paladin_6.json
@@ -45,8 +45,7 @@
         "HasCastBar": true,
         "WhenUsable": true,
         "Requirements": [
-          "(Divine Protection && Health% < 60) || (!Divine Protection && CD_Divine Protection > 0 && Health% < 50 && TargetHealth%>20 && LastMainHandMs <= 1000)",
-          "CD==0"
+          "(Divine Protection && Health% < 60) || (!Divine Protection && CD_Divine Protection > 0 && Health% < 50 && TargetHealth%>20 && LastMainHandMs <= 1000)"
         ]
       },
       {

--- a/Json/class/Paladin_8.json
+++ b/Json/class/Paladin_8.json
@@ -45,8 +45,7 @@
         "HasCastBar": true,
         "WhenUsable": true,
         "Requirements": [
-          "(Divine Protection && Health% < 60) || (!Divine Protection && CD_Divine Protection > 0 && Health% < 50 && TargetHealth%>20 && LastMainHandMs <= 1000)",
-          "CD==0"
+          "(Divine Protection && Health% < 60) || (!Divine Protection && CD_Divine Protection > 0 && Health% < 50 && TargetHealth%>20 && LastMainHandMs <= 1000)"
         ]
       },
       {

--- a/Json/class/Rogue_12.json
+++ b/Json/class/Rogue_12.json
@@ -10,8 +10,13 @@
         "HasCastbar": true,
         "WhenUsable": true,
         "WaitForWithinMeleeRange": true,
-        "CastIfAddsVisible": true,
-        "Requirements": ["HasRangedWeapon", "not InMeleeRange", "SpellInRange:1", "not Items Broken"]
+        "Requirements": [
+          "AddVisible",
+          "HasRangedWeapon",
+          "!InMeleeRange",
+          "SpellInRange:1",
+          "!Items Broken"
+        ]
       }
     ]
   },
@@ -30,14 +35,19 @@
         "WaitBuffAfterCast": true,
         "MinEnergy": 25,
         "MinComboPoints": 1,
-        "Requirements": ["not Slice and Dice"]
+        "Requirements": [
+          "!Slice and Dice"
+        ]
       },
       {
         "Name": "Eviscerate",
         "Key": "3",
         "MinEnergy": 35,
         "MinComboPoints": 2,
-        "Requirements": ["TargetHealth%>20", "LastMainHandMs<500"]
+        "Requirements": [
+          "TargetHealth%>20",
+          "LastMainHandMs<500"
+        ]
       },
       {
         "Name": "Sinister Strike",
@@ -47,7 +57,7 @@
       },
       {
         "Name": "AutoAttack",
-        "Requirement": "not AutoAttacking"
+        "Requirement": "!AutoAttacking"
       },
       {
         "Name": "Approach",
@@ -76,7 +86,10 @@
       {
         "Name": "Sell",
         "Key": "C",
-        "Requirements": ["BagFull", "BagGreyItem"],
+        "Requirements": [
+          "BagFull",
+          "BagGreyItem"
+        ],
         "PathFilename": "5_Gnome_Vendor.json",
         "Cost": 6
       }

--- a/Json/class/Warrior_10.json
+++ b/Json/class/Warrior_10.json
@@ -15,8 +15,12 @@
         "HasCastbar": true,
         "WhenUsable": true,
         "WaitForWithinMeleeRange": true,
-        "CastIfAddsVisible": true,
-        "Requirements": ["HasRangedWeapon && !Items Broken && SpellInRange:3"]
+        "Requirements": [
+          "AddVisible",
+          "SpellInRange:3",
+          "!Items Broken",
+          "HasRangedWeapon"
+        ]
       },
       {
         "Name": "Charge",
@@ -28,12 +32,16 @@
       {
         "Name": "StopAttack",
         "DelayBeforeCast": 30,
-        "Requirements": ["Battle Shout && AutoAttacking && Rage >= Cost_Heroic Strike"],
+        "Requirements": [
+          "Battle Shout && AutoAttacking && Rage >= Cost_Heroic Strike"
+        ],
         "DelayAfterCast": 50
       },
       {
         "Name": "Approach",
-        "Requirements": ["!Battle Shout && Rage < Cost_Heroic Strike"],
+        "Requirements": [
+          "!Battle Shout && Rage < Cost_Heroic Strike"
+        ],
         "Log": false
       }
     ]
@@ -45,7 +53,9 @@
         "Key": "6",
         "WhenUsable": true,
         "MinRage": 20,
-        "Requirements": ["!Thunder Clap && MobCount > 1"],
+        "Requirements": [
+          "!Thunder Clap && MobCount > 1"
+        ],
         "Form": "Warrior_BattleStance"
       },
       {
@@ -53,7 +63,9 @@
         "Key": "2",
         "WhenUsable": true,
         "MinRage": 15,
-        "Requirements": ["!Charge Stun && MainHandSwing > -400"],
+        "Requirements": [
+          "!Charge Stun && MainHandSwing > -400"
+        ],
         "AfterCastWaitNextSwing": true
       },
       {
@@ -61,12 +73,19 @@
         "Key": "5",
         "WhenUsable": true,
         "MinRage": 10,
-        "Requirements": ["!Charge Stun && TargetHealth% > 80", "!Rend"],
+        "Requirements": [
+          "!Charge Stun && TargetHealth% > 80",
+          "!Rend"
+        ],
         "Form": "Warrior_BattleStance"
       },
       {
         "Name": "AutoAttack",
-        "Requirements": ["InMeleeRange", "!Charge Stun", "!AutoAttacking"]
+        "Requirements": [
+          "InMeleeRange",
+          "!Charge Stun",
+          "!AutoAttacking"
+        ]
       },
       {
         "Name": "Approach",
@@ -107,7 +126,10 @@
       {
         "Name": "Sell",
         "Key": "C",
-        "Requirements": ["BagFull", "BagGreyItem"],
+        "Requirements": [
+          "BagFull",
+          "BagGreyItem"
+        ],
         "PathFilename": "5_Gnome_Vendor.json",
         "Cost": 6
       }

--- a/Json/class/Warrior_12.json
+++ b/Json/class/Warrior_12.json
@@ -15,8 +15,12 @@
         "HasCastbar": true,
         "WhenUsable": true,
         "WaitForWithinMeleeRange": true,
-        "CastIfAddsVisible": true,
-        "Requirements": ["HasRangedWeapon && !Items Broken && SpellInRange:3"]
+        "Requirements": [
+          "AddVisible",
+          "HasRangedWeapon",
+          "SpellInRange:3",
+          "!Items Broken"
+        ]
       },
       {
         "Name": "Charge",
@@ -28,12 +32,16 @@
       {
         "Name": "StopAttack",
         "DelayBeforeCast": 30,
-        "Requirements": ["Battle Shout && AutoAttacking && Rage >= Cost_Heroic Strike"],
+        "Requirements": [
+          "Battle Shout && AutoAttacking && Rage >= Cost_Heroic Strike"
+        ],
         "DelayAfterCast": 50
       },
       {
         "Name": "Approach",
-        "Requirements": ["!Battle Shout && Rage < Cost_Heroic Strike"],
+        "Requirements": [
+          "!Battle Shout && Rage < Cost_Heroic Strike"
+        ],
         "Log": false
       }
     ]
@@ -45,7 +53,9 @@
         "Key": "6",
         "WhenUsable": true,
         "MinRage": 20,
-        "Requirements": ["!Thunder Clap && MobCount > 1"],
+        "Requirements": [
+          "!Thunder Clap && MobCount > 1"
+        ],
         "Form": "Warrior_BattleStance"
       },
       {
@@ -59,7 +69,9 @@
         "Key": "2",
         "WhenUsable": true,
         "MinRage": 15,
-        "Requirements": ["!Charge Stun && MainHandSwing > -400"],
+        "Requirements": [
+          "!Charge Stun && MainHandSwing > -400"
+        ],
         "AfterCastWaitNextSwing": true
       },
       {
@@ -67,12 +79,19 @@
         "Key": "5",
         "WhenUsable": true,
         "MinRage": 10,
-        "Requirements": ["!Charge Stun && TargetHealth% > 50", "!Rend"],
+        "Requirements": [
+          "!Charge Stun && TargetHealth% > 50",
+          "!Rend"
+        ],
         "Form": "Warrior_BattleStance"
       },
       {
         "Name": "AutoAttack",
-        "Requirements": ["InMeleeRange", "!Charge Stun", "!AutoAttacking"]
+        "Requirements": [
+          "InMeleeRange",
+          "!Charge Stun",
+          "!AutoAttacking"
+        ]
       },
       {
         "Name": "Approach",
@@ -113,7 +132,10 @@
       {
         "Name": "Sell",
         "Key": "C",
-        "Requirements": ["BagFull", "BagGreyItem"],
+        "Requirements": [
+          "BagFull",
+          "BagGreyItem"
+        ],
         "PathFilename": "10_Loch_Modan_Vendor.json",
         "Cost": 6
       }

--- a/Json/class/Warrior_20.json
+++ b/Json/class/Warrior_20.json
@@ -15,8 +15,12 @@
         "HasCastbar": true,
         "WhenUsable": true,
         "WaitForWithinMeleeRange": true,
-        "CastIfAddsVisible": true,
-        "Requirements": ["HasRangedWeapon && !Items Broken && SpellInRange:3"]
+        "Requirements": [
+          "AddVisible",
+          "HasRangedWeapon",
+          "!Items Broken",
+          "SpellInRange:3"
+        ]
       },
       {
         "Name": "Charge",
@@ -28,12 +32,16 @@
       {
         "Name": "StopAttack",
         "DelayBeforeCast": 30,
-        "Requirements": ["Battle Shout && AutoAttacking && Rage >= Cost_Heroic Strike"],
+        "Requirements": [
+          "Battle Shout && AutoAttacking && Rage >= Cost_Heroic Strike"
+        ],
         "DelayAfterCast": 50
       },
       {
         "Name": "Approach",
-        "Requirements": ["!Battle Shout && Rage < Cost_Heroic Strike"],
+        "Requirements": [
+          "!Battle Shout && Rage < Cost_Heroic Strike"
+        ],
         "Log": false
       }
     ]
@@ -52,7 +60,9 @@
         "WhenUsable": true,
         "MinRage": 20,
         "Cooldown": 14000,
-        "Requirements": ["!Thunder Clap && MobCount > 1"],
+        "Requirements": [
+          "!Thunder Clap && MobCount > 1"
+        ],
         "Form": "Warrior_BattleStance"
       },
       {
@@ -66,7 +76,10 @@
         "Key": "1",
         "WhenUsable": true,
         "MinRage": 20,
-        "Requirements": ["!Charge Stun && MainHandSwing > -400", "MobCount > 1"],
+        "Requirements": [
+          "!Charge Stun && MainHandSwing > -400",
+          "MobCount > 1"
+        ],
         "AfterCastWaitNextSwing": true
       },
       {
@@ -74,7 +87,10 @@
         "Key": "2",
         "WhenUsable": true,
         "MinRage": 15,
-        "Requirements": ["!Charge Stun && MainHandSwing > -400", "MobCount < 2"],
+        "Requirements": [
+          "!Charge Stun && MainHandSwing > -400",
+          "MobCount < 2"
+        ],
         "AfterCastWaitNextSwing": true
       },
       {
@@ -82,12 +98,19 @@
         "Key": "5",
         "WhenUsable": true,
         "MinRage": 10,
-        "Requirements": ["!Charge Stun && TargetHealth% > 50", "!Rend"],
+        "Requirements": [
+          "!Charge Stun && TargetHealth% > 50",
+          "!Rend"
+        ],
         "Form": "Warrior_BattleStance"
       },
       {
         "Name": "AutoAttack",
-        "Requirements": ["InMeleeRange", "!Charge Stun", "!AutoAttacking"]
+        "Requirements": [
+          "InMeleeRange",
+          "!Charge Stun",
+          "!AutoAttacking"
+        ]
       },
       {
         "Name": "Approach",
@@ -128,7 +151,10 @@
       {
         "Name": "Sell",
         "Key": "C",
-        "Requirements": ["BagFull", "BagGreyItem"],
+        "Requirements": [
+          "BagFull",
+          "BagGreyItem"
+        ],
         "PathFilename": "10_Loch_Modan_Vendor.json",
         "Cost": 6
       }

--- a/Json/class/Warrior_24.json
+++ b/Json/class/Warrior_24.json
@@ -15,8 +15,12 @@
         "HasCastbar": true,
         "WhenUsable": true,
         "WaitForWithinMeleeRange": true,
-        "CastIfAddsVisible": true,
-        "Requirements": ["HasRangedWeapon && !Items Broken && SpellInRange:3"]
+        "Requirements": [
+          "AddVisible",
+          "HasRangedWeapon",
+          "!Items Broken",
+          "SpellInRange:3"
+        ]
       },
       {
         "Name": "Charge",
@@ -28,12 +32,16 @@
       {
         "Name": "StopAttack",
         "DelayBeforeCast": 30,
-        "Requirements": ["Battle Shout && AutoAttacking && Rage >= Cost_Heroic Strike"],
+        "Requirements": [
+          "Battle Shout && AutoAttacking && Rage >= Cost_Heroic Strike"
+        ],
         "DelayAfterCast": 50
       },
       {
         "Name": "Approach",
-        "Requirements": ["!Battle Shout && Rage < Cost_Heroic Strike"],
+        "Requirements": [
+          "!Battle Shout && Rage < Cost_Heroic Strike"
+        ],
         "Log": false
       }
     ]
@@ -52,7 +60,9 @@
         "WhenUsable": true,
         "MinRage": 20,
         "Cooldown": 14000,
-        "Requirements": ["!Thunder Clap && MobCount > 1"],
+        "Requirements": [
+          "!Thunder Clap && MobCount > 1"
+        ],
         "Form": "Warrior_BattleStance"
       },
       {
@@ -72,7 +82,10 @@
         "Key": "1",
         "WhenUsable": true,
         "MinRage": 20,
-        "Requirements": ["!Charge Stun && MainHandSwing > -400", "MobCount > 1"],
+        "Requirements": [
+          "!Charge Stun && MainHandSwing > -400",
+          "MobCount > 1"
+        ],
         "AfterCastWaitNextSwing": true
       },
       {
@@ -80,7 +93,10 @@
         "Key": "2",
         "WhenUsable": true,
         "MinRage": 15,
-        "Requirements": ["!Charge Stun && MainHandSwing > -400", "MobCount < 2"],
+        "Requirements": [
+          "!Charge Stun && MainHandSwing > -400",
+          "MobCount < 2"
+        ],
         "AfterCastWaitNextSwing": true
       },
       {
@@ -88,12 +104,19 @@
         "Key": "5",
         "WhenUsable": true,
         "MinRage": 10,
-        "Requirements": ["!Charge Stun && TargetHealth% > 50", "!Rend"],
+        "Requirements": [
+          "!Charge Stun && TargetHealth% > 50",
+          "!Rend"
+        ],
         "Form": "Warrior_BattleStance"
       },
       {
         "Name": "AutoAttack",
-        "Requirements": ["InMeleeRange", "!Charge Stun", "!AutoAttacking"]
+        "Requirements": [
+          "InMeleeRange",
+          "!Charge Stun",
+          "!AutoAttacking"
+        ]
       },
       {
         "Name": "Approach",
@@ -134,7 +157,10 @@
       {
         "Name": "Sell",
         "Key": "C",
-        "Requirements": ["BagFull", "BagGreyItem"],
+        "Requirements": [
+          "BagFull",
+          "BagGreyItem"
+        ],
         "PathFilename": "10_Loch_Modan_Vendor.json",
         "Cost": 6
       }

--- a/README.md
+++ b/README.md
@@ -352,7 +352,6 @@ Can specify conditions with `Requirement(s)` in order to create a matching actio
 | Key | The key to click (`ConsoleKey`) | `""` |
 | PressDuration | How many milliseconds to press the key for | `50` |
 | Form | Shapeshift/Stance form to be in to cast this spell | `Form.None` |
-| CastIfAddsVisible | If the bot can "See" any adds | `false` |
 | Charge | How many times shoud this Command be used in sequence and ignore its Cooldown | `1` |
 | Cooldown | **Note this is not the in-game cooldown!**<br>The time in milliseconds until the command can be used again.<br>This property will be updated when the backend registers the `Key` keypress. | `0` |
 | School | Indicate what type of element. `SchoolMask.`<br>(`Physical, Holy, Fire, Nature, Frost, Shadow, Arcane`) | `SchoolMask.None` |
@@ -971,6 +970,7 @@ Allow requirements about what buffs/debuffs you have or the target has or in gen
 | `"TargetsMe"` | The target currently targets the player |
 | `"TargetsPet"` | The target currently targets the player's pet |
 | `"TargetsNone"` | The target currently has not target |
+| `"AddVisible"` | Around the target there are possible additional NPCs |
 | `"TargetCastingSpell"` | Target casts any spell |
 | `"Swimming"` | The player is currently swimming. |
 | `"Falling"` | The player is currently falling down, not touching the ground. |


### PR DESCRIPTION
### Core Changes
* [Core: KeyAction.CastIfAddsVisible has been removed and replaced with Requirement of 'AddVisible'](https://github.com/Xian55/WowClassicGrindBot/commit/01e59135bf7b20e8990ad4cd10e7a4a437d03aab) 
* [Core: RequirementFactory: Upon 'WhenUsable' is enabled. Check the in-game cooldown existence and the actionbar usable api as well.](https://github.com/Xian55/WowClassicGrindBot/commit/c2b0369879b1fee4b764ad301e7c7a2e4f5678b5)
* [Druid Profiles: Update all of them to current standard. Format docs. Moonfire based pull uses 'AddVisible' requirement. AdhocGoals no longer needed to be guarded with 'AfterCastWaitBuff' and 'DelayAfterCast'. 'Cooldown' mostly removed.](https://github.com/Xian55/WowClassicGrindBot/commit/eca3e3bb8053aa9ae8897a1e50b27918861fd097)
* [Profiles: Replace 'CastIfAddsVisible' with 'AddVisible' requirement.](https://github.com/Xian55/WowClassicGrindBot/commit/1624432dab1919c006946ba429cc0f06bc99b4d0)
* [Paladin Profiles: Remove 'CD==0' requirement since 'WhenUsable' already contains the logic.](https://github.com/Xian55/WowClassicGrindBot/commit/24dcf3f8e8f26ee8c26e716fa470e81e2cac67e5) 
