### PR TITLE
Refactor: `WoWScreen.Enabled` and ScreenshotThread

### DIFF
--- a/Core/Goals/AdhocNPCGoal.cs
+++ b/Core/Goals/AdhocNPCGoal.cs
@@ -188,8 +188,8 @@ namespace Core.Goals
                 input.ClearTarget();
                 wait.Update(1);
 
-                SendActionEvent(new ActionEventArgs(GoapKey.wowscreen, true));
                 npcNameTargeting.ChangeNpcType(NpcNames.Friendly | NpcNames.Neutral);
+                SendActionEvent(new ActionEventArgs(GoapKey.wowscreen, true));
                 npcNameTargeting.WaitForNUpdate(1);
                 bool foundVendor = npcNameTargeting.FindBy(CursorType.Vendor, CursorType.Repair, CursorType.Innkeeper);
                 if (!foundVendor)

--- a/Core/Goals/ConsumeCorpse.cs
+++ b/Core/Goals/ConsumeCorpse.cs
@@ -42,7 +42,6 @@ namespace Core.Goals
 
             if (classConfig.Loot)
             {
-                SendActionEvent(new ActionEventArgs(GoapKey.wowscreen, true));
                 SendActionEvent(new ActionEventArgs(GoapKey.shouldloot, true));
             }
 

--- a/Core/Goals/CorpseConsumed.cs
+++ b/Core/Goals/CorpseConsumed.cs
@@ -29,7 +29,6 @@ namespace Core.Goals
             LogConsumed(logger, goapAgentState.LastCombatKillCount);
 
             SendActionEvent(new ActionEventArgs(GoapKey.consumecorpse, false));
-            SendActionEvent(new ActionEventArgs(GoapKey.wowscreen, false));
 
             return base.OnEnter();
         }

--- a/Core/Goals/FollowRouteGoal.cs
+++ b/Core/Goals/FollowRouteGoal.cs
@@ -32,7 +32,7 @@ namespace Core.Goals
 
         private readonly TargetFinder targetFinder;
         private readonly int minMs = 500, maxMs = 1000;
-        private readonly NpcNames NpcNameToFind = NpcNames.Enemy | NpcNames.Neutral;
+        private const NpcNames NpcNameToFind = NpcNames.Enemy | NpcNames.Neutral;
 
         private const int MIN_TIME_TO_START_CYCLE_PROFESSION = 5000;
         private const int CYCLE_PROFESSION_PERIOD = 8000;
@@ -204,7 +204,6 @@ namespace Core.Goals
             }
             else
             {
-                SendActionEvent(new ActionEventArgs(GoapKey.wowscreen, true));
                 sideActivityThread = new Thread(Thread_LookingForTarget);
                 sideActivityThread.Start();
             }
@@ -214,9 +213,13 @@ namespace Core.Goals
         {
             Log("Start searching for target...");
 
-            bool validTarget() =>
-                playerReader.HasTarget &&
-                !playerReader.Bits.TargetIsDead;
+            bool validTarget()
+            {
+                return playerReader.HasTarget &&
+                    !playerReader.Bits.TargetIsDead;
+            }
+
+            SendActionEvent(new ActionEventArgs(GoapKey.wowscreen, true));
 
             bool found = false;
             while (!found && !sideActivityCts.IsCancellationRequested)
@@ -232,8 +235,9 @@ namespace Core.Goals
             {
                 sideActivityCts.Cancel();
                 Log("Found target!");
-                SendActionEvent(new ActionEventArgs(GoapKey.wowscreen, false));
             }
+
+            SendActionEvent(new ActionEventArgs(GoapKey.wowscreen, false));
         }
 
         private void Thread_AttendedGather()

--- a/Core/Goals/LootGoal.cs
+++ b/Core/Goals/LootGoal.cs
@@ -67,6 +67,7 @@ namespace Core.Goals
 
             Log($"Search for {NpcNames.Corpse}");
             npcNameTargeting.ChangeNpcType(NpcNames.Corpse);
+            SendActionEvent(new ActionEventArgs(GoapKey.wowscreen, true));
 
             lastLoot = playerReader.LastLootTime;
 
@@ -138,6 +139,12 @@ namespace Core.Goals
             GoalExit();
 
             return ValueTask.CompletedTask;
+        }
+
+        public override ValueTask OnExit()
+        {
+            SendActionEvent(new ActionEventArgs(GoapKey.wowscreen, false));
+            return base.OnExit();
         }
 
         public override ValueTask PerformAction()

--- a/Core/Goals/SkinningGoal.cs
+++ b/Core/Goals/SkinningGoal.cs
@@ -70,6 +70,7 @@ namespace Core.Goals
 
             Log($"Search for {NpcNames.Corpse}");
             npcNameTargeting.ChangeNpcType(NpcNames.Corpse);
+            SendActionEvent(new ActionEventArgs(GoapKey.wowscreen, true));
 
             lastLoot = playerReader.LastLootTime;
 
@@ -143,6 +144,12 @@ namespace Core.Goals
             }
 
             return ValueTask.CompletedTask;
+        }
+
+        public override ValueTask OnExit()
+        {
+            SendActionEvent(new ActionEventArgs(GoapKey.wowscreen, false));
+            return base.OnExit();
         }
 
         public override ValueTask PerformAction()

--- a/Game/WoWScreen/WowScreen.cs
+++ b/Game/WoWScreen/WowScreen.cs
@@ -18,7 +18,7 @@ namespace Game
         public delegate void ScreenChangeEventHandler(object sender, ScreenChangeEventArgs args);
         public event ScreenChangeEventHandler OnScreenChanged;
 
-        private readonly List<Action<Graphics>> drawActions = new List<Action<Graphics>>();
+        private readonly List<Action<Graphics>> drawActions = new();
 
         public int Size { get; set; } = 1024;
 
@@ -69,9 +69,6 @@ namespace Game
 
         public void PostProcess()
         {
-            if (!EnablePostProcess)
-                return;
-
             using (var gr = Graphics.FromImage(Bitmap))
             {
                 using (var blackPen = new SolidBrush(Color.Black))


### PR DESCRIPTION
Changes:
* `ScreenshotThread`: Slightly reworked. When `WoWScreen.Enabled` changes state from disabled to active, it not going to wait the `screenshotTickMs` time rather instantly creates a `NpcNameFinder` state. Other word it takes less idle time to be activated.
* `WoWScreen` usage much defined in the Goals.
* As a result less likely burning massive amount of CPU time for no reason.