### PR TITLE
Addon [1.2.6]: Better body pull detection. Considering Targets us (player, pet, partyN, partyNpet)

### DIFF
--- a/Addons/DataToColor/Constants.lua
+++ b/Addons/DataToColor/Constants.lua
@@ -3,6 +3,8 @@ local DataToColor = unpack(Load)
 
 DataToColor.C.unitPlayer = "player"
 DataToColor.C.unitTarget = "target"
+DataToColor.C.unitParty = "party"
+DataToColor.C.unitRaid = "raid"
 DataToColor.C.unitPet = "pet"
 DataToColor.C.unitPetTarget = "pettarget"
 DataToColor.C.unitTargetTarget = "targettarget"

--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -644,7 +644,7 @@ function DataToColor:CreateFrames(n)
 
             MakePixelSquareArrI(DataToColor:CastingInfoSpellId(DataToColor.C.unitTarget), 58) -- Spell being cast by target
 
-            MakePixelSquareArrI(DataToColor:IsTargetOfTargetPlayerAsNumber(),59) -- IsTargetOfTargetPlayerAsNumber
+            MakePixelSquareArrI(DataToColor:TargetOfTargetAsNumber(),59) -- IsTargetOfTargetPlayerAsNumber
 
             MakePixelSquareArrI(DataToColor.lastAutoShot, 60)
             MakePixelSquareArrI(DataToColor.lastMainHandMeleeSwing, 61)

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors
-## Version: 1.2.5
+## Version: 1.2.6
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/Query.lua
+++ b/Addons/DataToColor/Query.lua
@@ -37,7 +37,7 @@ function DataToColor:Base2Converter()
     DataToColor:MakeIndexBase2(DataToColor:petHappy(), 12) +
     DataToColor:MakeIndexBase2(DataToColor:hasAmmo(), 13) +
     DataToColor:MakeIndexBase2(DataToColor:playerCombatStatus(), 14) +
-    DataToColor:MakeIndexBase2(DataToColor:IsTargetOfTargetPlayer(), 15) +
+    DataToColor:MakeIndexBase2(DataToColor:IsTargetOfTargetPlayerOrPet(), 15) +
     DataToColor:MakeIndexBase2(DataToColor:IsAutoRepeatSpellOn(DataToColor.C.Spell.AutoShotId), 16) +
     DataToColor:MakeIndexBase2(DataToColor:hasTarget(), 17) +
     DataToColor:MakeIndexBase2(DataToColor:IsPlayerMounted(), 18) +
@@ -562,18 +562,38 @@ function DataToColor:IsPlayerMounted()
     return IsMounted() and 1 or 0
 end
 
-function DataToColor:IsTargetOfTargetPlayerAsNumber()
+function DataToColor:TargetOfTargetAsNumber()
     if not(UnitName(DataToColor.C.unitTargetTarget)) then return 2 end -- target has no target
     if DataToColor.C.CHARACTER_NAME == UnitName(DataToColor.C.unitTarget) then return 0 end -- targeting self
     if UnitName(DataToColor.C.unitPet) == UnitName(DataToColor.C.unitTargetTarget) then return 4 end -- targetting my pet
     if DataToColor.C.CHARACTER_NAME == UnitName(DataToColor.C.unitTargetTarget) then return 1 end -- targetting me
     if UnitName(DataToColor.C.unitPet) == UnitName(DataToColor.C.unitTarget) and UnitName(DataToColor.C.unitTargetTarget) ~= nil then return 5 end
+    if IsInGroup() and DataToColor:TargetTargetsPartyOrPet() then return 6 end
     return 3
 end
 
+function DataToColor:TargetTargetsPartyOrPet()
+    for i=1, 4 do
+        local unit = DataToColor.C.unitParty..i
+        if UnitExists(unit) == false then
+            return false
+        end
+        local name = UnitName(unit)
+        if name == UnitName(DataToColor.C.unitTargetTarget) then return true end
+
+        unit = DataToColor.C.unitParty..i..DataToColor.C.unitPet
+        if UnitExists(unit) == false then
+            return false
+        end
+        name = UnitName(unit)
+        if name == UnitName(DataToColor.C.unitTargetTarget) then return true end
+    end
+    return false
+end
+
 -- Returns true if target of our target is us
-function DataToColor:IsTargetOfTargetPlayer()
-    local x = DataToColor:IsTargetOfTargetPlayerAsNumber()
+function DataToColor:IsTargetOfTargetPlayerOrPet()
+    local x = DataToColor:TargetOfTargetAsNumber()
     if x==1 or x==4 then return 1 else return 0 end
 end
 

--- a/Core/AddonComponent/AddonBits.cs
+++ b/Core/AddonComponent/AddonBits.cs
@@ -41,7 +41,7 @@
         public bool PetHappy => v1.IsBitSet(12);
         public bool HasAmmo => v1.IsBitSet(13);
         public bool PlayerInCombat => v1.IsBitSet(14);
-        public bool TargetOfTargetIsPlayer => v1.IsBitSet(15);
+        public bool TargetOfTargetIsPlayerOrPet => v1.IsBitSet(15);
         public bool IsAutoRepeatSpellOn_AutoShot => v1.IsBitSet(16);
         public bool HasTarget => v1.IsBitSet(17);
         public bool IsMounted => v1.IsBitSet(18);

--- a/Core/AddonComponent/TargetTargetEnum.cs
+++ b/Core/AddonComponent/TargetTargetEnum.cs
@@ -7,6 +7,7 @@
         None = 2,
         Unknown = 3,
         Pet = 4,
-        PetHasATarget = 5
+        PetHasATarget = 5,
+        PartyOrPet = 6
     };
 }

--- a/Core/Blacklist/Blacklist.cs
+++ b/Core/Blacklist/Blacklist.cs
@@ -53,7 +53,7 @@ namespace Core
             }
 
             // it is trying to kill me
-            if (playerReader.Bits.TargetOfTargetIsPlayer)
+            if (playerReader.Bits.TargetOfTargetIsPlayerOrPet)
             {
                 return false;
             }

--- a/Core/GOAP/GoapAgent.cs
+++ b/Core/GOAP/GoapAgent.cs
@@ -81,6 +81,10 @@ namespace Core.GOAP
                 { GoapKey.dangercombat, addonReader.PlayerReader.Bits.PlayerInCombat && addonReader.CombatCreatureCount > 0 },
                 { GoapKey.pethastarget, playerReader.PetHasTarget },
                 { GoapKey.targetisalive, playerReader.HasTarget && !playerReader.Bits.TargetIsDead },
+                { GoapKey.targettargetsus, playerReader.TargetTarget is
+                    TargetTargetEnum.Me or
+                    TargetTargetEnum.Pet or
+                    TargetTargetEnum.PartyOrPet },
                 { GoapKey.incombat, playerReader.Bits.PlayerInCombat },
                 { GoapKey.withinpullrange, playerReader.WithInPullRange },
                 { GoapKey.incombatrange, playerReader.WithInCombatRange },

--- a/Core/GOAP/GoapKey.cs
+++ b/Core/GOAP/GoapKey.cs
@@ -7,6 +7,7 @@ namespace Core.GOAP
         hastarget = 10,
         dangercombat = 11,
         targetisalive = 20,
+        targettargetsus = 21,
         incombat = 30,
         pethastarget = 31,
         withinpullrange = 40,
@@ -43,6 +44,9 @@ namespace Core.GOAP
 
             { new(GoapKey.targetisalive, true), "Target alive" },
             { new(GoapKey.targetisalive, false), "Target dead" },
+
+            { new(GoapKey.targettargetsus, true), "Targets us" },
+            { new(GoapKey.targettargetsus, false), "!Targets us" },
 
             { new(GoapKey.incombat, true), "Combat" },
             { new(GoapKey.incombat, false), "!Combat" },

--- a/Core/Goals/CastingHandler.cs
+++ b/Core/Goals/CastingHandler.cs
@@ -363,7 +363,7 @@ namespace Core.Goals
                     while (sw.ElapsedMilliseconds < item.DelayAfterCast)
                     {
                         wait.Update();
-                        if (playerReader.Bits.TargetOfTargetIsPlayer)
+                        if (playerReader.Bits.TargetOfTargetIsPlayerOrPet)
                         {
                             break;
                         }

--- a/Core/Goals/CombatGoal.cs
+++ b/Core/Goals/CombatGoal.cs
@@ -46,6 +46,7 @@ namespace Core.Goals
             AddPrecondition(GoapKey.incombat, true);
             AddPrecondition(GoapKey.hastarget, true);
             AddPrecondition(GoapKey.targetisalive, true);
+            AddPrecondition(GoapKey.targettargetsus, true);
             AddPrecondition(GoapKey.incombatrange, true);
 
             AddEffect(GoapKey.producedcorpse, true);
@@ -128,7 +129,7 @@ namespace Core.Goals
             get
             {
                 return this.playerReader.Bits.PlayerInCombat &&
-                    !this.playerReader.Bits.TargetOfTargetIsPlayer
+                    !this.playerReader.Bits.TargetOfTargetIsPlayerOrPet
                     && this.playerReader.TargetHealthPercentage == 100;
             }
         }
@@ -208,7 +209,7 @@ namespace Core.Goals
                 wait.Update();
                 if (playerReader.HasTarget)
                 {
-                    if (playerReader.Bits.TargetInCombat && playerReader.Bits.TargetOfTargetIsPlayer)
+                    if (playerReader.Bits.TargetInCombat && playerReader.Bits.TargetOfTargetIsPlayerOrPet)
                     {
                         ResetCooldowns();
 

--- a/Core/Goals/CombatUtil.cs
+++ b/Core/Goals/CombatUtil.cs
@@ -61,10 +61,10 @@ namespace Core
                 if (this.playerReader.PetHasTarget)
                 {
                     input.TargetPet();
-                    Log($"Pets target {this.playerReader.TargetTarget}");
-                    if (this.playerReader.TargetTarget == TargetTargetEnum.PetHasATarget)
+                    Log($"Pets target {playerReader.TargetTarget}");
+                    if (playerReader.TargetTarget == TargetTargetEnum.PetHasATarget)
                     {
-                        Log($"{nameof(CombatUtil)}.AquiredTarget: Found target by pet");
+                        Log($"{nameof(AquiredTarget)}: Found target by pet");
                         input.TargetOfTarget();
                         return true;
                     }
@@ -72,19 +72,19 @@ namespace Core
 
                 input.NearestTarget();
                 wait.Update();
-                if (this.playerReader.HasTarget && playerReader.Bits.TargetInCombat &&
-                    playerReader.Bits.TargetOfTargetIsPlayer)
+                if (playerReader.HasTarget && playerReader.Bits.TargetInCombat &&
+                    playerReader.Bits.TargetOfTargetIsPlayerOrPet)
                 {
                     Log("Found from nearest target");
                     return true;
                 }
 
-                if (wait.Till(200, () => playerReader.HasTarget))
+                if (wait.Till(400, () => playerReader.HasTarget || playerReader.PetHasTarget))
                 {
                     return true;
                 }
 
-                Log($"{nameof(CombatUtil)}.AquiredTarget: No target found");
+                Log($"{nameof(AquiredTarget)}: No target found");
                 input.ClearTarget();
                 wait.Update();
             }
@@ -124,7 +124,7 @@ namespace Core
         {
             if (debug)
             {
-                logger.LogInformation($"{nameof(CombatUtil)}: {text}");
+                logger.LogDebug($"{nameof(CombatUtil)}: {text}");
             }
         }
     }

--- a/Core/Goals/FollowRouteGoal.cs
+++ b/Core/Goals/FollowRouteGoal.cs
@@ -87,14 +87,14 @@ namespace Core.Goals
             navigation.OnDestinationReached += Navigation_OnDestinationReached;
             navigation.OnWayPointReached += Navigation_OnWayPointReached;
 
-            AddPrecondition(GoapKey.dangercombat, false);
-
             if (classConfig.Mode == Mode.AttendedGather)
             {
+                AddPrecondition(GoapKey.dangercombat, false);
                 navigation.OnAnyPointReached += Navigation_OnWayPointReached;
             }
             else
             {
+                AddPrecondition(GoapKey.incombat, false);
                 AddPrecondition(GoapKey.producedcorpse, false);
                 AddPrecondition(GoapKey.consumecorpse, false);
             }

--- a/Core/Goals/GoalFactory.cs
+++ b/Core/Goals/GoalFactory.cs
@@ -61,7 +61,7 @@ namespace Core
             WalkToCorpseGoal walkToCorpseAction = new(logger, input, wait, addonReader, corpseNav, stopMoving);
 
             CombatGoal genericCombat = new(logger, input, wait, addonReader, stopMoving, classConfig, castingHandler, mountHandler);
-            ApproachTargetGoal approachTarget = new(logger, input, wait, addonReader.PlayerReader, stopMoving, mountHandler);
+            ApproachTargetGoal approachTarget = new(logger, input, wait, addonReader.PlayerReader, stopMoving, mountHandler, combatUtil);
 
             availableActions.Clear();
 
@@ -183,7 +183,7 @@ namespace Core
                     availableActions.Add(new TargetPetTarget(input, addonReader.PlayerReader));
                 }
 
-                availableActions.Add(new PullTargetGoal(logger, input, wait, addonReader, blacklist, stopMoving, castingHandler, mountHandler, stuckDetector, classConfig));
+                availableActions.Add(new PullTargetGoal(logger, input, wait, addonReader, blacklist, stopMoving, castingHandler, mountHandler, stuckDetector, classConfig, combatUtil));
 
                 if (classConfig.Parallel.Sequence.Count > 0)
                 {


### PR DESCRIPTION
Key Changes:
- In order to detect body pull without immediately entering `CombatGoal` had to alter `FollowRouteGoal`, `CombatGoal` preconditions, to avoid pulling the original target which has not yet entered combat and the already pulled add(s).