### PR TITLE
Addon [1.2.5]: Improved interactive `AttendedGather` mode

### DIFF
--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors
-## Version: 1.2.4
+## Version: 1.2.5
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/EventHandlers.lua
+++ b/Addons/DataToColor/EventHandlers.lua
@@ -51,6 +51,7 @@ function DataToColor:RegisterEvents()
     DataToColor:RegisterEvent('ACTIONBAR_SLOT_CHANGED', 'ActionbarSlotChanged')
     DataToColor:RegisterEvent('CORPSE_IN_RANGE', 'CorpseInRangeEvent')
     DataToColor:RegisterEvent('CORPSE_OUT_OF_RANGE', 'CorpseOutOfRangeEvent')
+    DataToColor:RegisterEvent('CHAT_MSG_OPENING', 'ChatMessageOpeningEvent')
 end
 
 function DataToColor:OnUIErrorMessage(event, messageType, message)
@@ -281,6 +282,17 @@ end
 
 function DataToColor:CorpseOutOfRangeEvent(event)
     DataToColor.corpseInRange = 0
+end
+
+function DataToColor:ChatMessageOpeningEvent(event, ...)
+    local _, playerName, _, _, playerName2 = ...
+    local function isempty(s)
+        return s == nil or s == ''
+    end
+    if isempty(playerName) and isempty(playerName2) then
+        DataToColor.lastCastEvent = CAST_SUCCESS
+        DataToColor.uiErrorMessage = CAST_SUCCESS
+    end
 end
 
 DataToColor.playerInteractIterator = 0

--- a/Addons/DataToColor/Query.lua
+++ b/Addons/DataToColor/Query.lua
@@ -51,7 +51,8 @@ end
 function DataToColor:Base2Converter2()
     return
     DataToColor:MakeIndexBase2(DataToColor:IsPlayerDrowning(), 0) +
-    DataToColor:MakeIndexBase2(DataToColor.corpseInRange, 1)
+    DataToColor:MakeIndexBase2(DataToColor.corpseInRange, 1) +
+    DataToColor:MakeIndexBase2(DataToColor:IsIndoors(), 2)
 end
 
 function DataToColor:Base2CustomTrigger(t)
@@ -543,6 +544,10 @@ end
 
 function DataToColor:IsPlayerFalling()
     return IsFalling() and 1 or 0
+end
+
+function DataToColor:IsIndoors()
+    return IsIndoors() and 1 or 0
 end
 
 function DataToColor:IsPlayerDrowning()

--- a/BlazorServer/Pages/Gather.razor
+++ b/BlazorServer/Pages/Gather.razor
@@ -24,11 +24,14 @@ else
             <audio id="audio_player" controls loop></audio>
         </div>
     </div>
+    <div class="row">
+        <LogComponent />
+    </div>
 </div>
 }
 
 @code {
-    private bool lastFound = false;
+    private int lastAmount;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -38,15 +41,17 @@ else
         }
     }
 
-    protected void NodeFoundHandler(bool nodeFound)
+    protected void NodeFoundHandler(int nodeFound)
     {
-        if(lastFound != nodeFound)
-        {
-            lastFound = nodeFound;
+        if (!botController.IsBotActive)
+            return;
 
-            if (nodeFound)
+        if (lastAmount != nodeFound)
+        {
+            lastAmount = nodeFound;
+            if (nodeFound > 0)
             {
-                botController.StopBot();
+                botController.MinimapNodeFound();
                 JSRuntime.InvokeVoidAsync("play");
             }
             else

--- a/BlazorServer/Pages/LogComponent.razor
+++ b/BlazorServer/Pages/LogComponent.razor
@@ -9,6 +9,11 @@
         padding-right: 10px !important;
     }
 
+    .scrollable-wrapper {
+      max-height: 400px;
+      overflow: auto;
+    }
+
     .success {
         color: #28a745;
     }
@@ -26,6 +31,7 @@
     }
 </style>
 
+<div class="col-sm scrollable-wrapper">
 <table class="table table-borderless table-dark" cellspacing="20">
 @foreach (var evt in LoggerSink.Log.Reverse())
 {
@@ -35,6 +41,7 @@
     </tr>
 }
 </table>
+</div>
 
 @code {
 

--- a/BlazorServer/Pages/MiniMapComponent.razor
+++ b/BlazorServer/Pages/MiniMapComponent.razor
@@ -32,9 +32,10 @@
     public int Size { get; set; } = 200;
 
     [Parameter]
-    public EventCallback<bool> OnNodeFound { get; set; }
+    public EventCallback<int> OnNodeFound { get; set; }
 
     private bool lastNodeFound = false;
+    private int lastNodeCount = 0;
 
     private bool previewEnabled = true;
 
@@ -56,14 +57,16 @@
 
     private void NodeFound(object? source, NodeEventArgs e)
     {
-        var nodeFound = e.Point.X > 0 && e.Point.Y > 0;
+        if (!botController.IsBotActive) return;
 
-        if (lastNodeFound != nodeFound)
+        bool nodeFound = e.Point.X > 0 && e.Point.Y > 0;
+        if (lastNodeFound != nodeFound || e.Amount != lastNodeCount)
         {
             base.InvokeAsync(() =>
             {
-                OnNodeFound.InvokeAsync(nodeFound);
+                OnNodeFound.InvokeAsync(e.Amount);
             });
+            lastNodeCount = e.Amount;
         }
         lastNodeFound = nodeFound;
 

--- a/BlazorServer/Pages/_Host.cshtml
+++ b/BlazorServer/Pages/_Host.cshtml
@@ -80,7 +80,7 @@
         function draw() {
 
             gridNode = document.getElementById("grid")
-            panzoom = Panzoom(gridNode, { /*contain: 'outside',*/ excludeClass: 'group2', minScale: 0.99, roundPixels: true })
+            panzoom = Panzoom(gridNode, { /*contain: 'outside',*/ excludeClass: 'group2', minScale: 0.99, maxScale: 8, roundPixels: true })
             const parent = gridNode.parentElement
             parent.addEventListener('wheel', panzoom.zoomWithWheel)
 

--- a/BlazorServer/wwwroot/script/script.js
+++ b/BlazorServer/wwwroot/script/script.js
@@ -3,8 +3,10 @@ const clip = 'data:audio/ogg;base64,T2dnUwACAAAAAAAAAADSeWyXAAAAAHTSMw8BHgF2b3Ji
 
 function initAudioPlayer() {
     audio = document.getElementById("audio_player");
-    if(audio != null)
+    if (audio != null) {
         audio.src = clip;
+        audio.volume = 0.25;
+    }
 }
 
 function play() {

--- a/Core/AddonComponent/AddonBits.cs
+++ b/Core/AddonComponent/AddonBits.cs
@@ -55,5 +55,7 @@
         public bool IsDrowning => v2.IsBitSet(0);
 
         public bool IsCorpseInRange => v2.IsBitSet(1);
+
+        public bool IsIndoors => v2.IsBitSet(2);
     }
 }

--- a/Core/BotController.cs
+++ b/Core/BotController.cs
@@ -214,7 +214,7 @@ namespace Core
                         this.npcNameFinder.FakeUpdate();
                     }
 
-                    if (ClassConfig != null && this.ClassConfig.Mode == Mode.AttendedGather)
+                    if (ClassConfig?.Mode == Mode.AttendedGather)
                     {
                         minimapNodeFinder.TryFind();
                     }
@@ -238,7 +238,7 @@ namespace Core
             this.logger.LogInformation("Screenshot thread stoppped!");
         }
 
-        public bool IsBotActive => actionThread == null ? false : actionThread.Active;
+        public bool IsBotActive => actionThread != null && actionThread.Active;
 
         public void ToggleBotStatus()
         {
@@ -413,6 +413,11 @@ namespace Core
                 actionThread.Active = false;
                 StatusChanged?.Invoke(this, EventArgs.Empty);
             }
+        }
+
+        public void MinimapNodeFound()
+        {
+            GoapAgent?.NodeFound();
         }
 
         public void Shutdown()

--- a/Core/ConfigBotController.cs
+++ b/Core/ConfigBotController.cs
@@ -50,6 +50,11 @@ namespace Core
             throw new NotImplementedException();
         }
 
+        public void MinimapNodeFound()
+        {
+            throw new NotImplementedException();
+        }
+
         public void ToggleBotStatus()
         {
             throw new NotImplementedException();

--- a/Core/GOAP/GoapAgent.cs
+++ b/Core/GOAP/GoapAgent.cs
@@ -90,7 +90,8 @@ namespace Core.GOAP
                 // these hold their state
                 { GoapKey.consumecorpse, State.ShouldConsumeCorpse },
                 { GoapKey.shouldloot, State.NeedLoot },
-                { GoapKey.shouldskin, State.NeedSkin }
+                { GoapKey.shouldskin, State.NeedSkin },
+                { GoapKey.gathering, State.Gathering }
             };
         }
 
@@ -107,6 +108,9 @@ namespace Core.GOAP
                 case GoapKey.shouldskin:
                     State.NeedSkin = (bool)e.Value;
                     break;
+                case GoapKey.gathering:
+                    State.Gathering = (bool)e.Value;
+                    break;
             }
         }
 
@@ -115,15 +119,7 @@ namespace Core.GOAP
             if (Active)
             {
                 State.LastCombatKillCount++;
-
-                if (CurrentGoal == null)
-                {
-                    AvailableGoals.ToList().ForEach(x => x.OnActionEvent(this, new ActionEventArgs(GoapKey.producedcorpse, true)));
-                }
-                else
-                {
-                    CurrentGoal.OnActionEvent(this, new ActionEventArgs(GoapKey.producedcorpse, true));
-                }
+                Broadcast(GoapKey.producedcorpse, true);
 
                 LogActiveKillDetected(logger, State.LastCombatKillCount, addonReader.CombatCreatureCount);
             }
@@ -133,6 +129,24 @@ namespace Core.GOAP
             }
         }
 
+        private void Broadcast(GoapKey goapKey, bool value)
+        {
+            if (CurrentGoal == null)
+            {
+                AvailableGoals.ToList().ForEach(x => x.OnActionEvent(this, new ActionEventArgs(goapKey, value)));
+            }
+            else
+            {
+                CurrentGoal.OnActionEvent(this, new ActionEventArgs(goapKey, value));
+            }
+        }
+
+
+        public void NodeFound()
+        {
+            State.Gathering = true;
+            Broadcast(GoapKey.gathering, true);
+        }
 
         #region Logging
 

--- a/Core/GOAP/GoapAgentState.cs
+++ b/Core/GOAP/GoapAgentState.cs
@@ -7,5 +7,6 @@ namespace Core.GOAP
         public bool NeedLoot { get; set; }
         public bool NeedSkin { get; set; }
         public int LastCombatKillCount { get; set; }
+        public bool Gathering { get; set; }
     }
 }

--- a/Core/GOAP/GoapKey.cs
+++ b/Core/GOAP/GoapKey.cs
@@ -24,7 +24,8 @@ namespace Core.GOAP
         resume = 141,
         isalive = 170,
         isswimming = 180,
-        itemsbroken = 190
+        itemsbroken = 190,
+        gathering = 200
     }
 
     public static class GoapKeyDescription
@@ -86,6 +87,9 @@ namespace Core.GOAP
 
             { new(GoapKey.itemsbroken, true), "Broken" },
             { new(GoapKey.itemsbroken, false), "!Broken" },
+
+            { new(GoapKey.gathering, true), "Gathering" },
+            { new(GoapKey.gathering, false), "!Gathering" },
         };
 
         public static string ToString(GoapKey key, bool state)

--- a/Core/Goals/AdhocNPCGoal.cs
+++ b/Core/Goals/AdhocNPCGoal.cs
@@ -255,7 +255,7 @@ namespace Core.Goals
 
         private void MountIfRequired()
         {
-            if (shouldMount && !mountHandler.IsMounted())
+            if (shouldMount && mountHandler.CanMount())
             {
                 shouldMount = false;
                 mountHandler.MountUp();

--- a/Core/Goals/FollowRouteGoal.cs
+++ b/Core/Goals/FollowRouteGoal.cs
@@ -86,14 +86,14 @@ namespace Core.Goals
 
             AddPrecondition(GoapKey.dangercombat, false);
 
-            if (classConfig.Mode != Mode.AttendedGather)
+            if (classConfig.Mode == Mode.AttendedGather)
+            {
+                navigation.OnAnyPointReached += Navigation_OnWayPointReached;
+            }
+            else
             {
                 AddPrecondition(GoapKey.producedcorpse, false);
                 AddPrecondition(GoapKey.consumecorpse, false);
-            }
-            else if (classConfig.Mode == Mode.AttendedGather)
-            {
-                navigation.OnAnyPointReached += Navigation_OnWayPointReached;
             }
 
             sideActivityCts = new CancellationTokenSource();

--- a/Core/Goals/FollowRouteGoal.cs
+++ b/Core/Goals/FollowRouteGoal.cs
@@ -125,8 +125,9 @@ namespace Core.Goals
                 navigation.Resume();
             }
 
-            if (classConfig.UseMount &&
-                mountHandler.CanMount() && !shouldMount &&
+            if (!shouldMount &&
+                classConfig.UseMount &&
+                mountHandler.CanMount() &&
                 mountHandler.ShouldMount(navigation.TotalRoute.Last()))
             {
                 shouldMount = true;
@@ -170,7 +171,7 @@ namespace Core.Goals
 
             if (playerReader.Bits.IsDrowning)
             {
-                Log("Drowning! Swim up");
+                //Log("Drowning! Swim up");
                 input.Jump();
             }
 
@@ -251,19 +252,13 @@ namespace Core.Goals
 
         private void MountIfRequired()
         {
-            if (shouldMount && !mountHandler.IsMounted())
+            if (shouldMount && classConfig.UseMount && !npcNameFinder.MobsVisible &&
+                mountHandler.CanMount())
             {
-                if (!npcNameFinder.MobsVisible)
-                {
-                    shouldMount = false;
-                    Log("Mount up");
-                    mountHandler.MountUp();
-                    navigation.ResetStuckParameters();
-                }
-                else
-                {
-                    LogDebug("Not mounting as can see NPC.");
-                }
+                shouldMount = false;
+                Log("Mount up");
+                mountHandler.MountUp();
+                navigation.ResetStuckParameters();
             }
         }
 
@@ -282,7 +277,7 @@ namespace Core.Goals
 
         private void Navigation_OnWayPointReached(object? sender, EventArgs e)
         {
-            if (classConfig.Mode == Mode.AttendedGather && !mountHandler.IsMounted())
+            if (classConfig.Mode == Mode.AttendedGather)
             {
                 shouldMount = true;
             }

--- a/Core/Goals/GoalFactory.cs
+++ b/Core/Goals/GoalFactory.cs
@@ -76,9 +76,12 @@ namespace Core
             }
             else if (classConfig.Mode == Mode.AttendedGather)
             {
+                followNav.SimplifyRouteToWaypoint = false;
+
                 availableActions.Add(walkToCorpseAction);
                 availableActions.Add(genericCombat);
                 availableActions.Add(approachTarget);
+                availableActions.Add(new WaitForGathering(logger, wait, addonReader.PlayerReader, stopMoving));
                 availableActions.Add(followRouteAction);
 
                 if (classConfig.Parallel.Sequence.Count > 0)

--- a/Core/Goals/GoalFactory.cs
+++ b/Core/Goals/GoalFactory.cs
@@ -1,4 +1,4 @@
-﻿using Core.Goals;
+using Core.Goals;
 using SharedLib.NpcFinder;
 using Core.PPather;
 using Microsoft.Extensions.Logging;
@@ -50,7 +50,7 @@ namespace Core
 
             StuckDetector stuckDetector = new(logger, input, addonReader.PlayerReader, playerDirection, stopMoving);
             CombatUtil combatUtil = new(logger, input, wait, addonReader.PlayerReader);
-            MountHandler mountHandler = new(logger, input, classConfig, wait, addonReader.PlayerReader, castingHandler, stopMoving);
+            MountHandler mountHandler = new(logger, input, classConfig, wait, addonReader, castingHandler, stopMoving);
 
             TargetFinder targetFinder = new(logger, input, classConfig, wait, addonReader.PlayerReader, blacklist, npcNameTargeting);
 

--- a/Core/Goals/GoalFactory.cs
+++ b/Core/Goals/GoalFactory.cs
@@ -1,4 +1,4 @@
-using Core.Goals;
+﻿using Core.Goals;
 using SharedLib.NpcFinder;
 using Core.PPather;
 using Microsoft.Extensions.Logging;
@@ -54,10 +54,10 @@ namespace Core
 
             TargetFinder targetFinder = new(logger, input, classConfig, wait, addonReader.PlayerReader, blacklist, npcNameTargeting);
 
-            Navigation followNav = new(logger, playerDirection, input, addonReader, stopMoving, stuckDetector, pather, mountHandler);
+            Navigation followNav = new(logger, playerDirection, input, addonReader, stopMoving, stuckDetector, pather, mountHandler, classConfig.Mode);
             FollowRouteGoal followRouteAction = new(logger, input, wait, addonReader, classConfig, pathPoints, followNav, mountHandler, npcNameFinder, targetFinder);
 
-            Navigation corpseNav = new(logger, playerDirection, input, addonReader, stopMoving, stuckDetector, pather, mountHandler);
+            Navigation corpseNav = new(logger, playerDirection, input, addonReader, stopMoving, stuckDetector, pather, mountHandler, classConfig.Mode);
             WalkToCorpseGoal walkToCorpseAction = new(logger, input, wait, addonReader, corpseNav, stopMoving);
 
             CombatGoal genericCombat = new(logger, input, wait, addonReader, stopMoving, classConfig, castingHandler, mountHandler);
@@ -133,7 +133,7 @@ namespace Core
 
                 foreach (var item in classConfig.NPC.Sequence)
                 {
-                    var nav = new Navigation(logger, playerDirection, input, addonReader, stopMoving, stuckDetector, pather, mountHandler);
+                    var nav = new Navigation(logger, playerDirection, input, addonReader, stopMoving, stuckDetector, pather, mountHandler, classConfig.Mode);
                     availableActions.Add(new AdhocNPCGoal(logger, input, item, wait, addonReader, nav, stopMoving, npcNameTargeting, classConfig, blacklist, mountHandler, exec));
                     item.Path.Clear();
                     item.Path.AddRange(ReadPath(item.Name, item.PathFilename));
@@ -218,7 +218,7 @@ namespace Core
 
                 foreach (var item in classConfig.NPC.Sequence)
                 {
-                    var nav = new Navigation(logger, playerDirection, input, addonReader, stopMoving, stuckDetector, pather, mountHandler);
+                    var nav = new Navigation(logger, playerDirection, input, addonReader, stopMoving, stuckDetector, pather, mountHandler, classConfig.Mode);
                     availableActions.Add(new AdhocNPCGoal(logger, input, item, wait, addonReader, nav, stopMoving, npcNameTargeting, classConfig, blacklist, mountHandler, exec));
                     item.Path.Clear();
                     item.Path.AddRange(ReadPath(item.Name, item.PathFilename));

--- a/Core/Goals/WaitForGathering.cs
+++ b/Core/Goals/WaitForGathering.cs
@@ -1,0 +1,178 @@
+﻿using Core.GOAP;
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace Core.Goals
+{
+    public class WaitForGathering : GoapGoal
+    {
+        public override float CostOfPerformingAction => 17;
+
+        private const int Timeout = 5000;
+
+        private readonly ILogger logger;
+        private readonly Wait wait;
+        private readonly PlayerReader playerReader;
+        private readonly StopMoving stopMoving;
+        private readonly Stopwatch stopWatch;
+
+        private int lastKnownCast;
+
+        private readonly List<int> herbSpells = new()
+        {
+            2366,
+            2368,
+            3570,
+            11993,
+            28695,
+        };
+
+        private readonly List<int> miningSpells = new()
+        {
+            2575,
+            2576,
+            3564,
+            10248,
+            29354
+        };
+
+        private enum CastState
+        {
+            None,
+            Casting,
+            Failed,
+            Abort,
+            Success,
+            WaitUserInput,
+        }
+        private CastState state;
+
+        public WaitForGathering(ILogger logger, Wait wait, PlayerReader playerReader, StopMoving stopMoving)
+        {
+            this.logger = logger;
+            this.wait = wait;
+            this.playerReader = playerReader;
+            this.stopMoving = stopMoving;
+            this.stopWatch = new();
+
+            AddPrecondition(GoapKey.gathering, true);
+        }
+
+        public override ValueTask OnEnter()
+        {
+            stopMoving.Stop();
+            wait.Update(1);
+
+            while (playerReader.Bits.IsFalling)
+            {
+                wait.Update(1);
+            }
+
+            logger.LogInformation("Waiting indefinitely for [Gathering cast to start] or [Press Jump to Abort]");
+
+            return base.OnEnter();
+        }
+
+        public override ValueTask OnExit()
+        {
+            logger.LogInformation($"{state} -- Exit");
+
+            state = CastState.None;
+            lastKnownCast = 0;
+
+            stopWatch.Reset();
+            stopWatch.Stop();
+
+            return base.OnExit();
+        }
+
+        public override ValueTask PerformAction()
+        {
+            switch (state)
+            {
+                case CastState.None:
+                    if (playerReader.IsCasting &&
+                        (herbSpells.Contains(playerReader.CastSpellId.Value) ||
+                        miningSpells.Contains(playerReader.CastSpellId.Value)))
+                    {
+                        lastKnownCast = playerReader.CastSpellId.Value;
+                        state = CastState.Casting;
+
+                        logger.LogInformation(state.ToString());
+                    }
+
+                    if (playerReader.Bits.IsFalling)
+                    {
+                        state = CastState.Abort;
+                        logger.LogInformation(state.ToString());
+                    }
+                    break;
+                case CastState.Casting:
+                    if (!playerReader.IsCasting)
+                    {
+                        if (playerReader.LastUIErrorMessage == UI_ERROR.ERR_SPELL_FAILED_S)
+                        {
+                            state = CastState.Failed;
+                            logger.LogInformation($"{state} -- Waiting(max {Timeout} ms) for [Gathering cast to start] or [Press Jump to Abort]");
+                        }
+                        else
+                        {
+                            if (miningSpells.Contains(lastKnownCast))
+                            {
+                                state = CastState.WaitUserInput;
+                                logger.LogInformation($"{CastState.Success} -> {state} Waiting(max {Timeout} ms) for [More Mining cast] or [Press Jump to Abort]");
+                                stopWatch.Restart();
+                                wait.Update(1);
+                            }
+                            else
+                            {
+                                state = CastState.Success;
+                                logger.LogInformation(state.ToString());
+                            }
+                        }
+                    }
+                    break;
+                case CastState.Failed:
+                    stopWatch.Restart();
+                    state = CastState.WaitUserInput;
+                    logger.LogInformation($"{state} -- Waiting(max {Timeout} ms) for [Gathering cast to start] or [Press Jump to Abort]");
+                    wait.Update(1);
+                    break;
+                case CastState.Success:
+                case CastState.Abort:
+                    SendActionEvent(new ActionEventArgs(GoapKey.gathering, false));
+                    break;
+                case CastState.WaitUserInput:
+                    if (playerReader.IsCasting &&
+                        (herbSpells.Contains(playerReader.CastSpellId.Value) ||
+                        miningSpells.Contains(playerReader.CastSpellId.Value)))
+                    {
+                        lastKnownCast = playerReader.CastSpellId.Value;
+                        state = CastState.Casting;
+
+                        logger.LogInformation(state.ToString());
+
+                        stopWatch.Reset();
+                        stopWatch.Stop();
+                    }
+
+                    if (playerReader.Bits.IsFalling)
+                    {
+                        state = CastState.Abort;
+                        logger.LogInformation(state.ToString());
+                    }
+
+                    if (stopWatch.ElapsedMilliseconds > Timeout)
+                    {
+                        SendActionEvent(new ActionEventArgs(GoapKey.gathering, false));
+                    }
+                    break;
+            }
+
+            wait.Update(1);
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/Core/IBotController.cs
+++ b/Core/IBotController.cs
@@ -40,6 +40,8 @@ namespace Core
         void ToggleBotStatus();
         void StopBot();
 
+        void MinimapNodeFound();
+
         void Shutdown();
 
         bool IsBotActive { get; }

--- a/Core/MiniMapNodeAlert/IImageProvider.cs
+++ b/Core/MiniMapNodeAlert/IImageProvider.cs
@@ -12,9 +12,12 @@ namespace Core
     {
         public Point Point { get; }
 
-        public NodeEventArgs(Point point)
+        public int Amount { get; }
+
+        public NodeEventArgs(Point point, int amount)
         {
             Point = point;
+            Amount = amount;
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Take a look at the class files in `/Json/class` for examples of what you can do.
 | `"Parallel"` | Sequence of `KeyAction(s)` to execute upon [Parallel Goal](#Parallel-Goals) | true | `[]` |
 | `"NPC"` | Sequence of `KeyAction(s)` to execute upon [NPC Goal](#NPC-Goals) | true | `[]` |
 | --- | --- | --- | --- |
-| `"GatherFindKeys"` | List of strings for switching between gathering profiles | true | `[]` |
+| `"GatherFindKeys"` | List of strings for switching between gathering profiles | true | `string[]` |
 | `"JumpKey"` | `Consolekey` to be pressed on Jump | true | `"Spacebar"` |
 | `"InteractKey"` | `Consolekey` to be pressed on Interact | true | `"I"` |
 | `"TargetLastTargetKey"` | `Consolekey` to be pressed to Target last target | true | `"G"` |
@@ -1204,7 +1204,7 @@ e.g. Rogue.json
 {
     "PathFilename": "Herb_EPL.json",
     "Mode": "AttendedGather",
-    "GatherFindKeys":  [1,2]
+    "GatherFindKeys":  ["1","2"]
 }
 ```
 
@@ -1214,7 +1214,7 @@ The available modes are:
 | --- | --- |
 | `"Grind"` | This is the default mode where the bot will pull mobs and follow a route |
 | `"CorpseRun"` | This mode only has 2 goals. The "Wait" goal waits while you are alive. The "CorpseRun" will run back to your corpse when you die. This can be useful if you are farming an instance and die, the bot will run you back some or all of the way to the instance entrance. |
-| `"AttendedGather"` | When this mode is active and the Gather tab in the UI is selected, it will run the path and scan the minimap for the yellow nodes which indicate a herb or mining node. When it finds a node it will stop and alert you by playing a youtube video, you will then have to manually pick the herb/mine and then start the bot again. |
+| `"AttendedGather"` | When this mode is active, you have to `Start Bot` under `Gather` tab and stay at `Gather` tab. It will follow the path and scan the minimap for the yellow nodes which indicate a herb or mining node. Upon found one, the player movement going to stop and alert you by playing beeping sound. Manually have to click at the herb/mine. In the `LogComponent` the necessary prompt will be shown to proceed. **Important note**: `Falling` and `Jumping` means the same thing. So if you lose the ground the bot going to take over control however if a yellow node is visible on the minimap you going to get the control back! Be patient. |
 | `"AttendedGrind"` | This is useful if you want to control the path the bot takes, but want it to pull and kill any targets you select. |
 
 # User Interface


### PR DESCRIPTION
Key Changes for `AttendedGather` mode -> `WaitForGathering`:
* Instead of Stopping and Restarting required. When a gatherable yellow node found at the minimap the `WaitForGathering` Goal takes over the control. 
* Requires User interaction in order to proceed.
* Uses a non blocking state machine to handle different state of the gathering process.
* Considers failed gathering attempts and awaits for user input to proceed.
* Supports multiple taps from Mining vein.
* During `FollowRouteGoal` uses more strict distances to determine waypoint reached state.
* `Gather` tab got improved layout to supply the necessary prompt information.

Improvements:
* `MountHandler`: Considers more about the player be able to use mount.
* `MinimapNodeFinder`: Reports the amount of distinctly visible nodes.