### PR TITLE
Refactor: `enum.ToStringF()` - Convert few readonly Properties to Methods

### DIFF
--- a/Core/Addon/AddonReader.cs
+++ b/Core/Addon/AddonReader.cs
@@ -188,7 +188,7 @@ namespace Core
 
             UIMapId.Update(addonDataProvider);
 
-            CreatureHistory.Update(PlayerReader.TargetGuid, PlayerReader.TargetHealthPercentage);
+            CreatureHistory.Update(PlayerReader.TargetGuid, PlayerReader.TargetHealthPercentage());
 
             BagReader.Read();
             EquipmentReader.Read();

--- a/Core/Addon/PlayerReader.cs
+++ b/Core/Addon/PlayerReader.cs
@@ -35,33 +35,31 @@ namespace Core
 
         public AddonBits Bits { get; }
 
-        public int HealthMax => reader.GetInt(10);
-        public int HealthCurrent => reader.GetInt(11);
-        public int HealthPercent => HealthMax == 0 || HealthCurrent == 1 ? 0 : HealthCurrent * 100 / HealthMax;
+        public int HealthMax() => reader.GetInt(10);
+        public int HealthCurrent() => reader.GetInt(11);
+        public int HealthPercent() => HealthMax() == 0 || HealthCurrent() == 1 ? 0 : HealthCurrent() * 100 / HealthMax();
 
-        public int PTMax => reader.GetInt(12); // Maximum amount of Power Type (dynamic)
-        public int PTCurrent => reader.GetInt(13); // Current amount of Power Type (dynamic)
-        public int PTPercentage => PTMax == 0 ? 0 : PTCurrent * 100 / PTMax; // Power Type (dynamic) in terms of a percentage
+        public int PTMax() => reader.GetInt(12); // Maximum amount of Power Type (dynamic)
+        public int PTCurrent() => reader.GetInt(13); // Current amount of Power Type (dynamic)
+        public int PTPercentage() => PTMax() == 0 ? 0 : PTCurrent() * 100 / PTMax(); // Power Type (dynamic) in terms of a percentage
 
-        public int ManaMax => reader.GetInt(14);
-        public int ManaCurrent => reader.GetInt(15);
-        public int ManaPercentage => ManaMax == 0 ? 0 : ManaCurrent * 100 / ManaMax;
+        public int ManaMax() => reader.GetInt(14);
+        public int ManaCurrent() => reader.GetInt(15);
+        public int ManaPercentage() => ManaMax() == 0 ? 0 : ManaCurrent() * 100 / ManaMax();
 
-        public bool HasTarget => Bits.HasTarget;// || TargetHealth > 0;
-
-        public int TargetMaxHealth => reader.GetInt(18);
-        public int TargetHealth => reader.GetInt(19);
-        public int TargetHealthPercentage => TargetMaxHealth == 0 || TargetHealth == 1 ? 0 : TargetHealth * 100 / TargetMaxHealth;
+        public int TargetMaxHealth() => reader.GetInt(18);
+        public int TargetHealth() => reader.GetInt(19);
+        public int TargetHealthPercentage() => TargetMaxHealth() == 0 || TargetHealth() == 1 ? 0 : TargetHealth() * 100 / TargetMaxHealth();
 
 
-        public int PetMaxHealth => reader.GetInt(38);
-        public int PetHealth => reader.GetInt(39);
-        public int PetHealthPercentage => PetMaxHealth == 0 || PetHealth == 1 ? 0 : PetHealth * 100 / PetMaxHealth;
+        public int PetMaxHealth() => reader.GetInt(38);
+        public int PetHealth() => reader.GetInt(39);
+        public int PetHealthPercentage() => PetMaxHealth() == 0 || PetHealth() == 1 ? 0 : PetHealth() * 100 / PetMaxHealth();
 
 
         public SpellInRange SpellInRange { get; }
-        public bool WithInPullRange => SpellInRange.WithinPullRange(this, Class);
-        public bool WithInCombatRange => SpellInRange.WithinCombatRange(this, Class);
+        public bool WithInPullRange() => SpellInRange.WithinPullRange(this, Class);
+        public bool WithInCombatRange() => SpellInRange.WithinCombatRange(this, Class);
 
         public BuffStatus Buffs { get; }
         public TargetDebuffStatus TargetDebuffs { get; }
@@ -79,11 +77,11 @@ namespace Core
         public Stance Stance { get; }
         public Form Form => Stance.Get(this, Class);
 
-        public int MinRange => (int)(reader.GetInt(49) / 100000f);
-        public int MaxRange => (int)((reader.GetInt(49) - (MinRange * 100000f)) / 100f);
+        public int MinRange() => (int)(reader.GetInt(49) / 100000f);
+        public int MaxRange() => (int)((reader.GetInt(49) - (MinRange() * 100000f)) / 100f);
 
-        public bool IsInMeleeRange => MinRange == 0 && MaxRange != 0 && MaxRange <= 5;
-        public bool IsInDeadZone => MinRange >= 5 && Bits.IsInDeadZoneRange; // between 5-8 yard - hunter and warrior
+        public bool IsInMeleeRange() => MinRange() == 0 && MaxRange() != 0 && MaxRange() <= 5;
+        public bool IsInDeadZone() => MinRange() >= 5 && Bits.IsInDeadZoneRange(); // between 5-8 yard - hunter and warrior
 
         public RecordInt PlayerXp { get; } = new(50);
 
@@ -94,7 +92,7 @@ namespace Core
         public UI_ERROR LastUIError { get; set; }
 
         public int SpellBeingCast => reader.GetInt(53);
-        public bool IsCasting => SpellBeingCast != 0;
+        public bool IsCasting() => SpellBeingCast != 0;
 
         public int ComboPoints => reader.GetInt(54);
 
@@ -104,7 +102,7 @@ namespace Core
         public int TargetGuid => reader.GetInt(57);
 
         public int SpellBeingCastByTarget => reader.GetInt(58);
-        public bool IsTargetCasting => SpellBeingCastByTarget != 0;
+        public bool IsTargetCasting() => SpellBeingCastByTarget != 0;
 
         public TargetTargetEnum TargetTarget => (TargetTargetEnum)reader.GetInt(59);
 
@@ -124,9 +122,9 @@ namespace Core
 
         public BitStatus CustomTrigger1 { get; }
 
-        public int MainHandSpeedMs => (int)(reader.GetInt(75) / 10000f) * 10;
+        public int MainHandSpeedMs() => (int)(reader.GetInt(75) / 10000f) * 10;
 
-        public int OffHandSpeed => (int)(reader.GetInt(75) - (MainHandSpeedMs * 1000f));  // supposed to be 10000f - but theres a 10x
+        public int OffHandSpeed => (int)(reader.GetInt(75) - (MainHandSpeedMs() * 1000f));  // supposed to be 10000f - but theres a 10x
 
         public int LastLootTime => reader.GetInt(97);
 

--- a/Core/AddonComponent/AddonBits.cs
+++ b/Core/AddonComponent/AddonBits.cs
@@ -15,8 +15,8 @@
             this.cell1 = cell1;
             this.cell2 = cell2;
 
-            v1 = new BitStatus(reader.GetInt(cell1));
-            v2 = new BitStatus(reader.GetInt(cell2));
+            v1 = new(reader.GetInt(cell1));
+            v2 = new(reader.GetInt(cell2));
         }
 
         public void SetDirty()
@@ -26,36 +26,36 @@
         }
 
         // -- value1 based flags
-        public bool TargetInCombat => v1.IsBitSet(0);
-        public bool TargetIsDead => v1.IsBitSet(1);
-        public bool DeadStatus => v1.IsBitSet(2);
-        public bool TalentPoints => v1.IsBitSet(3);
-        public bool IsInDeadZoneRange => v1.IsBitSet(4);
-        public bool TargetCanBeHostile => v1.IsBitSet(5);
-        public bool HasPet => v1.IsBitSet(6);
-        public bool MainHandEnchant_Active => v1.IsBitSet(7);
-        public bool OffHandEnchant_Active => v1.IsBitSet(8);
-        public bool ItemsAreBroken => v1.IsBitSet(9);
-        public bool IsFlying => v1.IsBitSet(10);
-        public bool IsSwimming => v1.IsBitSet(11);
-        public bool PetHappy => v1.IsBitSet(12);
-        public bool HasAmmo => v1.IsBitSet(13);
-        public bool PlayerInCombat => v1.IsBitSet(14);
-        public bool TargetOfTargetIsPlayerOrPet => v1.IsBitSet(15);
-        public bool IsAutoRepeatSpellOn_AutoShot => v1.IsBitSet(16);
-        public bool HasTarget => v1.IsBitSet(17);
-        public bool IsMounted => v1.IsBitSet(18);
-        public bool IsAutoRepeatSpellOn_Shoot => v1.IsBitSet(19);
-        public bool IsAutoRepeatSpellOn_AutoAttack => v1.IsBitSet(20);
-        public bool TargetIsNormal => v1.IsBitSet(21);
-        public bool IsTagged => v1.IsBitSet(22);
-        public bool IsFalling => v1.IsBitSet(23);
+        public bool TargetInCombat() => v1.IsBitSet(0);
+        public bool TargetIsDead() => v1.IsBitSet(1);
+        public bool DeadStatus() => v1.IsBitSet(2);
+        public bool TalentPoints() => v1.IsBitSet(3);
+        public bool IsInDeadZoneRange() => v1.IsBitSet(4);
+        public bool TargetCanBeHostile() => v1.IsBitSet(5);
+        public bool HasPet() => v1.IsBitSet(6);
+        public bool MainHandEnchant_Active() => v1.IsBitSet(7);
+        public bool OffHandEnchant_Active() => v1.IsBitSet(8);
+        public bool ItemsAreBroken() => v1.IsBitSet(9);
+        public bool IsFlying() => v1.IsBitSet(10);
+        public bool IsSwimming() => v1.IsBitSet(11);
+        public bool PetHappy() => v1.IsBitSet(12);
+        public bool HasAmmo() => v1.IsBitSet(13);
+        public bool PlayerInCombat() => v1.IsBitSet(14);
+        public bool TargetOfTargetIsPlayerOrPet() => v1.IsBitSet(15);
+        public bool SpellOn_AutoShot() => v1.IsBitSet(16);
+        public bool HasTarget() => v1.IsBitSet(17);
+        public bool IsMounted() => v1.IsBitSet(18);
+        public bool SpellOn_Shoot() => v1.IsBitSet(19);
+        public bool SpellOn_AutoAttack() => v1.IsBitSet(20);
+        public bool TargetIsNormal() => v1.IsBitSet(21);
+        public bool IsTagged() => v1.IsBitSet(22);
+        public bool IsFalling() => v1.IsBitSet(23);
 
         // -- value2 based flags
-        public bool IsDrowning => v2.IsBitSet(0);
+        public bool IsDrowning() => v2.IsBitSet(0);
 
-        public bool IsCorpseInRange => v2.IsBitSet(1);
+        public bool IsCorpseInRange() => v2.IsBitSet(1);
 
-        public bool IsIndoors => v2.IsBitSet(2);
+        public bool IsIndoors() => v2.IsBitSet(2);
     }
 }

--- a/Core/AddonComponent/BuffStatus.cs
+++ b/Core/AddonComponent/BuffStatus.cs
@@ -22,90 +22,94 @@
         }
 
         // All
-        public bool Eating => IsBitSet(0);
-        public bool Drinking => IsBitSet(1);
-        public bool WellFed => IsBitSet(2);
-        public bool ManaRegeneration => IsBitSet(3);
-        public bool Clearcasting => IsBitSet(4);
+        public bool Food() => IsBitSet(0);
+
+        public bool Drink() => IsBitSet(1);
+
+        public bool Well_Fed() => IsBitSet(2);
+
+        public bool Mana_Regeneration() => IsBitSet(3);
+
+        public bool Clearcasting() => IsBitSet(4);
 
         // Priest
-        public bool Fortitude => IsBitSet(10);
-        public bool InnerFire => IsBitSet(11);
-        public bool Renew => IsBitSet(12);
-        public bool Shield => IsBitSet(13);
-        public bool DivineSpirit => IsBitSet(14);
+        public bool Fortitude() => IsBitSet(10);
+        public bool InnerFire() => IsBitSet(11);
+        public bool Renew() => IsBitSet(12);
+        public bool Shield() => IsBitSet(13);
+        public bool DivineSpirit() => IsBitSet(14);
 
         // Druid
-        public bool MarkOfTheWild => IsBitSet(10);
-        public bool Thorns => IsBitSet(11);
-        public bool TigersFury => IsBitSet(12);
-        public bool Prowl => IsBitSet(13);
-        public bool Rejuvenation => IsBitSet(14);
-        public bool Regrowth => IsBitSet(15);
-        public bool OmenOfClarity => IsBitSet(16);
+        public bool MarkOfTheWild() => IsBitSet(10);
+        public bool Thorns() => IsBitSet(11);
+        public bool TigersFury() => IsBitSet(12);
+        public bool Prowl() => IsBitSet(13);
+        public bool Rejuvenation() => IsBitSet(14);
+        public bool Regrowth() => IsBitSet(15);
+        public bool OmenOfClarity() => IsBitSet(16);
 
         // Paladin
-        public bool SealofRighteousness => IsBitSet(5);
-        public bool SealoftheCrusader => IsBitSet(6);
-        public bool SealofCommand => IsBitSet(7);
-        public bool SealofWisdom => IsBitSet(8);
-        public bool SealofLight => IsBitSet(9);
-        public bool SealofBlood => IsBitSet(10);
-        public bool SealofVengeance => IsBitSet(11);
+        public bool SealofRighteousness() => IsBitSet(5);
+        public bool SealoftheCrusader() => IsBitSet(6);
+        public bool SealofCommand() => IsBitSet(7);
+        public bool SealofWisdom() => IsBitSet(8);
+        public bool SealofLight() => IsBitSet(9);
+        public bool SealofBlood() => IsBitSet(10);
+        public bool SealofVengeance() => IsBitSet(11);
 
-        public bool BlessingofMight => IsBitSet(12);
-        public bool BlessingofProtection => IsBitSet(13);
-        public bool BlessingofWisdom => IsBitSet(14);
-        public bool BlessingofKings => IsBitSet(15);
-        public bool BlessingofSalvation => IsBitSet(16);
-        public bool BlessingofSanctuary => IsBitSet(17);
-        public bool BlessingofLight => IsBitSet(18);
+        public bool BlessingofMight() => IsBitSet(12);
+        public bool BlessingofProtection() => IsBitSet(13);
+        public bool BlessingofWisdom() => IsBitSet(14);
+        public bool BlessingofKings() => IsBitSet(15);
+        public bool BlessingofSalvation() => IsBitSet(16);
+        public bool BlessingofSanctuary() => IsBitSet(17);
+        public bool BlessingofLight() => IsBitSet(18);
 
-        public bool RighteousFury => IsBitSet(19);
-        public bool DivineProtection => IsBitSet(20);
-        public bool AvengingWrath => IsBitSet(21);
-        public bool HolyShield => IsBitSet(22);
+        public bool RighteousFury() => IsBitSet(19);
+        public bool DivineProtection() => IsBitSet(20);
+        public bool AvengingWrath() => IsBitSet(21);
+        public bool HolyShield() => IsBitSet(22);
 
         // Mage
-        public bool FrostArmor => IsBitSet(10);
-        public bool ArcaneIntellect => IsBitSet(11);
-        public bool IceBarrier => IsBitSet(12);
-        public bool Ward => IsBitSet(13);
-        public bool FirePower => IsBitSet(14);
-        public bool ManaShield => IsBitSet(15);
-        public bool PresenceOfMind => IsBitSet(16);
-        public bool ArcanePower => IsBitSet(17);
+        public bool FrostArmor() => IsBitSet(10);
+        public bool ArcaneIntellect() => IsBitSet(11);
+        public bool IceBarrier() => IsBitSet(12);
+        public bool Ward() => IsBitSet(13);
+        public bool FirePower() => IsBitSet(14);
+        public bool ManaShield() => IsBitSet(15);
+        public bool PresenceOfMind() => IsBitSet(16);
+        public bool ArcanePower() => IsBitSet(17);
 
         // Rogue
-        public bool SliceAndDice => IsBitSet(10);
-        public bool Stealth => IsBitSet(11);
+        public bool SliceAndDice() => IsBitSet(10);
+        public bool Stealth() => IsBitSet(11);
 
         // Warrior
-        public bool BattleShout => IsBitSet(10);
-        public bool Bloodrage => IsBitSet(11);
+        public bool BattleShout() => IsBitSet(10);
+        public bool Bloodrage() => IsBitSet(11);
 
         // Warlock
-        public bool Demon => IsBitSet(10); //Skin and Armor
-        public bool SoulLink => IsBitSet(11);
-        public bool SoulstoneResurrection => IsBitSet(12);
-        public bool ShadowTrance => IsBitSet(13);
-        public bool FelArmor => IsBitSet(14);
-        public bool FelDomination => IsBitSet(15);
-        public bool DemonicSacrifice => IsBitSet(16);
+        public bool Demon() => IsBitSet(10); //Skin and Armor
+        public bool SoulLink() => IsBitSet(11);
+        public bool SoulstoneResurrection() => IsBitSet(12);
+        public bool ShadowTrance() => IsBitSet(13);
+        public bool FelArmor() => IsBitSet(14);
+        public bool FelDomination() => IsBitSet(15);
+        public bool DemonicSacrifice() => IsBitSet(16);
 
         // Shaman
-        public bool LightningShield => IsBitSet(10);
-        public bool WaterShield => IsBitSet(11);
-        public bool ShamanisticFocus => IsBitSet(12);
-        public bool Stoneskin => IsBitSet(13);
+        public bool LightningShield() => IsBitSet(10);
+        public bool WaterShield() => IsBitSet(11);
+        public bool ShamanisticFocus() => IsBitSet(12);
+        public bool Stoneskin() => IsBitSet(13);
 
         // Hunter
-        public bool AspectoftheCheetah => IsBitSet(10);
-        public bool AspectofthePack => IsBitSet(11);
-        public bool AspectoftheHawk => IsBitSet(12);
-        public bool AspectoftheMonkey => IsBitSet(13);
-        public bool AspectoftheViper => IsBitSet(14);
-        public bool RapidFire => IsBitSet(15);
-        public bool QuickShots => IsBitSet(16);
+        public bool AspectoftheCheetah() => IsBitSet(10);
+        public bool AspectofthePack() => IsBitSet(11);
+        public bool AspectoftheHawk() => IsBitSet(12);
+        public bool AspectoftheMonkey() => IsBitSet(13);
+        public bool AspectoftheViper() => IsBitSet(14);
+        public bool RapidFire() => IsBitSet(15);
+        public bool QuickShots() => IsBitSet(16);
     }
 }

--- a/Core/AddonComponent/Form.cs
+++ b/Core/AddonComponent/Form.cs
@@ -32,4 +32,36 @@
         Paladin_Sanctity_Aura = 21,
         Paladin_Crusader_Aura = 22,
     }
+
+    public static class Form_Extension
+    {
+        public static string ToStringF(this Form value) => value switch
+        {
+            Form.None => nameof(Form.None),
+            Form.Druid_Bear => nameof(Form.Druid_Bear),
+            Form.Druid_Aquatic => nameof(Form.Druid_Aquatic),
+            Form.Druid_Cat => nameof(Form.Druid_Cat),
+            Form.Druid_Travel => nameof(Form.Druid_Travel),
+            Form.Druid_Moonkin => nameof(Form.Druid_Moonkin),
+            Form.Druid_Flight => nameof(Form.Druid_Flight),
+            Form.Druid_Cat_Prowl => nameof(Form.Druid_Cat_Prowl),
+            Form.Priest_Shadowform => nameof(Form.Priest_Shadowform),
+            Form.Rogue_Stealth => nameof(Form.Rogue_Stealth),
+            Form.Rogue_Vanish => nameof(Form.Rogue_Vanish),
+            Form.Shaman_GhostWolf => nameof(Form.Shaman_GhostWolf),
+            Form.Warrior_BattleStance => nameof(Form.Warrior_BattleStance),
+            Form.Warrior_DefensiveStance => nameof(Form.Warrior_DefensiveStance),
+            Form.Warrior_BerserkerStance => nameof(Form.Warrior_BerserkerStance),
+            Form.Paladin_Devotion_Aura => nameof(Form.Paladin_Devotion_Aura),
+            Form.Paladin_Retribution_Aura => nameof(Form.Paladin_Retribution_Aura),
+            Form.Paladin_Concentration_Aura => nameof(Form.Paladin_Concentration_Aura),
+            Form.Paladin_Shadow_Resistance_Aura => nameof(Form.Paladin_Shadow_Resistance_Aura),
+            Form.Paladin_Frost_Resistance_Aura => nameof(Form.Paladin_Frost_Resistance_Aura),
+            Form.Paladin_Fire_Resistance_Aura => nameof(Form.Paladin_Fire_Resistance_Aura),
+            Form.Paladin_Sanctity_Aura => nameof(Form.Paladin_Sanctity_Aura),
+            Form.Paladin_Crusader_Aura => nameof(Form.Paladin_Crusader_Aura),
+            _ => nameof(Form.None)
+        };
+    }
+
 }

--- a/Core/AddonComponent/PlayerClassEnum.cs
+++ b/Core/AddonComponent/PlayerClassEnum.cs
@@ -16,4 +16,25 @@
         Druid,
         DemonHunter
     }
+
+    public static class PlayerClassEnum_Extension
+    {
+        public static string ToStringF(this PlayerClassEnum value) => value switch
+        {
+            PlayerClassEnum.None => nameof(PlayerClassEnum.None),
+            PlayerClassEnum.Warrior => nameof(PlayerClassEnum.Warrior),
+            PlayerClassEnum.Paladin => nameof(PlayerClassEnum.Paladin),
+            PlayerClassEnum.Hunter => nameof(PlayerClassEnum.Hunter),
+            PlayerClassEnum.Rogue => nameof(PlayerClassEnum.Rogue),
+            PlayerClassEnum.Priest => nameof(PlayerClassEnum.Priest),
+            PlayerClassEnum.DeathKnight => nameof(PlayerClassEnum.DeathKnight),
+            PlayerClassEnum.Shaman => nameof(PlayerClassEnum.Shaman),
+            PlayerClassEnum.Mage => nameof(PlayerClassEnum.Mage),
+            PlayerClassEnum.Warlock => nameof(PlayerClassEnum.Warlock),
+            PlayerClassEnum.Monk => nameof(PlayerClassEnum.Monk),
+            PlayerClassEnum.Druid => nameof(PlayerClassEnum.Druid),
+            PlayerClassEnum.DemonHunter => nameof(PlayerClassEnum.DemonHunter),
+            _ => nameof(PlayerClassEnum.None)
+        };
+    }
 }

--- a/Core/AddonComponent/PowerType.cs
+++ b/Core/AddonComponent/PowerType.cs
@@ -9,4 +9,18 @@
         Focus = 4,
         Energy = 5
     }
+
+    public static class PowerType_Extension
+    {
+        public static string ToStringF(this PowerType value) => value switch
+        {
+            PowerType.HealtCost => nameof(PowerType.HealtCost),
+            PowerType.None => nameof(PowerType.None),
+            PowerType.Mana => nameof(PowerType.Mana),
+            PowerType.Rage => nameof(PowerType.Rage),
+            PowerType.Focus => nameof(PowerType.Focus),
+            PowerType.Energy => nameof(PowerType.Energy),
+            _ => nameof(PowerType.HealtCost)
+        };
+    }
 }

--- a/Core/AddonComponent/RaceEnum.cs
+++ b/Core/AddonComponent/RaceEnum.cs
@@ -15,4 +15,24 @@
         BloodElf,
         Draenei
     }
+
+    public static class RaceEnum_Extension
+    {
+        public static string ToStringF(this RaceEnum value) => value switch
+        {
+            RaceEnum.None => nameof(RaceEnum.None),
+            RaceEnum.Human => nameof(RaceEnum.Human),
+            RaceEnum.Orc => nameof(RaceEnum.Orc),
+            RaceEnum.Dwarf => nameof(RaceEnum.Dwarf),
+            RaceEnum.NightElf => nameof(RaceEnum.NightElf),
+            RaceEnum.Undead => nameof(RaceEnum.Undead),
+            RaceEnum.Tauren => nameof(RaceEnum.Tauren),
+            RaceEnum.Gnome => nameof(RaceEnum.Gnome),
+            RaceEnum.Troll => nameof(RaceEnum.Troll),
+            RaceEnum.Goblin => nameof(RaceEnum.Goblin),
+            RaceEnum.BloodElf => nameof(RaceEnum.BloodElf),
+            RaceEnum.Draenei => nameof(RaceEnum.Draenei),
+            _ => nameof(RaceEnum.None)
+        };
+    }
 }

--- a/Core/AddonComponent/RecordInt.cs
+++ b/Core/AddonComponent/RecordInt.cs
@@ -10,7 +10,7 @@ namespace Core
         public int Value { private set; get; }
         public DateTime LastChanged { private set; get; }
 
-        public int ElapsedMs => (int)(DateTime.UtcNow - LastChanged).TotalMilliseconds;
+        public int ElapsedMs() => (int)(DateTime.UtcNow - LastChanged).TotalMilliseconds;
 
         public event Action? Changed;
 

--- a/Core/AddonComponent/SchoolMask.cs
+++ b/Core/AddonComponent/SchoolMask.cs
@@ -11,4 +11,20 @@
         Shadow = 32,
         Arcane = 64,
     }
+
+    public static class SchoolMask_Extension
+    {
+        public static string ToStringF(this SchoolMask value) => value switch
+        {
+            SchoolMask.None => nameof(SchoolMask.None),
+            SchoolMask.Physical => nameof(SchoolMask.Physical),
+            SchoolMask.Holy => nameof(SchoolMask.Holy),
+            SchoolMask.Fire => nameof(SchoolMask.Fire),
+            SchoolMask.Nature => nameof(SchoolMask.Nature),
+            SchoolMask.Frost => nameof(SchoolMask.Frost),
+            SchoolMask.Shadow => nameof(SchoolMask.Shadow),
+            SchoolMask.Arcane => nameof(SchoolMask.Arcane),
+            _ => nameof(SchoolMask.None)
+        };
+    }
 }

--- a/Core/AddonComponent/SpellInRange.cs
+++ b/Core/AddonComponent/SpellInRange.cs
@@ -70,14 +70,14 @@
 
         public bool WithinPullRange(PlayerReader playerReader, PlayerClassEnum playerClass) => playerClass switch
         {
-            PlayerClassEnum.Warrior => (playerReader.Level.Value >= 4 && Warrior_Charge) || playerReader.IsInMeleeRange,
+            PlayerClassEnum.Warrior => (playerReader.Level.Value >= 4 && Warrior_Charge) || playerReader.IsInMeleeRange(),
             PlayerClassEnum.Rogue => Rogue_Throw,
             PlayerClassEnum.Priest => Priest_Smite,
             PlayerClassEnum.Druid => Druid_Wrath,
-            PlayerClassEnum.Paladin => (playerReader.Level.Value >= 4 && Paladin_Judgement) || playerReader.IsInMeleeRange ||
-                                       (playerReader.Level.Value >= 20 && playerReader.MinRange <= 20 && playerReader.MaxRange <= 25),
+            PlayerClassEnum.Paladin => (playerReader.Level.Value >= 4 && Paladin_Judgement) || playerReader.IsInMeleeRange() ||
+                                       (playerReader.Level.Value >= 20 && playerReader.MinRange() <= 20 && playerReader.MaxRange() <= 25),
             PlayerClassEnum.Mage => (playerReader.Level.Value >= 4 && Mage_Frostbolt) || Mage_Fireball,
-            PlayerClassEnum.Hunter => (playerReader.Level.Value >= 4 && Hunter_SerpentSting) || Hunter_AutoShoot,
+            PlayerClassEnum.Hunter => (playerReader.Level.Value >= 4 && Hunter_SerpentSting) || Hunter_AutoShoot || playerReader.IsInMeleeRange(),
             PlayerClassEnum.Warlock => Warlock_ShadowBolt,
             PlayerClassEnum.Shaman => (playerReader.Level.Value >= 4 && Shaman_EarthShock) || Shaman_LightningBolt,
             _ => true
@@ -85,13 +85,13 @@
 
         public bool WithinCombatRange(PlayerReader playerReader, PlayerClassEnum playerClass) => playerClass switch
         {
-            PlayerClassEnum.Warrior => (playerReader.Level.Value >= 4 && Warrior_Rend) || playerReader.IsInMeleeRange,
+            PlayerClassEnum.Warrior => (playerReader.Level.Value >= 4 && Warrior_Rend) || playerReader.IsInMeleeRange(),
             PlayerClassEnum.Rogue => Rogue_SinisterStrike,
             PlayerClassEnum.Priest => Priest_Smite,
-            PlayerClassEnum.Druid => Druid_Wrath || playerReader.IsInMeleeRange,
-            PlayerClassEnum.Paladin => (playerReader.Level.Value >= 4 && Paladin_Judgement) || playerReader.IsInMeleeRange,
+            PlayerClassEnum.Druid => Druid_Wrath || playerReader.IsInMeleeRange(),
+            PlayerClassEnum.Paladin => (playerReader.Level.Value >= 4 && Paladin_Judgement) || playerReader.IsInMeleeRange(),
             PlayerClassEnum.Mage => Mage_Frostbolt || Mage_Fireball,
-            PlayerClassEnum.Hunter => (playerReader.Level.Value >= 4 && Hunter_SerpentSting) || Hunter_AutoShoot || playerReader.IsInMeleeRange,
+            PlayerClassEnum.Hunter => (playerReader.Level.Value >= 4 && Hunter_SerpentSting) || Hunter_AutoShoot || playerReader.IsInMeleeRange(),
             PlayerClassEnum.Warlock => Warlock_ShadowBolt,
             PlayerClassEnum.Shaman => Shaman_LightningBolt,
             _ => true

--- a/Core/AddonComponent/Stance.cs
+++ b/Core/AddonComponent/Stance.cs
@@ -24,7 +24,7 @@
             PlayerClassEnum.Warrior => Form.Warrior_BattleStance + value - 1,
             PlayerClassEnum.Rogue => Form.Rogue_Stealth + value - 1,
             PlayerClassEnum.Priest => Form.Priest_Shadowform + value - 1,
-            PlayerClassEnum.Druid => playerReader.Buffs.Prowl ? Form.Druid_Cat_Prowl : Form.Druid_Bear + value - 1,
+            PlayerClassEnum.Druid => playerReader.Buffs.Prowl() ? Form.Druid_Cat_Prowl : Form.Druid_Bear + value - 1,
             PlayerClassEnum.Paladin => Form.Paladin_Devotion_Aura + value - 1,
             PlayerClassEnum.Shaman => Form.Shaman_GhostWolf + value - 1,
             _ => Form.None

--- a/Core/AddonComponent/TargetDebuffStatus.cs
+++ b/Core/AddonComponent/TargetDebuffStatus.cs
@@ -22,39 +22,39 @@
         }
 
         // Priest
-        public bool ShadowWordPain => IsBitSet(0);
+        public bool ShadowWordPain() => IsBitSet(0);
 
         // Druid
-        public bool Roar => IsBitSet(0);
-        public bool FaerieFire => IsBitSet(1);
-        public bool Rip => IsBitSet(2);
-        public bool Moonfire => IsBitSet(3);
-        public bool EntanglingRoots => IsBitSet(4);
-        public bool Rake => IsBitSet(5);
+        public bool Roar() => IsBitSet(0);
+        public bool FaerieFire() => IsBitSet(1);
+        public bool Rip() => IsBitSet(2);
+        public bool Moonfire() => IsBitSet(3);
+        public bool EntanglingRoots() => IsBitSet(4);
+        public bool Rake() => IsBitSet(5);
 
         // Paladin
-        public bool JudgementoftheCrusader => IsBitSet(0);
-        public bool HammerOfJustice => IsBitSet(1);
+        public bool JudgementoftheCrusader() => IsBitSet(0);
+        public bool HammerOfJustice() => IsBitSet(1);
 
         // Mage
-        public bool Frostbite => IsBitSet(0);
-        public bool Slow => IsBitSet(1);
+        public bool Frostbite() => IsBitSet(0);
+        public bool Slow() => IsBitSet(1);
 
         // Rogue
 
         // Warrior
-        public bool Rend => IsBitSet(0);
-        public bool ThunderClap => IsBitSet(1);
-        public bool Hamstring => IsBitSet(2);
-        public bool ChargeStun => IsBitSet(3);
+        public bool Rend() => IsBitSet(0);
+        public bool ThunderClap() => IsBitSet(1);
+        public bool Hamstring() => IsBitSet(2);
+        public bool ChargeStun() => IsBitSet(3);
 
         // Warlock
-        public bool Curseof => IsBitSet(0);
-        public bool Corruption => IsBitSet(1);
-        public bool Immolate => IsBitSet(2);
-        public bool SiphonLife => IsBitSet(3);
+        public bool Curseof() => IsBitSet(0);
+        public bool Corruption() => IsBitSet(1);
+        public bool Immolate() => IsBitSet(2);
+        public bool SiphonLife() => IsBitSet(3);
 
         // Hunter
-        public bool SerpentSting => IsBitSet(0);
+        public bool SerpentSting() => IsBitSet(0);
     }
 }

--- a/Core/Blacklist/Blacklist.cs
+++ b/Core/Blacklist/Blacklist.cs
@@ -36,7 +36,7 @@ namespace Core
 
         public bool IsTargetBlacklisted()
         {
-            if (!playerReader.HasTarget)
+            if (!playerReader.Bits.HasTarget())
             {
                 lastGuid = 0;
                 return false;
@@ -52,12 +52,12 @@ namespace Core
             }
 
             // it is trying to kill me
-            if (playerReader.Bits.TargetOfTargetIsPlayerOrPet)
+            if (playerReader.Bits.TargetOfTargetIsPlayerOrPet())
             {
                 return false;
             }
 
-            if (!playerReader.Bits.TargetIsNormal)
+            if (!playerReader.Bits.TargetIsNormal())
             {
                 if (lastGuid != playerReader.TargetGuid)
                 {
@@ -68,7 +68,7 @@ namespace Core
                 return true; // ignore elites
             }
 
-            if (!playerReader.Bits.TargetIsDead && playerReader.Bits.IsTagged)
+            if (!playerReader.Bits.TargetIsDead() && playerReader.Bits.IsTagged())
             {
                 if (lastGuid != playerReader.TargetGuid)
                 {
@@ -80,7 +80,7 @@ namespace Core
             }
 
 
-            if (playerReader.Bits.TargetCanBeHostile && playerReader.TargetLevel > playerReader.Level.Value + above)
+            if (playerReader.Bits.TargetCanBeHostile() && playerReader.TargetLevel > playerReader.Level.Value + above)
             {
                 if (lastGuid != playerReader.TargetGuid)
                 {
@@ -103,7 +103,7 @@ namespace Core
                     return true;
                 }
             }
-            else if (playerReader.Bits.TargetCanBeHostile && playerReader.TargetLevel < playerReader.Level.Value - below)
+            else if (playerReader.Bits.TargetCanBeHostile() && playerReader.TargetLevel < playerReader.Level.Value - below)
             {
                 if (lastGuid != playerReader.TargetGuid)
                 {

--- a/Core/BotController.cs
+++ b/Core/BotController.cs
@@ -1,4 +1,4 @@
-﻿using Core.Goals;
+using Core.Goals;
 using Core.GOAP;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -124,7 +124,7 @@ namespace Core
                 }
             } while (!Enum.GetValues(typeof(PlayerClassEnum)).Cast<PlayerClassEnum>().Contains(AddonReader.PlayerReader.Class));
 
-            logger.LogDebug($"Woohoo, I have read the player class. You are a {AddonReader.PlayerReader.Race} {AddonReader.PlayerReader.Class}.");
+            logger.LogDebug($"Woohoo, I have read the player class. You are a {AddonReader.PlayerReader.Race.ToStringF()} {AddonReader.PlayerReader.Class.ToStringF()}.");
 
             npcNameFinder = new(logger, WowScreen, npcNameFinderEvent);
             npcNameTargeting = new(logger, cts, WowScreen, npcNameFinder, wowProcessInput);

--- a/Core/BotController.cs
+++ b/Core/BotController.cs
@@ -1,4 +1,4 @@
-using Core.Goals;
+﻿using Core.Goals;
 using Core.GOAP;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -192,7 +192,7 @@ namespace Core
                 _ = pather.DrawSphere(
                     new SphereArgs("Player",
                     AddonReader.PlayerReader.PlayerLocation,
-                    AddonReader.PlayerReader.Bits.PlayerInCombat ? 1 : AddonReader.PlayerReader.HasTarget ? 6 : 2,
+                    AddonReader.PlayerReader.Bits.PlayerInCombat() ? 1 : AddonReader.PlayerReader.Bits.HasTarget() ? 6 : 2,
                     AddonReader.UIMapId.Value
                 ));
 

--- a/Core/ClassConfig/KeyAction.cs
+++ b/Core/ClassConfig/KeyAction.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -117,7 +117,7 @@ namespace Core
                 if (Enum.TryParse(Form, out Form desiredForm))
                 {
                     this.FormEnum = desiredForm;
-                    this.logger.LogInformation($"[{Name}] Required Form: {FormEnum}");
+                    this.logger.LogInformation($"[{Name}] Required Form: {FormEnum.ToStringF()}");
 
                     if (KeyReader.ActionBarSlotMap.TryGetValue(Key, out int slot))
                     {
@@ -255,10 +255,10 @@ namespace Core
                     formCost = playerReader.FormCost[FormEnum];
                 }
 
-                LogPowerCostChange(logger, Name, abc.PowerType, abc.Cost, oldValue);
+                LogPowerCostChange(logger, Name, abc.PowerType.ToStringF(), abc.Cost, oldValue);
                 if (formCost > 0)
                 {
-                    logger.LogInformation($"[{Name}] +{formCost} Mana to change {FormEnum} Form");
+                    logger.LogInformation($"[{Name}] +{formCost} Mana to change {FormEnum.ToStringF()} Form");
                 }
             }
 
@@ -290,7 +290,7 @@ namespace Core
 
             if (e.Cost != oldValue)
             {
-                LogPowerCostChange(logger, Name, e.PowerType, e.Cost, oldValue);
+                LogPowerCostChange(logger, Name, e.PowerType.ToStringF(), e.Cost, oldValue);
             }
         }
 
@@ -310,7 +310,7 @@ namespace Core
             EventId = 9,
             Level = LogLevel.Information,
             Message = "[{name}] Update {type} cost to {newCost} from {oldCost}")]
-        static partial void LogPowerCostChange(ILogger logger, string name, PowerType type, int newCost, int oldCost);
+        static partial void LogPowerCostChange(ILogger logger, string name, string type, int newCost, int oldCost);
 
         #endregion
     }

--- a/Core/ClassConfig/KeyAction.cs
+++ b/Core/ClassConfig/KeyAction.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -171,7 +171,7 @@ namespace Core
         public bool CanDoFormChangeAndHaveMinimumMana()
         {
             return playerReader.FormCost.ContainsKey(FormEnum) &&
-                playerReader.ManaCurrent >= playerReader.FormCost[FormEnum] + MinMana;
+                playerReader.ManaCurrent() >= playerReader.FormCost[FormEnum] + MinMana;
         }
 
         internal void SetClicked()

--- a/Core/Cursor/CursorClassifier.cs
+++ b/Core/Cursor/CursorClassifier.cs
@@ -53,7 +53,7 @@ namespace Core
                 .FirstOrDefault();
 
             classification = (CursorType)matching.index;
-            Debug.WriteLine($"[CursorClassifier.Classify] {classification} - {matching.similarity}");
+            Debug.WriteLine($"[CursorClassifier.Classify] {classification.ToStringF()} - {matching.similarity}");
         }
     }
 }

--- a/Core/Cursor/CursorType.cs
+++ b/Core/Cursor/CursorType.cs
@@ -13,4 +13,22 @@
         Innkeeper = 9,
         Quest = 10
     }
+
+    public static class CursorType_Extension
+    {
+        public static string ToStringF(this CursorType value) => value switch
+        {
+            CursorType.None => nameof(CursorType.None),
+            CursorType.Kill => nameof(CursorType.Kill),
+            CursorType.Loot => nameof(CursorType.Loot),
+            CursorType.Skin => nameof(CursorType.Skin),
+            CursorType.Mine => nameof(CursorType.Mine),
+            CursorType.Herb => nameof(CursorType.Herb),
+            CursorType.Vendor => nameof(CursorType.Vendor),
+            CursorType.Repair => nameof(CursorType.Repair),
+            CursorType.Innkeeper => nameof(CursorType.Innkeeper),
+            CursorType.Quest => nameof(CursorType.Quest),
+            _ => nameof(CursorType.None)
+        };
+    }
 }

--- a/Core/GOAP/GoapAgent.cs
+++ b/Core/GOAP/GoapAgent.cs
@@ -187,25 +187,25 @@ namespace Core.GOAP
         {
             return new()
             {
-                { GoapKey.hastarget, playerReader.HasTarget },
-                { GoapKey.dangercombat, playerReader.Bits.PlayerInCombat && addonReader.CombatCreatureCount > 0 },
+                { GoapKey.hastarget, playerReader.Bits.HasTarget() },
+                { GoapKey.dangercombat, playerReader.Bits.PlayerInCombat() && addonReader.CombatCreatureCount > 0 },
                 { GoapKey.pethastarget, playerReader.PetHasTarget },
-                { GoapKey.targetisalive, playerReader.HasTarget && !playerReader.Bits.TargetIsDead },
-                { GoapKey.targettargetsus, (playerReader.HasTarget && playerReader.TargetHealthPercentage < 30) || playerReader.TargetTarget is // hacky way to keep attacking fleeing humanoids
+                { GoapKey.targetisalive, playerReader.Bits.HasTarget() && !playerReader.Bits.TargetIsDead() },
+                { GoapKey.targettargetsus, (playerReader.Bits.HasTarget() && playerReader.TargetHealthPercentage() < 30) || playerReader.TargetTarget is // hacky way to keep attacking fleeing humanoids
                     TargetTargetEnum.Me or
                     TargetTargetEnum.Pet or
                     TargetTargetEnum.PartyOrPet },
-                { GoapKey.incombat, playerReader.Bits.PlayerInCombat },
+                { GoapKey.incombat, playerReader.Bits.PlayerInCombat() },
                 { GoapKey.ismounted,
                     (playerReader.Class == PlayerClassEnum.Druid &&
                     playerReader.Form is Form.Druid_Travel or Form.Druid_Flight)
-                    || playerReader.Bits.IsMounted },
-                { GoapKey.withinpullrange, playerReader.WithInPullRange },
-                { GoapKey.incombatrange, playerReader.WithInCombatRange },
+                    || playerReader.Bits.IsMounted() },
+                { GoapKey.withinpullrange, playerReader.WithInPullRange() },
+                { GoapKey.incombatrange, playerReader.WithInCombatRange() },
                 { GoapKey.pulled, false },
-                { GoapKey.isdead, playerReader.Bits.DeadStatus },
-                { GoapKey.isswimming, playerReader.Bits.IsSwimming },
-                { GoapKey.itemsbroken, playerReader.Bits.ItemsAreBroken },
+                { GoapKey.isdead, playerReader.Bits.DeadStatus() },
+                { GoapKey.isswimming, playerReader.Bits.IsSwimming() },
+                { GoapKey.itemsbroken, playerReader.Bits.ItemsAreBroken() },
                 { GoapKey.producedcorpse, State.LastCombatKillCount > 0 },
 
                 // these hold their state

--- a/Core/GOAP/GoapKey.cs
+++ b/Core/GOAP/GoapKey.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Core.GOAP
+﻿namespace Core.GOAP
 {
     public enum GoapKey
     {
@@ -28,76 +26,67 @@ namespace Core.GOAP
         gathering = 200
     }
 
-    public static class GoapKeyDescription
+    public static class GoapKey_Extension
     {
         private static readonly string unknown = "Unknown";
 
-        private static readonly Dictionary<KeyValuePair<GoapKey, bool>, string> table = new()
+        private static string ToStringTrue(GoapKey value) => value switch
         {
-            { new(GoapKey.hastarget, true), "Target" },
-            { new(GoapKey.hastarget, false), "!Target" },
-
-            { new(GoapKey.dangercombat, true), "Danger" },
-            { new(GoapKey.dangercombat, false), "!Danger" },
-
-            { new(GoapKey.targetisalive, true), "Target alive" },
-            { new(GoapKey.targetisalive, false), "Target dead" },
-
-            { new(GoapKey.targettargetsus, true), "Targets us" },
-            { new(GoapKey.targettargetsus, false), "!Targets us" },
-
-            { new(GoapKey.incombat, true), "Combat" },
-            { new(GoapKey.incombat, false), "!Combat" },
-
-            { new(GoapKey.pethastarget, true), "Pet target" },
-            { new(GoapKey.pethastarget, false), "!Pet target" },
-
-            { new(GoapKey.ismounted, true), "Mounted" },
-            { new(GoapKey.ismounted, false), "!Mounted" },
-
-            { new(GoapKey.withinpullrange, true), "Pull range" },
-            { new(GoapKey.withinpullrange, false), "!Pull range" },
-
-            { new(GoapKey.incombatrange, true), "Combat range" },
-            { new(GoapKey.incombatrange, false), "!combat range" },
-
-            { new(GoapKey.pulled, true), "Pulled" },
-            { new(GoapKey.pulled, false), "!Pulled" },
-
-            { new(GoapKey.isdead, true), "Dead" },
-            { new(GoapKey.isdead, false), "Alive" },
-
-            { new(GoapKey.shouldloot, true), "Loot" },
-            { new(GoapKey.shouldloot, false), "!Loot" },
-
-            { new(GoapKey.shouldskin, true), "Skin" },
-            { new(GoapKey.shouldskin, false), "!Skin" },
-
-            { new(GoapKey.newtarget, true), "New target" },
-            { new(GoapKey.newtarget, false), "!New target" },
-
-            { new(GoapKey.producedcorpse, true), "Killing blow" },
-            { new(GoapKey.producedcorpse, false), "!Killing blow" },
-
-            { new(GoapKey.consumecorpse, true), "Corpse nearby" },
-            { new(GoapKey.consumecorpse, false), "!Corpse nearby" },
-
-            { new(GoapKey.abort, true), "Abort" },
-            { new(GoapKey.abort, false), "!Abort" },
-
-            { new(GoapKey.isswimming, true), "Swimming" },
-            { new(GoapKey.isswimming, false), "!Swimming" },
-
-            { new(GoapKey.itemsbroken, true), "Broken" },
-            { new(GoapKey.itemsbroken, false), "!Broken" },
-
-            { new(GoapKey.gathering, true), "Gathering" },
-            { new(GoapKey.gathering, false), "!Gathering" },
+            GoapKey.hastarget => "Target",
+            GoapKey.dangercombat => "Danger",
+            GoapKey.targetisalive => "Target alive",
+            GoapKey.targettargetsus => "Targets us",
+            GoapKey.incombat => "Combat",
+            GoapKey.pethastarget => "Pet target",
+            GoapKey.ismounted => "Mounted",
+            GoapKey.withinpullrange => "Pull range",
+            GoapKey.incombatrange => "Combat range",
+            GoapKey.pulled => "Pulled",
+            GoapKey.isdead => "Dead",
+            GoapKey.shouldloot => "Loot",
+            GoapKey.shouldskin => "Skin",
+            GoapKey.newtarget => "New target",
+            GoapKey.producedcorpse => "Killing blow",
+            GoapKey.consumecorpse => "Corpse nearby",
+            GoapKey.abort => "Abort",
+            GoapKey.isswimming => "Swimming",
+            GoapKey.itemsbroken => "Broken",
+            GoapKey.gathering => "Gathering",
+            GoapKey.corpselocation => throw new System.NotImplementedException(),
+            GoapKey.resume => throw new System.NotImplementedException(),
+            _ => unknown
         };
 
-        public static string ToString(GoapKey key, bool state)
+        private static string ToStringFalse(GoapKey value) => value switch
         {
-            return table.TryGetValue(new(key, state), out var text) ? text : unknown;
+            GoapKey.hastarget => "!Target",
+            GoapKey.dangercombat => "!Danger",
+            GoapKey.targetisalive => "!Target alive",
+            GoapKey.targettargetsus => "!Targets us",
+            GoapKey.incombat => "!Combat",
+            GoapKey.pethastarget => "!Pet target",
+            GoapKey.ismounted => "!Mounted",
+            GoapKey.withinpullrange => "!Pull range",
+            GoapKey.incombatrange => "!Combat range",
+            GoapKey.pulled => "!Pulled",
+            GoapKey.isdead => "!Dead",
+            GoapKey.shouldloot => "!Loot",
+            GoapKey.shouldskin => "!Skin",
+            GoapKey.newtarget => "!New target",
+            GoapKey.producedcorpse => "!Killing blow",
+            GoapKey.consumecorpse => "!Corpse nearby",
+            GoapKey.abort => "!Abort",
+            GoapKey.isswimming => "!Swimming",
+            GoapKey.itemsbroken => "!Broken",
+            GoapKey.gathering => "!Gathering",
+            GoapKey.corpselocation => throw new System.NotImplementedException(),
+            GoapKey.resume => throw new System.NotImplementedException(),
+            _ => unknown
+        };
+
+        public static string ToStringF(this GoapKey key, bool state)
+        {
+            return state ? ToStringTrue(key) : ToStringFalse(key);
         }
     }
 }

--- a/Core/Goals/AdhocGoal.cs
+++ b/Core/Goals/AdhocGoal.cs
@@ -35,7 +35,7 @@ namespace Core.Goals
             this.castingHandler = castingHandler;
             this.mountHandler = mountHandler;
 
-            dangerCombat = () => addonReader.PlayerReader.Bits.PlayerInCombat &&
+            dangerCombat = () => addonReader.PlayerReader.Bits.PlayerInCombat() &&
                 addonReader.CombatCreatureCount > 0;
 
             if (key.InCombat == "false")
@@ -62,21 +62,21 @@ namespace Core.Goals
 
             castingHandler.CastIfReady(key, dangerCombat);
 
-            bool wasDrinkingOrEating = playerReader.Buffs.Drinking || playerReader.Buffs.Eating;
+            bool wasDrinkingOrEating = playerReader.Buffs.Drink() || playerReader.Buffs.Food();
 
             DateTime startTime = DateTime.UtcNow;
 
-            while ((playerReader.Buffs.Drinking || playerReader.Buffs.Eating || playerReader.IsCasting) && !dangerCombat())
+            while ((playerReader.Buffs.Drink() || playerReader.Buffs.Food() || playerReader.IsCasting()) && !dangerCombat())
             {
                 wait.Update();
 
-                if (playerReader.Buffs.Drinking)
+                if (playerReader.Buffs.Drink())
                 {
-                    if (playerReader.ManaPercentage > 98) { break; }
+                    if (playerReader.ManaPercentage() > 98) { break; }
                 }
-                else if (playerReader.Buffs.Eating && !key.Requirement.Contains("Well Fed"))
+                else if (playerReader.Buffs.Food() && !key.Requirement.Contains("Well Fed"))
                 {
-                    if (playerReader.HealthPercent > 98) { break; }
+                    if (playerReader.HealthPercent() > 98) { break; }
                 }
                 else if (!key.CanRun())
                 {

--- a/Core/Goals/AdhocNPCGoal.cs
+++ b/Core/Goals/AdhocNPCGoal.cs
@@ -144,9 +144,9 @@ namespace Core.Goals
 
         public override void PerformAction()
         {
-            if (playerReader.Bits.PlayerInCombat && classConfig.Mode != Mode.AttendedGather) { return; }
+            if (playerReader.Bits.PlayerInCombat() && classConfig.Mode != Mode.AttendedGather) { return; }
 
-            if (playerReader.Bits.IsDrowning)
+            if (playerReader.Bits.IsDrowning())
             {
                 LogWarn("Drowning! Swim up");
                 input.Jump();
@@ -189,7 +189,7 @@ namespace Core.Goals
                     input.KeyPress(key.ConsoleKey, input.defaultKeyPress);
                 }
 
-                (bool targetTimeout, double targetElapsedMs) = wait.Until(400, () => playerReader.HasTarget);
+                (bool targetTimeout, double targetElapsedMs) = wait.Until(400, playerReader.Bits.HasTarget);
                 if (targetTimeout)
                 {
                     LogWarn("No target found! Turn left to find NPC");
@@ -257,14 +257,14 @@ namespace Core.Goals
 
         private bool OpenMerchantWindow()
         {
-            (bool timeout, double elapsedMs) = wait.Until(GossipTimeout, () => gossipReader.GossipStart || gossipReader.MerchantWindowOpened);
-            if (gossipReader.MerchantWindowOpened)
+            (bool timeout, double elapsedMs) = wait.Until(GossipTimeout, gossipReader.GossipStartOrMerchantWindowOpened);
+            if (gossipReader.MerchantWindowOpened())
             {
                 LogWarn($"Gossip no options! {elapsedMs}ms");
             }
             else
             {
-                (bool gossipEndTimeout, double gossipEndElapsedMs) = wait.Until(GossipTimeout, () => gossipReader.GossipEnd);
+                (bool gossipEndTimeout, double gossipEndElapsedMs) = wait.Until(GossipTimeout, gossipReader.GossipEnd);
                 if (timeout)
                 {
                     LogWarn($"Gossip - {nameof(gossipReader.GossipEnd)} not fired after {gossipEndElapsedMs}ms");
@@ -287,12 +287,12 @@ namespace Core.Goals
 
             Log($"Merchant window opened after {elapsedMs}ms");
 
-            (bool sellStartedTimeout, double sellStartedElapsedMs) = wait.Until(GossipTimeout, () => gossipReader.MerchantWindowSelling);
+            (bool sellStartedTimeout, double sellStartedElapsedMs) = wait.Until(GossipTimeout, gossipReader.MerchantWindowSelling);
             if (!sellStartedTimeout)
             {
                 Log($"Merchant sell grey items started after {sellStartedElapsedMs}ms");
 
-                (bool sellFinishedTimeout, double sellFinishedElapsedMs) = wait.Until(GossipTimeout, () => gossipReader.MerchantWindowSellingFinished);
+                (bool sellFinishedTimeout, double sellFinishedElapsedMs) = wait.Until(GossipTimeout, gossipReader.MerchantWindowSellingFinished);
                 if (!sellFinishedTimeout)
                 {
                     Log($"Merchant sell grey items finished, took {sellFinishedElapsedMs}ms");

--- a/Core/Goals/ApproachTargetGoal.cs
+++ b/Core/Goals/ApproachTargetGoal.cs
@@ -35,8 +35,8 @@ namespace Core.Goals
         private double ApproachDurationMs => (DateTime.UtcNow - approachStart).TotalMilliseconds;
 
         private bool HasPickedUpAnAdd =>
-            playerReader.Bits.PlayerInCombat &&
-            !playerReader.Bits.TargetInCombat;
+            playerReader.Bits.PlayerInCombat() &&
+            !playerReader.Bits.TargetInCombat();
 
         public ApproachTargetGoal(ILogger logger, ConfigurableInput input, Wait wait, PlayerReader playerReader, StopMoving stopMoving, CombatUtil combatUtil, IBlacklist blacklist)
         {
@@ -67,7 +67,7 @@ namespace Core.Goals
         public override void OnEnter()
         {
             initialTargetGuid = playerReader.TargetGuid;
-            initialMinRange = playerReader.MinRange;
+            initialMinRange = playerReader.MinRange();
             lastPlayerLocation = playerReader.PlayerLocation;
 
             combatUtil.Update();
@@ -84,7 +84,7 @@ namespace Core.Goals
             if (combatUtil.EnteredCombat() && HasPickedUpAnAdd)
             {
                 if (debug)
-                    Log($"Add on approach! PlayerCombat={playerReader.Bits.PlayerInCombat}, Targets us={playerReader.Bits.TargetOfTargetIsPlayerOrPet}");
+                    Log($"Add on approach! PlayerCombat={playerReader.Bits.PlayerInCombat()}, Targets us={playerReader.Bits.TargetOfTargetIsPlayerOrPet()}");
 
                 stopMoving.Stop();
                 combatUtil.AquiredTarget(5000);
@@ -97,7 +97,7 @@ namespace Core.Goals
                 input.Approach();
             }
 
-            if (!playerReader.Bits.PlayerInCombat)
+            if (!playerReader.Bits.PlayerInCombat())
             {
                 NonCombatApproach();
             }
@@ -149,7 +149,7 @@ namespace Core.Goals
 
             if (playerReader.TargetGuid == initialTargetGuid)
             {
-                int initialTargetMinRange = playerReader.MinRange;
+                int initialTargetMinRange = playerReader.MinRange();
                 if (input.ClassConfig.TargetNearestTarget.GetCooldownRemaining() == 0)
                 {
                     input.NearestTarget();
@@ -158,14 +158,14 @@ namespace Core.Goals
 
                 if (playerReader.TargetGuid != initialTargetGuid)
                 {
-                    if (playerReader.HasTarget && !blacklist.IsTargetBlacklisted()) // blacklist
+                    if (playerReader.Bits.HasTarget() && !blacklist.IsTargetBlacklisted()) // blacklist
                     {
-                        if (playerReader.MinRange < initialTargetMinRange)
+                        if (playerReader.MinRange() < initialTargetMinRange)
                         {
                             if (debug)
-                                Log($"Found a closer target! {playerReader.MinRange} < {initialTargetMinRange}");
+                                Log($"Found a closer target! {playerReader.MinRange()} < {initialTargetMinRange}");
 
-                            initialMinRange = playerReader.MinRange;
+                            initialMinRange = playerReader.MinRange();
                         }
                         else
                         {
@@ -185,10 +185,10 @@ namespace Core.Goals
                 }
             }
 
-            if (ApproachDurationMs > 2000 && initialMinRange < playerReader.MinRange)
+            if (ApproachDurationMs > 2000 && initialMinRange < playerReader.MinRange())
             {
                 if (debug)
-                    Log($"Going away from the target! {initialMinRange} < {playerReader.MinRange}");
+                    Log($"Going away from the target! {initialMinRange} < {playerReader.MinRange()}");
 
                 input.ClearTarget();
             }

--- a/Core/Goals/BlacklistTargetGoal.cs
+++ b/Core/Goals/BlacklistTargetGoal.cs
@@ -17,7 +17,7 @@
 
         public override bool CheckIfActionCanRun()
         {
-            return playerReader.HasTarget && blacklist.IsTargetBlacklisted();
+            return playerReader.Bits.HasTarget() && blacklist.IsTargetBlacklisted();
         }
 
         public override void OnEnter()

--- a/Core/Goals/CastingHandler.cs
+++ b/Core/Goals/CastingHandler.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Diagnostics;
 using System.Numerics;
@@ -196,7 +196,7 @@ namespace Core.Goals
                 return false;
             }
             if (item.Log)
-                item.LogInformation($" ... casting: {playerReader.IsCasting} -- count:{playerReader.CastCount} -- usable: {beforeUsable}->{addonReader.UsableAction.Is(item)} -- {((UI_ERROR)beforeCastEventValue).ToStringF()}->{((UI_ERROR)playerReader.CastEvent.Value).ToStringF()}");
+                item.LogInformation($" ... casting: {playerReader.IsCasting()} -- count:{playerReader.CastCount} -- usable: {beforeUsable}->{addonReader.UsableAction.Is(item)} -- {((UI_ERROR)beforeCastEventValue).ToStringF()}->{((UI_ERROR)playerReader.CastEvent.Value).ToStringF()}");
 
             if (!CastSuccessfull((UI_ERROR)playerReader.CastEvent.Value))
             {
@@ -269,7 +269,7 @@ namespace Core.Goals
                     if (!beforeUsable && !addonReader.UsableAction.Is(item))
                     {
                         if (item.Log)
-                            item.LogInformation($" ... after switch {beforeForm}->{playerReader.Form} still not usable!");
+                            item.LogInformation($" ... after switch {beforeForm.ToStringF()}->{playerReader.Form.ToStringF()} still not usable!");
                         return false;
                     }
                 }
@@ -444,7 +444,7 @@ namespace Core.Goals
 
             (bool changedTimeOut, double elapsedMs) = wait.Until(SpellQueueTimeMs, () => playerReader.Form == item.FormEnum);
             if (item.Log)
-                item.LogInformation($" ... form changed: {!changedTimeOut} | {beforeForm} -> {playerReader.Form} | Delay: {elapsedMs}ms");
+                item.LogInformation($" ... form changed: {!changedTimeOut} | {beforeForm.ToStringF()} -> {playerReader.Form.ToStringF()} | Delay: {elapsedMs}ms");
 
             return playerReader.Form == item.FormEnum;
         }
@@ -623,7 +623,7 @@ namespace Core.Goals
                             (bool timeout, double elapsedMs) = wait.Until(MaxWaitCastTimeMs,
                                 () => minRange != playerReader.MinRange);
 
-                            logger.LogInformation($"{source} -- React to {UI_ERROR.ERR_SPELL_OUT_OF_RANGE.ToStringF()} -- Approached target {minRange}->{playerReader.MinRange}");
+                            logger.LogInformation($"{source} -- React to {UI_ERROR.ERR_SPELL_OUT_OF_RANGE.ToStringF()} -- Approached target {minRange}->{playerReader.MinRange()}");
                         }
                         else
                         {

--- a/Core/Goals/CastingHandler.cs
+++ b/Core/Goals/CastingHandler.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using System;
 using System.Diagnostics;
 using System.Numerics;
@@ -102,9 +102,9 @@ namespace Core.Goals
 
             if (item.AfterCastWaitNextSwing)
             {
-                (inputTimeOut, inputElapsedMs) = wait.Until(playerReader.MainHandSpeedMs,
+                (inputTimeOut, inputElapsedMs) = wait.Until(playerReader.MainHandSpeedMs(),
                     interrupt: () => !addonReader.CurrentAction.Is(item) ||
-                        playerReader.MainHandSwing.ElapsedMs < SpellQueueTimeMs, // swing timer reset from any miss
+                        playerReader.MainHandSwing.ElapsedMs() < SpellQueueTimeMs, // swing timer reset from any miss
                     repeat: RepeatStayCloseToTarget);
             }
             else
@@ -141,9 +141,9 @@ namespace Core.Goals
 
         private bool CastCastbar(KeyAction item, Func<bool> interrupt)
         {
-            if (playerReader.Bits.IsFalling)
+            if (playerReader.Bits.IsFalling())
             {
-                (bool fallTimeOut, double fallElapsedMs) = wait.Until(MaxAirTimeMs, () => !playerReader.Bits.IsFalling);
+                (bool fallTimeOut, double fallElapsedMs) = wait.UntilNot(MaxAirTimeMs, playerReader.Bits.IsFalling);
                 if (!fallTimeOut)
                 {
                     if (item.Log)
@@ -151,7 +151,7 @@ namespace Core.Goals
                 }
             }
 
-            if (playerReader.IsCasting && interrupt())
+            if (playerReader.IsCasting() && interrupt())
             {
                 //if (item.Log) // really spammy
                 //    item.LogInformation($" ... castbar during cast interrupted!");
@@ -204,11 +204,11 @@ namespace Core.Goals
                 return false;
             }
 
-            if (playerReader.IsCasting)
+            if (playerReader.IsCasting())
             {
                 if (item.Log)
                     item.LogInformation(" ... waiting for visible cast bar to end or interrupt.");
-                wait.Until(MaxCastTimeMs, () => !playerReader.IsCasting || prevState != interrupt(), RepeatPetAttack);
+                wait.Until(MaxCastTimeMs, () => !playerReader.IsCasting() || prevState != interrupt(), RepeatPetAttack);
                 if (prevState != interrupt())
                 {
                     if (item.Log)
@@ -235,7 +235,7 @@ namespace Core.Goals
 
         public bool CastIfReady(KeyAction item)
         {
-            return item.CanRun() && Cast(item, PlayerHasTarget);
+            return item.CanRun() && Cast(item, playerReader.Bits.HasTarget);
         }
 
         public bool CastIfReady(KeyAction item, Func<bool> interrupt)
@@ -245,7 +245,7 @@ namespace Core.Goals
 
         public bool Cast(KeyAction item)
         {
-            return Cast(item, PlayerHasTarget);
+            return Cast(item, playerReader.Bits.HasTarget);
         }
 
         public bool Cast(KeyAction item, Func<bool> interrupt)
@@ -253,7 +253,7 @@ namespace Core.Goals
             if (item.HasFormRequirement() && playerReader.Form != item.FormEnum)
             {
                 bool beforeUsable = addonReader.UsableAction.Is(item);
-                var beforeForm = playerReader.Form;
+                Form beforeForm = playerReader.Form;
 
                 if (!SwitchForm(beforeForm, item))
                 {
@@ -275,7 +275,7 @@ namespace Core.Goals
                 }
             }
 
-            if (playerReader.Bits.IsAutoRepeatSpellOn_Shoot)
+            if (playerReader.Bits.SpellOn_Shoot())
             {
                 logger.LogInformation("Stop AutoRepeat Shoot");
                 input.StopAttack();
@@ -347,7 +347,7 @@ namespace Core.Goals
                     while (sw.ElapsedMilliseconds < item.DelayAfterCast)
                     {
                         wait.Update();
-                        if (playerReader.Bits.TargetOfTargetIsPlayerOrPet)
+                        if (playerReader.Bits.TargetOfTargetIsPlayerOrPet())
                         {
                             break;
                         }
@@ -375,9 +375,7 @@ namespace Core.Goals
             {
                 if (item.RequirementObjects.Count > 0)
                 {
-                    (bool canRun, double canRunElapsedMs) = wait.Until(SpellQueueTimeMs,
-                        () => !item.CanRun()
-                    );
+                    (bool canRun, double canRunElapsedMs) = wait.UntilNot(SpellQueueTimeMs, item.CanRun);
                     if (item.Log)
                         item.LogInformation($" ... instant interrupt: {!canRun} | CanRun: {item.CanRun()} | Delay: {canRunElapsedMs}ms");
                 }
@@ -476,7 +474,7 @@ namespace Core.Goals
                     }
                     break;
                 case UI_ERROR.ERR_SPELL_OUT_OF_RANGE:
-                    if (playerReader.Class == PlayerClassEnum.Hunter && playerReader.IsInMeleeRange)
+                    if (playerReader.Class == PlayerClassEnum.Hunter && playerReader.IsInMeleeRange())
                     {
                         logger.LogInformation($"{source} -- As a Hunter didn't know how to react {UI_ERROR.ERR_SPELL_OUT_OF_RANGE.ToStringF()}");
                         return;
@@ -491,7 +489,7 @@ namespace Core.Goals
                     break;
                 case UI_ERROR.ERR_BADATTACKFACING:
 
-                    if (playerReader.IsInMeleeRange)
+                    if (playerReader.IsInMeleeRange())
                     {
                         logger.LogInformation($"{source} -- React to {UI_ERROR.ERR_BADATTACKFACING.ToStringF()} -- Interact!");
                         input.Interact();
@@ -517,7 +515,7 @@ namespace Core.Goals
                     break;
                 case UI_ERROR.ERR_SPELL_FAILED_ANOTHER_IN_PROGRESS:
                     logger.LogInformation($"{source} -- React to {UI_ERROR.ERR_SPELL_FAILED_ANOTHER_IN_PROGRESS.ToStringF()} -- Wait till casting!");
-                    wait.While(() => playerReader.IsCasting);
+                    wait.While(playerReader.IsCasting);
 
                     wait.Update();
                     playerReader.LastUIError = UI_ERROR.NONE;
@@ -529,7 +527,7 @@ namespace Core.Goals
                     playerReader.LastUIError = UI_ERROR.NONE;
                     break;
                 case UI_ERROR.ERR_BADATTACKPOS:
-                    if (playerReader.Bits.IsAutoRepeatSpellOn_AutoAttack)
+                    if (playerReader.Bits.SpellOn_AutoAttack())
                     {
                         logger.LogInformation($"{source} -- React to {UI_ERROR.ERR_BADATTACKPOS.ToStringF()} -- Interact!");
                         input.Interact();
@@ -588,14 +586,14 @@ namespace Core.Goals
 
                     break;
                 case UI_ERROR.ERR_SPELL_OUT_OF_RANGE:
-                    if (playerReader.Class == PlayerClassEnum.Hunter && playerReader.IsInMeleeRange)
+                    if (playerReader.Class == PlayerClassEnum.Hunter && playerReader.IsInMeleeRange())
                     {
                         logger.LogInformation($"{source} -- As a Hunter didn't know how to react {UI_ERROR.ERR_SPELL_OUT_OF_RANGE.ToStringF()}");
                         return;
                     }
 
-                    float minRange = playerReader.MinRange;
-                    if (playerReader.Bits.PlayerInCombat && playerReader.HasTarget && !playerReader.IsTargetCasting)
+                    float minRange = playerReader.MinRange();
+                    if (playerReader.Bits.PlayerInCombat() && playerReader.Bits.HasTarget() && !playerReader.IsTargetCasting())
                     {
                         wait.Update();
                         wait.Update();
@@ -604,7 +602,7 @@ namespace Core.Goals
                             logger.LogInformation($"{source} -- React to {UI_ERROR.ERR_SPELL_OUT_OF_RANGE.ToStringF()} -- Just wait for the target to get in range.");
 
                             (bool timeout, double elapsedMs) = wait.Until(MaxWaitCastTimeMs,
-                                () => minRange != playerReader.MinRange || playerReader.IsTargetCasting
+                                () => minRange != playerReader.MinRange() || playerReader.IsTargetCasting()
                             );
                         }
                     }
@@ -621,7 +619,7 @@ namespace Core.Goals
                             input.Interact();
 
                             (bool timeout, double elapsedMs) = wait.Until(MaxWaitCastTimeMs,
-                                () => minRange != playerReader.MinRange);
+                                () => minRange != playerReader.MinRange());
 
                             logger.LogInformation($"{source} -- React to {UI_ERROR.ERR_SPELL_OUT_OF_RANGE.ToStringF()} -- Approached target {minRange}->{playerReader.MinRange()}");
                         }
@@ -630,13 +628,11 @@ namespace Core.Goals
                             logger.LogInformation($"{source} -- React to {UI_ERROR.ERR_SPELL_OUT_OF_RANGE.ToStringF()} -- Start moving forward");
                             input.SetKeyState(input.ForwardKey, true);
                         }
-
-
                     }
 
                     break;
                 case UI_ERROR.ERR_BADATTACKFACING:
-                    if (playerReader.IsInMeleeRange)
+                    if (playerReader.IsInMeleeRange())
                     {
                         logger.LogInformation($"{source} -- React to {UI_ERROR.ERR_BADATTACKFACING.ToStringF()} -- Interact!");
                         input.Interact();
@@ -661,11 +657,11 @@ namespace Core.Goals
                     break;
                 case UI_ERROR.ERR_SPELL_FAILED_ANOTHER_IN_PROGRESS:
                     logger.LogInformation($"{source} -- React to {UI_ERROR.ERR_SPELL_FAILED_ANOTHER_IN_PROGRESS.ToStringF()} -- Wait till casting!");
-                    wait.While(() => playerReader.IsCasting);
+                    wait.While(playerReader.IsCasting);
 
                     break;
                 case UI_ERROR.ERR_BADATTACKPOS:
-                    if (playerReader.Bits.IsAutoRepeatSpellOn_AutoAttack)
+                    if (playerReader.Bits.SpellOn_AutoAttack())
                     {
                         logger.LogInformation($"{source} -- React to {UI_ERROR.ERR_BADATTACKPOS.ToStringF()} -- Interact!");
                         input.Interact();
@@ -691,15 +687,10 @@ namespace Core.Goals
             }
         }
 
-        private bool PlayerHasTarget()
-        {
-            return playerReader.HasTarget;
-        }
-
         private void RepeatPetAttack()
         {
-            if (playerReader.Bits.PlayerInCombat &&
-                playerReader.Bits.HasPet &&
+            if (playerReader.Bits.PlayerInCombat() &&
+                playerReader.Bits.HasPet() &&
                 !playerReader.PetHasTarget &&
                 input.ClassConfig.PetAttack.GetCooldownRemaining() == 0)
             {

--- a/Core/Goals/CombatGoal.cs
+++ b/Core/Goals/CombatGoal.cs
@@ -1,4 +1,4 @@
-﻿using Core.GOAP;
+using Core.GOAP;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Linq;
@@ -81,14 +81,8 @@ namespace Core.Goals
                     lastKnownMaxDistance = playerReader.MaxRange;
                 }
 
-                if (!playerReader.Bits.TargetIsDead && castingHandler.CastIfReady(item))
+                if (castingHandler.CastIfReady(item))
                 {
-                    if (item.Name == classConfiguration.Approach.Name ||
-                        item.Name == classConfiguration.AutoAttack.Name)
-                    {
-                        castingHandler.ReactToLastUIErrorMessage($"Fight {item.Name}");
-                    }
-
                     break;
                 }
             }

--- a/Core/Goals/CombatUtil.cs
+++ b/Core/Goals/CombatUtil.cs
@@ -27,27 +27,27 @@ namespace Core
             this.addonReader = addonReader;
             this.playerReader = addonReader.PlayerReader;
 
-            outOfCombat = !playerReader.Bits.PlayerInCombat;
+            outOfCombat = !playerReader.Bits.PlayerInCombat();
             lastPosition = playerReader.PlayerLocation;
         }
 
         public void Update()
         {
             // TODO: have to find a better way to reset outOfCombat
-            outOfCombat = !playerReader.Bits.PlayerInCombat;
+            outOfCombat = !playerReader.Bits.PlayerInCombat();
             lastPosition = playerReader.PlayerLocation;
         }
 
         public bool EnteredCombat()
         {
-            if (!outOfCombat && !playerReader.Bits.PlayerInCombat)
+            if (!outOfCombat && !playerReader.Bits.PlayerInCombat())
             {
                 Log("Combat Leave");
                 outOfCombat = true;
                 return false;
             }
 
-            if (outOfCombat && playerReader.Bits.PlayerInCombat)
+            if (outOfCombat && playerReader.Bits.PlayerInCombat())
             {
                 Log("Combat Enter");
                 outOfCombat = false;
@@ -59,7 +59,7 @@ namespace Core
 
         public bool AquiredTarget(int maxTimeMs = 400)
         {
-            if (this.playerReader.Bits.PlayerInCombat)
+            if (this.playerReader.Bits.PlayerInCombat())
             {
                 if (this.playerReader.PetHasTarget)
                 {
@@ -76,9 +76,9 @@ namespace Core
                 input.NearestTarget();
                 wait.Update();
 
-                if (playerReader.HasTarget &&
-                    playerReader.Bits.TargetInCombat &&
-                    (playerReader.Bits.TargetOfTargetIsPlayerOrPet ||
+                if (playerReader.Bits.HasTarget() &&
+                    playerReader.Bits.TargetInCombat() &&
+                    (playerReader.Bits.TargetOfTargetIsPlayerOrPet() ||
                     addonReader.CreatureHistory.DamageDone.Exists(x => x.Guid == playerReader.TargetGuid)))
                 {
                     Log("Found target");
@@ -128,7 +128,7 @@ namespace Core
 
         private bool PlayerOrPetHasTarget()
         {
-            return playerReader.HasTarget || playerReader.PetHasTarget;
+            return playerReader.Bits.HasTarget() || playerReader.PetHasTarget;
         }
 
         private bool StartedMoving()

--- a/Core/Goals/FollowRouteGoal.cs
+++ b/Core/Goals/FollowRouteGoal.cs
@@ -186,19 +186,19 @@ namespace Core.Goals
 
         public override void PerformAction()
         {
-            if (playerReader.HasTarget && playerReader.Bits.TargetIsDead)
+            if (playerReader.Bits.HasTarget() && playerReader.Bits.TargetIsDead())
             {
                 Log("Has target but its dead.");
                 input.ClearTarget();
                 wait.Update();
             }
 
-            if (playerReader.Bits.IsDrowning)
+            if (playerReader.Bits.IsDrowning())
             {
                 input.Jump();
             }
 
-            if (playerReader.Bits.PlayerInCombat && classConfig.Mode != Mode.AttendedGather) { return; }
+            if (playerReader.Bits.PlayerInCombat() && classConfig.Mode != Mode.AttendedGather) { return; }
 
             if (!sideActivityCts.IsCancellationRequested)
                 navigation.Update(sideActivityCts);
@@ -212,7 +212,7 @@ namespace Core.Goals
         {
             bool validTarget()
             {
-                return !playerReader.Bits.TargetIsDead;
+                return !playerReader.Bits.TargetIsDead();
             }
 
             sideActivityManualReset.WaitOne();
@@ -256,7 +256,7 @@ namespace Core.Goals
         private void AlternateGatherTypes()
         {
             var oldestKey = classConfig.GatherFindKeyConfig.MaxBy(x => x.MillisecondsSinceLastClick);
-            if (!playerReader.IsCasting &&
+            if (!playerReader.IsCasting() &&
                 oldestKey?.MillisecondsSinceLastClick > CYCLE_PROFESSION_PERIOD)
             {
                 logger.LogInformation($"[{oldestKey.Key}] {oldestKey.Name} pressed for {input.defaultKeyPress}ms");

--- a/Core/Goals/ItemsBrokenGoal.cs
+++ b/Core/Goals/ItemsBrokenGoal.cs
@@ -17,7 +17,7 @@ namespace Core.Goals
 
         public override bool CheckIfActionCanRun()
         {
-            return playerReader.Bits.ItemsAreBroken;
+            return playerReader.Bits.ItemsAreBroken();
         }
 
         public override void PerformAction()

--- a/Core/Goals/LastTargetLoot.cs
+++ b/Core/Goals/LastTargetLoot.cs
@@ -54,9 +54,9 @@ namespace Core.Goals
             Log("No corpse name found - check last dead target exists");
             input.LastTarget();
             wait.Update();
-            if (playerReader.HasTarget)
+            if (playerReader.Bits.HasTarget())
             {
-                if (playerReader.Bits.TargetIsDead)
+                if (playerReader.Bits.TargetIsDead())
                 {
                     Log("Found last dead target");
                     input.Interact();
@@ -109,7 +109,7 @@ namespace Core.Goals
 
             SendActionEvent(new ActionEventArgs(GoapKey.shouldloot, false));
 
-            if (playerReader.HasTarget && playerReader.Bits.TargetIsDead)
+            if (playerReader.Bits.HasTarget() && playerReader.Bits.TargetIsDead())
             {
                 input.ClearTarget();
                 wait.Update();

--- a/Core/Goals/LootGoal.cs
+++ b/Core/Goals/LootGoal.cs
@@ -103,9 +103,9 @@ namespace Core.Goals
                 Log("No corpse name found - check last dead target exists");
                 input.LastTarget();
                 wait.Update();
-                if (playerReader.HasTarget)
+                if (playerReader.Bits.HasTarget())
                 {
-                    if (playerReader.Bits.TargetIsDead)
+                    if (playerReader.Bits.TargetIsDead())
                     {
                         CheckForSkinning();
 
@@ -171,7 +171,7 @@ namespace Core.Goals
             }
 
             Log("Found corpse - clicked");
-            (bool searchTimeOut, double elapsedMs) = wait.Until(200, HasTarget);
+            (bool searchTimeOut, double elapsedMs) = wait.Until(200, playerReader.Bits.HasTarget);
             if (!searchTimeOut)
             {
                 Log($"Found target after {elapsedMs}ms");
@@ -239,7 +239,7 @@ namespace Core.Goals
 
             SendActionEvent(new ActionEventArgs(GoapKey.shouldloot, false));
 
-            if (playerReader.HasTarget && playerReader.Bits.TargetIsDead)
+            if (playerReader.Bits.HasTarget() && playerReader.Bits.TargetIsDead())
             {
                 input.ClearTarget();
                 wait.Update();
@@ -249,11 +249,6 @@ namespace Core.Goals
         private bool LootChanged()
         {
             return lastLoot != playerReader.LastLootTime;
-        }
-
-        private bool HasTarget()
-        {
-            return playerReader.HasTarget;
         }
 
         private void Log(string text)

--- a/Core/Goals/MountHandler.cs
+++ b/Core/Goals/MountHandler.cs
@@ -37,10 +37,10 @@ namespace Core
         public bool CanMount()
         {
             return playerReader.Level.Value >= minLevelToMount &&
-                !playerReader.Bits.IsIndoors &&
-                !playerReader.Bits.PlayerInCombat &&
-                !playerReader.Bits.IsSwimming &&
-                !playerReader.Bits.IsFalling &&
+                !playerReader.Bits.IsIndoors() &&
+                !playerReader.Bits.PlayerInCombat() &&
+                !playerReader.Bits.IsSwimming() &&
+                !playerReader.Bits.IsFalling() &&
                 !IsMounted() &&
                 addonReader.UsableAction.Is(classConfig.Mount) &&
                 addonReader.ActionBarCooldownReader.GetRemainingCooldown(playerReader, classConfig.Mount) == 0;
@@ -58,9 +58,9 @@ namespace Core
                 }
             }
 
-            if (playerReader.Bits.IsFalling)
+            if (playerReader.Bits.IsFalling())
             {
-                (bool fallTimeOut, double fallElapsedMs) = wait.Until(maxFallTimeMs, () => !playerReader.Bits.IsFalling);
+                (bool fallTimeOut, double fallElapsedMs) = wait.UntilNot(maxFallTimeMs, playerReader.Bits.IsFalling);
                 Log($"waited for landing interrupted: {!fallTimeOut} - {fallElapsedMs}ms");
             }
 
@@ -69,17 +69,17 @@ namespace Core
 
             input.Mount();
 
-            (bool castStartTimeOut, double castStartElapsedMs) = wait.Until(spellQueueWindowMs, () => playerReader.Bits.IsMounted || playerReader.IsCasting);
-            Log($"cast_start: {!castStartTimeOut} | Mounted: {playerReader.Bits.IsMounted} | Delay: {castStartElapsedMs}ms");
+            (bool castStartTimeOut, double castStartElapsedMs) = wait.Until(spellQueueWindowMs, () => playerReader.Bits.IsMounted() || playerReader.IsCasting());
+            Log($"cast_start: {!castStartTimeOut} | Mounted: {playerReader.Bits.IsMounted()} | Delay: {castStartElapsedMs}ms");
 
-            if (!playerReader.Bits.IsMounted)
+            if (!playerReader.Bits.IsMounted())
             {
-                bool hadTarget = playerReader.HasTarget;
-                (bool castEndTimeOut, double elapsedMs) = wait.Until(mountCastTimeMs, () => playerReader.Bits.IsMounted || !playerReader.IsCasting || playerReader.HasTarget != hadTarget);
-                Log($"cast_ended: {!castEndTimeOut} | Mounted: {playerReader.Bits.IsMounted} | Delay: {elapsedMs}ms");
+                bool hadTarget = playerReader.Bits.HasTarget();
+                (bool castEndTimeOut, double elapsedMs) = wait.Until(mountCastTimeMs, () => playerReader.Bits.IsMounted() || !playerReader.IsCasting() || playerReader.Bits.HasTarget() != hadTarget);
+                Log($"cast_ended: {!castEndTimeOut} | Mounted: {playerReader.Bits.IsMounted()} | Delay: {elapsedMs}ms");
 
-                (bool mountedTimeOut, elapsedMs) = wait.Until(spellQueueWindowMs, () => playerReader.Bits.IsMounted);
-                Log($"interupted: {!mountedTimeOut} | Mounted: {playerReader.Bits.IsMounted} | Delay: {elapsedMs}ms");
+                (bool mountedTimeOut, elapsedMs) = wait.Until(spellQueueWindowMs, playerReader.Bits.IsMounted);
+                Log($"interupted: {!mountedTimeOut} | Mounted: {playerReader.Bits.IsMounted()} | Delay: {elapsedMs}ms");
             }
         }
 
@@ -109,7 +109,7 @@ namespace Core
         {
             return (playerReader.Class == PlayerClassEnum.Druid &&
                 playerReader.Form is Form.Druid_Flight or Form.Druid_Travel)
-                || playerReader.Bits.IsMounted;
+                || playerReader.Bits.IsMounted();
         }
 
         private void Log(string text)

--- a/Core/Goals/ParallelGoal.cs
+++ b/Core/Goals/ParallelGoal.cs
@@ -66,24 +66,24 @@ namespace Core.Goals
                 return Task.CompletedTask;
             });
 
-            bool wasDrinkingOrEating = playerReader.Buffs.Drinking || playerReader.Buffs.Eating;
+            bool wasDrinkingOrEating = playerReader.Buffs.Drink() || playerReader.Buffs.Food();
 
             DateTime startTime = DateTime.UtcNow;
-            while ((playerReader.Buffs.Drinking || playerReader.Buffs.Eating || playerReader.IsCasting) && !playerReader.Bits.PlayerInCombat)
+            while ((playerReader.Buffs.Drink() || playerReader.Buffs.Food() || playerReader.IsCasting()) && !playerReader.Bits.PlayerInCombat())
             {
                 wait.Update();
 
-                if (playerReader.Buffs.Drinking && playerReader.Buffs.Eating)
+                if (playerReader.Buffs.Drink() && playerReader.Buffs.Food())
                 {
-                    if (playerReader.ManaPercentage > 98 && playerReader.HealthPercent > 98) { break; }
+                    if (playerReader.ManaPercentage() > 98 && playerReader.HealthPercent() > 98) { break; }
                 }
-                else if (playerReader.Buffs.Drinking)
+                else if (playerReader.Buffs.Drink())
                 {
-                    if (playerReader.ManaPercentage > 98) { break; }
+                    if (playerReader.ManaPercentage() > 98) { break; }
                 }
-                else if (playerReader.Buffs.Eating)
+                else if (playerReader.Buffs.Food())
                 {
-                    if (playerReader.HealthPercent > 98) { break; }
+                    if (playerReader.HealthPercent() > 98) { break; }
                 }
 
                 if ((DateTime.UtcNow - startTime).TotalSeconds >= 25)

--- a/Core/Goals/PullTargetGoal.cs
+++ b/Core/Goals/PullTargetGoal.cs
@@ -128,7 +128,7 @@ namespace Core.Goals
             {
                 if (combatUtil.EnteredCombat() && HasPickedUpAnAdd)
                 {
-                    Log($"Add on pull! Combat={playerReader.Bits.PlayerInCombat}, Targets me={playerReader.Bits.TargetOfTargetIsPlayerOrPet}");
+                    Log($"Add on pull! Combat={playerReader.Bits.PlayerInCombat()}, Targets me={playerReader.Bits.TargetOfTargetIsPlayerOrPet()}");
 
                     stopMoving.Stop();
                     if (combatUtil.AquiredTarget(5000))
@@ -148,8 +148,8 @@ namespace Core.Goals
         }
 
         protected bool HasPickedUpAnAdd =>
-            playerReader.Bits.PlayerInCombat &&
-            !playerReader.Bits.TargetInCombat;
+            playerReader.Bits.PlayerInCombat() &&
+            !playerReader.Bits.TargetInCombat();
 
         protected void WaitForWithinMeleeRange(KeyAction item, bool lastCastSuccess)
         {
@@ -157,20 +157,20 @@ namespace Core.Goals
             wait.Update();
 
             var start = DateTime.UtcNow;
-            var lastKnownHealth = playerReader.HealthCurrent;
+            var lastKnownHealth = playerReader.HealthCurrent();
             double maxWaitTimeMs = 10_000;
 
             Log($"Waiting for the target to reach melee range - max {maxWaitTimeMs}ms");
 
-            while (playerReader.HasTarget && !playerReader.IsInMeleeRange && (DateTime.UtcNow - start).TotalMilliseconds < maxWaitTimeMs)
+            while (playerReader.Bits.HasTarget() && !playerReader.IsInMeleeRange() && (DateTime.UtcNow - start).TotalMilliseconds < maxWaitTimeMs)
             {
-                if (playerReader.HealthCurrent < lastKnownHealth)
+                if (playerReader.HealthCurrent() < lastKnownHealth)
                 {
                     Log("Got damage. Stop waiting for melee range.");
                     break;
                 }
 
-                if (playerReader.IsTargetCasting)
+                if (playerReader.IsTargetCasting())
                 {
                     Log("Target started casting. Stop waiting for melee range.");
                     break;
@@ -189,7 +189,7 @@ namespace Core.Goals
 
         public bool Pull()
         {
-            if (playerReader.Bits.HasPet && !playerReader.PetHasTarget)
+            if (playerReader.Bits.HasPet() && !playerReader.PetHasTarget)
             {
                 if (input.ClassConfig.PetAttack.GetCooldownRemaining() == 0)
                     input.PetAttack();
@@ -209,7 +209,7 @@ namespace Core.Goals
                 bool success = castingHandler.Cast(item, PullPrevention);
                 if (success)
                 {
-                    if (!playerReader.HasTarget)
+                    if (!playerReader.Bits.HasTarget())
                     {
                         return false;
                     }
@@ -222,10 +222,10 @@ namespace Core.Goals
                     }
                 }
                 else if (PullPrevention() &&
-                    (playerReader.IsCasting ||
-                     playerReader.Bits.IsAutoRepeatSpellOn_AutoAttack ||
-                     playerReader.Bits.IsAutoRepeatSpellOn_AutoShot ||
-                     playerReader.Bits.IsAutoRepeatSpellOn_Shoot))
+                    (playerReader.IsCasting() ||
+                     playerReader.Bits.SpellOn_AutoAttack() ||
+                     playerReader.Bits.SpellOn_AutoShot() ||
+                     playerReader.Bits.SpellOn_Shoot()))
                 {
                     Log("Preventing pulling possible tagged target!");
                     input.StopAttack();
@@ -244,7 +244,7 @@ namespace Core.Goals
                 }
             }
 
-            return playerReader.Bits.PlayerInCombat;
+            return playerReader.Bits.PlayerInCombat();
         }
 
         private void DefaultApproach()
@@ -286,8 +286,8 @@ namespace Core.Goals
                         TargetTargetEnum.Me or
                         TargetTargetEnum.Pet or
                         TargetTargetEnum.PartyOrPet ||
-                        addonReader.CreatureHistory.CombatDamageDoneGuid.ElapsedMs < CastingHandler.GCD ||
-                        playerReader.IsInMeleeRange;
+                        addonReader.CreatureHistory.CombatDamageDoneGuid.ElapsedMs() < CastingHandler.GCD ||
+                        playerReader.IsInMeleeRange();
         }
 
         private bool PullPrevention()
@@ -302,7 +302,7 @@ namespace Core.Goals
 
         private bool IsInMeleeRange()
         {
-            return playerReader.IsInMeleeRange;
+            return playerReader.IsInMeleeRange();
         }
 
         private void Log(string text)

--- a/Core/Goals/SkinningGoal.cs
+++ b/Core/Goals/SkinningGoal.cs
@@ -109,7 +109,7 @@ namespace Core.Goals
                     }
 
                     // wait until start casting
-                    wait.Till(500, StartsCasting);
+                    wait.Till(500, playerReader.IsCasting);
                     Log("Started casting...");
 
                     playerReader.LastUIError = UI_ERROR.NONE;
@@ -164,7 +164,7 @@ namespace Core.Goals
 
             SendActionEvent(new ActionEventArgs(GoapKey.shouldskin, false));
 
-            if (playerReader.HasTarget && playerReader.Bits.TargetIsDead)
+            if (playerReader.Bits.HasTarget() && playerReader.Bits.TargetIsDead())
             {
                 input.ClearTarget();
                 wait.Update();
@@ -200,14 +200,9 @@ namespace Core.Goals
             return lastLoot != playerReader.LastLootTime;
         }
 
-        private bool StartsCasting()
-        {
-            return playerReader.IsCasting;
-        }
-
         private bool CastFinishedOrInterrupted()
         {
-            return !playerReader.IsCasting || playerReader.LastUIError != UI_ERROR.NONE;
+            return !playerReader.IsCasting() || playerReader.LastUIError != UI_ERROR.NONE;
         }
 
         private void Log(string text)

--- a/Core/Goals/TargetFinder.cs
+++ b/Core/Goals/TargetFinder.cs
@@ -37,7 +37,7 @@ namespace Core.Goals
                 input.NearestTarget();
             }
 
-            if (!cts.IsCancellationRequested && !classConfig.KeyboardOnly && !playerReader.HasTarget)
+            if (!cts.IsCancellationRequested && !classConfig.KeyboardOnly && !playerReader.Bits.HasTarget())
             {
                 npcNameTargeting.ChangeNpcType(target);
                 if (!cts.IsCancellationRequested && npcNameTargeting.NpcCount > 0)
@@ -46,7 +46,7 @@ namespace Core.Goals
                 }
             }
 
-            return playerReader.HasTarget;
+            return playerReader.Bits.HasTarget();
         }
 
     }

--- a/Core/Goals/TargetPetTarget.cs
+++ b/Core/Goals/TargetPetTarget.cs
@@ -25,7 +25,7 @@ namespace Core.Goals
         {
             input.TargetPet();
             input.TargetOfTarget();
-            if (playerReader.HasTarget && (playerReader.Bits.TargetIsDead || playerReader.TargetGuid == playerReader.PetGuid))
+            if (playerReader.Bits.HasTarget() && (playerReader.Bits.TargetIsDead() || playerReader.TargetGuid == playerReader.PetGuid))
             {
                 input.ClearTarget();
             }

--- a/Core/Goals/Wait.cs
+++ b/Core/Goals/Wait.cs
@@ -52,6 +52,23 @@ namespace Core
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public (bool timeout, double elapsedMs) UntilNot(int timeoutMs, Func<bool> interrupt, Action? repeat = null)
+        {
+            DateTime start = DateTime.UtcNow;
+            double elapsedMs;
+            while ((elapsedMs = (DateTime.UtcNow - start).TotalMilliseconds) < timeoutMs)
+            {
+                repeat?.Invoke();
+                if (!interrupt())
+                    return (false, elapsedMs);
+
+                Update();
+            }
+
+            return (true, elapsedMs);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void While(Func<bool> condition)
         {
             while (condition())

--- a/Core/Goals/WaitForGathering.cs
+++ b/Core/Goals/WaitForGathering.cs
@@ -64,7 +64,7 @@ namespace Core.Goals
             stopMoving.Stop();
             wait.Update();
 
-            while (playerReader.Bits.IsFalling)
+            while (playerReader.Bits.IsFalling())
             {
                 wait.Update();
             }
@@ -91,7 +91,7 @@ namespace Core.Goals
                     CheckCastStarted(false);
                     break;
                 case CastState.Casting:
-                    if (!playerReader.IsCasting)
+                    if (!playerReader.IsCasting())
                     {
                         wait.Update();
                         if (playerReader.LastUIError == UI_ERROR.ERR_SPELL_FAILED_S)
@@ -141,7 +141,7 @@ namespace Core.Goals
 
         private void CheckCastStarted(bool restartTimer)
         {
-            if (playerReader.IsCasting &&
+            if (playerReader.IsCasting() &&
                 (herbSpells.Contains(playerReader.CastSpellId.Value) ||
                 miningSpells.Contains(playerReader.CastSpellId.Value)))
             {
@@ -157,7 +157,7 @@ namespace Core.Goals
                 }
             }
 
-            if (playerReader.Bits.IsFalling)
+            if (playerReader.Bits.IsFalling())
             {
                 state = CastState.Abort;
                 LogState(logger, state);

--- a/Core/Goals/WalkToCorpseGoal.cs
+++ b/Core/Goals/WalkToCorpseGoal.cs
@@ -100,7 +100,7 @@ namespace Core.Goals
 
         public override void PerformAction()
         {
-            if (!playerReader.Bits.IsCorpseInRange)
+            if (!playerReader.Bits.IsCorpseInRange())
             {
                 navigation.Update();
             }

--- a/Core/Gossip/GossipReader.cs
+++ b/Core/Gossip/GossipReader.cs
@@ -15,16 +15,18 @@ namespace Core
 
         public bool Ready => Gossips.Count == Count;
 
-        public bool GossipStart => data == 69;
-        public bool GossipEnd => data == 9999994;
+        public bool GossipStart() => data == 69;
+        public bool GossipEnd() => data == 9999994;
 
-        public bool MerchantWindowOpened => data == 9999999;
+        public bool MerchantWindowOpened() => data == 9999999;
 
-        public bool MerchantWindowClosed => data == 9999998;
+        public bool MerchantWindowClosed() => data == 9999998;
 
-        public bool MerchantWindowSelling => data == 9999997;
+        public bool MerchantWindowSelling() => data == 9999997;
 
-        public bool MerchantWindowSellingFinished => data == 9999996;
+        public bool MerchantWindowSellingFinished() => data == 9999996;
+
+        public bool GossipStartOrMerchantWindowOpened() => GossipStart() || MerchantWindowOpened();
 
         public GossipReader(AddonDataProvider reader, int cGossip)
         {
@@ -37,10 +39,14 @@ namespace Core
             data = reader.GetInt(cGossip);
 
             // used for merchant window open state
-            if (MerchantWindowClosed || MerchantWindowOpened || MerchantWindowSelling || MerchantWindowSellingFinished || GossipEnd)
+            if (MerchantWindowClosed() ||
+                MerchantWindowOpened() ||
+                MerchantWindowSelling() ||
+                MerchantWindowSellingFinished() ||
+                GossipEnd())
                 return;
 
-            if (data == 0 || GossipStart)
+            if (data == 0 || GossipStart())
             {
                 Count = 0;
                 Gossips.Clear();

--- a/Core/Path/StuckDetector.cs
+++ b/Core/Path/StuckDetector.cs
@@ -66,7 +66,7 @@ namespace Core
 
         public void Update()
         {
-            if (playerReader.Bits.IsFalling)
+            if (playerReader.Bits.IsFalling())
                 return;
 
             if (debug)

--- a/Core/Requirement/RequirementFactory.cs
+++ b/Core/Requirement/RequirementFactory.cs
@@ -53,7 +53,7 @@ namespace Core
 
             this.keyActions = new KeyActions();
 
-            requirementMap = new Dictionary<string, Func<string, Requirement>>()
+            requirementMap = new()
             {
                 { ">=", CreateGreaterOrEquals },
                 { "<=", CreateLesserOrEquals },
@@ -72,10 +72,7 @@ namespace Core
                 { "Usable:", CreateUsable }
             };
 
-            bool FrostArmor() => playerReader.Buffs.FrostArmor;
-            bool Curseof() => playerReader.TargetDebuffs.Curseof;
-
-            boolVariables = new Dictionary<string, Func<bool>>
+            boolVariables = new()
             {
                 // Target Based
                 { "TargetYieldXP", () => playerReader.TargetYieldXP },
@@ -86,59 +83,59 @@ namespace Core
                 { AddVisible, () => npcNameFinder.PotentialAddsExist },
 
                 // Range
-                { "InMeleeRange", () => playerReader.IsInMeleeRange },
-                { "InDeadZoneRange", () => playerReader.IsInDeadZone },
-                { "OutOfCombatRange", () => !playerReader.WithInCombatRange },
-                { "InCombatRange", () => playerReader.WithInCombatRange },
+                { "InMeleeRange", playerReader.IsInMeleeRange },
+                { "InDeadZoneRange", playerReader.IsInDeadZone },
+                { "OutOfCombatRange", () => !playerReader.WithInCombatRange() },
+                { "InCombatRange", playerReader.WithInCombatRange },
                 
                 // Pet
-                { "Has Pet", () => playerReader.Bits.HasPet },
-                { "Pet Happy", () => playerReader.Bits.PetHappy },
+                { "Has Pet", playerReader.Bits.HasPet },
+                { "Pet Happy", playerReader.Bits.PetHappy },
                 
                 // Auto Spell
-                { "AutoAttacking", () => playerReader.Bits.IsAutoRepeatSpellOn_AutoAttack },
-                { "Shooting", () => playerReader.Bits.IsAutoRepeatSpellOn_Shoot },
-                { "AutoShot", () => playerReader.Bits.IsAutoRepeatSpellOn_AutoShot },
+                { "AutoAttacking", playerReader.Bits.SpellOn_AutoAttack },
+                { "Shooting", playerReader.Bits.SpellOn_Shoot },
+                { "AutoShot", playerReader.Bits.SpellOn_AutoShot },
                 
                 // Temporary Enchants
-                { "HasMainHandEnchant", () => playerReader.Bits.MainHandEnchant_Active },
-                { "HasOffHandEnchant", () => playerReader.Bits.OffHandEnchant_Active },
+                { "HasMainHandEnchant", playerReader.Bits.MainHandEnchant_Active },
+                { "HasOffHandEnchant", playerReader.Bits.OffHandEnchant_Active },
                 
                 // Equipment - Bag
-                { "Items Broken", () => playerReader.Bits.ItemsAreBroken },
+                { "Items Broken", playerReader.Bits.ItemsAreBroken },
                 { "BagFull", () => bagReader.BagsFull },
                 { "BagGreyItem", () => bagReader.AnyGreyItem },
                 { "HasRangedWeapon", () => equipmentReader.HasRanged() },
-                { "HasAmmo", () => playerReader.Bits.HasAmmo },
+                { "HasAmmo", playerReader.Bits.HasAmmo },
 
-                { "Casting", () => playerReader.IsCasting },
+                { "Casting", playerReader.IsCasting },
 
                 // General Buff Condition
-                { "Eating", () => playerReader.Buffs.Eating },
-                { "Drinking", () => playerReader.Buffs.Drinking },
-                { "Mana Regeneration", () => playerReader.Buffs.ManaRegeneration },
-                { "Well Fed", () => playerReader.Buffs.WellFed },
-                { "Clearcasting", () => playerReader.Buffs.Clearcasting },
+                { "Eating", playerReader.Buffs.Food },
+                { "Drinking", playerReader.Buffs.Drink },
+                { "Mana Regeneration", playerReader.Buffs.Mana_Regeneration },
+                { "Well Fed", playerReader.Buffs.Well_Fed },
+                { "Clearcasting", playerReader.Buffs.Clearcasting },
 
                 // Player Affected
-                { "Swimming", () => playerReader.Bits.IsSwimming },
-                { "Falling", () => playerReader.Bits.IsFalling },
+                { "Swimming", playerReader.Bits.IsSwimming },
+                { "Falling", playerReader.Bits.IsFalling },
 
                 //Priest
-                { "Fortitude", () => playerReader.Buffs.Fortitude },
-                { "InnerFire", () => playerReader.Buffs.InnerFire },
-                { "Divine Spirit", () => playerReader.Buffs.DivineSpirit },
-                { "Renew", () => playerReader.Buffs.Renew },
-                { "Shield", () => playerReader.Buffs.Shield },
+                { "Fortitude", playerReader.Buffs.Fortitude },
+                { "InnerFire", playerReader.Buffs.InnerFire },
+                { "Divine Spirit", playerReader.Buffs.DivineSpirit },
+                { "Renew", playerReader.Buffs.Renew },
+                { "Shield", playerReader.Buffs.Shield },
 
                 // Druid
-                { "Mark of the Wild", () => playerReader.Buffs.MarkOfTheWild },
-                { "Thorns", () => playerReader.Buffs.Thorns },
-                { "TigersFury", () => playerReader.Buffs.TigersFury },
-                { "Prowl", () => playerReader.Buffs.Prowl },
-                { "Rejuvenation", () => playerReader.Buffs.Rejuvenation },
-                { "Regrowth", () => playerReader.Buffs.Regrowth },
-                { "Omen of Clarity", () => playerReader.Buffs.OmenOfClarity },
+                { "Mark of the Wild", playerReader.Buffs.MarkOfTheWild },
+                { "Thorns", playerReader.Buffs.Thorns },
+                { "TigersFury", playerReader.Buffs.TigersFury },
+                { "Prowl", playerReader.Buffs.Prowl },
+                { "Rejuvenation", playerReader.Buffs.Rejuvenation },
+                { "Regrowth", playerReader.Buffs.Regrowth },
+                { "Omen of Clarity", playerReader.Buffs.OmenOfClarity },
 
                 // Paladin
                 { "Concentration Aura", () => playerReader.Form is Form.Paladin_Concentration_Aura },
@@ -149,136 +146,135 @@ namespace Core
                 { "Frost Resistance Aura", () => playerReader.Form is Form.Paladin_Frost_Resistance_Aura },
                 { "Retribution Aura", () => playerReader.Form is Form.Paladin_Retribution_Aura },
                 { "Shadow Resistance Aura", () => playerReader.Form is Form.Paladin_Shadow_Resistance_Aura },
-                { "Seal of Righteousness", () => playerReader.Buffs.SealofRighteousness },
-                { "Seal of the Crusader", () => playerReader.Buffs.SealoftheCrusader },
-                { "Seal of Command", () => playerReader.Buffs.SealofCommand },
-                { "Seal of Wisdom", () => playerReader.Buffs.SealofWisdom },
-                { "Seal of Light", () => playerReader.Buffs.SealofLight },
-                { "Seal of Blood", () => playerReader.Buffs.SealofBlood },
-                { "Seal of Vengeance", () => playerReader.Buffs.SealofVengeance },
-                { "Blessing of Might", () => playerReader.Buffs.BlessingofMight },
-                { "Blessing of Protection", () => playerReader.Buffs.BlessingofProtection },
-                { "Blessing of Wisdom", () => playerReader.Buffs.BlessingofWisdom },
-                { "Blessing of Kings", () => playerReader.Buffs.BlessingofKings },
-                { "Blessing of Salvation", () => playerReader.Buffs.BlessingofSalvation },
-                { "Blessing of Sanctuary", () => playerReader.Buffs.BlessingofSanctuary },
-                { "Blessing of Light", () => playerReader.Buffs.BlessingofLight },
-                { "Righteous Fury", () => playerReader.Buffs.RighteousFury },
-                { "Divine Protection", () => playerReader.Buffs.DivineProtection },
-                { "Avenging Wrath", () => playerReader.Buffs.AvengingWrath },
-                { "Holy Shield", () => playerReader.Buffs.HolyShield },
+
+                { "Seal of Righteousness", playerReader.Buffs.SealofRighteousness },
+                { "Seal of the Crusader", playerReader.Buffs.SealoftheCrusader },
+                { "Seal of Command", playerReader.Buffs.SealofCommand },
+                { "Seal of Wisdom", playerReader.Buffs.SealofWisdom },
+                { "Seal of Light", playerReader.Buffs.SealofLight },
+                { "Seal of Blood", playerReader.Buffs.SealofBlood },
+                { "Seal of Vengeance", playerReader.Buffs.SealofVengeance },
+                { "Blessing of Might", playerReader.Buffs.BlessingofMight },
+                { "Blessing of Protection", playerReader.Buffs.BlessingofProtection },
+                { "Blessing of Wisdom", playerReader.Buffs.BlessingofWisdom },
+                { "Blessing of Kings", playerReader.Buffs.BlessingofKings },
+                { "Blessing of Salvation", playerReader.Buffs.BlessingofSalvation },
+                { "Blessing of Sanctuary", playerReader.Buffs.BlessingofSanctuary },
+                { "Blessing of Light", playerReader.Buffs.BlessingofLight },
+                { "Righteous Fury", playerReader.Buffs.RighteousFury },
+                { "Divine Protection", playerReader.Buffs.DivineProtection },
+                { "Avenging Wrath", playerReader.Buffs.AvengingWrath },
+                { "Holy Shield", playerReader.Buffs.HolyShield },
 
                 // Mage
-                { "Frost Armor", FrostArmor },
-                { "Ice Armor", FrostArmor },
-                { "Molten Armor", FrostArmor },
-                { "Mage Armor", FrostArmor },
-                { "Arcane Intellect", () => playerReader.Buffs.ArcaneIntellect },
-                { "Ice Barrier", () => playerReader.Buffs.IceBarrier },
-                { "Ward", () => playerReader.Buffs.Ward },
-                { "Fire Power", () => playerReader.Buffs.FirePower },
-                { "Mana Shield", () => playerReader.Buffs.ManaShield },
-                { "Presence of Mind", () => playerReader.Buffs.PresenceOfMind },
-                { "Arcane Power", () => playerReader.Buffs.ArcanePower },
+                { "Frost Armor", playerReader.Buffs.FrostArmor },
+                { "Ice Armor", playerReader.Buffs.FrostArmor },
+                { "Molten Armor", playerReader.Buffs.FrostArmor },
+                { "Mage Armor", playerReader.Buffs.FrostArmor },
+                { "Arcane Intellect", playerReader.Buffs.ArcaneIntellect },
+                { "Ice Barrier", playerReader.Buffs.IceBarrier },
+                { "Ward", playerReader.Buffs.Ward },
+                { "Fire Power", playerReader.Buffs.FirePower },
+                { "Mana Shield", playerReader.Buffs.ManaShield },
+                { "Presence of Mind", playerReader.Buffs.PresenceOfMind },
+                { "Arcane Power", playerReader.Buffs.ArcanePower },
                 
                 // Rogue
-                { "Slice and Dice", () => playerReader.Buffs.SliceAndDice },
-                { "Stealth", () => playerReader.Buffs.Stealth },
+                { "Slice and Dice", playerReader.Buffs.SliceAndDice },
+                { "Stealth", playerReader.Buffs.Stealth },
                 
                 // Warrior
-                { "Battle Shout", () => playerReader.Buffs.BattleShout },
-                { "Bloodrage", () => playerReader.Buffs.Bloodrage },
+                { "Battle Shout", playerReader.Buffs.BattleShout },
+                { "Bloodrage", playerReader.Buffs.Bloodrage },
                 
                 // Warlock
-                { "Demon Skin", () => playerReader.Buffs.Demon },
-                { "Demon Armor", () => playerReader.Buffs.Demon },
-                { "Soul Link", () => playerReader.Buffs.SoulLink },
-                { "Soulstone Resurrection", () => playerReader.Buffs.SoulstoneResurrection },
-                { "Shadow Trance", () => playerReader.Buffs.ShadowTrance },
-                { "Fel Armor", () => playerReader.Buffs.FelArmor },
-                { "Fel Domination", () => playerReader.Buffs.FelDomination },
-                { "Demonic Sacrifice", () => playerReader.Buffs.DemonicSacrifice },
+                { "Demon Skin", playerReader.Buffs.Demon },
+                { "Demon Armor", playerReader.Buffs.Demon },
+                { "Soul Link", playerReader.Buffs.SoulLink },
+                { "Soulstone Resurrection", playerReader.Buffs.SoulstoneResurrection },
+                { "Shadow Trance", playerReader.Buffs.ShadowTrance },
+                { "Fel Armor", playerReader.Buffs.FelArmor },
+                { "Fel Domination", playerReader.Buffs.FelDomination },
+                { "Demonic Sacrifice", playerReader.Buffs.DemonicSacrifice },
                 
                 // Shaman
-                { "Lightning Shield", () => playerReader.Buffs.LightningShield },
-                { "Water Shield", () => playerReader.Buffs.WaterShield },
-                { "Shamanistic Focus", () => playerReader.Buffs.ShamanisticFocus },
-                { "Focused", () => playerReader.Buffs.ShamanisticFocus },
-                { "Stoneskin", () => playerReader.Buffs.Stoneskin },
+                { "Lightning Shield", playerReader.Buffs.LightningShield },
+                { "Water Shield", playerReader.Buffs.WaterShield },
+                { "Shamanistic Focus", playerReader.Buffs.ShamanisticFocus },
+                { "Focused", playerReader.Buffs.ShamanisticFocus },
+                { "Stoneskin", playerReader.Buffs.Stoneskin },
                 
                 //Hunter
-                { "Aspect of the Cheetah", () => playerReader.Buffs.AspectoftheCheetah },
-                { "Aspect of the Pack", () => playerReader.Buffs.AspectofthePack },
-                { "Aspect of the Hawk", () => playerReader.Buffs.AspectoftheHawk },
-                { "Aspect of the Monkey", () => playerReader.Buffs.AspectoftheMonkey },
-                { "Aspect of the Viper", () => playerReader.Buffs.AspectoftheViper },
-                { "Rapid Fire", () => playerReader.Buffs.RapidFire },
-                { "Quick Shots", () => playerReader.Buffs.QuickShots },
+                { "Aspect of the Cheetah", playerReader.Buffs.AspectoftheCheetah },
+                { "Aspect of the Pack", playerReader.Buffs.AspectofthePack },
+                { "Aspect of the Hawk", playerReader.Buffs.AspectoftheHawk },
+                { "Aspect of the Monkey", playerReader.Buffs.AspectoftheMonkey },
+                { "Aspect of the Viper", playerReader.Buffs.AspectoftheViper },
+                { "Rapid Fire", playerReader.Buffs.RapidFire },
+                { "Quick Shots", playerReader.Buffs.QuickShots },
 
                 // Debuff Section
                 // Druid Debuff
-                { "Demoralizing Roar", () => playerReader.TargetDebuffs.Roar },
-                { "Faerie Fire", () => playerReader.TargetDebuffs.FaerieFire },
-                { "Rip", () => playerReader.TargetDebuffs.Rip },
-                { "Moonfire", () => playerReader.TargetDebuffs.Moonfire },
-                { "Entangling Roots", () => playerReader.TargetDebuffs.EntanglingRoots },
-                { "Rake", () => playerReader.TargetDebuffs.Rake },
+                { "Demoralizing Roar", playerReader.TargetDebuffs.Roar },
+                { "Faerie Fire", playerReader.TargetDebuffs.FaerieFire },
+                { "Rip", playerReader.TargetDebuffs.Rip },
+                { "Moonfire", playerReader.TargetDebuffs.Moonfire },
+                { "Entangling Roots", playerReader.TargetDebuffs.EntanglingRoots },
+                { "Rake", playerReader.TargetDebuffs.Rake },
                 
                 // Paladin Debuff
-                { "Judgement of the Crusader", () => playerReader.TargetDebuffs.JudgementoftheCrusader },
-                { "Hammer of Justice", () => playerReader.TargetDebuffs.HammerOfJustice },
+                { "Judgement of the Crusader", playerReader.TargetDebuffs.JudgementoftheCrusader },
+                { "Hammer of Justice", playerReader.TargetDebuffs.HammerOfJustice },
 
                 // Warrior Debuff
-                { "Rend", () => playerReader.TargetDebuffs.Rend },
-                { "Thunder Clap", () => playerReader.TargetDebuffs.ThunderClap },
-                { "Hamstring", () => playerReader.TargetDebuffs.Hamstring },
-                { "Charge Stun", () => playerReader.TargetDebuffs.ChargeStun },
+                { "Rend", playerReader.TargetDebuffs.Rend },
+                { "Thunder Clap", playerReader.TargetDebuffs.ThunderClap },
+                { "Hamstring", playerReader.TargetDebuffs.Hamstring },
+                { "Charge Stun", playerReader.TargetDebuffs.ChargeStun },
                 
                 // Priest Debuff
-                { "Shadow Word: Pain", () => playerReader.TargetDebuffs.ShadowWordPain },
+                { "Shadow Word: Pain", playerReader.TargetDebuffs.ShadowWordPain },
                 
                 // Mage Debuff
-                { "Frostbite", () => playerReader.TargetDebuffs.Frostbite },
-                { "Slow", () => playerReader.TargetDebuffs.Slow },
+                { "Frostbite", playerReader.TargetDebuffs.Frostbite },
+                { "Slow", playerReader.TargetDebuffs.Slow },
                 
                 // Warlock Debuff
-                { "Curse of Weakness", Curseof },
-                { "Curse of Elements", Curseof },
-                { "Curse of Recklessness", Curseof },
-                { "Curse of Shadow", Curseof },
-                { "Curse of Agony", Curseof },
-                { "Curse of", Curseof },
-                { "Corruption", () => playerReader.TargetDebuffs.Corruption },
-                { "Immolate", () => playerReader.TargetDebuffs.Immolate },
-                { "Siphon Life", () => playerReader.TargetDebuffs.SiphonLife },
+                { "Curse of Weakness", playerReader.TargetDebuffs.Curseof },
+                { "Curse of Elements", playerReader.TargetDebuffs.Curseof },
+                { "Curse of Recklessness", playerReader.TargetDebuffs.Curseof },
+                { "Curse of Shadow", playerReader.TargetDebuffs.Curseof },
+                { "Curse of Agony", playerReader.TargetDebuffs.Curseof },
+                { "Curse of", playerReader.TargetDebuffs.Curseof },
+                { "Corruption", playerReader.TargetDebuffs.Corruption },
+                { "Immolate", playerReader.TargetDebuffs.Immolate },
+                { "Siphon Life", playerReader.TargetDebuffs.SiphonLife },
                 
                 // Hunter Debuff
-                { "Serpent Sting", () => playerReader.TargetDebuffs.SerpentSting },
+                { "Serpent Sting", playerReader.TargetDebuffs.SerpentSting },
             };
-
-            int PTCurrent() => playerReader.PTCurrent;
 
             intVariables = new Dictionary<string, Func<int>>
             {
-                { "Health%", () => playerReader.HealthPercent },
-                { "TargetHealth%", () => playerReader.TargetHealthPercentage },
-                { "PetHealth%", () => playerReader.PetHealthPercentage },
-                { "Mana%", () => playerReader.ManaPercentage },
-                { "Mana", () => playerReader.ManaCurrent },
-                { "Energy", PTCurrent },
-                { "Rage", PTCurrent },
+                { "Health%", playerReader.HealthPercent },
+                { "TargetHealth%", playerReader.TargetHealthPercentage },
+                { "PetHealth%", playerReader.PetHealthPercentage },
+                { "Mana%", playerReader.ManaPercentage },
+                { "Mana", playerReader.ManaCurrent },
+                { "Energy", playerReader.PTCurrent },
+                { "Rage", playerReader.PTCurrent },
                 { "Combo Point", () => playerReader.ComboPoints },
                 { "BagCount", () => bagReader.BagItems.Count },
                 { "MobCount", () => addonReader.CombatCreatureCount },
-                { "MinRange", () => playerReader.MinRange },
-                { "MaxRange", () => playerReader.MaxRange },
-                { "LastAutoShotMs", () => playerReader.AutoShot.ElapsedMs },
-                { "LastMainHandMs", () => playerReader.MainHandSwing.ElapsedMs },
-                { "LastTargetDodgeMs", () => Math.Max(0, playerReader.LastTargetDodge.ElapsedMs) },
+                { "MinRange", playerReader.MinRange },
+                { "MaxRange", playerReader.MaxRange },
+                { "LastAutoShotMs", playerReader.AutoShot.ElapsedMs },
+                { "LastMainHandMs", playerReader.MainHandSwing.ElapsedMs },
+                { "LastTargetDodgeMs", () => Math.Max(0, playerReader.LastTargetDodge.ElapsedMs()) },
                 //"CD_{KeyAction.Name}
                 //"Cost_{KeyAction.Name}"
-                { "MainHandSpeed", () => playerReader.MainHandSpeedMs },
-                { "MainHandSwing", () => Math.Clamp(playerReader.MainHandSwing.ElapsedMs - playerReader.MainHandSpeedMs, -playerReader.MainHandSpeedMs, 0) }
+                { "MainHandSpeed", playerReader.MainHandSpeedMs },
+                { "MainHandSwing", () => Math.Clamp(playerReader.MainHandSwing.ElapsedMs() - playerReader.MainHandSpeedMs(), -playerReader.MainHandSpeedMs(), 0) }
             };
         }
 
@@ -408,7 +404,7 @@ namespace Core
         {
             if (item.UseWhenTargetIsCasting != null)
             {
-                bool f() => playerReader.IsTargetCasting == item.UseWhenTargetIsCasting.Value;
+                bool f() => playerReader.IsTargetCasting() == item.UseWhenTargetIsCasting.Value;
                 string l() => "Target casting";
                 itemRequirementObjects.Add(new Requirement
                 {
@@ -431,8 +427,8 @@ namespace Core
             switch (type)
             {
                 case PowerType.Mana:
-                    bool fmana() => playerReader.ManaCurrent >= keyAction.MinMana || playerReader.Buffs.Clearcasting;
-                    string smana() => $"{type} {playerReader.ManaCurrent} >= {keyAction.MinMana}";
+                    bool fmana() => playerReader.ManaCurrent() >= keyAction.MinMana || playerReader.Buffs.Clearcasting();
+                    string smana() => $"{type.ToStringF()} {playerReader.ManaCurrent()} >= {keyAction.MinMana}";
                     RequirementObjects.Add(new Requirement
                     {
                         HasRequirement = fmana,
@@ -441,8 +437,8 @@ namespace Core
                     });
                     break;
                 case PowerType.Rage:
-                    bool frage() => playerReader.PTCurrent >= keyAction.MinRage || playerReader.Buffs.Clearcasting;
-                    string srage() => $"{type} {playerReader.PTCurrent} >= {keyAction.MinRage}";
+                    bool frage() => playerReader.PTCurrent() >= keyAction.MinRage || playerReader.Buffs.Clearcasting();
+                    string srage() => $"{type.ToStringF()} {playerReader.PTCurrent()} >= {keyAction.MinRage}";
                     RequirementObjects.Add(new Requirement
                     {
                         HasRequirement = frage,
@@ -451,8 +447,8 @@ namespace Core
                     });
                     break;
                 case PowerType.Energy:
-                    bool fenergy() => playerReader.PTCurrent >= keyAction.MinEnergy || playerReader.Buffs.Clearcasting;
-                    string senergy() => $"{type} {playerReader.PTCurrent} >= {keyAction.MinEnergy}";
+                    bool fenergy() => playerReader.PTCurrent() >= keyAction.MinEnergy || playerReader.Buffs.Clearcasting();
+                    string senergy() => $"{type.ToStringF()} {playerReader.PTCurrent()} >= {keyAction.MinEnergy}";
                     RequirementObjects.Add(new Requirement
                     {
                         HasRequirement = fenergy,
@@ -524,7 +520,7 @@ namespace Core
             if (item.School != SchoolMask.None)
             {
                 bool f() => immunityBlacklist.TryGetValue(playerReader.TargetId, out var immuneAgaints) ? !immuneAgaints.Contains(item.School) : true;
-                string s() => item.School.ToString();
+                string s() => item.School.ToStringF();
                 RequirementObjects.Add(new Requirement
                 {
                     HasRequirement = f,
@@ -624,11 +620,10 @@ namespace Core
             }
             else
             {
-                bool f() => playerReader.IsTargetCasting;
                 string s() => "Target casting";
                 return new Requirement
                 {
-                    HasRequirement = f,
+                    HasRequirement = playerReader.IsTargetCasting,
                     LogMessage = s
                 };
             }
@@ -655,7 +650,7 @@ namespace Core
             var race = Enum.Parse<RaceEnum>(parts[1]);
 
             bool f() => playerReader.Race == race;
-            string s() => $"{playerReader.Race}";
+            string s() => playerReader.Race.ToStringF();
 
             return new Requirement
             {

--- a/Frontend/Pages/BotHeader.razor
+++ b/Frontend/Pages/BotHeader.razor
@@ -1,4 +1,6 @@
-﻿@inject IAddonReader addonReader
+﻿@using Core.GOAP
+
+@inject IAddonReader addonReader
 @inject IBotController botController
 
 @implements IDisposable
@@ -6,8 +8,8 @@
 <div class="card @(Hide ? "hide" : string.Empty)">
     <div class="card-header">
         Player <InitButton /> <ToggleButton Disable="@(botController.ClassConfig?.Mode == Mode.AttendedGather)" />
-        <span class="float-right badge @CombatBadge()">@Core.GOAP.GoapKeyDescription.ToString(Core.GOAP.GoapKey.incombat, PlayerInCombat)</span>
-        <span class="float-right">@playerReader.Race @playerReader.Class</span>
+        <span class="float-right badge @CombatBadge()">@GoapKey_Extension.ToStringF(GoapKey.incombat, PlayerInCombat)</span>
+        <span class="float-right">@playerReader.Race.ToStringF() @playerReader.Class.ToStringF()</span>
     </div>
     <div class="card-body p-0">
         <table class="table">
@@ -23,20 +25,20 @@
                     Time to level: @levelTracker.TimeToLevel<br />
                     at @levelTracker.PredictedLevelUpTime.ToString("HH:mm:ss")
                 </td>
-                <td>@playerReader.HealthCurrent (@playerReader.HealthPercent %)<br />@playerReader.PTCurrent (@playerReader.PTPercentage %)</td>
+                <td>@playerReader.HealthCurrent() (@playerReader.HealthPercent() %)<br />@playerReader.PTCurrent() (@playerReader.PTPercentage() %)</td>
 
                 <td>@addonReader.BagReader.BagItems.Count / @addonReader.BagReader.SlotCount</td>
                 <td>@addonReader.ActionBarCostReader.Count / @addonReader.SpellBookReader.Count / @addonReader.TalentReader.Count</td>
                 <td>
-                    @if (addonReader.PlayerReader.Bits.HasTarget)
+                    @if (addonReader.PlayerReader.Bits.HasTarget())
                     {
                         <a href="@($"{WApi.NpcId}{playerReader.TargetId}")" target="_blank">
                             <div>
                                 @addonReader.TargetName<br />
-                                (@playerReader.TargetLevel) @((int)playerReader.TargetHealthPercentage) %<br />
+                                (@playerReader.TargetLevel) @((int)playerReader.TargetHealthPercentage()) %<br />
                                 GUID: @playerReader.TargetGuid
 
-                                @if (!playerReader.Bits.TargetIsNormal)
+                                @if (!playerReader.Bits.TargetIsNormal())
                                 {
                                     <div>NOT NORMAL</div>
                                 }
@@ -83,7 +85,7 @@
     private PlayerReader playerReader => addonReader.PlayerReader;
     private LevelTracker levelTracker => addonReader.LevelTracker;
 
-    private bool PlayerInCombat => this.playerReader.Bits.PlayerInCombat;
+    private bool PlayerInCombat => this.playerReader.Bits.PlayerInCombat();
 
     private string CombatBadge()
     {

--- a/Frontend/Pages/FrameConfiguration.razor
+++ b/Frontend/Pages/FrameConfiguration.razor
@@ -168,8 +168,8 @@
     {
         if (frameConfigurator.ResolveClass() && frameConfigurator.AddonReader != null)
         {
-            playerClass = frameConfigurator.AddonReader.PlayerReader.Race.ToString()
-                + " " + frameConfigurator.AddonReader.PlayerReader.Class.ToString();
+            playerClass = frameConfigurator.AddonReader.PlayerReader.Race.ToStringF()
+                + " " + frameConfigurator.AddonReader.PlayerReader.Class.ToStringF();
         }
         else
         {

--- a/Frontend/Pages/GoalsComponent.razor
+++ b/Frontend/Pages/GoalsComponent.razor
@@ -5,7 +5,7 @@
 
 <div class="card" style="margin-top: 10px">
     <div class="card-header">
-        Goals -> @addonReader.PlayerReader.MinRange - @addonReader.PlayerReader.MaxRange
+        Goals -> @addonReader.PlayerReader.MinRange() - @addonReader.PlayerReader.MaxRange()
         | Expand <input type="checkbox" @bind="@Expand" />
         <ToggleButton Disable="@(botController.ClassConfig?.Mode == Mode.AttendedGather)" />
         <span class="float-right">

--- a/Frontend/Pages/GoapGoalView.razor
+++ b/Frontend/Pages/GoapGoalView.razor
@@ -8,7 +8,7 @@
     <td>
         @foreach (var item in this.goal.State)
         {
-            <span class="badge @Badge(item.Value)">@GoapKeyDescription.ToString(item.Key, this.goal.Preconditions.GetValueOrDefault(item.Key))</span>
+            <span class="badge @Badge(item.Value)">@item.Key.ToStringF(this.goal.Preconditions.GetValueOrDefault(item.Key))</span>
         }
         @if (this.goal.Keys.Count == 1)
         {

--- a/Frontend/Pages/RouteComponent.razor
+++ b/Frontend/Pages/RouteComponent.razor
@@ -29,7 +29,7 @@
                 </g>
                 <g class="group2">
                     @{
-                        var colour = addonReader.PlayerReader.Bits.PlayerInCombat ? "red" : "orange";
+                        var colour = addonReader.PlayerReader.Bits.PlayerInCombat() ? "red" : "orange";
                         if (botController.GoapAgent?.CurrentGoal is FollowRouteGoal)
                         {
                             colour = "blue";


### PR DESCRIPTION
Key Changes:
* Mentioned enums no longer allocate memory when using `ToString()` -> `ToStringF()`
* `RequirementFactory` be able to use function delegates directly without wrapping them.