### PR TITLE
Core: Avoid using getter-only (readonly) auto implemented property

### DIFF
--- a/Core/Actionbar/ActionBarBits.cs
+++ b/Core/Actionbar/ActionBarBits.cs
@@ -2,23 +2,50 @@
 {
     public class ActionBarBits
     {
+        private readonly ISquareReader reader;
+        private readonly int[] cells;
+
         private readonly BitStatus[] bits;
         private readonly PlayerReader playerReader;
 
+        private bool isDirty;
+
         public ActionBarBits(PlayerReader playerReader, ISquareReader reader, params int[] cells)
         {
+            this.reader = reader;
             this.playerReader = playerReader;
+            this.cells = cells;
 
             bits = new BitStatus[cells.Length];
             for (int i = 0; i < bits.Length; i++)
             {
-                bits[i] = new BitStatus(reader.GetIntAtCell(cells[i]));
+                bits[i] = new(reader.GetIntAtCell(cells[i]));
             }
         }
+
+        public void SetDirty()
+        {
+            isDirty = true;
+        }
+
+        private void Update()
+        {
+            for (int i = 0; i < bits.Length; i++)
+            {
+                bits[i].Update(reader.GetIntAtCell(cells[i]));
+            }
+        }
+
 
         // https://wowwiki-archive.fandom.com/wiki/ActionSlot
         public bool Is(KeyAction item)
         {
+            if (isDirty)
+            {
+                Update();
+                isDirty = false;
+            }
+
             if (KeyReader.ActionBarSlotMap.TryGetValue(item.Key, out int slot))
             {
                 slot += Stance.RuntimeSlotToActionBar(item, playerReader, slot);

--- a/Core/Addon/AddonReader.cs
+++ b/Core/Addon/AddonReader.cs
@@ -25,8 +25,8 @@ namespace Core
 
         public ActionBarCooldownReader ActionBarCooldownReader { get; }
 
-        public ActionBarBits CurrentAction => new(PlayerReader, squareReader, 26, 27, 28, 29, 30);
-        public ActionBarBits UsableAction => new(PlayerReader, squareReader, 31, 32, 33, 34, 35);
+        public ActionBarBits CurrentAction { get; }
+        public ActionBarBits UsableAction { get; }
 
         public GossipReader GossipReader { get; }
 
@@ -98,6 +98,9 @@ namespace Core
             this.PlayerReader = new PlayerReader(squareReader);
             this.LevelTracker = new LevelTracker(this);
             this.TalentReader = new TalentReader(squareReader, 72, PlayerReader, talentDB);
+
+            this.CurrentAction = new(PlayerReader, squareReader, 26, 27, 28, 29, 30);
+            this.UsableAction = new(PlayerReader, squareReader, 31, 32, 33, 34, 35);
 
             UpdateLatencys = new CircularBuffer<double>(10);
 
@@ -206,6 +209,10 @@ namespace Core
                 AvgUpdateLatency += UpdateLatencys.PeekAt(i);
             }
             AvgUpdateLatency /= UpdateLatencys.Size;
+
+            CurrentAction.SetDirty();
+            UsableAction.SetDirty();
+            PlayerReader.SetDirty();
         }
     }
 }

--- a/Core/Addon/PlayerReader.cs
+++ b/Core/Addon/PlayerReader.cs
@@ -10,6 +10,12 @@ namespace Core
         public PlayerReader(ISquareReader reader)
         {
             this.reader = reader;
+            Bits = new(reader, 8, 9);
+            SpellInRange = new(reader, 40);
+            Buffs = new(reader, 41);
+            TargetDebuffs = new(reader, 42);
+            Stance = new(reader, 48);
+            CustomTrigger1 = new(reader.GetIntAtCell(74));
         }
 
         public Dictionary<Form, int> FormCost { get; } = new();
@@ -27,7 +33,7 @@ namespace Core
         public float CorpseX => reader.GetFixedPointAtCell(6) * 10;
         public float CorpseY => reader.GetFixedPointAtCell(7) * 10;
 
-        public AddonBits Bits => new(reader.GetIntAtCell(8), reader.GetIntAtCell(9));
+        public AddonBits Bits { get; }
 
         public int HealthMax => reader.GetIntAtCell(10);
         public int HealthCurrent => reader.GetIntAtCell(11);
@@ -41,7 +47,6 @@ namespace Core
         public int ManaCurrent => reader.GetIntAtCell(15);
         public int ManaPercentage => ManaMax == 0 ? 0 : (ManaCurrent * 100) / ManaMax;
 
-        // TODO: check this
         public bool HasTarget => Bits.HasTarget;// || TargetHealth > 0;
 
         public int TargetMaxHealth => reader.GetIntAtCell(18);
@@ -54,12 +59,12 @@ namespace Core
         public int PetHealthPercentage => PetMaxHealth == 0 || PetHealth == 1 ? 0 : (PetHealth * 100) / PetMaxHealth;
 
 
-        public SpellInRange SpellInRange => new(reader.GetIntAtCell(40));
+        public SpellInRange SpellInRange { get; }
         public bool WithInPullRange => SpellInRange.WithinPullRange(this, Class);
         public bool WithInCombatRange => SpellInRange.WithinCombatRange(this, Class);
 
-        public BuffStatus Buffs => new(reader.GetIntAtCell(41));
-        public TargetDebuffStatus TargetDebuffs => new(reader.GetIntAtCell(42));
+        public BuffStatus Buffs { get; }
+        public TargetDebuffStatus TargetDebuffs { get; }
 
         public int TargetLevel => reader.GetIntAtCell(43);
 
@@ -71,7 +76,7 @@ namespace Core
 
         // 47 empty
 
-        public Stance Stance => new(reader.GetIntAtCell(48));
+        public Stance Stance { get; }
         public Form Form => Stance.Get(this, Class);
 
         public int MinRange => (int)(reader.GetIntAtCell(49) / 100000f);
@@ -114,7 +119,7 @@ namespace Core
 
         public int CastCount => reader.GetIntAtCell(70);
 
-        public BitStatus CustomTrigger1 => new(reader.GetIntAtCell(74));
+        public BitStatus CustomTrigger1 { get; }
 
         public int MainHandSpeedMs => (int)(reader.GetIntAtCell(75) / 10000f) * 10;
 
@@ -146,6 +151,16 @@ namespace Core
             MainHandSwing.Update(reader);
             CastEvent.Update(reader);
             CastSpellId.Update(reader);
+        }
+
+        public void SetDirty()
+        {
+            Bits.SetDirty();
+            SpellInRange.SetDirty();
+            Buffs.SetDirty();
+            TargetDebuffs.SetDirty();
+            Stance.SetDirty();
+            CustomTrigger1.Update(reader.GetIntAtCell(74));
         }
 
         public void Reset()

--- a/Core/AddonComponent/AddonBits.cs
+++ b/Core/AddonComponent/AddonBits.cs
@@ -2,13 +2,27 @@
 {
     public class AddonBits
     {
-        private readonly BitStatus v1;
-        private readonly BitStatus v2;
+        private readonly ISquareReader reader;
+        private readonly int cell1;
+        private readonly int cell2;
 
-        public AddonBits(int value1, int value2)
+        private BitStatus v1 = null!;
+        private BitStatus v2 = null!;
+
+        public AddonBits(ISquareReader reader, int cell1, int cell2)
         {
-            v1 = new BitStatus(value1);
-            v2 = new BitStatus(value2);
+            this.reader = reader;
+            this.cell1 = cell1;
+            this.cell2 = cell2;
+
+            v1 = new BitStatus(reader.GetIntAtCell(cell1));
+            v2 = new BitStatus(reader.GetIntAtCell(cell2));
+        }
+
+        public void SetDirty()
+        {
+            v1.Update(reader.GetIntAtCell(cell1));
+            v2.Update(reader.GetIntAtCell(cell2));
         }
 
         // -- value1 based flags

--- a/Core/AddonComponent/BitStatus.cs
+++ b/Core/AddonComponent/BitStatus.cs
@@ -4,11 +4,16 @@ namespace Core
 {
     public class BitStatus
     {
-        private readonly int value;
+        private int value;
 
         public BitStatus(int value)
         {
             this.value = value;
+        }
+
+        public void Update(int v)
+        {
+            value = v;
         }
 
         public bool IsBitSet(int pos)

--- a/Core/AddonComponent/BuffStatus.cs
+++ b/Core/AddonComponent/BuffStatus.cs
@@ -2,8 +2,18 @@
 {
     public class BuffStatus : BitStatus
     {
-        public BuffStatus(int value) : base(value)
+        private readonly ISquareReader reader;
+        private readonly int cell;
+
+        public BuffStatus(ISquareReader reader, int cell) : base(reader.GetIntAtCell(cell))
         {
+            this.reader = reader;
+            this.cell = cell;
+        }
+
+        public void SetDirty()
+        {
+            Update(reader.GetIntAtCell(cell));
         }
 
         // All

--- a/Core/AddonComponent/SpellInRange.cs
+++ b/Core/AddonComponent/SpellInRange.cs
@@ -2,8 +2,18 @@
 {
     public class SpellInRange : BitStatus
     {
-        public SpellInRange(int value) : base(value)
+        private readonly ISquareReader reader;
+        private readonly int cell;
+
+        public SpellInRange(ISquareReader reader, int cell) : base(reader.GetIntAtCell(cell))
         {
+            this.reader = reader;
+            this.cell = cell;
+        }
+
+        public void SetDirty()
+        {
+            Update(reader.GetIntAtCell(cell));
         }
 
         // Warrior

--- a/Core/AddonComponent/Stance.cs
+++ b/Core/AddonComponent/Stance.cs
@@ -2,11 +2,21 @@
 {
     public class Stance
     {
-        private readonly int value;
+        private readonly ISquareReader reader;
+        private readonly int cell;
 
-        public Stance(int value)
+        private int value;
+
+        public Stance(ISquareReader reader, int cell)
         {
-            this.value = value;
+            this.reader = reader;
+            this.cell = cell;
+            SetDirty();
+        }
+
+        public void SetDirty()
+        {
+            value = reader.GetIntAtCell(cell);
         }
 
         public Form Get(PlayerReader playerReader, PlayerClassEnum playerClass) => value == 0 ? Form.None : playerClass switch

--- a/Core/AddonComponent/TargetDebuffStatus.cs
+++ b/Core/AddonComponent/TargetDebuffStatus.cs
@@ -2,8 +2,18 @@
 {
     public class TargetDebuffStatus : BitStatus
     {
-        public TargetDebuffStatus(int value) : base(value)
+        private readonly ISquareReader reader;
+        private readonly int cell;
+
+        public TargetDebuffStatus(ISquareReader reader, int cell) : base(reader.GetIntAtCell(cell))
         {
+            this.reader = reader;
+            this.cell = cell;
+        }
+
+        public void SetDirty()
+        {
+            Update(reader.GetIntAtCell(cell));
         }
 
         // Priest


### PR DESCRIPTION
### The issue
Some property under `PlayerReader` and `AddonReader` getting recreated as a new object each time accessing it via read only auto implemented getter property. ex. `Bits`, `Actionbar*`

### Solution
Avoid creating new instance of the type. Rather use Dirty pattern on each type. Some Bit based object has to recalculate once per `GameTime` change, other might only needed to be updated once its accessed.