### PR TITLE
Tidy up: requirement factory

### DIFF
--- a/Core/BotController.cs
+++ b/Core/BotController.cs
@@ -286,6 +286,7 @@ namespace Core
             Stopwatch stopwatch = Stopwatch.StartNew();
             try
             {
+                ClassConfig?.Dispose();
                 ClassConfig = ReadClassConfiguration(classFile, pathFile);
             }
             catch (Exception e)

--- a/Core/ClassConfig/ClassConfiguration.cs
+++ b/Core/ClassConfig/ClassConfiguration.cs
@@ -108,7 +108,7 @@ namespace Core
         {
             SpiritPathFilename = string.Empty;
 
-            requirementFactory.PopulateUserDefinedIntVariables(IntVariables);
+            requirementFactory.InitUserDefinedIntVariables(IntVariables);
 
             Jump.Key = JumpKey;
             Jump.Initialise(addonReader, requirementFactory, logger);

--- a/Core/ClassConfig/ClassConfiguration.cs
+++ b/Core/ClassConfig/ClassConfiguration.cs
@@ -22,7 +22,7 @@ namespace Core
     }
 
 
-    public class ClassConfiguration
+    public class ClassConfiguration : IDisposable
     {
         public string ClassName { get; set; } = string.Empty;
         public bool Loot { get; set; } = true;
@@ -210,6 +210,15 @@ namespace Core
             }
 
             CheckConfigConsistency(logger);
+        }
+
+        public void Dispose()
+        {
+            Pull.Dispose();
+            Combat.Dispose();
+            Parallel.Dispose();
+            Adhoc.Dispose();
+            NPC.Dispose();
         }
 
         private void CheckConfigConsistency(ILogger logger)

--- a/Core/ClassConfig/KeyAction.cs
+++ b/Core/ClassConfig/KeyAction.cs
@@ -7,7 +7,7 @@ using System.Numerics;
 
 namespace Core
 {
-    public class KeyAction
+    public partial class KeyAction
     {
         public string Name { get; set; } = string.Empty;
         public bool HasCastBar { get; set; }
@@ -80,9 +80,9 @@ namespace Core
 
         private ILogger logger = null!;
 
-        public void CreateDynamicBinding(RequirementFactory requirementFactory)
+        public void InitDynamicBinding(RequirementFactory requirementFactory)
         {
-            requirementFactory.CreateDynamicBindings(this);
+            requirementFactory.InitDynamicBindings(this);
         }
 
         public void Initialise(AddonReader addonReader, RequirementFactory requirementFactory, ILogger logger, KeyActions? keyActions = null)
@@ -123,7 +123,7 @@ namespace Core
 
             ConsoleKeyFormHash = ((int)FormEnum * 1000) + (int)ConsoleKey;
 
-            InitialiseMinResourceRequirement(playerReader, addonReader.ActionBarCostReader);
+            InitMinPowerType(playerReader, addonReader.ActionBarCostReader);
 
             requirementFactory.InitialiseRequirements(this, keyActions);
         }
@@ -214,7 +214,7 @@ namespace Core
             return !string.IsNullOrEmpty(Form);
         }
 
-        private void InitialiseMinResourceRequirement(PlayerReader playerReader, ActionBarCostReader actionBarCostReader)
+        private void InitMinPowerType(PlayerReader playerReader, ActionBarCostReader actionBarCostReader)
         {
             var (type, cost) = actionBarCostReader.GetCostByActionBarSlot(playerReader, this);
             if (cost != 0)
@@ -279,17 +279,27 @@ namespace Core
 
                 if (e.cost != oldValue)
                 {
-                    logger.LogInformation($"[{Name}] Update {e.powerType} cost to {e.cost} from {oldValue}");
+                    LogPowerCostChange(logger, Name, e.powerType, e.cost, oldValue);
                 }
             }
         }
+
+        #region Logging
 
         public void LogInformation(string message)
         {
             if (Log)
             {
-                logger.LogInformation($"{Name}: {message}");
+                logger.LogInformation($"[{Name}]: {message}");
             }
         }
+
+        [LoggerMessage(
+            EventId = 9,
+            Level = LogLevel.Information,
+            Message = "[{name}] Update {type} cost to {newCost} from {oldCost}")]
+        static partial void LogPowerCostChange(ILogger logger, string name, PowerType type, int newCost, int oldCost);
+
+        #endregion
     }
 }

--- a/Core/ClassConfig/KeyActions.cs
+++ b/Core/ClassConfig/KeyActions.cs
@@ -1,9 +1,10 @@
 ﻿using Microsoft.Extensions.Logging;
+using System;
 using System.Collections.Generic;
 
 namespace Core
 {
-    public partial class KeyActions
+    public partial class KeyActions : IDisposable
     {
         public List<KeyAction> Sequence { get; } = new List<KeyAction>();
 
@@ -25,6 +26,11 @@ namespace Core
             }
 
             Sequence.ForEach(i => i.Initialise(addonReader, requirementFactory, logger, this));
+        }
+
+        public void Dispose()
+        {
+            Sequence.ForEach(i => i.Dispose());
         }
 
         [LoggerMessage(

--- a/Core/ClassConfig/KeyActions.cs
+++ b/Core/ClassConfig/KeyActions.cs
@@ -14,7 +14,7 @@ namespace Core
                 LogDynamicBinding(logger, prefix);
             }
 
-            Sequence.ForEach(i => i.CreateDynamicBinding(requirementFactory));
+            Sequence.ForEach(i => i.InitDynamicBinding(requirementFactory));
         }
 
         public void Initialise(string prefix, AddonReader addonReader, RequirementFactory requirementFactory, ILogger logger)


### PR DESCRIPTION
### Changes
* Refactor: `RequirementFactory` have some naming convention. Unify arithmetic requirements. Use 'Add' prefix where the requirement maybe added depending on the condition. Use 'Create' prefix where new requirement going to be allocated. Use template generated log messages.
* Fix: an issue were `ActionBarCostReader_OnActionCostChanged` not properly handled upon `ClassConfiguration` discarded.

