### PR TITLE
Refactor: `WoWScreen` - `NpcNameFinder` relationship cleanup.

### DIFF
--- a/Core/BotController.cs
+++ b/Core/BotController.cs
@@ -127,7 +127,7 @@ namespace Core
             logger.LogDebug($"Woohoo, I have read the player class. You are a {AddonReader.PlayerReader.Race} {AddonReader.PlayerReader.Class}.");
 
             npcNameFinder = new(logger, WowScreen, npcNameFinderEvent);
-            npcNameTargeting = new(logger, cts, npcNameFinder, wowProcessInput);
+            npcNameTargeting = new(logger, cts, WowScreen, npcNameFinder, wowProcessInput);
             WowScreen.AddDrawAction(npcNameFinder.ShowNames);
             WowScreen.AddDrawAction(npcNameTargeting.ShowClickPositions);
 
@@ -168,10 +168,6 @@ namespace Core
 
                     if (WowScreen.EnablePostProcess)
                         WowScreen.PostProcess();
-                }
-                else
-                {
-                    npcNameFinder.FakeUpdate();
                 }
 
                 if (ClassConfig?.Mode == Mode.AttendedGather)

--- a/Core/GOAP/GoapAgent.cs
+++ b/Core/GOAP/GoapAgent.cs
@@ -17,7 +17,7 @@ namespace Core.GOAP
         private readonly IGrindSessionDAO sessionDAO;
         private readonly AddonReader addonReader;
         private readonly PlayerReader playerReader;
-        private readonly WowScreen wowScreen;
+        private readonly IWowScreen wowScreen;
         private readonly RouteInfo routeInfo;
         private readonly ConfigurableInput input;
 
@@ -77,7 +77,7 @@ namespace Core.GOAP
         public Stack<GoapGoal> Plan { get; private set; }
         public GoapGoal? CurrentGoal { get; private set; }
 
-        public GoapAgent(ILogger logger, ClassConfiguration classConfig, IGrindSessionDAO sessionDAO, WowScreen wowScreen, GoapAgentState goapAgentState, AddonReader addonReader, HashSet<GoapGoal> availableGoals, RouteInfo routeInfo, ConfigurableInput input)
+        public GoapAgent(ILogger logger, ClassConfiguration classConfig, IGrindSessionDAO sessionDAO, IWowScreen wowScreen, GoapAgentState goapAgentState, AddonReader addonReader, HashSet<GoapGoal> availableGoals, RouteInfo routeInfo, ConfigurableInput input)
         {
             this.logger = logger;
             this.classConfig = classConfig;
@@ -231,9 +231,6 @@ namespace Core.GOAP
                     break;
                 case GoapKey.gathering:
                     State.Gathering = (bool)e.Value;
-                    break;
-                case GoapKey.wowscreen:
-                    wowScreen.Enabled = (bool)e.Value;
                     break;
             }
 

--- a/Core/GOAP/GoapKey.cs
+++ b/Core/GOAP/GoapKey.cs
@@ -25,8 +25,7 @@ namespace Core.GOAP
         resume = 141,
         isswimming = 180,
         itemsbroken = 190,
-        gathering = 200,
-        wowscreen = 9999,
+        gathering = 200
     }
 
     public static class GoapKeyDescription

--- a/Core/Goals/AdhocNPCGoal.cs
+++ b/Core/Goals/AdhocNPCGoal.cs
@@ -138,7 +138,7 @@ namespace Core.Goals
         public override void OnExit()
         {
             navigation.Stop();
-            SendActionEvent(new ActionEventArgs(GoapKey.wowscreen, false));
+            npcNameTargeting.ChangeNpcType(NpcNames.None);
         }
 
         public override void PerformAction()
@@ -180,7 +180,6 @@ namespace Core.Goals
                 wait.Update();
 
                 npcNameTargeting.ChangeNpcType(NpcNames.Friendly | NpcNames.Neutral);
-                SendActionEvent(new ActionEventArgs(GoapKey.wowscreen, true));
                 npcNameTargeting.WaitForUpdate();
                 bool foundVendor = npcNameTargeting.FindBy(CursorType.Vendor, CursorType.Repair, CursorType.Innkeeper);
                 if (!foundVendor)

--- a/Core/Goals/FollowRouteGoal.cs
+++ b/Core/Goals/FollowRouteGoal.cs
@@ -127,22 +127,13 @@ namespace Core.Goals
 
         private void Abort()
         {
-            if (classConfig.Mode != Mode.AttendedGather)
-            {
-                SendActionEvent(new ActionEventArgs(GoapKey.wowscreen, false));
-            }
-
             navigation.Stop();
+            targetFinder.Reset();
         }
 
         private void Resume()
         {
             onEnterTime = DateTime.UtcNow;
-
-            if (classConfig.Mode != Mode.AttendedGather)
-            {
-                SendActionEvent(new ActionEventArgs(GoapKey.wowscreen, true));
-            }
 
             if (!navigation.HasWaypoint())
             {
@@ -218,6 +209,8 @@ namespace Core.Goals
             {
                 return !playerReader.Bits.TargetIsDead;
             }
+
+            sideActivityManualReset.WaitOne();
 
             while (!sideActivityCts.IsCancellationRequested)
             {

--- a/Core/Goals/GoalFactory.cs
+++ b/Core/Goals/GoalFactory.cs
@@ -192,7 +192,7 @@ namespace Core
                     availableActions.Add(new TargetPetTarget(input, addonReader.PlayerReader));
                 }
 
-                availableActions.Add(new PullTargetGoal(logger, input, wait, addonReader, blacklist, stopMoving, castingHandler, mountHandler, stuckDetector, combatUtil));
+                availableActions.Add(new PullTargetGoal(logger, input, wait, addonReader, blacklist, stopMoving, castingHandler, mountHandler, npcNameTargeting, stuckDetector, combatUtil));
 
                 if (classConfig.Parallel.Sequence.Count > 0)
                 {

--- a/Core/Goals/LootGoal.cs
+++ b/Core/Goals/LootGoal.cs
@@ -42,7 +42,7 @@ namespace Core.Goals
             this.areaDb = addonReader.AreaDb;
             this.stopMoving = stopMoving;
             this.bagReader = addonReader.BagReader;
-            
+
             this.classConfiguration = classConfiguration;
             this.npcNameTargeting = npcNameTargeting;
             this.combatUtil = combatUtil;
@@ -66,7 +66,6 @@ namespace Core.Goals
 
             Log($"Search for {NpcNames.Corpse}");
             npcNameTargeting.ChangeNpcType(NpcNames.Corpse);
-            SendActionEvent(new ActionEventArgs(GoapKey.wowscreen, true));
 
             lastLoot = playerReader.LastLootTime;
 
@@ -86,8 +85,6 @@ namespace Core.Goals
                 var closestCorpse = GetClosestCorpse();
                 var heading = DirectionCalculator.CalculateHeading(location, closestCorpse);
                 playerDirection.SetDirection(heading, closestCorpse);
-                npcNameTargeting.WaitForUpdate();
-                npcNameTargeting.WaitForUpdate();
                 logger.LogInformation("Look at possible corpse and try again");
 
                 if (FoundByCursor())
@@ -145,7 +142,10 @@ namespace Core.Goals
 
         public override void OnExit()
         {
-            SendActionEvent(new ActionEventArgs(GoapKey.wowscreen, false));
+            if (!classConfiguration.Skin)
+            {
+                npcNameTargeting.ChangeNpcType(NpcNames.None);
+            }
         }
 
         public override void PerformAction()
@@ -156,7 +156,6 @@ namespace Core.Goals
         {
             if (e.Key == GoapKey.corpselocation && e.Value is CorpseLocation location)
             {
-                //logger.LogInformation($"{nameof(LootGoal)}: --- Target is killed! Recorded death location.");
                 corpseLocations.Add(location.Location);
             }
         }

--- a/Core/Goals/PullTargetGoal.cs
+++ b/Core/Goals/PullTargetGoal.cs
@@ -1,5 +1,6 @@
 using Core.GOAP;
 using Microsoft.Extensions.Logging;
+using SharedLib.NpcFinder;
 using System;
 using System.Linq;
 
@@ -16,7 +17,7 @@ namespace Core.Goals
         private readonly PlayerReader playerReader;
         private readonly StopMoving stopMoving;
         private readonly StuckDetector stuckDetector;
-
+        private readonly NpcNameTargeting npcNameTargeting;
         private readonly CastingHandler castingHandler;
         private readonly MountHandler mountHandler;
         private readonly CombatUtil combatUtil;
@@ -34,7 +35,7 @@ namespace Core.Goals
 
         private double PullDurationMs => (DateTime.UtcNow - pullStart).TotalMilliseconds;
 
-        public PullTargetGoal(ILogger logger, ConfigurableInput input, Wait wait, AddonReader addonReader, IBlacklist blacklist, StopMoving stopMoving, CastingHandler castingHandler, MountHandler mountHandler, StuckDetector stuckDetector, CombatUtil combatUtil)
+        public PullTargetGoal(ILogger logger, ConfigurableInput input, Wait wait, AddonReader addonReader, IBlacklist blacklist, StopMoving stopMoving, CastingHandler castingHandler, MountHandler mountHandler, NpcNameTargeting npcNameTargeting, StuckDetector stuckDetector, CombatUtil combatUtil)
         {
             this.logger = logger;
             this.input = input;
@@ -44,7 +45,7 @@ namespace Core.Goals
             this.stopMoving = stopMoving;
             this.castingHandler = castingHandler;
             this.mountHandler = mountHandler;
-
+            this.npcNameTargeting = npcNameTargeting;
             this.stuckDetector = stuckDetector;
             this.combatUtil = combatUtil;
 
@@ -89,7 +90,7 @@ namespace Core.Goals
 
             if (requiresNpcNameFinder)
             {
-                SendActionEvent(new ActionEventArgs(GoapKey.wowscreen, true));
+                npcNameTargeting.ChangeNpcType(NpcNames.Enemy);
             }
 
             pullStart = DateTime.UtcNow;
@@ -99,7 +100,7 @@ namespace Core.Goals
         {
             if (requiresNpcNameFinder)
             {
-                SendActionEvent(new ActionEventArgs(GoapKey.wowscreen, false));
+                npcNameTargeting.ChangeNpcType(NpcNames.None);
             }
         }
 

--- a/Core/Goals/SkinningGoal.cs
+++ b/Core/Goals/SkinningGoal.cs
@@ -69,10 +69,6 @@ namespace Core.Goals
 
             Log($"Search for {NpcNames.Corpse}");
             npcNameTargeting.ChangeNpcType(NpcNames.Corpse);
-            SendActionEvent(new ActionEventArgs(GoapKey.wowscreen, true));
-            // attempt to add some delay
-            // upon an npc become corpse 
-            npcNameTargeting.WaitForUpdate();
             npcNameTargeting.WaitForUpdate();
 
             lastLoot = playerReader.LastLootTime;
@@ -147,7 +143,7 @@ namespace Core.Goals
 
         public override void OnExit()
         {
-            SendActionEvent(new ActionEventArgs(GoapKey.wowscreen, false));
+            npcNameTargeting.ChangeNpcType(NpcNames.None);
         }
 
         public override void PerformAction()

--- a/Core/Goals/TargetFinder.cs
+++ b/Core/Goals/TargetFinder.cs
@@ -20,6 +20,11 @@ namespace Core.Goals
             this.npcNameTargeting = npcNameTargeting;
         }
 
+        public void Reset()
+        {
+            npcNameTargeting.ChangeNpcType(NpcNames.None);
+        }
+
         public bool Search(NpcNames target, Func<bool> validTarget, CancellationTokenSource cts)
         {
             return LookForTarget(target, cts) && validTarget();
@@ -43,5 +48,6 @@ namespace Core.Goals
 
             return playerReader.HasTarget;
         }
+
     }
 }

--- a/CoreTests/NpcNameFinder/MockWoWScreen.cs
+++ b/CoreTests/NpcNameFinder/MockWoWScreen.cs
@@ -1,0 +1,31 @@
+﻿using Game;
+using System;
+using System.Drawing;
+
+namespace CoreTests
+{
+    public class MockWoWScreen : IWowScreen
+    {
+        public bool Enabled { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+        public Bitmap GetBitmap(int width, int height)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Color GetColorAt(Point point)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void GetPosition(ref Point point)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void GetRectangle(out Rectangle rect)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/CoreTests/NpcNameFinder/Test_NpcNameFinder.cs
+++ b/CoreTests/NpcNameFinder/Test_NpcNameFinder.cs
@@ -39,7 +39,8 @@ namespace CoreTests
             npcNameFinder = new(logger, capturer, new AutoResetEvent(false));
 
             MockWoWProcess mockWoWProcess = new();
-            npcNameTargeting = new(logger, new(), npcNameFinder, mockWoWProcess);
+            MockWoWScreen mockWoWScreen = new();
+            npcNameTargeting = new(logger, new(), mockWoWScreen, npcNameFinder, mockWoWProcess);
 
             npcNameFinder.ChangeNpcType(types);
 
@@ -90,10 +91,10 @@ namespace CoreTests
 
                 npcNameFinder.Npcs.ForEach(n =>
                 {
-                    npcNameTargeting.locTargetingAndClickNpc.ForEach(l =>
+                    foreach (var l in npcNameTargeting.locTargetingAndClickNpc)
                     {
                         paint.DrawEllipse(whitePen, l.X + n.ClickPoint.X, l.Y + n.ClickPoint.Y, 5, 5);
-                    });
+                    }
                 });
 
                 npcNameFinder.Npcs.ForEach(n => paint.DrawRectangle(whitePen, new Rectangle(n.Min, new Size(n.Width, n.Height))));

--- a/Game/WoWScreen/IWowScreen.cs
+++ b/Game/WoWScreen/IWowScreen.cs
@@ -4,6 +4,6 @@ namespace Game
 {
     public interface IWowScreen : IColorReader, IRectProvider
     {
-
+        bool Enabled { get; set; }
     }
 }


### PR DESCRIPTION
Issue: 
* With the previous construct sometimes due the `FakeUpdate()` it was possible that invalid NpcNameFinder.Npcs state kept and `WaitForUpdate()` let the BotThread continue!