### PR TITLE
Refactor: Input and input logging rework.

### DIFF
--- a/Core/ClassConfig/ClassConfiguration.cs
+++ b/Core/ClassConfig/ClassConfiguration.cs
@@ -97,6 +97,9 @@ namespace Core
         public KeyAction Mount { get; set; } = new();
         public string MountKey { get; set; } = "O";
 
+        public KeyAction Hearthstone { get; set; } = new();
+        public string HearthstoneKey { get; set; } = "I";
+
         public ConsoleKey ForwardKey { get; set; } = ConsoleKey.UpArrow;  // 38
         public ConsoleKey BackwardKey { get; set; } = ConsoleKey.DownArrow; // 40
         public ConsoleKey TurnLeftKey { get; set; } = ConsoleKey.LeftArrow; // 37
@@ -142,6 +145,9 @@ namespace Core
 
             Mount.Key = MountKey;
             Mount.Initialise(addonReader, requirementFactory, logger);
+
+            Hearthstone.Key = HearthstoneKey;
+            Hearthstone.Initialise(addonReader, requirementFactory, logger);
 
             Interact.Key = InteractKey;
             Interact.Name = "Interact";

--- a/Core/ClassConfig/ClassConfiguration.cs
+++ b/Core/ClassConfig/ClassConfiguration.cs
@@ -24,6 +24,8 @@ namespace Core
 
     public class ClassConfiguration : IDisposable
     {
+        public bool Log { get; set; } = true;
+
         public string ClassName { get; set; } = string.Empty;
         public bool Loot { get; set; } = true;
         public bool Skin { get; set; }
@@ -112,42 +114,42 @@ namespace Core
             requirementFactory.InitUserDefinedIntVariables(IntVariables);
 
             Jump.Key = JumpKey;
-            Jump.Initialise(addonReader, requirementFactory, logger);
+            Jump.Initialise(addonReader, requirementFactory, logger, Log);
 
             TargetLastTarget.Key = TargetLastTargetKey;
-            TargetLastTarget.Initialise(addonReader, requirementFactory, logger);
+            TargetLastTarget.Initialise(addonReader, requirementFactory, logger, Log);
 
             StandUp.Key = StandUpKey;
-            StandUp.Initialise(addonReader, requirementFactory, logger);
+            StandUp.Initialise(addonReader, requirementFactory, logger, Log);
 
             ClearTarget.Key = ClearTargetKey;
-            ClearTarget.Initialise(addonReader, requirementFactory, logger);
+            ClearTarget.Initialise(addonReader, requirementFactory, logger, Log);
 
             StopAttack.Key = StopAttackKey;
-            StopAttack.Initialise(addonReader, requirementFactory, logger);
+            StopAttack.Initialise(addonReader, requirementFactory, logger, Log);
             StopAttack.PressDuration = 10;
             StopAttack.Cooldown = 400;
 
             TargetNearestTarget.Key = TargetNearestTargetKey;
             TargetNearestTarget.Cooldown = 400;
-            TargetNearestTarget.Initialise(addonReader, requirementFactory, logger);
+            TargetNearestTarget.Initialise(addonReader, requirementFactory, logger, Log);
 
             TargetPet.Key = TargetPetKey;
-            TargetPet.Initialise(addonReader, requirementFactory, logger);
+            TargetPet.Initialise(addonReader, requirementFactory, logger, Log);
 
             TargetTargetOfTarget.Key = TargetTargetOfTargetKey;
-            TargetTargetOfTarget.Initialise(addonReader, requirementFactory, logger);
+            TargetTargetOfTarget.Initialise(addonReader, requirementFactory, logger, Log);
 
             PetAttack.Key = PetAttackKey;
             PetAttack.PressDuration = 10;
             PetAttack.Cooldown = 400;
-            PetAttack.Initialise(addonReader, requirementFactory, logger);
+            PetAttack.Initialise(addonReader, requirementFactory, logger, Log);
 
             Mount.Key = MountKey;
-            Mount.Initialise(addonReader, requirementFactory, logger);
+            Mount.Initialise(addonReader, requirementFactory, logger, Log);
 
             Hearthstone.Key = HearthstoneKey;
-            Hearthstone.Initialise(addonReader, requirementFactory, logger);
+            Hearthstone.Initialise(addonReader, requirementFactory, logger, Log);
 
             Interact.Key = InteractKey;
             Interact.Name = "Interact";
@@ -155,7 +157,7 @@ namespace Core
             Interact.DelayAfterCast = 0;
             Interact.PressDuration = 30;
             Interact.SkipValidation = true;
-            Interact.Initialise(addonReader, requirementFactory, logger);
+            Interact.Initialise(addonReader, requirementFactory, logger, Log);
 
             Approach.Key = InteractKey;
             Approach.Name = "Approach";
@@ -164,14 +166,14 @@ namespace Core
             Approach.PressDuration = 10;
             Approach.Cooldown = 400;
             Approach.SkipValidation = true;
-            Approach.Initialise(addonReader, requirementFactory, logger);
+            Approach.Initialise(addonReader, requirementFactory, logger, Log);
 
             AutoAttack.Key = InteractKey;
             AutoAttack.Name = "AutoAttack";
             AutoAttack.WaitForGCD = false;
             AutoAttack.DelayAfterCast = 0;
             AutoAttack.SkipValidation = true;
-            AutoAttack.Initialise(addonReader, requirementFactory, logger);
+            AutoAttack.Initialise(addonReader, requirementFactory, logger, Log);
 
             StopAttack.Name = "StopAttack";
             StopAttack.WaitForGCD = false;
@@ -182,7 +184,7 @@ namespace Core
             InitializeKeyActions(Combat, Interact, Approach, AutoAttack, StopAttack);
 
             logger.LogInformation($"[{nameof(Form)}] Initialise KeyActions.");
-            Form.ForEach(i => i.InitialiseForm(addonReader, requirementFactory, logger));
+            Form.ForEach(i => i.InitialiseForm(addonReader, requirementFactory, logger, Log));
 
             Pull.PreInitialise(nameof(Pull), requirementFactory, logger);
             Combat.PreInitialise(nameof(Combat), requirementFactory, logger);
@@ -190,16 +192,16 @@ namespace Core
             NPC.PreInitialise(nameof(NPC), requirementFactory, logger);
             Parallel.PreInitialise(nameof(Parallel), requirementFactory, logger);
 
-            Pull.Initialise(nameof(Pull), addonReader, requirementFactory, logger);
-            Combat.Initialise(nameof(Combat), addonReader, requirementFactory, logger);
-            Adhoc.Initialise(nameof(Adhoc), addonReader, requirementFactory, logger);
-            NPC.Initialise(nameof(NPC), addonReader, requirementFactory, logger);
-            Parallel.Initialise(nameof(Parallel), addonReader, requirementFactory, logger);
+            Pull.Initialise(nameof(Pull), addonReader, requirementFactory, logger, Log);
+            Combat.Initialise(nameof(Combat), addonReader, requirementFactory, logger, Log);
+            Adhoc.Initialise(nameof(Adhoc), addonReader, requirementFactory, logger, Log);
+            NPC.Initialise(nameof(NPC), addonReader, requirementFactory, logger, Log);
+            Parallel.Initialise(nameof(Parallel), addonReader, requirementFactory, logger, Log);
 
             GatherFindKeys.ForEach(key =>
             {
                 GatherFindKeyConfig.Add(new KeyAction { Key = key });
-                GatherFindKeyConfig.Last().Initialise(addonReader, requirementFactory, logger);
+                GatherFindKeyConfig.Last().Initialise(addonReader, requirementFactory, logger, Log);
             });
 
             OverridePathFilename = overridePathProfileFile;

--- a/Core/ClassConfig/KeyAction.cs
+++ b/Core/ClassConfig/KeyAction.cs
@@ -85,11 +85,14 @@ namespace Core
             requirementFactory.InitDynamicBindings(this);
         }
 
-        public void Initialise(AddonReader addonReader, RequirementFactory requirementFactory, ILogger logger, KeyActions? keyActions = null)
+        public void Initialise(AddonReader addonReader, RequirementFactory requirementFactory, ILogger logger, bool globalLog, KeyActions? keyActions = null)
         {
             this.playerReader = addonReader.PlayerReader;
             this.costReader = addonReader.ActionBarCostReader;
             this.logger = logger;
+
+            if (!globalLog)
+                Log = false;
 
             ResetCharges();
 
@@ -135,9 +138,9 @@ namespace Core
             costReader.OnActionCostChanged -= ActionBarCostReader_OnActionCostChanged;
         }
 
-        public void InitialiseForm(AddonReader addonReader, RequirementFactory requirementFactory, ILogger logger)
+        public void InitialiseForm(AddonReader addonReader, RequirementFactory requirementFactory, ILogger logger, bool globalLog)
         {
-            Initialise(addonReader, requirementFactory, logger);
+            Initialise(addonReader, requirementFactory, logger, globalLog);
 
             if (HasFormRequirement())
             {
@@ -295,18 +298,12 @@ namespace Core
 
         public void LogInformation(string message)
         {
-            if (Log)
-            {
-                logger.LogInformation($"[{Name}]: {message}");
-            }
+            logger.LogInformation($"[{Name}]: {message}");
         }
 
         public void LogWarning(string message)
         {
-            if (Log)
-            {
-                logger.LogWarning($"[{Name}]: {message}");
-            }
+            logger.LogWarning($"[{Name}]: {message}");
         }
 
         [LoggerMessage(

--- a/Core/ClassConfig/KeyActions.cs
+++ b/Core/ClassConfig/KeyActions.cs
@@ -18,14 +18,14 @@ namespace Core
             Sequence.ForEach(i => i.InitDynamicBinding(requirementFactory));
         }
 
-        public void Initialise(string prefix, AddonReader addonReader, RequirementFactory requirementFactory, ILogger logger)
+        public void Initialise(string prefix, AddonReader addonReader, RequirementFactory requirementFactory, ILogger logger, bool globalLog)
         {
             if (Sequence.Count > 0)
             {
                 LogInitKeyActions(logger, prefix);
             }
 
-            Sequence.ForEach(i => i.Initialise(addonReader, requirementFactory, logger, this));
+            Sequence.ForEach(i => i.Initialise(addonReader, requirementFactory, logger, globalLog, this));
         }
 
         public void Dispose()

--- a/Core/GOAP/GoapAgent.cs
+++ b/Core/GOAP/GoapAgent.cs
@@ -64,8 +64,8 @@ namespace Core.GOAP
         {
             if (blacklist.IsTargetBlacklisted())
             {
-                input.TapStopAttack();
-                input.TapClearTarget();
+                input.StopAttack();
+                input.ClearTarget();
                 UpdateWorldState();
             }
 

--- a/Core/Goals/AdhocGoal.cs
+++ b/Core/Goals/AdhocGoal.cs
@@ -93,7 +93,7 @@ namespace Core.Goals
 
             if (wasDrinkingOrEating)
             {
-                input.TapStopKey();
+                input.Stop();
             }
 
             wait.Update(1);

--- a/Core/Goals/AdhocNPCGoal.cs
+++ b/Core/Goals/AdhocNPCGoal.cs
@@ -119,7 +119,7 @@ namespace Core.Goals
         {
             SendActionEvent(new ActionEventArgs(GoapKey.fighting, false));
 
-            input.TapClearTarget();
+            input.ClearTarget();
             stopMoving.Stop();
 
             var path = key.Path.ToList();
@@ -151,7 +151,8 @@ namespace Core.Goals
 
             if (playerReader.Bits.IsDrowning)
             {
-                input.TapJump("Drowning! Swim up");
+                LogWarn("Drowning! Swim up");
+                input.Jump();
             }
 
             if (pathState != PathState.Finished)
@@ -181,7 +182,7 @@ namespace Core.Goals
                 LogDebug("Reached defined path end");
                 stopMoving.Stop();
 
-                input.TapClearTarget();
+                input.ClearTarget();
                 wait.Update(1);
 
                 npcNameTargeting.ChangeNpcType(NpcNames.Friendly | NpcNames.Neutral);
@@ -196,9 +197,9 @@ namespace Core.Goals
                 (bool targetTimeout, double targetElapsedMs) = wait.Until(400, () => playerReader.HasTarget);
                 if (targetTimeout)
                 {
-                    LogWarn("No target found!");
+                    LogWarn("No target found! Turn left to find NPC");
                     using var cts = new CancellationTokenSource();
-                    input.KeyPressSleep(input.TurnLeftKey, 250, cts, "Turn left to find NPC");
+                    input.KeyPressSleep(input.TurnLeftKey, 250, cts);
                     return;
                 }
 
@@ -206,7 +207,8 @@ namespace Core.Goals
 
                 if (!foundVendor)
                 {
-                    input.TapInteractKey("Interact with target from macro");
+                    LogWarn("Interact with target from macro");
+                    input.Interact();
                 }
 
                 if (OpenMerchantWindow())
@@ -217,7 +219,7 @@ namespace Core.Goals
                     }
 
                     input.KeyPress(ConsoleKey.Escape, input.defaultKeyPress);
-                    input.TapClearTarget();
+                    input.ClearTarget();
                     wait.Update(1);
 
                     var path = key.Path.ToList();

--- a/Core/Goals/ApproachTargetGoal.cs
+++ b/Core/Goals/ApproachTargetGoal.cs
@@ -95,13 +95,13 @@ namespace Core.Goals
                     logger.LogInformation($"Combat={playerReader.Bits.PlayerInCombat}, Is Target targetting me={playerReader.Bits.TargetOfTargetIsPlayer}");
 
                     stopMoving.Stop();
-                    input.TapClearTarget();
+                    input.ClearTarget();
                     wait.Update(1);
 
                     if (playerReader.PetHasTarget)
                     {
-                        input.TapTargetPet();
-                        input.TapTargetOfTarget();
+                        input.TargetPet();
+                        input.TargetOfTarget();
                         wait.Update(1);
                     }
                 }
@@ -111,7 +111,7 @@ namespace Core.Goals
 
             if (input.ClassConfig.Approach.GetCooldownRemaining() == 0)
             {
-                input.TapApproachKey("");
+                input.Approach();
             }
 
             lastPlayerDistance = playerReader.PlayerLocation.DistanceXYTo(lastPlayerLocation);
@@ -120,24 +120,27 @@ namespace Core.Goals
             {
                 playerReader.LastUIErrorMessage = UI_ERROR.NONE;
 
-                input.SetKeyState(input.ForwardKey, true, false, $"{nameof(ApproachTargetGoal)}: Too far, start moving forward!");
+                Log("Too far, start moving forward!");
+                input.SetKeyState(input.ForwardKey, true);
                 wait.Update(1);
             }
 
             if (SecondsSinceApproachStarted > 1 && lastPlayerDistance < 0.05 && !playerReader.Bits.PlayerInCombat)
             {
-                input.TapClearTarget("");
+                input.ClearTarget();
                 wait.Update(1);
-                input.KeyPress(random.Next(2) == 0 ? input.TurnLeftKey : input.TurnRightKey, 1000, $"Seems stuck! Clear Target. Turn away. d: {lastPlayerDistance}");
+                Log($"Seems stuck! Clear Target. Turn away. d: {lastPlayerDistance}");
+                input.KeyPress(random.Next(2) == 0 ? input.TurnLeftKey : input.TurnRightKey, 1000);
 
                 approachStart = DateTime.UtcNow;
             }
 
             if (SecondsSinceApproachStarted > 15 && !playerReader.Bits.PlayerInCombat)
             {
-                input.TapClearTarget("");
+                input.ClearTarget();
                 wait.Update(1);
-                input.KeyPress(random.Next(2) == 0 ? input.TurnLeftKey : input.TurnRightKey, 1000, "Too long time. Clear Target. Turn away.");
+                Log("Too long time. Clear Target. Turn away.");
+                input.KeyPress(random.Next(2) == 0 ? input.TurnLeftKey : input.TurnRightKey, 1000);
 
                 approachStart = DateTime.UtcNow;
             }
@@ -149,7 +152,8 @@ namespace Core.Goals
                 {
                     if (input.ClassConfig.TargetNearestTarget.GetCooldownRemaining() == 0)
                     {
-                        input.TapNearestTarget("Try to find closer target...");
+                        Log("Try to find closer target...");
+                        input.NearestTarget();
                         wait.Update(1);
                     }
                 }
@@ -166,7 +170,8 @@ namespace Core.Goals
                         else
                         {
                             initialTargetGuid = -1;
-                            input.TapLastTargetKey($"Stick to initial target!");
+                            Log("Stick to initial target!");
+                            input.LastTarget();
                             wait.Update(1);
                         }
                     }
@@ -180,7 +185,7 @@ namespace Core.Goals
             if (initialMinRange < playerReader.MinRange && !playerReader.Bits.PlayerInCombat)
             {
                 Log($"We are going away from the target! {initialMinRange} < {playerReader.MinRange}");
-                input.TapClearTarget();
+                input.ClearTarget();
                 wait.Update(1);
 
                 approachStart = DateTime.UtcNow;
@@ -203,7 +208,7 @@ namespace Core.Goals
         {
             if ((DateTime.UtcNow - approachStart).TotalSeconds > 2 && input.ClassConfig.Jump.MillisecondsSinceLastClick > random.Next(5000, 25_000))
             {
-                input.TapJump();
+                input.Jump();
             }
         }
 

--- a/Core/Goals/CastingHandler.cs
+++ b/Core/Goals/CastingHandler.cs
@@ -170,8 +170,8 @@ namespace Core.Goals
 
             if (playerReader.IsCasting && interrupt())
             {
-                if (item.Log)
-                    item.LogInformation($" ... castbar during cast interrupted!");
+                //if (item.Log) // really spammy
+                //    item.LogInformation($" ... castbar during cast interrupted!");
                 return false;
             }
 

--- a/Core/Goals/CastingHandler.cs
+++ b/Core/Goals/CastingHandler.cs
@@ -67,7 +67,14 @@ namespace Core.Goals
         private void PressKeyAction(KeyAction item)
         {
             playerReader.LastUIErrorMessage = UI_ERROR.NONE;
-            input.KeyPress(item.ConsoleKey, item.PressDuration, item.Log ? item.Name + (item.AfterCastWaitNextSwing ? " and wait for next swing!" : "") : string.Empty);
+
+            if (item.AfterCastWaitNextSwing)
+            {
+                if (item.Log)
+                    item.LogInformation("wait for next swing!");
+            }
+
+            input.KeyPress(item.ConsoleKey, item.PressDuration);
             item.SetClicked();
         }
 
@@ -97,7 +104,8 @@ namespace Core.Goals
 
             if (item.SkipValidation)
             {
-                item.LogInformation($" ... instant skip validation");
+                if (item.Log)
+                    item.LogInformation($" ... instant skip validation");
                 return true;
             }
 
@@ -112,7 +120,7 @@ namespace Core.Goals
                     {
                         if (classConfig.Approach.GetCooldownRemaining() == 0)
                         {
-                            input.TapApproachKey("");
+                            input.Approach();
                         }
                     });
             }
@@ -127,15 +135,18 @@ namespace Core.Goals
 
             if (!inputTimeOut)
             {
-                item.LogInformation($" ... instant input {inputElapsedMs}ms");
+                if (item.Log)
+                    item.LogInformation($" ... instant input {inputElapsedMs}ms");
             }
             else
             {
-                item.LogInformation($" ... instant input not registered! {inputElapsedMs}ms");
+                if (item.Log)
+                    item.LogInformation($" ... instant input not registered! {inputElapsedMs}ms");
                 return false;
             }
 
-            item.LogInformation($" ... usable: {beforeUsable}->{addonReader.UsableAction.Is(item)} -- ({(UI_ERROR)beforeCastEventValue}->{(UI_ERROR)playerReader.CastEvent.Value})");
+            if (item.Log)
+                item.LogInformation($" ... usable: {beforeUsable}->{addonReader.UsableAction.Is(item)} -- ({(UI_ERROR)beforeCastEventValue}->{(UI_ERROR)playerReader.CastEvent.Value})");
 
             if (!CastSuccessfull((UI_ERROR)playerReader.CastEvent.Value))
             {
@@ -152,12 +163,15 @@ namespace Core.Goals
                 (bool fallTimeOut, double fallElapsedMs) = wait.Until(MaxAirTimeMs, () => !playerReader.Bits.IsFalling);
                 if (!fallTimeOut)
                 {
-                    item.LogInformation($" ... castbar waited for landing {fallElapsedMs}ms");
+                    if (item.Log)
+                        item.LogInformation($" ... castbar waited for landing {fallElapsedMs}ms");
                 }
             }
 
             if (playerReader.IsCasting && interrupt())
             {
+                if (item.Log)
+                    item.LogInformation($" ... castbar during cast interrupted!");
                 return false;
             }
 
@@ -177,7 +191,8 @@ namespace Core.Goals
 
             if (item.SkipValidation)
             {
-                item.LogInformation($" ... castbar skip validation");
+                if (item.Log)
+                    item.LogInformation($" ... castbar skip validation");
                 return true;
             }
 
@@ -190,15 +205,17 @@ namespace Core.Goals
 
             if (!inputTimeOut)
             {
-                item.LogInformation($" ... castbar input {inputElapsedMs}ms");
+                if (item.Log)
+                    item.LogInformation($" ... castbar input {inputElapsedMs}ms");
             }
             else
             {
-                item.LogInformation($" ... castbar input not registered! {inputElapsedMs}ms");
+                if (item.Log)
+                    item.LogInformation($" ... castbar input not registered! {inputElapsedMs}ms");
                 return false;
             }
-
-            item.LogInformation($" ... casting: {playerReader.IsCasting} -- count:{playerReader.CastCount} -- usable: {beforeUsable}->{addonReader.UsableAction.Is(item)} -- {(UI_ERROR)beforeCastEventValue}->{(UI_ERROR)playerReader.CastEvent.Value}");
+            if (item.Log)
+                item.LogInformation($" ... casting: {playerReader.IsCasting} -- count:{playerReader.CastCount} -- usable: {beforeUsable}->{addonReader.UsableAction.Is(item)} -- {(UI_ERROR)beforeCastEventValue}->{(UI_ERROR)playerReader.CastEvent.Value}");
 
             if (!CastSuccessfull((UI_ERROR)playerReader.CastEvent.Value))
             {
@@ -208,22 +225,26 @@ namespace Core.Goals
 
             if (playerReader.IsCasting)
             {
-                item.LogInformation(" ... waiting for visible cast bar to end or interrupt.");
+                if (item.Log)
+                    item.LogInformation(" ... waiting for visible cast bar to end or interrupt.");
                 wait.Until(MaxCastTimeMs, () => !playerReader.IsCasting || prevState != interrupt());
                 if (prevState != interrupt())
                 {
-                    item.LogWarning(" ... visible castbar interrupted!");
+                    if (item.Log)
+                        item.LogWarning(" ... visible castbar interrupted!");
                     return false;
                 }
             }
             else if ((UI_ERROR)playerReader.CastEvent.Value == UI_ERROR.CAST_START)
             {
                 beforeCastEventValue = playerReader.CastEvent.Value;
-                item.LogInformation(" ... waiting for hidden cast bar to end or interrupt.");
+                if (item.Log)
+                    item.LogInformation(" ... waiting for hidden cast bar to end or interrupt.");
                 wait.Until(MaxCastTimeMs, () => beforeCastEventValue != playerReader.CastEvent.Value || prevState != interrupt());
                 if (prevState != interrupt())
                 {
-                    item.LogWarning(" ... hidden castbar interrupted!");
+                    if (item.Log)
+                        item.LogWarning(" ... hidden castbar interrupted!");
                     return false;
                 }
             }
@@ -261,7 +282,8 @@ namespace Core.Goals
                     //TODO: upon form change and GCD - have to check Usable state
                     if (!beforeUsable && !addonReader.UsableAction.Is(item))
                     {
-                        item.LogInformation($" ... after switch {beforeForm}->{playerReader.Form} still not usable!");
+                        if (item.Log)
+                            item.LogInformation($" ... after switch {beforeForm}->{playerReader.Form} still not usable!");
                         return false;
                     }
                 }
@@ -269,8 +291,9 @@ namespace Core.Goals
 
             if (playerReader.Bits.IsAutoRepeatSpellOn_Shoot)
             {
-                input.TapStopAttack("Stop AutoRepeat Shoot");
-                input.TapStopAttack("Stop AutoRepeat Shoot");
+                logger.LogInformation("Stop AutoRepeat Shoot");
+                input.StopAttack();
+                input.StopAttack();
                 wait.Update(1);
             }
 
@@ -284,7 +307,8 @@ namespace Core.Goals
                     wait.Update(1);
                 }
 
-                item.LogInformation($" Wait {item.DelayBeforeCast}ms before press.");
+                if (item.Log)
+                    item.LogInformation($" Wait {item.DelayBeforeCast}ms before press.");
                 Thread.Sleep(item.DelayBeforeCast);
             }
 
@@ -322,14 +346,16 @@ namespace Core.Goals
             if (item.AfterCastWaitBuff)
             {
                 (bool changeTimeOut, double elapsedMs) = wait.Until(MaxWaitBuffTimeMs, () => auraHash != playerReader.AuraCount.Hash);
-                item.LogInformation($" ... AfterCastWaitBuff: Buff: {!changeTimeOut} | {playerReader.AuraCount} | Delay: {elapsedMs}ms");
+                if (item.Log)
+                    item.LogInformation($" ... AfterCastWaitBuff: Buff: {!changeTimeOut} | {playerReader.AuraCount} | Delay: {elapsedMs}ms");
             }
 
             if (item.DelayAfterCast != defaultKeyAction.DelayAfterCast)
             {
                 if (item.DelayUntilCombat) // stop waiting if the mob is targetting me
                 {
-                    item.LogInformation($" ... DelayUntilCombat ... delay after cast {item.DelayAfterCast}ms");
+                    if (item.Log)
+                        item.LogInformation($" ... DelayUntilCombat ... delay after cast {item.DelayAfterCast}ms");
 
                     var sw = new Stopwatch();
                     sw.Start();
@@ -344,15 +370,19 @@ namespace Core.Goals
                 }
                 else if (item.DelayAfterCast > 0)
                 {
-                    item.LogInformation($" ... delay after cast {item.DelayAfterCast}ms");
+                    if (item.Log)
+                        item.LogInformation($" ... delay after cast {item.DelayAfterCast}ms");
                     (bool delayTimeOut, double delayElaspedMs) = wait.Until(item.DelayAfterCast, () => prevState != interrupt());
-                    if (!delayTimeOut)
+                    if (item.Log)
                     {
-                        item.LogInformation($" .... delay after cast interrupted {delayElaspedMs}ms");
-                    }
-                    else
-                    {
-                        item.LogInformation($" .... delay after cast not interrupted {delayElaspedMs}ms");
+                        if (!delayTimeOut)
+                        {
+                            item.LogInformation($" .... delay after cast interrupted {delayElaspedMs}ms");
+                        }
+                        else
+                        {
+                            item.LogInformation($" .... delay after cast not interrupted {delayElaspedMs}ms");
+                        }
                     }
                 }
             }
@@ -363,20 +393,24 @@ namespace Core.Goals
                     (bool canRun, double canRunElapsedMs) = wait.Until(SpellQueueTimeMs,
                         () => !item.CanRun()
                     );
-                    item.LogInformation($" ... instant interrupt: {!canRun} | CanRun: {item.CanRun()} | Delay: {canRunElapsedMs}ms");
+                    if (item.Log)
+                        item.LogInformation($" ... instant interrupt: {!canRun} | CanRun: {item.CanRun()} | Delay: {canRunElapsedMs}ms");
                 }
             }
 
             if (item.StepBackAfterCast > 0)
             {
-                input.SetKeyState(input.BackwardKey, true, false, $"Step back for {item.StepBackAfterCast}ms");
+                if (item.Log)
+                    item.LogInformation($"Step back for {item.StepBackAfterCast}ms");
+                input.SetKeyState(input.BackwardKey, true);
                 (bool stepbackTimeOut, double stepbackElapsedMs) =
                     wait.Until(item.StepBackAfterCast, () => prevState != interrupt());
                 if (!stepbackTimeOut)
                 {
-                    item.LogInformation($" .... interrupted stepback | interrupted? {prevState != interrupt()} | {stepbackElapsedMs}ms");
+                    if (item.Log)
+                        item.LogInformation($" .... interrupted stepback | interrupted? {prevState != interrupt()} | {stepbackElapsedMs}ms");
                 }
-                input.SetKeyState(input.BackwardKey, false, false);
+                input.SetKeyState(input.BackwardKey, false);
             }
 
             if (item.AfterCastWaitNextSwing)
@@ -395,16 +429,18 @@ namespace Core.Goals
                 () => addonReader.UsableAction.Is(item) || before != interrupt());
             if (!timeout)
             {
-                item.LogInformation($" ... gcd interrupted {elapsedMs}ms");
+                //item.LogInformation($" ... gcd interrupted {elapsedMs}ms");
                 if (before != interrupt())
                 {
-                    item.LogInformation($" ... gcd interrupted!");
+                    if (item.Log)
+                        item.LogInformation($" ... gcd interrupted! interrupt: {before} -> {interrupt()}");
                     return false;
                 }
             }
             else
             {
-                item.LogInformation($" ... gcd fully waited {elapsedMs}ms");
+                if (item.Log)
+                    item.LogInformation($" ... gcd fully waited {elapsedMs}ms");
             }
 
             return true;
@@ -422,7 +458,8 @@ namespace Core.Goals
             PressKeyAction(classConfig.Form[index]);
 
             (bool changedTimeOut, double elapsedMs) = wait.Until(SpellQueueTimeMs, () => playerReader.Form == item.FormEnum);
-            item.LogInformation($" ... form changed: {!changedTimeOut} | {beforeForm} -> {playerReader.Form} | Delay: {elapsedMs}ms");
+            if (item.Log)
+                item.LogInformation($" ... form changed: {!changedTimeOut} | {beforeForm} -> {playerReader.Form} | Delay: {elapsedMs}ms");
 
             return playerReader.Form == item.FormEnum;
         }
@@ -461,8 +498,8 @@ namespace Core.Goals
                     }
 
                     logger.LogInformation($"{source} -- React to {UI_ERROR.ERR_SPELL_OUT_OF_RANGE} -- Face enemy and start moving forward");
-                    input.TapInteractKey("");
-                    input.SetKeyState(input.ForwardKey, true, false, "");
+                    input.Interact();
+                    input.SetKeyState(input.ForwardKey, true);
 
                     wait.Update(1);
                     playerReader.LastUIErrorMessage = UI_ERROR.NONE;
@@ -472,7 +509,7 @@ namespace Core.Goals
                     if (playerReader.IsInMeleeRange)
                     {
                         logger.LogInformation($"{source} -- React to {UI_ERROR.ERR_BADATTACKFACING} -- Interact!");
-                        input.TapInteractKey("");
+                        input.Interact();
                     }
                     else
                     {
@@ -510,7 +547,7 @@ namespace Core.Goals
                     if (playerReader.Bits.IsAutoRepeatSpellOn_AutoAttack)
                     {
                         logger.LogInformation($"{source} -- React to {UI_ERROR.ERR_BADATTACKPOS} -- Interact!");
-                        input.TapInteractKey("");
+                        input.Interact();
                         stopMoving.Stop();
                         wait.Update(1);
 
@@ -588,14 +625,14 @@ namespace Core.Goals
                     else
                     {
                         double beforeDirection = playerReader.Direction;
-                        input.TapInteractKey("");
-                        input.TapStopAttack();
+                        input.Interact();
+                        input.StopAttack();
                         stopMoving.Stop();
                         wait.Update(1);
 
                         if (beforeDirection != playerReader.Direction)
                         {
-                            input.TapInteractKey("");
+                            input.Interact();
 
                             (bool timeout, double elapsedMs) = wait.Until(MaxWaitCastTimeMs,
                                 () => minRange != playerReader.MinRange);
@@ -605,7 +642,7 @@ namespace Core.Goals
                         else
                         {
                             logger.LogInformation($"{source} -- React to {UI_ERROR.ERR_SPELL_OUT_OF_RANGE} -- Start moving forward");
-                            input.SetKeyState(input.ForwardKey, true, false, "");
+                            input.SetKeyState(input.ForwardKey, true);
                         }
 
 
@@ -616,7 +653,7 @@ namespace Core.Goals
                     if (playerReader.IsInMeleeRange)
                     {
                         logger.LogInformation($"{source} -- React to {UI_ERROR.ERR_BADATTACKFACING} -- Interact!");
-                        input.TapInteractKey("");
+                        input.Interact();
                     }
                     else
                     {
@@ -645,7 +682,7 @@ namespace Core.Goals
                     if (playerReader.Bits.IsAutoRepeatSpellOn_AutoAttack)
                     {
                         logger.LogInformation($"{source} -- React to {UI_ERROR.ERR_BADATTACKPOS} -- Interact!");
-                        input.TapInteractKey("");
+                        input.Interact();
                         stopMoving.Stop();
                         wait.Update(1);
                     }

--- a/Core/Goals/CombatGoal.cs
+++ b/Core/Goals/CombatGoal.cs
@@ -60,7 +60,7 @@ namespace Core.Goals
             if (playerReader.Bits.HasPet && !playerReader.PetHasTarget)
             {
                 if (input.ClassConfig.PetAttack.GetCooldownRemaining() == 0)
-                    input.TapPetAttack();
+                    input.PetAttack();
             }
 
             foreach (var item in Keys)
@@ -195,15 +195,16 @@ namespace Core.Goals
                 logger.LogWarning("---- My pet has a target!");
                 ResetCooldowns();
 
-                input.TapTargetPet();
-                input.TapTargetOfTarget();
+                input.TargetPet();
+                input.TargetOfTarget();
                 wait.Update(1);
                 return;
             }
 
             if (addonReader.CombatCreatureCount > 1)
             {
-                input.TapNearestTarget($"{nameof(CombatGoal)}: Checking target in front of me");
+                logger.LogInformation($"{nameof(CombatGoal)}: Checking target in front of me");
+                input.NearestTarget();
                 wait.Update(1);
                 if (playerReader.HasTarget)
                 {
@@ -211,14 +212,14 @@ namespace Core.Goals
                     {
                         ResetCooldowns();
 
-                        logger.LogWarning("---- Somebody is attacking me!");
-                        input.TapInteractKey("Found new target to attack");
+                        logger.LogWarning($"{nameof(CombatGoal)}: Somebody is attacking me! Found new target to attack");
+                        input.Interact();
                         stopMoving.Stop();
                         wait.Update(1);
                         return;
                     }
 
-                    input.TapClearTarget();
+                    input.ClearTarget();
                     wait.Update(1);
                 }
                 else
@@ -236,7 +237,8 @@ namespace Core.Goals
 
         private void StopDrowning()
         {
-            input.TapJump("Drowning! Swim up");
+            logger.LogWarning($"{nameof(CombatGoal)}: Drowning! Swim up");
+            input.Jump();
             wait.Update(1);
         }
 

--- a/Core/Goals/CombatUtil.cs
+++ b/Core/Goals/CombatUtil.cs
@@ -62,16 +62,17 @@ namespace Core
             {
                 if (this.playerReader.PetHasTarget)
                 {
-                    input.TapTargetPet();
+                    input.TargetPet();
                     Log($"Pets target {this.playerReader.TargetTarget}");
                     if (this.playerReader.TargetTarget == TargetTargetEnum.PetHasATarget)
                     {
-                        input.TapTargetOfTarget($"{nameof(CombatUtil)}.AquiredTarget: Found target by pet");
+                        Log($"{nameof(CombatUtil)}.AquiredTarget: Found target by pet");
+                        input.TargetOfTarget();
                         return true;
                     }
                 }
 
-                input.TapNearestTarget();
+                input.NearestTarget();
                 wait.Update(1);
                 if (this.playerReader.HasTarget && playerReader.Bits.TargetInCombat &&
                     playerReader.Bits.TargetOfTargetIsPlayer)
@@ -85,7 +86,8 @@ namespace Core
                     return true;
                 }
 
-                input.TapClearTarget($"{nameof(CombatUtil)}.AquiredTarget: No target found");
+                Log($"{nameof(CombatUtil)}.AquiredTarget: No target found");
+                input.ClearTarget();
                 wait.Update(1);
             }
             return false;

--- a/Core/Goals/CorpseRunGoal.cs
+++ b/Core/Goals/CorpseRunGoal.cs
@@ -80,7 +80,7 @@ namespace Core.Goals
             else if (!this.stuckDetector.IsGettingCloser())
             {
                 // stuck so jump
-                input.SetKeyState(input.ForwardKey, true, false, "WalkToCorpseAction");
+                input.SetKeyState(input.ForwardKey, true);
                 await Task.Delay(100);
                 if (HasBeenActiveRecently())
                 {

--- a/Core/Goals/FollowRouteGoal.cs
+++ b/Core/Goals/FollowRouteGoal.cs
@@ -165,13 +165,15 @@ namespace Core.Goals
         {
             if (playerReader.HasTarget && playerReader.Bits.TargetIsDead)
             {
-                input.TapClearTarget("Has target but its dead.");
+                Log("Has target but its dead.");
+                input.ClearTarget();
                 wait.Update(1);
             }
 
             if (playerReader.Bits.IsDrowning)
             {
-                input.TapJump("Drowning! Swim up");
+                Log("Drowning! Swim up");
+                input.Jump();
             }
 
             if (classConfig.Mode == Mode.AttendedGather)
@@ -212,7 +214,7 @@ namespace Core.Goals
             {
                 if (classConfig.TargetNearestTarget.MillisecondsSinceLastClick > random.Next(minMs, maxMs))
                 {
-                    found = targetFinder.Search(NpcNameToFind, validTarget, nameof(FollowRouteGoal), targetFinderCts);
+                    found = targetFinder.Search(NpcNameToFind, validTarget, targetFinderCts);
                 }
                 wait.Update(1);
             }
@@ -328,7 +330,8 @@ namespace Core.Goals
         {
             if ((DateTime.UtcNow - onEnterTime).TotalSeconds > 5 && classConfig.Jump.MillisecondsSinceLastClick > random.Next(10_000, 25_000))
             {
-                input.TapJump("Random jump");
+                Log("Random jump");
+                input.Jump();
             }
         }
 

--- a/Core/Goals/LastTargetLoot.cs
+++ b/Core/Goals/LastTargetLoot.cs
@@ -54,13 +54,15 @@ namespace Core.Goals
             stopMoving.Stop();
             combatUtil.Update();
 
-            input.TapLastTargetKey($"{nameof(LastTargetLoot)}: No corpse name found - check last dead target exists");
+            Log("No corpse name found - check last dead target exists");
+            input.LastTarget();
             wait.Update(1);
             if (playerReader.HasTarget)
             {
                 if (playerReader.Bits.TargetIsDead)
                 {
-                    input.TapInteractKey($"{nameof(LastTargetLoot)}: Found last dead target");
+                    Log("Found last dead target");
+                    input.Interact();
                     wait.Update(1);
 
                     (bool foundTarget, bool moved) = combatUtil.FoundTargetWhileMoved();
@@ -72,12 +74,14 @@ namespace Core.Goals
 
                     if (moved)
                     {
-                        input.TapInteractKey($"{nameof(LastTargetLoot)}: Last dead target double");
+                        Log("Last dead target double");
+                        input.Interact();
                     }
                 }
                 else
                 {
-                    input.TapClearTarget($"{nameof(LastTargetLoot)}: Don't attack the target!");
+                    Log("Don't attack the target!");
+                    input.ClearTarget();
                 }
             }
 
@@ -108,7 +112,8 @@ namespace Core.Goals
 
             if (playerReader.HasTarget && playerReader.Bits.TargetIsDead)
             {
-                input.TapClearTarget($"{nameof(LastTargetLoot)}: Exit Goal");
+                //$"{nameof(LastTargetLoot)}: Exit Goal"
+                input.ClearTarget();
                 wait.Update(1);
             }
         }

--- a/Core/Goals/LootGoal.cs
+++ b/Core/Goals/LootGoal.cs
@@ -100,7 +100,8 @@ namespace Core.Goals
             {
                 corpseLocations.Remove(GetClosestCorpse());
 
-                input.TapLastTargetKey($"{nameof(LootGoal)}: No corpse name found - check last dead target exists");
+                Log("No corpse name found - check last dead target exists");
+                input.LastTarget();
                 wait.Update(1);
                 if (playerReader.HasTarget)
                 {
@@ -108,7 +109,8 @@ namespace Core.Goals
                     {
                         CheckForSkinning();
 
-                        input.TapInteractKey($"{nameof(LootGoal)}: Found last dead target");
+                        Log("Found last dead target");
+                        input.Interact();
                         wait.Update(1);
 
                         (bool foundTarget, bool moved) = combatUtil.FoundTargetWhileMoved();
@@ -120,12 +122,14 @@ namespace Core.Goals
 
                         if (moved)
                         {
-                            input.TapInteractKey($"{nameof(LootGoal)}: Last dead target double");
+                            Log("Last dead target double");
+                            input.Interact();
                         }
                     }
                     else
                     {
-                        input.TapClearTarget($"{nameof(LootGoal)}: Don't attack the target!");
+                        Log("Don't attack the target!");
+                        input.ClearTarget();
                     }
                 }
             }
@@ -174,7 +178,8 @@ namespace Core.Goals
 
             if (moved)
             {
-                input.TapInteractKey($"{nameof(LootGoal)}: Had to move so interact again");
+                Log("Had to move so interact again");
+                input.Interact();
                 wait.Update(1);
             }
 
@@ -226,7 +231,7 @@ namespace Core.Goals
 
             if (playerReader.HasTarget && playerReader.Bits.TargetIsDead)
             {
-                input.TapClearTarget($"{nameof(LootGoal)}: Exit Goal");
+                input.ClearTarget();
             }
 
             wait.Update(1);

--- a/Core/Goals/MountHandler.cs
+++ b/Core/Goals/MountHandler.cs
@@ -63,7 +63,7 @@ namespace Core
             stopMoving.Stop();
             wait.Update(1);
 
-            input.TapMount();
+            input.Mount();
 
             (bool castStartTimeOut, double castStartElapsedMs) = wait.Until(spellQueueWindowMs, () => playerReader.Bits.IsMounted || playerReader.IsCasting);
             Log($"casting: {!castStartTimeOut} | Mounted: {playerReader.Bits.IsMounted} | Delay: {castStartElapsedMs}ms");
@@ -95,7 +95,7 @@ namespace Core
             }
             else
             {
-                input.TapDismount();
+                input.Dismount();
             }
         }
 

--- a/Core/Goals/Navigation.cs
+++ b/Core/Goals/Navigation.cs
@@ -138,7 +138,7 @@ namespace Core.Goals
             }
 
             LastActive = DateTime.UtcNow;
-            input.SetKeyState(input.ForwardKey, true, false);
+            input.SetKeyState(input.ForwardKey, true);
 
             // main loop
             var location = playerReader.PlayerLocation;

--- a/Core/Goals/ParallelGoal.cs
+++ b/Core/Goals/ParallelGoal.cs
@@ -95,7 +95,7 @@ namespace Core.Goals
 
             if (wasDrinkingOrEating)
             {
-                input.TapStandUpKey();
+                input.StandUp();
             }
         }
 

--- a/Core/Goals/PullTargetGoal.cs
+++ b/Core/Goals/PullTargetGoal.cs
@@ -74,7 +74,8 @@ namespace Core.Goals
             {
                 if (input.ClassConfig.StopAttack.GetCooldownRemaining() == 0)
                 {
-                    input.TapStopAttack("Stop auto interact!");
+                    Log("Stop auto interact!");
+                    input.StopAttack();
                     wait.Update(1);
                 }
             }
@@ -96,8 +97,9 @@ namespace Core.Goals
         {
             if (SecondsSincePullStarted > 10)
             {
-                input.TapClearTarget();
-                input.KeyPress(random.Next(2) == 0 ? input.TurnLeftKey : input.TurnRightKey, 1000, "Too much time to pull!");
+                input.ClearTarget();
+                Log("Too much time to pull!");
+                input.KeyPress(random.Next(2) == 0 ? input.TurnLeftKey : input.TurnRightKey, 1000);
                 pullStart = DateTime.UtcNow;
 
                 return ValueTask.CompletedTask;
@@ -114,7 +116,7 @@ namespace Core.Goals
 
                     stopMoving.Stop();
 
-                    input.TapNearestTarget();
+                    input.NearestTarget();
                     wait.Update(1);
 
                     if (playerReader.HasTarget && playerReader.Bits.TargetInCombat &&
@@ -123,7 +125,7 @@ namespace Core.Goals
                         return ValueTask.CompletedTask;
                     }
 
-                    input.TapClearTarget();
+                    input.ClearTarget();
                     wait.Update(1);
                     pullStart = DateTime.UtcNow;
 
@@ -137,7 +139,7 @@ namespace Core.Goals
 
                 if (playerReader.HasTarget && classConfiguration.Approach.GetCooldownRemaining() == 0)
                 {
-                    input.TapApproachKey($"{nameof(PullTargetGoal)}");
+                    input.Approach();
                 }
             }
             else
@@ -199,7 +201,7 @@ namespace Core.Goals
             if (playerReader.Bits.HasPet && !playerReader.PetHasTarget)
             {
                 if (input.ClassConfig.PetAttack.GetCooldownRemaining() == 0)
-                    input.TapPetAttack();
+                    input.PetAttack();
             }
 
             bool castAny = false;
@@ -231,8 +233,9 @@ namespace Core.Goals
                      playerReader.Bits.IsAutoRepeatSpellOn_AutoShot ||
                      playerReader.Bits.IsAutoRepeatSpellOn_Shoot))
                 {
-                    input.TapStopAttack("Preventing pulling possible tagged target!");
-                    input.TapClearTarget();
+                    Log("Preventing pulling possible tagged target!");
+                    input.StopAttack();
+                    input.ClearTarget();
                     wait.Update(1);
                     return false;
                 }

--- a/Core/Goals/SkinningGoal.cs
+++ b/Core/Goals/SkinningGoal.cs
@@ -105,7 +105,8 @@ namespace Core.Goals
 
                     if (moved)
                     {
-                        input.TapInteractKey($"{nameof(SkinningGoal)}: Had to move so interact again");
+                        Log("Had to move so interact again");
+                        input.Interact();
                         wait.Update(1);
                     }
 
@@ -166,7 +167,7 @@ namespace Core.Goals
 
             if (playerReader.HasTarget && playerReader.Bits.TargetIsDead)
             {
-                input.TapClearTarget();
+                input.ClearTarget();
             }
 
             wait.Update(1);

--- a/Core/Goals/StopMoving.cs
+++ b/Core/Goals/StopMoving.cs
@@ -40,13 +40,15 @@ namespace Core.Goals
                 if (!input.IsKeyDown(input.BackwardKey) && !input.IsKeyDown(input.ForwardKey) &&
                     (MathF.Abs(XCoord - playerReader.XCoord) > MinDist || MathF.Abs(YCoord - playerReader.YCoord) > MinDist))
                 {
-                    input.SetKeyState(input.ForwardKey, true, false, "StopForward - Cancel interact");
+                    //"StopForward - Cancel interact"
+                    input.SetKeyState(input.ForwardKey, true);
                     cts.Token.WaitHandle.WaitOne(2);
                 }
 
-                input.SetKeyState(input.ForwardKey, false, false, "");
+                input.SetKeyState(input.ForwardKey, false);
                 cts.Token.WaitHandle.WaitOne(2);
-                input.SetKeyState(input.BackwardKey, false, false, "StopForward");
+                //"StopForward"
+                input.SetKeyState(input.BackwardKey, false);
                 cts.Token.WaitHandle.WaitOne(10);
             }
 
@@ -58,8 +60,9 @@ namespace Core.Goals
         {
             if (Direction != playerReader.Direction)
             {
-                input.SetKeyState(input.TurnLeftKey, false, false, "");
-                input.SetKeyState(input.TurnRightKey, false, false, "StopTurn");
+                input.SetKeyState(input.TurnLeftKey, false);
+                //"StopTurn"
+                input.SetKeyState(input.TurnRightKey, false);
                 cts.Token.WaitHandle.WaitOne(1);
             }
 

--- a/Core/Goals/TargetFinder.cs
+++ b/Core/Goals/TargetFinder.cs
@@ -28,20 +28,21 @@ namespace Core.Goals
             this.npcNameTargeting = npcNameTargeting;
         }
 
-        public bool Search(NpcNames target, Func<bool> validTarget, string source, CancellationTokenSource cts)
+        public bool Search(NpcNames target, Func<bool> validTarget, CancellationTokenSource cts)
         {
-            if (LookForTarget(target, source, cts))
+            if (LookForTarget(target, cts))
             {
                 if (validTarget() && !blacklist.IsTargetBlacklisted())
                 {
-                    logger.LogInformation($"{source}: Has target!");
+                    logger.LogInformation("Has target!");
                     return true;
                 }
                 else
                 {
                     if (!cts.IsCancellationRequested)
                     {
-                        input.TapClearTarget($"{source}: Target is invalid!");
+                        logger.LogWarning("Target is invalid!");
+                        input.ClearTarget();
                         wait.Update(1);
                     }
                 }
@@ -50,12 +51,12 @@ namespace Core.Goals
             return false;
         }
 
-        private bool LookForTarget(NpcNames target, string source, CancellationTokenSource cts)
+        private bool LookForTarget(NpcNames target, CancellationTokenSource cts)
         {
             if (!cts.IsCancellationRequested)
             {
                 npcNameTargeting.ChangeNpcType(target);
-                input.TapNearestTarget(source);
+                input.NearestTarget();
                 wait.Update(1);
             }
 

--- a/Core/Goals/TargetLastDeadGoal.cs
+++ b/Core/Goals/TargetLastDeadGoal.cs
@@ -24,8 +24,7 @@ namespace Core.Goals
 
         public override ValueTask PerformAction()
         {
-            input.TapLastTargetKey(nameof(TargetLastDeadGoal));
-
+            input.LastTarget();
             return ValueTask.CompletedTask;
         }
 

--- a/Core/Goals/TargetPetTarget.cs
+++ b/Core/Goals/TargetPetTarget.cs
@@ -24,11 +24,11 @@ namespace Core.Goals
 
         public override ValueTask PerformAction()
         {
-            input.TapTargetPet();
-            input.TapTargetOfTarget();
+            input.TargetPet();
+            input.TargetOfTarget();
             if (playerReader.HasTarget && (playerReader.Bits.TargetIsDead || playerReader.TargetGuid == playerReader.PetGuid))
             {
-                input.TapClearTarget();
+                input.ClearTarget();
             }
 
             return ValueTask.CompletedTask;

--- a/Core/Goals/WalkToCorpseGoal.cs
+++ b/Core/Goals/WalkToCorpseGoal.cs
@@ -120,7 +120,8 @@ namespace Core.Goals
         {
             if ((DateTime.UtcNow - onEnterTime).TotalSeconds > 5 && input.ClassConfig.Jump.MillisecondsSinceLastClick > random.Next(10_000, 25_000))
             {
-                input.TapJump("Random jump");
+                Log("Random jump");
+                input.Jump();
             }
         }
 

--- a/Core/Goals/WrongZoneGoal.cs
+++ b/Core/Goals/WrongZoneGoal.cs
@@ -47,7 +47,7 @@ namespace Core.Goals
             SendActionEvent(new ActionEventArgs(GoapKey.fighting, false));
 
             await Task.Delay(200);
-            input.SetKeyState(input.ForwardKey, true, false, "FollowRouteAction 5");
+            input.SetKeyState(input.ForwardKey, true);
 
             if (this.playerReader.Bits.PlayerInCombat) { return; }
 
@@ -67,7 +67,7 @@ namespace Core.Goals
             else if (!this.stuckDetector.IsGettingCloser())
             {
                 // stuck so jump
-                input.SetKeyState(input.ForwardKey, true, false, "FollowRouteAction 6");
+                input.SetKeyState(input.ForwardKey, true);
                 await Task.Delay(100);
                 if (HasBeenActiveRecently())
                 {

--- a/Core/Input/ConfigurableInput.cs
+++ b/Core/Input/ConfigurableInput.cs
@@ -6,8 +6,6 @@ namespace Core
 {
     public class ConfigurableInput : WowProcessInput
     {
-        private readonly bool log = true;
-
         public ClassConfiguration ClassConfig { get; }
 
         public readonly int defaultKeyPress = 50;
@@ -25,98 +23,94 @@ namespace Core
             BackwardKey = classConfig.BackwardKey;
             TurnLeftKey = classConfig.TurnLeftKey;
             TurnRightKey = classConfig.TurnRightKey;
-
-            if (log)
-            {
-                logger.LogInformation($"[{nameof(ConfigurableInput)}] Movement Keys. Forward: {ForwardKey} - Backward: {BackwardKey} - TurnLeft: {TurnLeftKey} - TurnRight: {TurnRightKey}");
-            }
         }
 
-        public void TapStopKey(string desc = "")
+        public void Stop()
         {
-            KeyPress(ForwardKey, defaultKeyPress, log ? $"TapStopKey: {desc}" : "");
+            KeyPress(ForwardKey, defaultKeyPress);
         }
 
-        public void TapInteractKey(string source)
+        public void Interact()
         {
-            KeyPress(ClassConfig.Interact.ConsoleKey, defaultKeyPress, log && string.IsNullOrEmpty(source) ? "" : $"TapInteract ({source})");
-            this.ClassConfig.Interact.SetClicked();
+            KeyPress(ClassConfig.Interact.ConsoleKey, defaultKeyPress);
+            ClassConfig.Interact.SetClicked();
         }
 
-        public void TapApproachKey(string source)
+        public void Approach()
         {
-            KeyPress(ClassConfig.Approach.ConsoleKey, ClassConfig.Approach.PressDuration, log && string.IsNullOrEmpty(source) ? "" : $"TapApproachKey ({source})");
-            this.ClassConfig.Approach.SetClicked();
+            KeyPress(ClassConfig.Approach.ConsoleKey, ClassConfig.Approach.PressDuration);
+            ClassConfig.Approach.SetClicked();
         }
 
-        public void TapLastTargetKey(string source)
+        public void LastTarget()
         {
-            KeyPress(ClassConfig.TargetLastTarget.ConsoleKey, defaultKeyPress, log ? $"TapLastTarget ({source})" : "");
-            this.ClassConfig.TargetLastTarget.SetClicked();
+            KeyPress(ClassConfig.TargetLastTarget.ConsoleKey, defaultKeyPress);
+            ClassConfig.TargetLastTarget.SetClicked();
         }
 
-        public void TapStandUpKey(string desc = "")
+        public void StandUp()
         {
-            KeyPress(ClassConfig.StandUp.ConsoleKey, defaultKeyPress, log ? $"TapStandUpKey: {desc}" : "");
-            this.ClassConfig.StandUp.SetClicked();
+            KeyPress(ClassConfig.StandUp.ConsoleKey, defaultKeyPress);
+            ClassConfig.StandUp.SetClicked();
         }
 
-        public void TapClearTarget(string desc = "")
+        public void ClearTarget()
         {
-            KeyPress(ClassConfig.ClearTarget.ConsoleKey, defaultKeyPress, log && string.IsNullOrEmpty(desc) ? "" : $"TapClearTarget: {desc}");
-            this.ClassConfig.ClearTarget.SetClicked();
+            KeyPress(ClassConfig.ClearTarget.ConsoleKey, defaultKeyPress);
+            ClassConfig.ClearTarget.SetClicked();
         }
 
-        public void TapStopAttack(string desc = "")
+        public void StopAttack()
         {
-            KeyPress(ClassConfig.StopAttack.ConsoleKey, ClassConfig.StopAttack.PressDuration, log && string.IsNullOrEmpty(desc) ? "" : $"TapStopAttack: {desc}");
-            this.ClassConfig.StopAttack.SetClicked();
+            KeyPress(ClassConfig.StopAttack.ConsoleKey, ClassConfig.StopAttack.PressDuration);
+            ClassConfig.StopAttack.SetClicked();
         }
 
-        public void TapNearestTarget(string desc = "")
+        public void NearestTarget()
         {
-            KeyPress(ClassConfig.TargetNearestTarget.ConsoleKey, defaultKeyPress, log ? $"TapNearestTarget: {desc}" : "");
-            this.ClassConfig.TargetNearestTarget.SetClicked();
+            KeyPress(ClassConfig.TargetNearestTarget.ConsoleKey, defaultKeyPress);
+            ClassConfig.TargetNearestTarget.SetClicked();
         }
 
-        public void TapTargetPet(string desc = "")
+        public void TargetPet()
         {
-            KeyPress(ClassConfig.TargetPet.ConsoleKey, defaultKeyPress, log ? $"TapTargetPet: {desc}" : "");
-            this.ClassConfig.TargetPet.SetClicked();
+            KeyPress(ClassConfig.TargetPet.ConsoleKey, defaultKeyPress);
+            ClassConfig.TargetPet.SetClicked();
         }
 
-        public void TapTargetOfTarget(string desc = "")
+        public void TargetOfTarget()
         {
-            KeyPress(ClassConfig.TargetTargetOfTarget.ConsoleKey, defaultKeyPress, log ? $"TapTargetsTarget: {desc}" : "");
-            this.ClassConfig.TargetTargetOfTarget.SetClicked();
+            KeyPress(ClassConfig.TargetTargetOfTarget.ConsoleKey, defaultKeyPress);
+            ClassConfig.TargetTargetOfTarget.SetClicked();
         }
 
-        public void TapJump(string desc = "")
+        public void Jump()
         {
-            KeyPress(ClassConfig.Jump.ConsoleKey, defaultKeyPress, log ? $"TapJump: {desc}" : "");
-            this.ClassConfig.Jump.SetClicked();
+            KeyPress(ClassConfig.Jump.ConsoleKey, defaultKeyPress);
+            ClassConfig.Jump.SetClicked();
         }
 
-        public void TapPetAttack(string source = "")
+        public void PetAttack()
         {
-            KeyPress(ClassConfig.PetAttack.ConsoleKey, ClassConfig.PetAttack.PressDuration, log ? $"TapPetAttack ({source})" : "");
-            this.ClassConfig.PetAttack.SetClicked();
+            KeyPress(ClassConfig.PetAttack.ConsoleKey, ClassConfig.PetAttack.PressDuration);
+            ClassConfig.PetAttack.SetClicked();
         }
 
-        public void TapHearthstone()
+        public void Hearthstone()
         {
-            KeyPress(ConsoleKey.I, defaultKeyPress, log ? "TapHearthstone" : "");
+            KeyPress(ClassConfig.Hearthstone.ConsoleKey, defaultKeyPress);
+            ClassConfig.Hearthstone.SetClicked();
         }
 
-        public void TapMount()
+        public void Mount()
         {
-            KeyPress(ClassConfig.Mount.ConsoleKey, defaultKeyPress, log ? "TapMount" : "");
-            this.ClassConfig.Mount.SetClicked();
+            KeyPress(ClassConfig.Mount.ConsoleKey, defaultKeyPress);
+            ClassConfig.Mount.SetClicked();
         }
 
-        public void TapDismount()
+        public void Dismount()
         {
-            KeyPress(ClassConfig.Mount.ConsoleKey, defaultKeyPress, log ? "TapDismount" : "");
+            KeyPress(ClassConfig.Mount.ConsoleKey, defaultKeyPress);
         }
     }
 }

--- a/Core/Path/PlayerDirection.cs
+++ b/Core/Path/PlayerDirection.cs
@@ -43,14 +43,18 @@ namespace Core
             float distance = playerReader.PlayerLocation.DistanceXYTo(point);
             if (distance < ignoreDistance)
             {
-                Log($"Too close, ignoring direction change. {distance} < {ignoreDistance}");
+                if(debug)
+                    Log($"Too close, ignoring direction change. {distance} < {ignoreDistance}");
+
                 return;
             }
 
+            if(debug)
+                Log($"SetDirection: {source}-- Current: {playerReader.Direction:0.000} -> Target: {desiredDirection:0.000} - Distance: {distance:0.000}");
+
             input.KeyPressSleep(GetDirectionKeyToPress(desiredDirection),
                 TurnDuration(desiredDirection),
-                cts,
-                debug ? $"SetDirection: {source}-- Current: {playerReader.Direction:0.000} -> Target: {desiredDirection:0.000} - Distance: {distance:0.000}" : string.Empty);
+                cts);
 
             LastSetDirection = DateTime.UtcNow;
         }
@@ -75,10 +79,7 @@ namespace Core
 
         private void Log(string text)
         {
-            if (debug)
-            {
-                logger.LogInformation($"[{nameof(PlayerDirection)}]: {text}");
-            }
+            logger.LogInformation($"[{nameof(PlayerDirection)}]: {text}");
         }
     }
 }

--- a/Core/Path/StuckDetector.cs
+++ b/Core/Path/StuckDetector.cs
@@ -74,7 +74,7 @@ namespace Core
 
         public void Unstick()
         {
-            input.TapJump();
+            input.Jump();
 
             logger.LogInformation($"Stuck for {actionDurationSeconds}s, last tried to unstick {unstickSeconds}s ago. Unstick seconds={unstickSeconds}.");
 
@@ -99,10 +99,10 @@ namespace Core
                 {
                     // back up a bit, added "remove" move forward
                     logger.LogInformation($"Trying to unstick by backing up for {actionDuration}ms");
-                    input.SetKeyState(input.BackwardKey, true, false, "StuckDetector_back_up");
-                    input.SetKeyState(input.ForwardKey, false, false, "StuckDetector");
+                    input.SetKeyState(input.BackwardKey, true);
+                    input.SetKeyState(input.ForwardKey, false);
                     Thread.Sleep(actionDuration);
-                    input.SetKeyState(input.BackwardKey, false, false, "StuckDetector");
+                    input.SetKeyState(input.BackwardKey, false);
                 }
                 this.stopMoving.Stop();
 
@@ -111,17 +111,17 @@ namespace Core
                 var key = r == 0 ? input.TurnLeftKey : input.TurnRightKey;
                 var turnDuration = random.Next(0, 800) + 200;
                 logger.LogInformation($"Trying to unstick by turning for {turnDuration}ms");
-                input.SetKeyState(key, true, false, "StuckDetector");
+                input.SetKeyState(key, true);
                 Thread.Sleep(turnDuration);
-                input.SetKeyState(key, false, false, "StuckDetector");
+                input.SetKeyState(key, false);
 
                 // Move forward
                 var strafeDuration = random.Next(0, 2000) + actionDurationSeconds;
                 logger.LogInformation($"Trying to unstick by moving forward after turning for {strafeDuration}ms");
-                input.SetKeyState(input.ForwardKey, true, false, "StuckDetector");
+                input.SetKeyState(input.ForwardKey, true);
                 Thread.Sleep(strafeDuration);
 
-                input.TapJump();
+                input.Jump();
 
                 var heading = DirectionCalculator.CalculateHeading(this.playerReader.PlayerLocation, targetLocation);
                 playerDirection.SetDirection(heading, targetLocation, "Move to next point");
@@ -131,7 +131,7 @@ namespace Core
             }
             else
             {
-                input.TapJump();
+                input.Jump();
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ Take a look at the class files in `/Json/class` for examples of what you can do.
 
 | Property Name | Description | Optional | Default value |
 | --- | --- | --- | --- |
+| `"Log"` | Should logging enabled for `KeyAction(s)`. Requires restart. | true | `true` |
 | `"Loot"` | Should loot the mob | true | `true` |
 | `"Skin"` | Should skin the mob | true | `false` |
 | `"UseMount"` | Should use mount when its possible | true | `false` |

--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ Take a look at the class files in `/Json/class` for examples of what you can do.
 | `"TargetPetKey"` | `Consolekey` to be pressed to target pet | true | `"Multiply"` |
 | `"PetAttackKey"` | `Consolekey` to be pressed to send attack pet | true | `"Subtract"` |
 | `"MountKey"` | `Consolekey` to be pressed to use mount | true | `"O"` |
+| `"HearthstoneKey"` | `Consolekey` to be pressed to use hearthstone | true | `"I"` |
 | `"ForwardKey"` | `Consolekey` to be pressed to move forward | true | `"UpArrow"` |
 | `"BackwardKey"` | `Consolekey` to be pressed to move backward | true | `"DownArrow"` |
 | `"TurnLeftKey"` | `Consolekey` to be pressed to turn left | true | `"LeftArrow"` |


### PR DESCRIPTION
Rework how `WowProcessInput`, `ConfigurableInput` handles logging. No longer accepts source and description string, reason most of the codebase didn't used at all, just allocated empty strings. Rather use logging one level higher in where the input classes being utilized. 

`KeyAction` and `WoWProcessInput` uses `Dictionary` instead of `ConcurrentDictionary` reducing the read access time quite significantly.

As of today at `WoWProcessInput` level there aren't at least two thread which tries writing `KeyAction.Key`.

During initialization phase `ClassConfiuration` going to add every `KeyAction` to the `LastClicked` dictionary, and so there is no reason to `Remove` and `Add` these KeyValuePairs. Upon `RemoveCooldown` happens just set the last known time to current time minus 1 day.

`ConfigurableInput` api uses less convoluted function names.

`ClassConfiguration` has a new property `Log` which can override the enabled `KeyAction.Log` property to false and thus disable these logging.

`ClassConfiguration` added configurable key for `Hearthstone`.

`CastingHandler` upon the context `KeyAction.Log` is disabled, no longer allocate and discard the strings for logging.
