### PR TITLE
Addon: [1.5.3] - Use GCD times from API. KeyAction `AfterCastWaitItem` and `DelayUntilCombat`

### DIFF
--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -568,8 +568,14 @@ function DataToColor:CreateFrames(n)
                 if actionCooldownKey then
                     DataToColor.actionBarCooldownQueue:setDirty(actionCooldownKey)
 
-                    --DataToColor:Print("actionBarCooldownQueue: "..actionCooldownKey.." "..floor(actionCooldownValue) * 100)
-                    Pixel(int, actionCooldownKey * 100000 + floor(actionCooldownValue) * 100, 37)
+                    -- have to add 1s because its excluded from total cooldown
+                    if actionCooldownValue > 0 then
+                        actionCooldownValue = actionCooldownValue + 1
+                    end
+                    local valueMs = (floor(actionCooldownValue) * 100)
+
+                    --DataToColor:Print("actionBarCooldownQueue: ", actionCooldownKey, " ", valueMs)
+                    Pixel(int, actionCooldownKey * 100000 + valueMs, 37)
 
                     if actionCooldownValue == 0 then
                         DataToColor.actionBarCooldownQueue:remove(actionCooldownKey)

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -3,7 +3,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors
-## Version: 1.5.2
+## Version: 1.5.3
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/EventHandlers.lua
+++ b/Addons/DataToColor/EventHandlers.lua
@@ -275,7 +275,6 @@ function DataToColor:OnCombatEvent(...)
                 end
 
                 local _, _, _, castTime = GetSpellInfo(spellId)
-
                 if castTime == nil then
                     castTime = 0
                 end
@@ -289,21 +288,16 @@ function DataToColor:OnCombatEvent(...)
                 end
 
                 if hasGCD then
-                    -- Rogue, Death Knight and Druid Cat have 1s gcd.
-                    if DataToColor.C.CHARACTER_CLASS_ID == 4 or
-                    DataToColor.C.CHARACTER_CLASS_ID == 6 or
-                    (DataToColor.C.CHARACTER_CLASS_ID == 11 and DataToColor:shapeshiftForm() == 3) then
-                        castTime = 1000
-                    elseif spellId == DataToColor.C.Spell.ShootId then
+                    if spellId == DataToColor.C.Spell.ShootId then
                         castTime = floor(UnitRangedDamage(DataToColor.C.unitPlayer) * 1000)
                     else
-                        castTime = 1500
+                        castTime = gcdMS
                     end
 
                     DataToColor.gcdExpirationTime = GetTime() + (castTime / 1000)
-                    --DataToColor:Print(subEvent, " ", spellId, " ", castTime)
+                    --DataToColor:Print(subEvent, " ", spellName, " ", spellId, " ", castTime)
                 else
-                    --DataToColor:Print(subEvent, " ", spellId)
+                    --DataToColor:Print(subEvent, " ", spellName, " ", spellId, " has no GCD")
                 end
             end
         end

--- a/Core/Bag/BagReader.cs
+++ b/Core/Bag/BagReader.cs
@@ -25,6 +25,8 @@ namespace Core
 
         public event Action? DataChanged;
 
+        public int Hash { private set; get; }
+
         private bool changedFromEvent;
 
         public BagReader(AddonDataProvider reader, ItemDB itemDb, EquipmentReader equipmentReader, int cbagMeta, int citemNumCount, int cItemId)
@@ -66,6 +68,11 @@ namespace Core
                 changedFromEvent = false;
                 DataChanged?.Invoke();
                 lastEvent = DateTime.UtcNow;
+
+                if (metaChanged || inventoryChanged)
+                {
+                    Hash++;
+                }
             }
         }
 

--- a/Core/ClassConfig/KeyAction.cs
+++ b/Core/ClassConfig/KeyAction.cs
@@ -49,6 +49,8 @@ namespace Core
 
         public bool AfterCastWaitBuff { get; set; }
 
+        public bool AfterCastWaitItem { get; set; }
+
         public bool AfterCastWaitNextSwing { get; set; }
 
         public bool DelayUntilCombat { get; set; }

--- a/Core/Goals/CombatGoal.cs
+++ b/Core/Goals/CombatGoal.cs
@@ -1,4 +1,4 @@
-﻿using Core.GOAP;
+using Core.GOAP;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Numerics;
@@ -132,9 +132,15 @@ namespace Core.Goals
                     input.PetAttack();
                 }
 
-                for (int i = 0; i < Keys.Length && !castingHandler.SpellInQueue(); i++)
+                for (int i = 0; i < Keys.Length; i++)
                 {
                     KeyAction keyAction = Keys[i];
+
+                    if (castingHandler.SpellInQueue() && !keyAction.SkipValidation)
+                    {
+                        continue;
+                    }
+
                     if (castingHandler.CastIfReady(keyAction))
                     {
                         break;

--- a/Core/Goals/LootGoal.cs
+++ b/Core/Goals/LootGoal.cs
@@ -1,4 +1,4 @@
-using Core.Database;
+﻿using Core.Database;
 using Core.GOAP;
 using SharedLib.NpcFinder;
 using Microsoft.Extensions.Logging;

--- a/Core/Goals/PullTargetGoal.cs
+++ b/Core/Goals/PullTargetGoal.cs
@@ -187,7 +187,7 @@ namespace Core.Goals
                 }
             }
 
-            if (!castAny && !spellInQueue)
+            if (!castAny && !spellInQueue && !playerReader.IsCasting())
             {
                 if (combatUtil.EnteredCombat())
                 {

--- a/Core/Goals/SkinningGoal.cs
+++ b/Core/Goals/SkinningGoal.cs
@@ -1,4 +1,4 @@
-using Core.GOAP;
+﻿using Core.GOAP;
 using SharedLib.NpcFinder;
 using Microsoft.Extensions.Logging;
 using System;

--- a/Core/GoalsComponent/CastingHandler.cs
+++ b/Core/GoalsComponent/CastingHandler.cs
@@ -123,7 +123,7 @@ namespace Core.Goals
                 return false;
 
             if (item.Log)
-                LogInstantUsableChange(logger, item.Name, beforeUsable, addonReader.UsableAction.Is(item), ((UI_ERROR)beforeCastEventValue).ToStringF(), ((UI_ERROR)playerReader.CastEvent.Value).ToStringF());
+                LogInstantUsableChange(logger, item.Name, beforeUsable, addonReader.UsableAction.Is(item), ((UI_ERROR)beforeCastEventValue).ToStringF(), ((UI_ERROR)playerReader.CastEvent.Value).ToStringF(), playerReader.GCD.Value);
 
             item.SetClicked();
 
@@ -133,6 +133,9 @@ namespace Core.Goals
                 return false;
             }
 
+            (bool gcdTimeout, double elapsedMs) = wait.Until(playerReader.NetworkLatency.Value, () => playerReader.GCD.Value != 0);
+            logger.LogInformation($"Instant - has GCD ? {!gcdTimeout} | {playerReader.GCD.Value}ms | {elapsedMs}ms");
+
             return true;
         }
 
@@ -140,13 +143,11 @@ namespace Core.Goals
         {
             wait.While(bits.IsFalling);
 
-            if (playerReader.IsCasting() && interrupt())
+            if (!playerReader.IsCasting())
             {
-                return false;
+                stopMoving.Stop();
+                wait.Update();
             }
-
-            stopMoving.Stop();
-            wait.Update();
 
             bool prevState = interrupt();
 
@@ -170,7 +171,8 @@ namespace Core.Goals
                 interrupt: () =>
                 beforeCastEventValue != playerReader.CastEvent.Value ||
                 beforeSpellId != playerReader.CastSpellId.Value ||
-                beforeCastCount != playerReader.CastCount
+                beforeCastCount != playerReader.CastCount ||
+                prevState != interrupt()
                 );
 
             if (item.Log)
@@ -250,6 +252,8 @@ namespace Core.Goals
 
         public bool Cast(KeyAction item, Func<bool> interrupt)
         {
+            DateTime begin = DateTime.UtcNow;
+
             if (item.HasFormRequirement() && playerReader.Form != item.FormEnum)
             {
                 bool beforeUsable = addonReader.UsableAction.Is(item);
@@ -284,14 +288,17 @@ namespace Core.Goals
                 input.StopAttack();
 
                 int waitTime = Math.Max(playerReader.GCD.Value, playerReader.RemainCastMs) + (2 * playerReader.NetworkLatency.Value);
-
-                logger.LogInformation($"Stop {nameof(bits.SpellOn_Shoot)} and GCD {waitTime}ms");
-
                 (bool gcdTimeout, double elapsedMs) = wait.Until(waitTime, () => prevState != interrupt());
+                logger.LogInformation($"Stop {nameof(bits.SpellOn_Shoot)} and wait {waitTime}ms | {elapsedMs}ms");
                 if (!gcdTimeout)
                 {
                     return false;
                 }
+            }
+
+            if (item.WaitForGCD && !WaitForGCD(item, interrupt))
+            {
+                return false;
             }
 
             if (item.DelayBeforeCast > 0)
@@ -340,45 +347,67 @@ namespace Core.Goals
 
             if (item.AfterCastWaitBuff)
             {
-                (bool changeTimeOut, double elapsedMs) = wait.Until(GCD, () => auraHash != playerReader.AuraCount.Hash);
+                // GCD means projectile travel time
+                int totalTime = Math.Max(playerReader.GCD.Value, playerReader.RemainCastMs) + 2 * SpellQueueTimeMs;
+
+                (bool changeTimeOut, double elapsedMs) = wait.Until(totalTime, () => auraHash != playerReader.AuraCount.Hash);
                 if (item.Log)
                     LogAfterCastWaitBuff(logger, item.Name, !changeTimeOut, playerReader.AuraCount.ToString(), elapsedMs);
             }
 
             if (item.DelayAfterCast != defaultKeyAction.DelayAfterCast)
             {
-                if (item.DelayUntilCombat) // stop waiting if the mob is targetting me
-                {
-                    if (item.Log)
-                        LogDelayUntilCombat(logger, item.Name, item.DelayAfterCast);
 
-                    wait.Until(item.DelayAfterCast, bits.TargetOfTargetIsPlayerOrPet);
-                }
-                else if (item.DelayAfterCast > 0)
-                {
-                    if (item.Log)
-                        LogDelayAfterCast(logger, item.Name, item.DelayAfterCast);
+            if (item.DelayUntilCombat) // stop waiting if the mob is targetting me
+            {
+                stopMoving.Stop();
+                (bool timeout, double elapsedMs) = wait.Until(2 * item.DelayAfterCast, bits.TargetOfTargetIsPlayerOrPet); // possible travel speed projectile
 
-                    (bool delayTimeOut, double delayElapsedMs) = wait.Until(item.DelayAfterCast, () => prevState != interrupt());
-                    if (item.Log)
+                if (item.Log)
+                    LogDelayUntilCombat(logger, item.Name, !timeout, elapsedMs);
+            }
+
+            if (item.DelayAfterCast != defaultKeyAction.DelayAfterCast && item.DelayAfterCast > 0)
+            {
+                if (item.Log)
+                    LogDelayAfterCast(logger, item.Name, item.DelayAfterCast);
+
+                (bool delayTimeOut, double delayElapsedMs) = wait.Until(item.DelayAfterCast, () => prevState != interrupt());
+                if (item.Log)
+                {
+                    if (!delayTimeOut)
                     {
-                        if (!delayTimeOut)
-                        {
-                            LogDelayAfterCastInterrupted(logger, item.Name, delayElapsedMs);
-                        }
+                        LogDelayAfterCastInterrupted(logger, item.Name, delayElapsedMs);
                     }
                 }
             }
 
-            if (item.StepBackAfterCast > 0)
+            if (item.StepBackAfterCast != 0)
             {
                 if (item.Log)
                     LogStepBackAfterCast(logger, item.Name, item.StepBackAfterCast);
 
                 input.Proc.SetKeyState(input.Proc.BackwardKey, true);
 
-                (bool stepbackTimeOut, double stepbackElapsedMs) =
-                    wait.Until(item.StepBackAfterCast, () => prevState != interrupt());
+                bool stepbackTimeOut = false;
+                double stepbackElapsedMs = 0;
+
+                if (Random.Shared.Next(3) == 0) // 33 %
+                    input.Jump();
+
+                if (item.StepBackAfterCast == -1)
+                {
+                    int waitAmount = playerReader.GCD.Value;
+                    if (waitAmount == 0)
+                    {
+                        waitAmount = MIN_GCD - SpellQueueTimeMs;
+                    }
+                    (stepbackTimeOut, stepbackElapsedMs) = wait.Until(waitAmount, () => prevState != interrupt());
+                }
+                else
+                {
+                    (stepbackTimeOut, stepbackElapsedMs) = wait.Until(item.StepBackAfterCast, () => prevState != interrupt());
+                }
 
                 if (item.Log)
                     LogStepBackAfterCastInterrupted(logger, item.Name, !stepbackTimeOut, stepbackElapsedMs);
@@ -386,7 +415,7 @@ namespace Core.Goals
                 input.Proc.SetKeyState(input.Proc.BackwardKey, false);
             }
 
-            UpdateSpellQueue(item);
+            UpdateSpellQueue(item, begin);
 
             item.ConsumeCharge();
             return true;
@@ -427,7 +456,7 @@ namespace Core.Goals
 
             PressKeyAction(classConfig.Form[index]);
 
-            (bool changedTimeOut, double elapsedMs) = wait.Until(SpellQueueTimeMs, () => playerReader.Form == item.FormEnum);
+            (bool changedTimeOut, double elapsedMs) = wait.Until(SpellQueueTimeMs + playerReader.NetworkLatency.Value, () => playerReader.Form == item.FormEnum);
             if (item.Log)
                 LogFormChanged(logger, item.Name, !changedTimeOut, beforeForm.ToStringF(), playerReader.Form.ToStringF(), elapsedMs);
 
@@ -436,26 +465,17 @@ namespace Core.Goals
             return playerReader.Form == item.FormEnum;
         }
 
-        private void UpdateSpellQueue(KeyAction item)
+        private void UpdateSpellQueue(KeyAction item, DateTime begin)
         {
-            if (item.WaitForGCD)
-            {
-                int duration;
+            int duration = Math.Max(playerReader.GCD.Value, playerReader.RemainCastMs)
+                - SpellQueueTimeMs
+                - (int)(DateTime.UtcNow - begin).TotalMilliseconds
+                + playerReader.NetworkLatency.Value; /* - (2 * playerReader.NetworkLatency.Value)*/;
 
-                if (item.HasCastBar)
-                    duration = Math.Max(playerReader.GCD.Value, playerReader.RemainCastMs);
-                else
-                    duration = MIN_GCD - SpellQueueTimeMs - (2 * playerReader.NetworkLatency.Value);
+            SpellQueueOpen = DateTime.UtcNow.AddMilliseconds(duration);
 
-                SpellQueueOpen = DateTime.UtcNow.AddMilliseconds(duration);
-
-                if (item.Log)
-                    logger.LogInformation($"[{item.Name}] GCD: {playerReader.GCD.Value}ms | castRem: {playerReader.RemainCastMs} | Next Spell can be queued after {duration}ms");
-
-                return;
-            }
-
-            SpellQueueOpen = default;
+            if (item.Log)
+                logger.LogInformation($"[{item.Name}] GCD: {playerReader.GCD.Value}ms | castRem: {playerReader.RemainCastMs} | Next Spell can be queued after {duration}ms");
         }
 
         private void ReactToLastCastingEvent(KeyAction item, string source)
@@ -495,6 +515,10 @@ namespace Core.Goals
 
                     break;
                 case UI_ERROR.ERR_SPELL_OUT_OF_RANGE:
+
+                    if (!playerReader.Bits.HasTarget())
+                        return;
+
                     if (playerReader.Class == PlayerClassEnum.Hunter && playerReader.IsInMeleeRange())
                     {
                         logger.LogInformation($"{source} -- As a Hunter didn't know how to react {value.ToStringF()}");
@@ -544,20 +568,44 @@ namespace Core.Goals
                     {
                         logger.LogInformation($"{source} -- React to {value.ToStringF()} -- Interact!");
                         input.Interact();
+                        stopMoving.Stop();
                     }
                     else
                     {
-                        logger.LogInformation($"{source} -- React to {value.ToStringF()} -- Turning 180!");
-
-                        float desiredDirection = playerReader.Direction + MathF.PI;
-                        desiredDirection = desiredDirection > MathF.PI * 2 ? desiredDirection - (MathF.PI * 2) : desiredDirection;
-                        direction.SetDirection(desiredDirection, Vector3.Zero);
+                        switch (playerReader.Class)
+                        {
+                            case PlayerClassEnum.None:
+                                break;
+                            case PlayerClassEnum.Monk:
+                            case PlayerClassEnum.DemonHunter:
+                            case PlayerClassEnum.Druid:
+                            case PlayerClassEnum.DeathKnight:
+                            case PlayerClassEnum.Warrior:
+                            case PlayerClassEnum.Paladin:
+                            case PlayerClassEnum.Rogue:
+                                logger.LogInformation($"{source} -- React to {value.ToStringF()} -- Interact!");
+                                input.Interact();
+                                stopMoving.Stop();
+                                break;
+                            case PlayerClassEnum.Hunter:
+                            case PlayerClassEnum.Priest:
+                            case PlayerClassEnum.Shaman:
+                            case PlayerClassEnum.Mage:
+                            case PlayerClassEnum.Warlock:
+                                stopMoving.Stop();
+                                logger.LogInformation($"{source} -- React to {value.ToStringF()} -- Turning 180!");
+                                float desiredDirection = playerReader.Direction + MathF.PI;
+                                desiredDirection = desiredDirection > MathF.PI * 2 ? desiredDirection - (MathF.PI * 2) : desiredDirection;
+                                direction.SetDirection(desiredDirection, Vector3.Zero);
+                                break;
+                        }
 
                         wait.Update();
                     }
                     break;
                 case UI_ERROR.SPELL_FAILED_MOVING:
                     logger.LogInformation($"{source} -- React to {value.ToStringF()} -- Stop moving!");
+                    wait.While(playerReader.Bits.IsFalling);
                     stopMoving.Stop();
                     wait.Update();
                     break;
@@ -627,8 +675,8 @@ namespace Core.Goals
         [LoggerMessage(
             EventId = 73,
             Level = LogLevel.Information,
-            Message = "[{name}] ... usable: {beforeUsable}->{afterUsable} -- {beforeCastEvent}->{afterCastEvent}")]
-        static partial void LogInstantUsableChange(ILogger logger, string name, bool beforeUsable, bool afterUsable, string beforeCastEvent, string afterCastEvent);
+            Message = "[{name}] ... usable: {beforeUsable}->{afterUsable} -- {beforeCastEvent}->{afterCastEvent} -- GCD: {gcd}")]
+        static partial void LogInstantUsableChange(ILogger logger, string name, bool beforeUsable, bool afterUsable, string beforeCastEvent, string afterCastEvent, int gcd);
 
         [LoggerMessage(
             EventId = 74,
@@ -694,9 +742,8 @@ namespace Core.Goals
         [LoggerMessage(
             EventId = 84,
             Level = LogLevel.Information,
-            Message = "[{name}] ... DelayUntilCombat ... DelayAfterCast {delayAfterCast}ms")]
-        static partial void LogDelayUntilCombat(ILogger logger, string name, int delayAfterCast);
-
+            Message = "[{name}] ... DelayUntilCombat ? {success} {delayAfterCast}ms")]
+        static partial void LogDelayUntilCombat(ILogger logger, string name, bool success, double delayAfterCast);
 
         [LoggerMessage(
             EventId = 85,
@@ -739,6 +786,12 @@ namespace Core.Goals
             Level = LogLevel.Information,
             Message = "[{name}] ... form changed: {changedTimeOut} | {before}->{after} | {elapsedMs}ms")]
         static partial void LogFormChanged(ILogger logger, string name, bool changedTimeOut, string before, string after, double elapsedMs);
+
+        [LoggerMessage(
+            EventId = 92,
+            Level = LogLevel.Information,
+            Message = "[{name}] ... AfterCastWaitItem ? {changeTimeOut} | {elapsedMs}ms")]
+        static partial void LogAfterCastWaitItem(ILogger logger, string name, bool changeTimeOut, double elapsedMs);
 
         #endregion
     }

--- a/HeadlessServer/HeadlessServer.cs
+++ b/HeadlessServer/HeadlessServer.cs
@@ -50,13 +50,11 @@ namespace HeadlessServer
 
             int actionbarCost;
             int spellBook;
-            int bagCount;
 
             do
             {
                 actionbarCost = addonReader.ActionBarCostReader.Count;
                 spellBook = addonReader.SpellBookReader.Count;
-                bagCount = addonReader.BagReader.BagItems.Count;
 
                 for (int i = 0; i < TICK_INTERVAL; i++)
                 {
@@ -65,10 +63,10 @@ namespace HeadlessServer
 
             } while (
                 actionbarCost != addonReader.ActionBarCostReader.Count ||
-                spellBook != addonReader.SpellBookReader.Count ||
-                bagCount != addonReader.BagReader.BagItems.Count);
+                spellBook != addonReader.SpellBookReader.Count);
 
-            logger.LogInformation($"{nameof(addonReader.ActionBarCostReader)}: {actionbarCost} | {nameof(addonReader.SpellBookReader)}: {spellBook} | {nameof(addonReader.BagReader)}: {bagCount}");
+            wait.Fixed(8000); // todo get a better way to figure out how to detect bag items obtained
+            logger.LogInformation($"{nameof(addonReader.ActionBarCostReader)}: {actionbarCost} | {nameof(addonReader.SpellBookReader)}: {spellBook} | {nameof(addonReader.BagReader)}: {addonReader.BagReader.BagItems.Count}");
         }
 
     }

--- a/Json/class/DeathKnight_80_Unholy.json
+++ b/Json/class/DeathKnight_80_Unholy.json
@@ -1,7 +1,8 @@
 {
   "ClassName": "DeatkKnight",
-  "Mode": "AttendedGrind", //Grind
+  //"Mode": "AttendedGrind", //Grind
   "Loot": true,
+  //"KeyboardOnly": true,
   "PathFilename": "_pack\\40-50\\The Hinterlands\\41-42 wolves.json", // todo update profile
   "PathReduceSteps": true,
   "PathThereAndBack": false,
@@ -40,16 +41,19 @@
           "!TargetCastingSpell",
           "!Frost Fever",
           "SpellInRange:0"
-        ]
+        ],
+        "AfterCastWaitBuff": true,
+        "DelayUntilCombat": true
       },
       {
         "Name": "Death Grip",
         "Key": "0",
         "WhenUsable": true,
         "Requirements": [
-          "MinRange > 20",
           "SpellInRange:2"
-        ]
+        ],
+        "DelayUntilCombat": true,
+        "WaitForWithinMeleeRange": true
       }
     ]
   },
@@ -59,18 +63,25 @@
         "Name": "Trinket 1",
         "Key": "N1",
         "WhenUsable": true,
-        "WaitForGCD": false
+        "Requirements": [
+          "InMeleeRange"
+        ],
+        "DelayAfterCast": 50
       },
       {
         "Name": "Trinket 2",
         "Key": "N2",
         "WhenUsable": true,
-        "WaitForGCD": false
+        "Requirements": [
+          "InMeleeRange"
+        ],
+        "DelayAfterCast": 50
       },
       {
         "Name": "Bone Shield",
         "Key": "N4",
         "WhenUsable": true,
+        "AfterCastWaitBuff": true,
         "Requirements": [
           "!Bone Shield"
         ]
@@ -79,7 +90,6 @@
         "Name": "Empower Rune Weapon",
         "Key": "N3",
         "WhenUsable": true,
-        "WaitForGCD": false,
         "Requirements": [
           "TotalRune == 0",
           "RunicPower <= 105",
@@ -90,7 +100,6 @@
         "Name": "Death Strike",
         "Key": "F5",
         "WhenUsable": true,
-        "WaitForGCD": false,
         "Requirements": [
           "Health% < 30"
         ]
@@ -125,6 +134,7 @@
         "Name": "Blood Strike",
         "Key": "3",
         "WhenUsable": true,
+        "Cooldown": 2000,
         "Requirements": [
           "MobCount < 2",
           "Frost Fever",
@@ -136,6 +146,7 @@
         "Name": "Scourge Strike",
         "Key": "2",
         "WhenUsable": true,
+        "Cooldown": 2000,
         "Requirements": [
           "MobCount < 2",
           "Frost Fever",

--- a/Json/class/Mage.json
+++ b/Json/class/Mage.json
@@ -98,14 +98,14 @@
         "Key": "9",
         "HasCastBar": true,
         "Requirement": "not BagItem:8077:4",
-        "Cooldown": 30000
+        "AfterCastWaitItem": true
       },
       {
         "Name": "Conjure Food",
         "Key": "8",
         "HasCastBar": true,
         "Requirement": "not BagItem:1487:4",
-        "Cooldown": 30000
+        "AfterCastWaitItem": true
       }
     ]}
 }

--- a/Json/class/MageAttendedGrind.json
+++ b/Json/class/MageAttendedGrind.json
@@ -101,7 +101,7 @@
         "HasCastBar": true,
         "Key": "9",
         "Requirement": "not BagItem:8079:4",
-        "Cooldown": 30000,
+        "AfterCastWaitItem": true,
         "Log": false
       },
       {
@@ -109,7 +109,7 @@
         "HasCastBar": true,
         "Key": "8",
         "Requirement": "not BagItem:8076:4",
-        "Cooldown": 30000,
+        "AfterCastWaitItem": true,
         "Log": false
       }
     ]

--- a/Json/class/MageGrind.json
+++ b/Json/class/MageGrind.json
@@ -96,7 +96,7 @@
         "HasCastBar": true,
         "Key": "9",
         "Requirement": "not BagItem:8079:4",
-        "Cooldown": 30000,
+        "AfterCastWaitItem": true,
         "Log": false
       },
       {
@@ -104,7 +104,7 @@
         "HasCastBar": true,
         "Key": "8",
         "Requirement": "not BagItem:8076:4",
-        "Cooldown": 30000,
+        "AfterCastWaitItem": true,
         "Log": false
       },
       {

--- a/Json/class/MageRaid.json
+++ b/Json/class/MageRaid.json
@@ -94,7 +94,7 @@
         "HasCastBar": true,
         "Key": "9",
         "Requirement": "not BagItem:8079:4",
-        "Cooldown": 30000,
+        "AfterCastWaitItem": true,
         "Log": false
       },
       {
@@ -102,7 +102,7 @@
         "HasCastBar": true,
         "Key": "8",
         "Requirement": "not BagItem:8076:4",
-        "Cooldown": 30000,
+        "AfterCastWaitItem": true,
         "Log": false
       }
     ]

--- a/Json/class/Mage_10.json
+++ b/Json/class/Mage_10.json
@@ -114,13 +114,15 @@
         "Name": "Conjure Water",
         "Key": "9",
         "HasCastBar": true,
-        "Requirement": "!BagItem:2288:4"
+        "Requirement": "!BagItem:2288:4",
+        "AfterCastWaitItem": true
       },
       {
         "Name": "Conjure Food",
         "Key": "8",
         "HasCastBar": true,
-        "Requirement": "!BagItem:5349:4"
+        "Requirement": "!BagItem:5349:4",
+        "AfterCastWaitItem": true
       }
     ]
   },

--- a/Json/class/Mage_10_Arcane.json
+++ b/Json/class/Mage_10_Arcane.json
@@ -117,13 +117,15 @@
         "Name": "Conjure Water",
         "Key": "9",
         "HasCastBar": true,
-        "Requirement": "!BagItem:2288:4"
+        "Requirement": "!BagItem:2288:4",
+        "AfterCastWaitItem": true
       },
       {
         "Name": "Conjure Food",
         "Key": "8",
         "HasCastBar": true,
-        "Requirement": "!BagItem:5349:4"
+        "Requirement": "!BagItem:5349:4",
+        "AfterCastWaitItem": true
       }
     ]
   },

--- a/Json/class/Mage_12_Arcane.json
+++ b/Json/class/Mage_12_Arcane.json
@@ -9,7 +9,7 @@
     "MIN_FOOD%": 50,
     "MIN_WATER%": 30,
     "MIN_MANA_SPELL%": 60,
-    "MIN_TARGET_HP_NOVA%": 10
+    "MIN_TARGET_HP_NOVA%": 15
   },
   "Pull": {
     "Sequence": [
@@ -23,7 +23,7 @@
         "Name": "Shoot",
         "Key": "0",
         "HasCastbar": true,
-        "DelayAfterCast": 500,
+        "DelayBeforeCast": 100,
         "Requirements": [
           "HasRangedWeapon",
           "!Shooting",
@@ -36,15 +36,6 @@
   "Combat": {
     "Sequence": [
       {
-        "Name": "Fire Blast",
-        "Key": "5",
-        "WhenUsable": true,
-        "Requirements": [
-          "TargetHealth% < 45",
-          "SpellInRange:4"
-        ]
-      },
-      {
         "Name": "Frost Nova",
         "Key": "6",
         "WhenUsable": true,
@@ -52,8 +43,16 @@
           "InMeleeRange",
           "TargetHealth% > MIN_TARGET_HP_NOVA%"
         ],
-        "StepBackAfterCast": 1000,
-        "DelayAfterCast": 0
+        "StepBackAfterCast": -1 //1000
+      },
+      {
+        "Name": "Fire Blast",
+        "Key": "5",
+        "WhenUsable": true,
+        "Requirements": [
+          "TargetHealth% < 45",
+          "SpellInRange:4"
+        ]
       },
       {
         "Name": "Arcane Missiles",
@@ -69,6 +68,7 @@
         "Name": "Shoot",
         "Key": "0",
         "HasCastBar": true,
+        "DelayBeforeCast": 100,
         "Requirements": [
           "HasRangedWeapon",
           "!Shooting",
@@ -114,13 +114,15 @@
         "Name": "Conjure Water",
         "Key": "9",
         "HasCastBar": true,
-        "Requirement": "!BagItem:2288:4"
+        "Requirement": "!BagItem:2288:4",
+        "AfterCastWaitItem": true
       },
       {
         "Name": "Conjure Food",
         "Key": "8",
         "HasCastBar": true,
-        "Requirement": "!BagItem:1113:4"
+        "Requirement": "!BagItem:1113:4",
+        "AfterCastWaitItem": true
       }
     ]
   }

--- a/Json/class/Mage_12_Fire.json
+++ b/Json/class/Mage_12_Fire.json
@@ -87,14 +87,14 @@
         "Key": "9",
         "HasCastBar": true,
         "Requirement": "not BagItem:2288:4",
-        "Cooldown": 30000
+        "AfterCastWaitItem": true
       },
       {
         "Name": "Conjure Food",
         "Key": "8",
         "HasCastBar": true,
         "Requirement": "not BagItem:1113:4",
-        "Cooldown": 30000
+        "AfterCastWaitItem": true
       }
     ]},
     "NPC": {

--- a/Json/class/Mage_14_Arcane_Frost.json
+++ b/Json/class/Mage_14_Arcane_Frost.json
@@ -86,14 +86,14 @@
         "Key": "9",
         "HasCastBar": true,
         "Requirement": "not BagItem:2288:4",
-        "Cooldown": 30000
+        "AfterCastWaitItem": true
       },
       {
         "Name": "Conjure Food",
         "Key": "8",
         "HasCastBar": true,
         "Requirement": "not BagItem:1113:4",
-        "Cooldown": 30000
+        "AfterCastWaitItem": true
       }
     ]},
     "NPC": {

--- a/Json/class/Mage_16_Arcane_Fire.json
+++ b/Json/class/Mage_16_Arcane_Fire.json
@@ -95,14 +95,14 @@
         "Key": "9",
         "HasCastBar": true,
         "Requirement": "not BagItem:2288:4",
-        "Cooldown": 30000
+        "AfterCastWaitItem": true
       },
       {
         "Name": "Conjure Food",
         "Key": "8",
         "HasCastBar": true,
         "Requirement": "not BagItem:1113:4",
-        "Cooldown": 30000
+        "AfterCastWaitItem": true
       }
     ]
   }

--- a/Json/class/Mage_4.json
+++ b/Json/class/Mage_4.json
@@ -77,7 +77,8 @@
         "Name": "Conjure Water",
         "Key": "9",
         "HasCastBar": true,
-        "Requirement": "!BagItem:5350:4"
+        "Requirement": "!BagItem:5350:4",
+        "AfterCastWaitItem": true
       }
     ]
   },

--- a/Json/class/Mage_54_Frost_Arcane.json
+++ b/Json/class/Mage_54_Frost_Arcane.json
@@ -124,7 +124,7 @@
         "HasCastBar": true,
         "Key": "9",
         "Requirement": "not BagItem:8078:4",
-        "Cooldown": 30000,
+        "AfterCastWaitItem": true,
         "Log": false
       },
       {
@@ -132,7 +132,7 @@
         "HasCastBar": true,
         "Key": "8",
         "Requirement": "not BagItem:8076:4",
-        "Cooldown": 30000,
+        "AfterCastWaitItem": true,
         "Log": false
       }
     ]

--- a/Json/class/Mage_6.json
+++ b/Json/class/Mage_6.json
@@ -110,13 +110,15 @@
         "Name": "Conjure Water",
         "Key": "9",
         "HasCastBar": true,
-        "Requirement": "!BagItem:5350:4"
+        "Requirement": "!BagItem:5350:4",
+        "AfterCastWaitItem": true
       },
       {
         "Name": "Conjure Food",
         "Key": "8",
         "HasCastBar": true,
-        "Requirement": "!BagItem:5349:4"
+        "Requirement": "!BagItem:5349:4",
+        "AfterCastWaitItem": true
       }
     ]
   },

--- a/Json/class/Mage_herb.json
+++ b/Json/class/Mage_herb.json
@@ -105,7 +105,7 @@
         "HasCastBar": true,
         "Key": "9",
         "Requirement": "not BagItem:8079:4",
-        "Cooldown": 30000,
+        "AfterCastWaitItem": true,
         "Log": false
       },
       {
@@ -113,7 +113,7 @@
         "HasCastBar": true,
         "Key": "8",
         "Requirement": "not BagItem:8076:4",
-        "Cooldown": 30000,
+        "AfterCastWaitItem": true,
         "Log": false
       },
       {

--- a/Json/class/Mage_weeping.json
+++ b/Json/class/Mage_weeping.json
@@ -115,7 +115,7 @@
         "HasCastBar": true,
         "Key": "9",
         "Requirement": "not BagItem:8079:4",
-        "Cooldown": 30000,
+        "AfterCastWaitItem": true,
         "Log": false
       },
       {
@@ -123,7 +123,7 @@
         "HasCastBar": true,
         "Key": "8",
         "Requirement": "not BagItem:8076:4",
-        "Cooldown": 30000,
+        "AfterCastWaitItem": true,
         "Log": false
       },
       {

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Similar to BlazorServer project, except without Frontend. Should consume less sy
 
 Everything has to be setup inside the Class Configuration, in prior.
 
-A successfull [Configuration process](#5-BlazorServer-Configuration-process) has a result of a following configuration files
+A successful [Configuration process](#5-BlazorServer-Configuration-process) has a result of a following configuration files
 * `data_config.json`
 * `addon_config.json`
 * `frame_config.json`
@@ -422,11 +422,12 @@ Can specify conditions with [Requirement(s)](#Requirement) in order to create a 
 | `"DelayBeforeCast"` | Delay in milliseconds before key press happens | `0` |
 | `"DelayAfterCast"` | Delay in milliseconds after the key press happened | `1450` |
 | `"DelayUntilCombat"` | After cast, waits until player enters combat, good for pulling. | `false` |
+| `"AfterCastWaitBuff"` | After a successful cast, should wait until __(player debuff/buff or target debuff/buff)__ changed. | `false` |
 | `"AfterCastWaitBuff"` | After a successfull cast, should wait until __(player debuff/buff or target debuff/buff)__ changed. | `false` |
 | `"AfterCastWaitNextSwing"` | After cast wait for next melee swing happen. | `false` | 
 | `"Cost"` | [Adhoc Goals](#Adhoc-Goals) or [NPC Goal](#NPC-Goals) only the priority | `18` |
 | `"InCombat"` | Should combat matter when attempt to cast?<br>Accepted values:<br>* `"any value for doesn't matter"`<br>* `"true"`<br>* `"false"` | `false` |
-| `"StepBackAfterCast"` | After successfull cast, start backpedaling for milliseconds. | `0` |
+| `"StepBackAfterCast"` | After successful cast, start backpedaling for milliseconds.<br> If value set to `-1` attempts to use the whole remaining GCD duration. | `0` |
 | `"PathFilename"` | [NPC Goal](#NPC-Goals) only, this is a short path to get close to the NPC to avoid walls etc. | `""` |
 | `"UseWhenTargetIsCasting"` | Checks for the target casting/channeling.<br>Accepted values:<br>* `null` -> ignore<br>* `false` -> when enemy not casting<br>* `true` -> when enemy casting | `null` |
 

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ Can specify conditions with [Requirement(s)](#Requirement) in order to create a 
 | `"DelayAfterCast"` | Delay in milliseconds after the key press happened | `1450` |
 | `"DelayUntilCombat"` | After cast, waits until player enters combat, good for pulling. | `false` |
 | `"AfterCastWaitBuff"` | After a successful cast, should wait until __(player debuff/buff or target debuff/buff)__ changed. | `false` |
-| `"AfterCastWaitBuff"` | After a successfull cast, should wait until __(player debuff/buff or target debuff/buff)__ changed. | `false` |
+| `"AfterCastWaitItem"` | After a successful cast, should wait until __(inventory change)__ changed. | `false` |
 | `"AfterCastWaitNextSwing"` | After cast wait for next melee swing happen. | `false` | 
 | `"Cost"` | [Adhoc Goals](#Adhoc-Goals) or [NPC Goal](#NPC-Goals) only the priority | `18` |
 | `"InCombat"` | Should combat matter when attempt to cast?<br>Accepted values:<br>* `"any value for doesn't matter"`<br>* `"true"`<br>* `"false"` | `false` |


### PR DESCRIPTION
Fixes various timing issues with not properly waiting for GCD and SpellQueueTimeWindow

CastingHandler: Blocks `Castbar` based actions only till the cast has been started.