### PR TITLE
Feature: nonblocking navigation - small fixes

### DIFF
--- a/BlazorServer/PathingApi/LocalPathingApi.cs
+++ b/BlazorServer/PathingApi/LocalPathingApi.cs
@@ -20,8 +20,6 @@ namespace BlazorServer
 
         private bool Enabled = true;
 
-        private int targetMapId;
-
         public LocalPathingApi(ILogger logger, PPatherService service)
         {
             this.logger = logger;
@@ -51,12 +49,10 @@ namespace BlazorServer
                 return new ValueTask<List<Vector3>>();
             }
 
-            targetMapId = map;
-
             var sw = new Stopwatch();
             sw.Start();
 
-            service.SetLocations(service.GetWorldLocation(map, fromPoint.X, fromPoint.Y, fromPoint.Z), service.GetWorldLocation(targetMapId, toPoint.X, toPoint.Y));
+            service.SetLocations(service.GetWorldLocation(map, fromPoint.X, fromPoint.Y, fromPoint.Z), service.GetWorldLocation(map, toPoint.X, toPoint.Y));
             var path = service.DoSearch(PatherPath.Graph.PathGraph.eSearchScoreSpot.A_Star_With_Model_Avoidance);
 
             if (path == null)
@@ -73,11 +69,6 @@ namespace BlazorServer
             var worldLocations = path.locations.Select(s => service.ToMapAreaSpot(s.X, s.Y, s.Z, map));
             var result = worldLocations.Select(l => new Vector3(l.X, l.Y, l.Z)).ToList();
             return new ValueTask<List<Vector3>>(result);
-        }
-
-        public ValueTask<List<Vector3>> FindRouteTo(AddonReader addonReader, Vector3 destination)
-        {
-            return FindRoute(addonReader.UIMapId.Value, addonReader.PlayerReader.PlayerLocation, destination);
         }
 
         public bool SelfTest()

--- a/Core/Goals/AdhocGoal.cs
+++ b/Core/Goals/AdhocGoal.cs
@@ -100,6 +100,12 @@ namespace Core.Goals
 
         public override ValueTask PerformAction()
         {
+            if (key.Charge >= 1)
+            {
+                castingHandler.CastIfReady(key, key.DelayBeforeCast);
+            }
+
+            wait.Update(1);
             return ValueTask.CompletedTask;
         }
     }

--- a/Core/Goals/AdhocNPCGoal.cs
+++ b/Core/Goals/AdhocNPCGoal.cs
@@ -122,7 +122,7 @@ namespace Core.Goals
             input.TapClearTarget();
             stopMoving.Stop();
 
-            var path = key.Path;
+            var path = key.Path.ToList();
             navigation.SetWayPoints(path);
 
             pathState = PathState.ApproachPathStart;
@@ -175,7 +175,7 @@ namespace Core.Goals
             }
         }
 
-        private async void Navigation_OnDestinationReached(object? sender, EventArgs e)
+        private void Navigation_OnDestinationReached(object? sender, EventArgs e)
         {
             if (pathState == PathState.ApproachPathStart)
             {
@@ -221,6 +221,7 @@ namespace Core.Goals
                     wait.Update(1);
 
                     var path = key.Path.ToList();
+                    path.Reverse();
                     navigation.SetWayPoints(path);
 
                     pathState++;
@@ -233,7 +234,7 @@ namespace Core.Goals
                     // instead keep it trapped to follow the route back
                     while (navigation.HasWaypoint())
                     {
-                        await navigation.Update();
+                        navigation.Update();
                         wait.Update(1);
                     }
 

--- a/Core/Goals/AdhocNPCGoal.cs
+++ b/Core/Goals/AdhocNPCGoal.cs
@@ -1,4 +1,4 @@
-using Core.GOAP;
+﻿using Core.GOAP;
 using SharedLib.NpcFinder;
 using Microsoft.Extensions.Logging;
 using System;
@@ -15,7 +15,6 @@ namespace Core.Goals
         {
             ApproachPathStart,
             FollowPath,
-            MoveBackToPathStart,
             Finished,
         }
 
@@ -169,8 +168,7 @@ namespace Core.Goals
         {
             if (pathState is PathState.ApproachPathStart)
             {
-                LogDebug("Reached the start point of the path.");
-
+                LogDebug("1 Reached the start point of the path.");
                 navigation.SimplifyRouteToWaypoint = false;
             }
         }
@@ -238,17 +236,13 @@ namespace Core.Goals
                         wait.Update(1);
                     }
 
-                    pathState++;
+                    pathState = PathState.Finished;
 
-                    LogDebug("Reached the start point of the path.");
+                    LogDebug("2 Reached the start point of the path.");
                     stopMoving.Stop();
+
+                    navigation.SimplifyRouteToWaypoint = true;
                 }
-            }
-            else if (pathState == PathState.MoveBackToPathStart)
-            {
-                navigation.SimplifyRouteToWaypoint = true;
-                pathState++;
-                stopMoving.Stop();
             }
         }
 

--- a/Core/Goals/AdhocNPCGoal.cs
+++ b/Core/Goals/AdhocNPCGoal.cs
@@ -1,4 +1,4 @@
-﻿using Core.GOAP;
+using Core.GOAP;
 using SharedLib.NpcFinder;
 using Microsoft.Extensions.Logging;
 using System;
@@ -145,9 +145,9 @@ namespace Core.Goals
             return base.OnExit();
         }
 
-        public override async ValueTask PerformAction()
+        public override ValueTask PerformAction()
         {
-            if (this.playerReader.Bits.PlayerInCombat && this.classConfig.Mode != Mode.AttendedGather) { return; }
+            if (this.playerReader.Bits.PlayerInCombat && this.classConfig.Mode != Mode.AttendedGather) { return ValueTask.CompletedTask; }
 
             if (playerReader.Bits.IsDrowning)
             {
@@ -155,11 +155,13 @@ namespace Core.Goals
             }
 
             if (pathState != PathState.Finished)
-                await navigation.Update();
+                navigation.Update();
 
             MountIfRequired();
 
             wait.Update(1);
+
+            return ValueTask.CompletedTask;
         }
 
 

--- a/Core/Goals/FollowRouteGoal.cs
+++ b/Core/Goals/FollowRouteGoal.cs
@@ -141,7 +141,7 @@ namespace Core.Goals
             return base.OnExit();
         }
 
-        public override async ValueTask PerformAction()
+        public override ValueTask PerformAction()
         {
             if (playerReader.HasTarget && playerReader.Bits.TargetIsDead)
             {
@@ -159,13 +159,15 @@ namespace Core.Goals
                 AlternateGatherTypes();
             }
 
-            if (playerReader.Bits.PlayerInCombat && classConfig.Mode != Mode.AttendedGather) { return; }
+            if (playerReader.Bits.PlayerInCombat && classConfig.Mode != Mode.AttendedGather) { return ValueTask.CompletedTask; }
 
-            await navigation.Update();
+            navigation.Update();
 
             RandomJump();
 
             wait.Update(1);
+
+            return ValueTask.CompletedTask;
         }
 
         private void StartLookingForTarget()

--- a/Core/Goals/FollowRouteGoal.cs
+++ b/Core/Goals/FollowRouteGoal.cs
@@ -76,6 +76,7 @@ namespace Core.Goals
             this.targetFinder = targetFinder;
 
             this.navigation = navigation;
+            navigation.OnPathCalculated += Navigation_OnPathCalculated;
             navigation.OnDestinationReached += Navigation_OnDestinationReached;
             navigation.OnWayPointReached += Navigation_OnWayPointReached;
 
@@ -100,6 +101,15 @@ namespace Core.Goals
                 {
                     StartLookingForTarget();
                     navigation.ResetStuckParameters();
+
+                    if (!navigation.HasWaypoint())
+                    {
+                        RefillWaypoints(true);
+                    }
+                    else
+                    {
+                        navigation.Resume();
+                    }
                 }
             }
         }
@@ -246,6 +256,11 @@ namespace Core.Goals
         }
 
         #region Refill rules
+
+        private void Navigation_OnPathCalculated(object? sender, EventArgs e)
+        {
+            MountIfRequired();
+        }
 
         private void Navigation_OnDestinationReached(object? sender, EventArgs e)
         {

--- a/Core/Goals/GoalFactory.cs
+++ b/Core/Goals/GoalFactory.cs
@@ -151,6 +151,7 @@ namespace Core
                 {
                     var nav = new Navigation(logger, playerDirection, input, addonReader, stopMoving, stuckDetector, pather, mountHandler);
                     availableActions.Add(new AdhocNPCGoal(logger, input, item, wait, addonReader, nav, stopMoving, npcNameTargeting, classConfig, blacklist, mountHandler, exec));
+                    item.Path.Clear();
                     item.Path.AddRange(ReadPath(item.Name, item.PathFilename));
                 }
 

--- a/Core/Goals/GoalThread.cs
+++ b/Core/Goals/GoalThread.cs
@@ -4,7 +4,6 @@ using SharedLib.Extensions;
 using System;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace Core.Goals
 {

--- a/Core/Goals/Navigation.cs
+++ b/Core/Goals/Navigation.cs
@@ -292,7 +292,7 @@ namespace Core.Goals
                     if (!active)
                         return;
 
-                    if (path == null)
+                    if (!success || path == null)
                     {
                         LogWarn($"Unable to find path {location} -> {wayPoints.Peek()}. Character may stuck!");
                         return;

--- a/Core/Goals/WalkToCorpseGoal.cs
+++ b/Core/Goals/WalkToCorpseGoal.cs
@@ -93,11 +93,11 @@ namespace Core.Goals
             return base.OnExit();
         }
 
-        public override async ValueTask PerformAction()
+        public override ValueTask PerformAction()
         {
             if (!playerReader.Bits.IsCorpseInRange)
             {
-                await navigation.Update();
+                navigation.Update();
             }
             else
             {
@@ -108,6 +108,8 @@ namespace Core.Goals
             RandomJump();
 
             wait.Update(1);
+
+            return ValueTask.CompletedTask;
         }
 
         private void RandomJump()

--- a/Core/Input/ConfigurableInput.cs
+++ b/Core/Input/ConfigurableInput.cs
@@ -6,6 +6,8 @@ namespace Core
 {
     public class ConfigurableInput : WowProcessInput
     {
+        private readonly bool log = true;
+
         public ClassConfiguration ClassConfig { private set; get; }
 
         public readonly int defaultKeyPress = 50;
@@ -24,94 +26,97 @@ namespace Core
             TurnLeftKey = classConfig.TurnLeftKey;
             TurnRightKey = classConfig.TurnRightKey;
 
-            logger.LogInformation($"[{nameof(ConfigurableInput)}] Movement Keys. Forward: {ForwardKey} - Backward: {BackwardKey} - TurnLeft: {TurnLeftKey} - TurnRight: {TurnRightKey}");
+            if (log)
+            {
+                logger.LogInformation($"[{nameof(ConfigurableInput)}] Movement Keys. Forward: {ForwardKey} - Backward: {BackwardKey} - TurnLeft: {TurnLeftKey} - TurnRight: {TurnRightKey}");
+            }
         }
 
         public void TapStopKey(string desc = "")
         {
-            KeyPress(ForwardKey, defaultKeyPress, $"TapStopKey: {desc}");
+            KeyPress(ForwardKey, defaultKeyPress, log ? $"TapStopKey: {desc}" : "");
         }
 
         public void TapInteractKey(string source)
         {
-            KeyPress(ClassConfig.Interact.ConsoleKey, defaultKeyPress, string.IsNullOrEmpty(source) ? "" : $"TapInteract ({source})");
+            KeyPress(ClassConfig.Interact.ConsoleKey, defaultKeyPress, log && string.IsNullOrEmpty(source) ? "" : $"TapInteract ({source})");
             this.ClassConfig.Interact.SetClicked();
         }
 
         public void TapApproachKey(string source)
         {
-            KeyPress(ClassConfig.Approach.ConsoleKey, ClassConfig.Approach.PressDuration, string.IsNullOrEmpty(source) ? "" : $"TapApproachKey ({source})");
+            KeyPress(ClassConfig.Approach.ConsoleKey, ClassConfig.Approach.PressDuration, log && string.IsNullOrEmpty(source) ? "" : $"TapApproachKey ({source})");
             this.ClassConfig.Approach.SetClicked();
         }
 
         public void TapLastTargetKey(string source)
         {
-            KeyPress(ClassConfig.TargetLastTarget.ConsoleKey, defaultKeyPress, $"TapLastTarget ({source})");
+            KeyPress(ClassConfig.TargetLastTarget.ConsoleKey, defaultKeyPress, log ? $"TapLastTarget ({source})" : "");
             this.ClassConfig.TargetLastTarget.SetClicked();
         }
 
         public void TapStandUpKey(string desc = "")
         {
-            KeyPress(ClassConfig.StandUp.ConsoleKey, defaultKeyPress, $"TapStandUpKey: {desc}");
+            KeyPress(ClassConfig.StandUp.ConsoleKey, defaultKeyPress, log ? $"TapStandUpKey: {desc}" : "");
             this.ClassConfig.StandUp.SetClicked();
         }
 
         public void TapClearTarget(string desc = "")
         {
-            KeyPress(ClassConfig.ClearTarget.ConsoleKey, defaultKeyPress, string.IsNullOrEmpty(desc) ? "" : $"TapClearTarget: {desc}");
+            KeyPress(ClassConfig.ClearTarget.ConsoleKey, defaultKeyPress, log && string.IsNullOrEmpty(desc) ? "" : $"TapClearTarget: {desc}");
             this.ClassConfig.ClearTarget.SetClicked();
         }
 
         public void TapStopAttack(string desc = "")
         {
-            KeyPress(ClassConfig.StopAttack.ConsoleKey, ClassConfig.StopAttack.PressDuration, string.IsNullOrEmpty(desc) ? "" : $"TapStopAttack: {desc}");
+            KeyPress(ClassConfig.StopAttack.ConsoleKey, ClassConfig.StopAttack.PressDuration, log && string.IsNullOrEmpty(desc) ? "" : $"TapStopAttack: {desc}");
             this.ClassConfig.StopAttack.SetClicked();
         }
 
         public void TapNearestTarget(string desc = "")
         {
-            KeyPress(ClassConfig.TargetNearestTarget.ConsoleKey, defaultKeyPress, $"TapNearestTarget: {desc}");
+            KeyPress(ClassConfig.TargetNearestTarget.ConsoleKey, defaultKeyPress, log ? $"TapNearestTarget: {desc}" : "");
             this.ClassConfig.TargetNearestTarget.SetClicked();
         }
 
         public void TapTargetPet(string desc = "")
         {
-            KeyPress(ClassConfig.TargetPet.ConsoleKey, defaultKeyPress, $"TapTargetPet: {desc}");
+            KeyPress(ClassConfig.TargetPet.ConsoleKey, defaultKeyPress, log ? $"TapTargetPet: {desc}" : "");
             this.ClassConfig.TargetPet.SetClicked();
         }
 
         public void TapTargetOfTarget(string desc = "")
         {
-            KeyPress(ClassConfig.TargetTargetOfTarget.ConsoleKey, defaultKeyPress, $"TapTargetsTarget: {desc}");
+            KeyPress(ClassConfig.TargetTargetOfTarget.ConsoleKey, defaultKeyPress, log ? $"TapTargetsTarget: {desc}" : "");
             this.ClassConfig.TargetTargetOfTarget.SetClicked();
         }
 
         public void TapJump(string desc = "")
         {
-            KeyPress(ClassConfig.Jump.ConsoleKey, defaultKeyPress, $"TapJump: {desc}");
+            KeyPress(ClassConfig.Jump.ConsoleKey, defaultKeyPress, log ? $"TapJump: {desc}" : "");
             this.ClassConfig.Jump.SetClicked();
         }
 
         public void TapPetAttack(string source = "")
         {
-            KeyPress(ClassConfig.PetAttack.ConsoleKey, ClassConfig.PetAttack.PressDuration, $"TapPetAttack ({source})");
+            KeyPress(ClassConfig.PetAttack.ConsoleKey, ClassConfig.PetAttack.PressDuration, log ? $"TapPetAttack ({source})" : "");
             this.ClassConfig.PetAttack.SetClicked();
         }
 
         public void TapHearthstone()
         {
-            KeyPress(ConsoleKey.I, defaultKeyPress, "TapHearthstone");
+            KeyPress(ConsoleKey.I, defaultKeyPress, log ? "TapHearthstone" : "");
         }
 
         public void TapMount()
         {
-            KeyPress(ClassConfig.Mount.ConsoleKey, defaultKeyPress, "TapMount");
+            KeyPress(ClassConfig.Mount.ConsoleKey, defaultKeyPress, log ? "TapMount" : "");
             this.ClassConfig.Mount.SetClicked();
         }
 
         public void TapDismount()
         {
-            KeyPress(ClassConfig.Mount.ConsoleKey, defaultKeyPress, "TapDismount");
+            KeyPress(ClassConfig.Mount.ConsoleKey, defaultKeyPress, log ? "TapDismount" : "");
         }
     }
 }

--- a/Core/PPather/IPPather.cs
+++ b/Core/PPather/IPPather.cs
@@ -8,7 +8,6 @@ namespace Core
     public interface IPPather
     {
         ValueTask<List<Vector3>> FindRoute(int map, Vector3 fromPoint, Vector3 toPoint);
-        ValueTask<List<Vector3>> FindRouteTo(AddonReader addonReader, Vector3 wowPoint);
         ValueTask DrawLines(List<LineArgs> lineArgs);
         ValueTask DrawLines();
         ValueTask DrawSphere(SphereArgs args);

--- a/Core/PPather/RemotePathingAPI.cs
+++ b/Core/PPather/RemotePathingAPI.cs
@@ -24,8 +24,6 @@ namespace Core
 
         private List<LineArgs> lineArgs = new List<LineArgs>();
 
-        private int targetMapId;
-
         public RemotePathingAPI(ILogger logger, string host="", int port=0)
         {
             this.logger = logger;
@@ -71,12 +69,10 @@ namespace Core
 
         public async ValueTask<List<Vector3>> FindRoute(int map, Vector3 fromPoint, Vector3 toPoint)
         {
-            targetMapId = map;
-
             try
             {
-                logger.LogInformation($"Finding route from {fromPoint} map {map} to {toPoint} map {targetMapId}...");
-                var url = $"{api}MapRoute?map1={map}&x1={fromPoint.X}&y1={fromPoint.Y}&map2={targetMapId}&x2={toPoint.X}&y2={toPoint.Y}";
+                logger.LogInformation($"Finding route from {fromPoint} map {map} to {toPoint} map {map}...");
+                var url = $"{api}MapRoute?map1={map}&x1={fromPoint.X}&y1={fromPoint.Y}&map2={map}&x2={toPoint.X}&y2={toPoint.Y}";
                 var sw = new Stopwatch();
                 sw.Start();
 
@@ -87,7 +83,7 @@ namespace Core
                         var responseString = await client.GetStringAsync(url);
                         logger.LogInformation($"Finding route from {fromPoint} map {map} to {toPoint} took {sw.ElapsedMilliseconds} ms.");
                         var path = JsonConvert.DeserializeObject<IEnumerable<WorldMapAreaSpot>>(responseString);
-                        var result = path.Select(l => new Vector3(l.X, l.Y, 0)).ToList();
+                        var result = path.Select(l => new Vector3(l.X, l.Y, l.Z)).ToList();
                         return result;
                     }
                 }

--- a/Core/PPather/RemotePathingAPI.cs
+++ b/Core/PPather/RemotePathingAPI.cs
@@ -96,11 +96,6 @@ namespace Core
             }
         }
 
-        public async ValueTask<List<Vector3>> FindRouteTo(AddonReader addonReader, Vector3 destination)
-        {
-            return await FindRoute(addonReader.UIMapId.Value, addonReader.PlayerReader.PlayerLocation, destination);
-        }
-
         public async Task<bool> PingServer()
         {
             try

--- a/Core/PPather/RemotePathingAPIV3.cs
+++ b/Core/PPather/RemotePathingAPIV3.cs
@@ -75,19 +75,10 @@ namespace Core
 
         public ValueTask<List<Vector3>> FindRoute(int uiMapId, Vector3 fromPoint, Vector3 toPoint)
         {
-            return new ValueTask<List<Vector3>>();
-        }
-
-        public ValueTask<List<Vector3>> FindRouteTo(AddonReader addonReader, Vector3 destination)
-        {
             if (!Client.IsConnected)
             {
                 return new ValueTask<List<Vector3>>();
             }
-
-            int uiMapId = addonReader.UIMapId.Value;
-            Vector3 fromPoint = addonReader.PlayerReader.PlayerLocation;
-            Vector3 toPoint = destination;
 
             try
             {
@@ -123,18 +114,6 @@ namespace Core
                     result.Add(point);
                 }
 
-                if (result.Count > 0)
-                {
-                    addonReader.PlayerReader.ZCoord = result[0].Z;
-                    if (debug)
-                        logger.LogInformation($"PlayerLocation.Z = {addonReader.PlayerReader.PlayerLocation.Z}");
-                }
-                else
-                {
-                    if (debug)
-                        logger.LogWarning($"Found route length is {path.Length}");
-                }
-
                 return new ValueTask<List<Vector3>>(result);
             }
             catch (Exception ex)
@@ -143,7 +122,6 @@ namespace Core
                 Console.WriteLine(ex);
                 return new ValueTask<List<Vector3>>();
             }
-
         }
 
 

--- a/Game/Input/WowProcessInput.cs
+++ b/Game/Input/WowProcessInput.cs
@@ -8,6 +8,8 @@ namespace Game
 {
     public partial class WowProcessInput : IMouseInput
     {
+        private readonly bool log = true;
+
         private const int MIN_DELAY = 25;
         private const int MAX_DELAY = 55;
 
@@ -41,7 +43,7 @@ namespace Game
                 }
             }
 
-            if (!string.IsNullOrEmpty(description))
+            if (log && !string.IsNullOrEmpty(description))
                 LogKeyDown(logger, key, description);
 
             nativeInput.KeyDown((int)key);
@@ -65,7 +67,7 @@ namespace Game
                 }
             }
 
-            if (!string.IsNullOrEmpty(description))
+            if (log && !string.IsNullOrEmpty(description))
                 LogKeyUp(logger, key, description);
 
             nativeInput.KeyUp((int)key);
@@ -103,7 +105,7 @@ namespace Game
             keyDict[key] = true;
             int totalElapsedMs = nativeInput.KeyPress((int)key, milliseconds);
             keyDict[key] = false;
-            if (!string.IsNullOrEmpty(description))
+            if (log && !string.IsNullOrEmpty(description))
             {
                 LogKeyPress(logger, key, description, totalElapsedMs);
             }
@@ -114,7 +116,7 @@ namespace Game
             if (milliseconds < 1)
                 return;
 
-            if (!string.IsNullOrEmpty(description))
+            if (log && !string.IsNullOrEmpty(description))
             {
                 LogKeyPress(logger, key, description, milliseconds);
             }
@@ -126,7 +128,7 @@ namespace Game
 
         public void SetKeyState(ConsoleKey key, bool pressDown, bool forceClick, string description = "")
         {
-            if (!string.IsNullOrEmpty(description))
+            if (log && !string.IsNullOrEmpty(description))
                 description = "SetKeyState-" + description;
 
             if (pressDown) { KeyDown(key, description); } else { KeyUp(key, forceClick, description); }

--- a/PathingAPI/Data/DummyVector3.cs
+++ b/PathingAPI/Data/DummyVector3.cs
@@ -1,0 +1,9 @@
+﻿namespace PathingAPI.Data
+{
+    public class DummyVector3
+    {
+        public float X { get; set; }
+        public float Y { get; set; }
+        public float Z { get; set; }
+    }
+}

--- a/PathingAPI/Data/Lines.cs
+++ b/PathingAPI/Data/Lines.cs
@@ -8,7 +8,7 @@ namespace PathingAPI.Data
         public Lines(){}
 
         public string Name { get; set; }
-        public List<Vector3> Spots { get; set; }
+        public List<DummyVector3> Spots { get; set; }
         public int Colour { get; set; }
         public int MapId { get; set; }
     }

--- a/PathingAPI/Data/Sphere.cs
+++ b/PathingAPI/Data/Sphere.cs
@@ -7,7 +7,7 @@ namespace PathingAPI.Data
         public Sphere() { }
 
         public string Name { get; set; }
-        public Vector3 Spot { get; set; }
+        public DummyVector3 Spot { get; set; }
         public int Colour { get; set; }
         public int MapId { get; set; }
     }


### PR DESCRIPTION
### Changes
* Cleanup the `PPather` related codebase
* `Navigation` pathfinding has been delegated to a worker thread. No longer blocks the bot thread.
* `Navigation` path result can be discarded incase the component no longer active.

### Bug Fixes
* `RemotePathingV1`: `System.Numerics.Vector3` were not serialized properly.
* `AdhocNPCGoals`: when route keep getting added after reinitializing `ClassConfig`.
* `AdhocNpcGoal`: where the original path route modified after `Reverse`.
* `AdhocGoal`: regarding `Life tap` like spell unable to use more than 1 charge.