### PR TITLE
Feature: HeadlessServer - Run without UI

### DIFF
--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -30,9 +30,12 @@
   <ItemGroup>
     <PackageReference Include="Cyotek.CircularBuffer" Version="1.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
+    <PackageReference Include="Serilog" Version="2.11.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+    <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
     <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
-    <PackageReference Include="TextCopy" Version="5.0.2" />
+    <PackageReference Include="TextCopy" Version="6.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CoreTests/CoreTests.csproj
+++ b/CoreTests/CoreTests.csproj
@@ -6,6 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+    <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" />
   </ItemGroup>
 

--- a/Frontend/Frontend.csproj
+++ b/Frontend/Frontend.csproj
@@ -18,7 +18,8 @@
   <ItemGroup>
     <PackageReference Include="BlazorTable" Version="1.17.0" />
     <PackageReference Include="MatBlazor" Version="2.8.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.6" />
+    <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Game/Game.csproj
+++ b/Game/Game.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GregsStack.InputSimulatorStandard" Version="1.3.3" />
+    <PackageReference Include="GregsStack.InputSimulatorStandard" Version="1.3.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HeadlessServer/HeadlessServer.cs
+++ b/HeadlessServer/HeadlessServer.cs
@@ -1,0 +1,64 @@
+﻿using CommandLine;
+using Core;
+using Microsoft.Extensions.Logging;
+
+namespace HeadlessServer
+{
+    public class HeadlessServer
+    {
+        private readonly ILogger logger;
+        private readonly IBotController botController;
+        private readonly IAddonReader addonReader;
+        private readonly ExecGameCommand exec;
+        private readonly AddonConfigurator addonConfigurator;
+        private readonly Wait wait;
+
+        public HeadlessServer(ILogger logger, IBotController botController,
+            IAddonReader addonReader, ExecGameCommand exec, AddonConfigurator addonConfigurator, Wait wait)
+        {
+            this.logger = logger;
+            this.botController = botController;
+            this.addonReader = addonReader;
+            this.exec = exec;
+            this.addonConfigurator = addonConfigurator;
+            this.wait = wait;
+        }
+
+        public void Run(ParserResult<Options> options)
+        {
+            logger.LogInformation($"Running {nameof(HeadlessServer)}!");
+
+            InitState();
+
+            botController.LoadClassProfile(options.Value.ClassConfig!);
+
+            botController.ToggleBotStatus();
+        }
+
+        private void InitState()
+        {
+            addonReader.FullReset();
+            exec.Run($"/{addonConfigurator.Config.CommandFlush}");
+
+            int actionbarCost;
+            int spellBook;
+
+            do
+            {
+                actionbarCost = addonReader.ActionBarCostReader.Count;
+                spellBook = addonReader.SpellBookReader.Count;
+
+                // corresponding cells changes at every 5th update 
+                for (int i = 0; i < 10; i++)
+                {
+                    wait.Update();
+                }
+
+            } while (actionbarCost != addonReader.ActionBarCostReader.Count ||
+            spellBook != addonReader.SpellBookReader.Count);
+
+            logger.LogInformation($"${nameof(addonReader.ActionBarCostReader)}: {actionbarCost} | ${nameof(addonReader.SpellBookReader)}: {spellBook}");
+        }
+
+    }
+}

--- a/HeadlessServer/HeadlessServer.csproj
+++ b/HeadlessServer/HeadlessServer.csproj
@@ -1,0 +1,41 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="addon_config.json" />
+    <None Remove="data_config.json" />
+    <None Remove="frame_config.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="addon_config.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="data_config.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="frame_config.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Core\Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/HeadlessServer/Program.cs
+++ b/HeadlessServer/Program.cs
@@ -1,0 +1,181 @@
+﻿using Core;
+using Core.Database;
+using Core.Session;
+using Game;
+using Microsoft.Extensions.DependencyInjection;
+using PPather;
+using Serilog;
+using Serilog.Events;
+using Serilog.Extensions.Logging;
+using CommandLine;
+
+namespace HeadlessServer
+{
+    public class Options
+    {
+        [Value(0, MetaName = "ClassConfig file", Required = true, HelpText = "ClassConfiguration file example: Warrior_1.json")]
+        public string? ClassConfig { get; set; }
+
+        [Option('m', "mode", Default = nameof(StartupConfigPathing.Types.Local), Required = false,
+            HelpText = $"PPather service: {nameof(StartupConfigPathing.Types.Local)} | {nameof(StartupConfigPathing.Types.RemoteV1)} | {nameof(StartupConfigPathing.Types.RemoteV3)}")]
+        public string? Mode { get; set; }
+
+        [Option("hostv1", Default = "localhost", Required = false, HelpText = $"PPather Remote V1 host")]
+        public string? Hostv1 { get; set; }
+
+        [Option("portv1", Default = 5001, Required = false, HelpText = $"PPather Remote V1 port")]
+        public int Portv1 { get; set; }
+
+        [Option("hostv3", Default = "127.0.0.1", Required = false, HelpText = $"PPather Remote V3 host")]
+        public string? Hostv3 { get; set; }
+
+        [Option("portv3", Default = 47111, Required = false, HelpText = $"PPather Remote V3 port")]
+        public int Portv3 { get; set; }
+    }
+
+    internal class Program
+    {
+        private static void Main(string[] args)
+        {
+            string logfile = "out.log";
+            var config = new LoggerConfiguration()
+                .MinimumLevel.Debug()
+                .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
+                .WriteTo.File(logfile, rollingInterval: RollingInterval.Day)
+                .WriteTo.Debug(outputTemplate: "[{Timestamp:HH:mm:ss:fff} {Level:u3}] {Message:lj}{NewLine}{Exception}")
+                .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss:fff} {Level:u3}] {Message:lj}{NewLine}{Exception}");
+
+            Log.Logger = config.CreateLogger();
+            Log.Logger.Debug("Main()");
+
+            ParserResult<Options> options = Parser.Default.ParseArguments<Options>(args).WithNotParsed(a =>
+            {
+                Log.Logger.Error("Missing Required command line argument!");
+            });
+
+            if (options.Tag == ParserResultType.NotParsed)
+            {
+                Console.ReadLine();
+                return;
+            }
+
+            if (!FrameConfig.Exists() || !AddonConfig.Exists())
+            {
+                Log.Logger.Error("Unable to run headless server as crucial configuration files missing!");
+                Log.Logger.Warning($"Please be sure, the following validated configuration files present next to the executable:");
+                Log.Logger.Warning($"* {DataConfigMeta.DefaultFileName}");
+                Log.Logger.Warning($"* {FrameConfigMeta.DefaultFilename}");
+                Log.Logger.Warning($"* {AddonConfigMeta.DefaultFileName}");
+                Console.ReadLine();
+                return;
+            }
+
+            while (WowProcess.Get() == null)
+            {
+                Log.Information("Unable to find the Wow process is it running ?");
+                Thread.Sleep(2000);
+            }
+
+            ServiceCollection services = new();
+            ConfigureServices(services, options);
+
+            services
+                .AddSingleton<HeadlessServer, HeadlessServer>()
+                .BuildServiceProvider()
+                .GetService<HeadlessServer>()?
+                .Run(options);
+
+            Console.ReadLine();
+        }
+
+        private static void ConfigureServices(IServiceCollection services, ParserResult<Options> options)
+        {
+            var logger = new SerilogLoggerProvider(Log.Logger).CreateLogger(nameof(Program));
+            services.AddSingleton(logger);
+
+            services.AddSingleton(DataConfig.Load());
+            services.AddSingleton<WowProcess>();
+            services.AddSingleton<WowScreen>();
+            services.AddSingleton<WowProcessInput>();
+            services.AddSingleton<ExecGameCommand>();
+            services.AddSingleton<AddonConfigurator>();
+
+            services.AddSingleton<MinimapNodeFinder>();
+
+            services.AddSingleton<IGrindSessionDAO, LocalGrindSessionDAO>();
+            services.AddSingleton<IPPather>(x => GetPather(logger, x.GetRequiredService<DataConfig>(), options));
+
+            services.AddSingleton<AutoResetEvent>(x => new(false));
+            services.AddSingleton<DataFrame[]>(x => FrameConfig.LoadFrames());
+            services.AddSingleton<AddonDataProvider>();
+            services.AddSingleton<Wait>();
+
+            services.AddSingleton<AreaDB>();
+            services.AddSingleton<WorldMapAreaDB>();
+            services.AddSingleton<ItemDB>();
+            services.AddSingleton<CreatureDB>();
+            services.AddSingleton<SpellDB>();
+            services.AddSingleton<TalentDB>();
+
+            services.AddSingleton<IAddonReader, AddonReader>();
+            services.AddSingleton<IBotController, BotController>();
+        }
+
+        private static IPPather GetPather(Microsoft.Extensions.Logging.ILogger logger, DataConfig dataConfig, ParserResult<Options> options)
+        {
+            StartupConfigPathing scp = new(options.Value.Mode!,
+                options.Value.Hostv1!, options.Value.Portv1,
+                options.Value.Hostv3!, options.Value.Portv3);
+
+            bool failed = false;
+
+            if (scp.Type == StartupConfigPathing.Types.RemoteV3)
+            {
+                RemotePathingAPIV3 api = new(logger, scp.hostv3, scp.portv3, new WorldMapAreaDB(dataConfig));
+                if (api.PingServer())
+                {
+                    Log.Information("++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
+                    Log.Debug($"Using {StartupConfigPathing.Types.RemoteV3}({api.GetType().Name}) {scp.hostv3}:{scp.portv3}");
+                    Log.Information("++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
+                    return api;
+                }
+                api.Dispose();
+                failed = true;
+            }
+
+            if (scp.Type == StartupConfigPathing.Types.RemoteV1 || failed)
+            {
+                RemotePathingAPI api = new(logger, scp.hostv1, scp.portv1);
+                var pingTask = Task.Run(api.PingServer);
+                pingTask.Wait();
+                if (pingTask.Result)
+                {
+                    Log.Information("++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
+
+                    if (scp.Type == StartupConfigPathing.Types.RemoteV3)
+                    {
+                        Log.Debug($"Unavailable {StartupConfigPathing.Types.RemoteV3} {scp.hostv3}:{scp.portv3} - Fallback to {StartupConfigPathing.Types.RemoteV1}");
+                    }
+
+                    Log.Debug($"Using {StartupConfigPathing.Types.RemoteV1}({api.GetType().Name}) {scp.hostv1}:{scp.portv1}");
+                    Log.Information("++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
+                    return api;
+                }
+
+                failed = true;
+            }
+
+            Log.Information("++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
+            if (scp.Type != StartupConfigPathing.Types.Local)
+            {
+                Log.Debug($"{scp.Type} not available!");
+            }
+            Log.Information("++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
+
+            LocalPathingApi localApi = new(logger, new PPatherService(logger, dataConfig), dataConfig);
+            Log.Information($"Using {StartupConfigPathing.Types.Local}({localApi.GetType().Name}) pathing API.");
+            Log.Information("++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
+            return localApi;
+        }
+    }
+}

--- a/HeadlessServer/Properties/launchSettings.json
+++ b/HeadlessServer/Properties/launchSettings.json
@@ -1,0 +1,7 @@
+{
+  "profiles": {
+    "HeadlessServer": {
+      "commandName": "Project"
+    }
+  }
+}

--- a/MasterOfPuppets.sln
+++ b/MasterOfPuppets.sln
@@ -29,6 +29,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PPather", "PPather\PPather.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Frontend", "Frontend\Frontend.csproj", "{A8281286-7AAA-4386-9919-6AB5BEA39BAF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HeadlessServer", "HeadlessServer\HeadlessServer.csproj", "{8364AC12-DBF5-4DFF-B3A2-87472413DE01}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -79,6 +81,10 @@ Global
 		{A8281286-7AAA-4386-9919-6AB5BEA39BAF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A8281286-7AAA-4386-9919-6AB5BEA39BAF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A8281286-7AAA-4386-9919-6AB5BEA39BAF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8364AC12-DBF5-4DFF-B3A2-87472413DE01}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8364AC12-DBF5-4DFF-B3A2-87472413DE01}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8364AC12-DBF5-4DFF-B3A2-87472413DE01}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8364AC12-DBF5-4DFF-B3A2-87472413DE01}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SharedLib/SharedLib.csproj
+++ b/SharedLib/SharedLib.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
At first started as a debugging tool for memory usage. Run the app without UI. Trims off a little bit of CPU and memory usage.

It has no `AddonConfig`, `FrameConfig` configuring capabilities, first have to run the `BlazorServer` and copy the

Configuration files
* `addon_config.json`
* `data_config.json`
* `frame_config.json`

to the `WowClassicGrindBot\HeadlessServer` project and build it **or** straight next to the executable.

Then run from command line ex. `HeadlessServer.exe Warrior_1.json`