### PR TITLE
`KeyAction` uses more annotations to help `CastingHandler`

### DIFF
--- a/Core/Bag/BagReader.cs
+++ b/Core/Bag/BagReader.cs
@@ -201,9 +201,9 @@ namespace Core
 
         public bool HasItem(int itemId) => ItemCount(itemId) != 0;
 
-        public int HighestQuantityOfWaterId()
+        public int HighestQuantityOfDrinkId()
         {
-            return ItemDB.WaterIds.
+            return ItemDB.DrinkIds.
                 OrderByDescending(c => ItemCount(c)).
                 FirstOrDefault();
         }

--- a/Core/ClassConfig/ClassConfiguration.cs
+++ b/Core/ClassConfig/ClassConfiguration.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -121,87 +121,96 @@ namespace Core
 
             Jump.Key = JumpKey;
             Jump.Name = nameof(Jump);
+            Jump.BaseAction = true;
             Jump.Initialise(this, addonReader, requirementFactory, logger, Log);
 
             TargetLastTarget.Key = TargetLastTargetKey;
             TargetLastTarget.Name = nameof(TargetLastTarget);
             TargetLastTarget.Cooldown = 0;
+            TargetLastTarget.BaseAction = true;
             TargetLastTarget.Initialise(this, addonReader, requirementFactory, logger, Log);
 
             StandUp.Key = StandUpKey;
             StandUp.Name = nameof(StandUp);
             StandUp.Cooldown = 0;
+            StandUp.BaseAction = true;
             StandUp.Initialise(this, addonReader, requirementFactory, logger, Log);
 
             ClearTarget.Key = ClearTargetKey;
             ClearTarget.Name = nameof(ClearTarget);
             ClearTarget.Cooldown = 0;
+            ClearTarget.BaseAction = true;
             ClearTarget.Initialise(this, addonReader, requirementFactory, logger, Log);
 
             StopAttack.Key = StopAttackKey;
             StopAttack.Name = nameof(StopAttack);
-            StopAttack.Cooldown = 400;
-            StopAttack.WaitForGCD = false;
             StopAttack.PressDuration = 20;
-            StopAttack.SkipValidation = true;
+            StopAttack.BaseAction = true;
             StopAttack.Initialise(this, addonReader, requirementFactory, logger, Log);
 
             TargetNearestTarget.Key = TargetNearestTargetKey;
             TargetNearestTarget.Name = nameof(TargetNearestTarget);
-            TargetNearestTarget.Cooldown = 400;
+            TargetNearestTarget.BaseAction = true;
             TargetNearestTarget.Initialise(this, addonReader, requirementFactory, logger, Log);
 
             TargetPet.Key = TargetPetKey;
             TargetPet.Name = nameof(TargetPet);
             TargetPet.Cooldown = 0;
+            TargetPet.BaseAction = true;
             TargetPet.Initialise(this, addonReader, requirementFactory, logger, Log);
 
             TargetTargetOfTarget.Key = TargetTargetOfTargetKey;
             TargetTargetOfTarget.Name = nameof(TargetTargetOfTarget);
             TargetTargetOfTarget.Cooldown = 0;
+            TargetTargetOfTarget.BaseAction = true;
             TargetTargetOfTarget.Initialise(this, addonReader, requirementFactory, logger, Log);
 
             TargetFocus.Key = TargetFocusKey;
             TargetFocus.Name = nameof(TargetFocus);
             TargetFocus.Cooldown = 0;
+            TargetFocus.BaseAction = true;
             TargetFocus.Initialise(this, addonReader, requirementFactory, logger, Log);
 
             FollowTarget.Key = FollowTargetKey;
             FollowTarget.Name = nameof(FollowTarget);
             FollowTarget.Cooldown = 0;
+            FollowTarget.BaseAction = true;
             FollowTarget.Initialise(this, addonReader, requirementFactory, logger, Log);
 
             PetAttack.Key = PetAttackKey;
             PetAttack.Name = nameof(PetAttack);
             PetAttack.PressDuration = 10;
-            PetAttack.Cooldown = 400;
+            PetAttack.BaseAction = true;
             PetAttack.Initialise(this, addonReader, requirementFactory, logger, Log);
 
             Mount.Key = MountKey;
             Mount.Name = nameof(Mount);
+            Mount.BaseAction = true;
             Mount.Initialise(this, addonReader, requirementFactory, logger, Log);
 
             Hearthstone.Key = HearthstoneKey;
             Hearthstone.Name = nameof(Hearthstone);
+            Hearthstone.HasCastBar = true;
+            Hearthstone.AfterCastWaitCastbar = true;
             Hearthstone.Initialise(this, addonReader, requirementFactory, logger, Log);
 
             Interact.Key = InteractKey;
             Interact.Name = nameof(Interact);
             Interact.Cooldown = 0;
-            Interact.WaitForGCD = false;
-            Interact.DelayAfterCast = 0;
             Interact.PressDuration = 30;
+            Interact.BaseAction = true;
             Interact.Initialise(this, addonReader, requirementFactory, logger, Log);
 
             Approach.Key = InteractKey;
             Approach.Name = nameof(Approach);
-            Approach.WaitForGCD = false;
-            Approach.DelayAfterCast = 0;
             Approach.PressDuration = 10;
+            Approach.BaseAction = true;
             Approach.Initialise(this, addonReader, requirementFactory, logger, Log);
 
             AutoAttack.Key = InteractKey;
             AutoAttack.Name = nameof(AutoAttack);
+            AutoAttack.BaseAction = true;
+            AutoAttack.Item = true;
             AutoAttack.Initialise(this, addonReader, requirementFactory, logger, Log);
 
             InitializeKeyActions(Pull, Interact, Approach, AutoAttack, StopAttack);
@@ -293,23 +302,25 @@ namespace Core
                         continue;
 
                     user.Key = @default.Key;
-                    user.WaitForGCD = @default.WaitForGCD;
 
                     //if (!string.IsNullOrEmpty(@default.Requirement))
                     //    user.Requirement += " " + @default.Requirement;
                     //user.Requirements.AddRange(@default.Requirements);
 
-                    if (user.DelayAfterCast == dummyDefault.DelayAfterCast)
-                        user.DelayAfterCast = @default.DelayAfterCast;
+                    if (user.AfterCastDelay == dummyDefault.AfterCastDelay)
+                        user.AfterCastDelay = @default.AfterCastDelay;
 
-                    if (user.DelayAfterCast == dummyDefault.DelayAfterCast)
+                    if (user.PressDuration == dummyDefault.PressDuration)
                         user.PressDuration = @default.PressDuration;
 
                     if (user.Cooldown == dummyDefault.Cooldown)
                         user.Cooldown = @default.Cooldown;
 
-                    if (user.SkipValidation == dummyDefault.SkipValidation)
-                        user.SkipValidation = @default.SkipValidation;
+                    if (user.BaseAction == dummyDefault.BaseAction)
+                        user.BaseAction = @default.BaseAction;
+
+                    if (user.Item == dummyDefault.Item)
+                        user.Item = @default.Item;
                 }
             }
         }

--- a/Core/ClassConfig/KeyAction.cs
+++ b/Core/ClassConfig/KeyAction.cs
@@ -1,3 +1,4 @@
+﻿using Core.Goals;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -11,7 +12,6 @@ namespace Core
         public float Cost { get; set; } = 18;
         public string Name { get; set; } = string.Empty;
         public bool HasCastBar { get; set; }
-        public bool StopBeforeCast { get; set; }
         public ConsoleKey ConsoleKey { get; set; }
         public string Key { get; set; } = string.Empty;
         public int Slot { get; set; }
@@ -20,6 +20,7 @@ namespace Core
         public string Form { get; set; } = string.Empty;
         public Form FormEnum { get; set; } = Core.Form.None;
         public bool FormAction { get; private set; }
+        public float Cooldown { get; set; } = CastingHandler.SpellQueueTimeMs;
 
         private int _charge;
         public int Charge { get; set; } = 1;
@@ -45,37 +46,34 @@ namespace Core
 
         public bool WhenUsable { get; set; }
 
-        public bool WaitForWithinMeleeRange { get; set; }
         public bool ResetOnNewTarget { get; set; }
 
         public bool Log { get; set; } = true;
-        public int DelayAfterCast { get; set; } = 1450; // GCD 1500 - but spell queue window 400 ms
 
-        public bool WaitForGCD { get; set; } = true;
+        public bool BaseAction { get; set; }
 
-        public bool SkipValidation { get; set; }
+        public bool Item { get; set; }
 
+        public int BeforeCastDelay { get; set; }
+        public bool BeforeCastStop { get; set; }
+
+        public int AfterCastDelay { get; set; }
+        public bool AfterCastWaitMeleeRange { get; set; }
         public bool AfterCastWaitBuff { get; set; }
-
-        public bool AfterCastWaitItem { get; set; }
-
-        public bool AfterCastWaitNextSwing { get; set; }
-
+        public bool AfterCastWaitBag { get; set; }
+        public bool AfterCastWaitSwing { get; set; }
         public bool AfterCastWaitCastbar { get; set; }
+        public bool AfterCastWaitCombat { get; set; }
+        public bool AfterCastWaitGCD { get; set; }
+        public bool AfterCastAuraExpected { get; set; }
+        public int AfterCastStepBack { get; set; }
 
-        public bool DelayUntilCombat { get; set; }
-        public int DelayBeforeCast { get; set; }
-        public float Cost { get; set; } = 18;
         public string InCombat { get; set; } = "false";
 
         public bool? UseWhenTargetIsCasting { get; set; }
 
         public string PathFilename { get; set; } = string.Empty;
         public Vector3[] Path { get; set; } = Array.Empty<Vector3>();
-
-        public int StepBackAfterCast { get; set; }
-
-        public Vector3 LastClickPostion { get; private set; }
 
         public int ConsoleKeyFormHash { private set; get; }
 
@@ -212,10 +210,9 @@ namespace Core
             return playerReader.ManaCurrent() >= FormCost() + MinMana;
         }
 
-        internal void SetClicked()
+        public void SetClicked(double offset = 0)
         {
-            LastClickPostion = playerReader.PlayerLocation;
-            LastClicked[ConsoleKeyFormHash] = DateTime.UtcNow;
+            LastClicked[ConsoleKeyFormHash] = DateTime.UtcNow.AddMilliseconds(offset);
         }
 
         public double MillisecondsSinceLastClick =>

--- a/Core/Database/ItemDB.cs
+++ b/Core/Database/ItemDB.cs
@@ -11,7 +11,7 @@ namespace Core.Database
 
         public Dictionary<int, Item> Items { get; } = new();
         public int[] FoodIds { get; }
-        public int[] WaterIds { get; }
+        public int[] DrinkIds { get; }
 
         public ItemDB(DataConfig dataConfig)
         {
@@ -22,7 +22,7 @@ namespace Core.Database
             }
 
             FoodIds = JsonConvert.DeserializeObject<int[]>(File.ReadAllText(Path.Join(dataConfig.Dbc, "foods.json")));
-            WaterIds = JsonConvert.DeserializeObject<int[]>(File.ReadAllText(Path.Join(dataConfig.Dbc, "waters.json")));
+            DrinkIds = JsonConvert.DeserializeObject<int[]>(File.ReadAllText(Path.Join(dataConfig.Dbc, "waters.json")));
         }
     }
 }

--- a/Core/Goals/AdhocGoal.cs
+++ b/Core/Goals/AdhocGoal.cs
@@ -55,6 +55,8 @@ namespace Core.Goals
                 mountHandler.Dismount();
                 wait.Update();
             }
+
+            castingHandler.UpdateGCD(true);
         }
 
         public override void OnExit()

--- a/Core/Goals/CombatGoal.cs
+++ b/Core/Goals/CombatGoal.cs
@@ -90,6 +90,8 @@ namespace Core.Goals
                 mountHandler.Dismount();
             }
 
+            castingHandler.UpdateGCD(true);
+
             lastDirection = playerReader.Direction;
         }
 
@@ -136,7 +138,7 @@ namespace Core.Goals
                 {
                     KeyAction keyAction = Keys[i];
 
-                    if (castingHandler.SpellInQueue() && !keyAction.SkipValidation)
+                    if (castingHandler.SpellInQueue() && !keyAction.BaseAction)
                     {
                         continue;
                     }

--- a/Core/Goals/ParallelGoal.cs
+++ b/Core/Goals/ParallelGoal.cs
@@ -55,9 +55,11 @@ namespace Core.Goals
                 wait.Update();
             }
 
+            castingHandler.UpdateGCD(true);
+
             for (int i = 0; i < Keys.Length; i++)
             {
-                if (Keys[i].StopBeforeCast)
+                if (Keys[i].BeforeCastStop)
                 {
                     stopMoving.Stop();
                     wait.Update();

--- a/Core/Goals/PullTargetGoal.cs
+++ b/Core/Goals/PullTargetGoal.cs
@@ -85,6 +85,9 @@ namespace Core.Goals
         {
             combatUtil.Update();
             wait.Update();
+            stuckDetector.Reset();
+
+            castingHandler.UpdateGCD(true);
 
             if (mountHandler.IsMounted())
             {
@@ -152,7 +155,7 @@ namespace Core.Goals
             {
                 KeyAction keyAction = Keys[i];
 
-                if (keyAction.Name == input.ClassConfig.Approach.Name)
+                if (keyAction.Name.Equals(input.ClassConfig.Approach.Name, StringComparison.OrdinalIgnoreCase))
                     continue;
 
                 if (!keyAction.CanRun())

--- a/Core/Goals/PullTargetGoal.cs
+++ b/Core/Goals/PullTargetGoal.cs
@@ -168,10 +168,7 @@ namespace Core.Goals
 
                 if (castAny = castingHandler.Cast(keyAction, PullPrevention))
                 {
-                    if (keyAction.WaitForWithinMeleeRange)
-                    {
-                        WaitForWithinMeleeRange(keyAction, castAny);
-                    }
+
                 }
                 else if (PullPrevention() &&
                     (playerReader.IsCasting() ||
@@ -191,8 +188,8 @@ namespace Core.Goals
             {
                 if (combatUtil.EnteredCombat())
                 {
-                    (bool timeout, double elapsedMs) = wait.Until(5000, CombatLogChanged);
-                    if (!timeout)
+                    (bool t, double e) = wait.Until(5000, CombatLogChanged);
+                    if (!t)
                     {
                         if (addonReader.DamageTakenCount > 0 && !playerReader.Bits.TargetInCombat())
                         {
@@ -208,6 +205,11 @@ namespace Core.Goals
                         SendGoapEvent(new GoapStateEvent(GoapKey.pulled, true));
                         return;
                     }
+                }
+                else if (playerReader.Bits.PlayerInCombat())
+                {
+                    SendGoapEvent(new GoapStateEvent(GoapKey.pulled, true));
+                    return;
                 }
 
                 approachAction();
@@ -226,52 +228,15 @@ namespace Core.Goals
                 TargetTargetEnum.PartyOrPet;
         }
 
-
-        protected void WaitForWithinMeleeRange(KeyAction item, bool lastCastSuccess)
-        {
-            stopMoving.Stop();
-            wait.Update();
-
-            var start = DateTime.UtcNow;
-            var lastKnownHealth = playerReader.HealthCurrent();
-            double maxWaitTimeMs = 10_000;
-
-            Log($"Waiting for the target to reach melee range - max {maxWaitTimeMs}ms");
-
-            while (playerReader.Bits.HasTarget() && !playerReader.IsInMeleeRange() && (DateTime.UtcNow - start).TotalMilliseconds < maxWaitTimeMs)
-            {
-                if (playerReader.HealthCurrent() < lastKnownHealth)
-                {
-                    Log("Got damage. Stop waiting for melee range.");
-                    break;
-                }
-
-                if (playerReader.IsTargetCasting())
-                {
-                    Log("Target started casting. Stop waiting for melee range.");
-                    break;
-                }
-
-                if (lastCastSuccess && addonReader.UsableAction.Is(item))
-                {
-                    Log($"While waiting, repeat current action: {item.Name}");
-                    lastCastSuccess = castingHandler.CastIfReady(item, playerReader.IsInMeleeRange);
-                    Log($"Repeat current action: {lastCastSuccess}");
-                }
-
-                wait.Update();
-            }
-        }
-
         private void DefaultApproach()
         {
-            if (!stuckDetector.IsMoving())
-            {
-                stuckDetector.Update();
-            }
-
             if (input.ClassConfig.Approach.GetCooldownRemaining() == 0)
             {
+                if (!stuckDetector.IsMoving())
+                {
+                    stuckDetector.Update();
+                }
+
                 input.Approach();
             }
         }

--- a/Core/Goals/SkinningGoal.cs
+++ b/Core/Goals/SkinningGoal.cs
@@ -337,7 +337,7 @@ namespace Core.Goals
 
         private bool CastStartedOrFailed()
         {
-            return successfulInBackground || playerReader.SpellBeingCast != 0;
+            return successfulInBackground || playerReader.IsCasting();
         }
 
         private bool MinRangeZero()

--- a/Core/GoalsComponent/CastingHandler.cs
+++ b/Core/GoalsComponent/CastingHandler.cs
@@ -1,12 +1,13 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using System;
-using System.Numerics;
 using System.Threading;
 
 namespace Core.Goals
 {
-    public partial class CastingHandler : IDisposable
+    public partial class CastingHandler
     {
+        private const bool Log = false;
+
         private readonly ILogger logger;
         private readonly CancellationTokenSource cts;
         private readonly ConfigurableInput input;
@@ -14,22 +15,25 @@ namespace Core.Goals
         private readonly Wait wait;
         private readonly AddonReader addonReader;
         private readonly PlayerReader playerReader;
-        private readonly AddonBits bits;
 
         private readonly ClassConfiguration classConfig;
         private readonly PlayerDirection direction;
         private readonly StopMoving stopMoving;
 
-        private readonly KeyAction defaultKeyAction = new();
+        private readonly ReactCastError react;
 
         public const int GCD = 1500;
         public const int MIN_GCD = 1000;
         public const int SpellQueueTimeMs = 400;
 
+        private const int MAX_WAIT_MELEE_RANGE = 10_000;
+
         public DateTime SpellQueueOpen { get; private set; }
         public bool SpellInQueue() => DateTime.UtcNow < SpellQueueOpen;
 
-        public CastingHandler(ILogger logger, CancellationTokenSource cts, ConfigurableInput input, Wait wait, AddonReader addonReader, PlayerDirection direction, StopMoving stopMoving)
+        public CastingHandler(ILogger logger, CancellationTokenSource cts,
+            ConfigurableInput input, Wait wait, AddonReader addonReader,
+            PlayerDirection direction, StopMoving stopMoving, ReactCastError react)
         {
             this.logger = logger;
             this.cts = cts;
@@ -38,37 +42,34 @@ namespace Core.Goals
             this.wait = wait;
             this.addonReader = addonReader;
             this.playerReader = addonReader.PlayerReader;
-            this.bits = playerReader.Bits;
 
             this.classConfig = input.ClassConfig;
             this.direction = direction;
             this.stopMoving = stopMoving;
-        }
 
-        public void Dispose()
-        {
-            defaultKeyAction.Dispose();
+            this.react = react;
         }
 
         private int PressKeyAction(KeyAction item)
         {
             playerReader.LastUIError = UI_ERROR.NONE;
 
-            if (item.AfterCastWaitNextSwing)
+            if (item.AfterCastWaitSwing)
             {
-                if (item.Log)
-                    LogWaitNextSwing(logger, item.Name);
+                if (Log && item.Log)
+                    LogAfterCastWaitSwing(logger, item.Name);
 
                 input.StopAttack();
             }
 
+            //item.SetClicked();
             return input.Proc.KeyPress(item.ConsoleKey, item.PressDuration);
         }
 
-        private static bool CastSuccessful(UI_ERROR uiEvent)
+        private static bool CastSuccessful(int uiEvent)
         {
             return
-                uiEvent is
+                (UI_ERROR)uiEvent is
                 UI_ERROR.CAST_START or
                 UI_ERROR.CAST_SUCCESS or
                 UI_ERROR.NONE;
@@ -76,7 +77,7 @@ namespace Core.Goals
 
         private bool CastInstant(KeyAction item)
         {
-            if (item.StopBeforeCast)
+            if (!playerReader.IsCasting() && item.BeforeCastStop)
             {
                 stopMoving.Stop();
                 wait.Update();
@@ -86,63 +87,71 @@ namespace Core.Goals
             int beforeCastEventValue = playerReader.CastEvent.Value;
             int beforeSpellId = playerReader.CastSpellId.Value;
             bool beforeUsable = addonReader.UsableAction.Is(item);
+            int beforePT = playerReader.PTCurrent();
 
-            int pressTime = PressKeyAction(item);
-
-            if (item.SkipValidation)
+            int pressMs = PressKeyAction(item);
+            if (item.BaseAction)
             {
-                //if (item.Log)
-                //    LogInstantSkipValidation(logger, item.Name);
                 item.SetClicked();
                 return true;
             }
 
-            bool inputTimeOut;
-            double inputElapsedMs;
+            bool t;
+            double e;
 
-            if (item.AfterCastWaitNextSwing)
+            if (item.AfterCastWaitSwing)
             {
-                (inputTimeOut, inputElapsedMs) = wait.Until(playerReader.MainHandSpeedMs() + playerReader.NetworkLatency.Value,
+                (t, e) = wait.Until(playerReader.MainHandSpeedMs() + playerReader.NetworkLatency.Value,
                     interrupt: () => !addonReader.CurrentAction.Is(item) ||
                         playerReader.MainHandSwing.ElapsedMs() < SpellQueueTimeMs, // swing timer reset from any miss
-                    repeat: RepeatStayCloseToTarget);
+                    repeat: input.ApproachOnCooldown);
+            }
+            else if (item.Item)
+            {
+                (t, e) = wait.Until(SpellQueueTimeMs + playerReader.NetworkLatency.Value,
+                    interrupt: () =>
+                        beforeUsable != addonReader.UsableAction.Is(item) ||
+                        addonReader.CurrentAction.Is(item));
             }
             else
             {
-                (inputTimeOut, inputElapsedMs) = wait.Until(SpellQueueTimeMs + playerReader.NetworkLatency.Value,
+                (t, e) = wait.Until(SpellQueueTimeMs + playerReader.NetworkLatency.Value,
                     interrupt: () =>
-                    (beforeSpellId != playerReader.CastSpellId.Value && beforeCastEventValue != playerReader.CastEvent.Value) ||
-                    beforeUsable != addonReader.UsableAction.Is(item)
-                );
+                    (beforeSpellId != playerReader.CastSpellId.Value &&
+                    beforeCastEventValue != playerReader.CastEvent.Value) ||
+                    beforePT != playerReader.PTCurrent());
             }
 
-            if (item.Log)
-                LogInstantInput(logger, item.Name, pressTime, !inputTimeOut, inputElapsedMs);
+            if (Log && item.Log)
+                LogInstantInput(logger, item.Name, pressMs, !t, e);
 
-            if (inputTimeOut)
+            if (t)
                 return false;
 
-            if (item.Log)
-                LogInstantUsableChange(logger, item.Name, beforeUsable, addonReader.UsableAction.Is(item), ((UI_ERROR)beforeCastEventValue).ToStringF(), ((UI_ERROR)playerReader.CastEvent.Value).ToStringF(), playerReader.GCD.Value);
+            if (Log && item.Log)
+                LogInstantUsableChange(logger, item.Name, beforeUsable, addonReader.UsableAction.Is(item), ((UI_ERROR)beforeCastEventValue).ToStringF(), ((UI_ERROR)playerReader.CastEvent.Value).ToStringF());
+
+            if (!CastSuccessful(playerReader.CastEvent.Value))
+            {
+                react.Do(item, $"{item.Name}-{nameof(CastingHandler)}: {nameof(CastInstant)}");
+                return false;
+            }
 
             item.SetClicked();
-
-            if (!CastSuccessful((UI_ERROR)playerReader.CastEvent.Value))
+            if (item.Item)
             {
-                ReactToLastCastingEvent(item, $"{item.Name}-{nameof(CastingHandler)}: CastInstant");
-                return false;
+                playerReader.LastCastGCD = 0;
+                wait.Update();
             }
-
-            //wait.Update();
-            //(bool gcdTimeout, double elapsedMs) = wait.Until(2 * playerReader.NetworkLatency.Value, () => playerReader.GCD.Value != 0);
-            //logger.LogInformation($"Instant - has GCD ? {!gcdTimeout} | {playerReader.GCD.Value}ms | {elapsedMs}ms");
+            else
+                playerReader.ReadLastCastGCD();
 
             return true;
         }
 
         private bool CastCastbar(KeyAction item, Func<bool> interrupt)
         {
-            wait.While(bits.IsFalling);
+            wait.While(playerReader.Bits.IsFalling);
 
             if (!playerReader.IsCasting())
             {
@@ -150,65 +159,61 @@ namespace Core.Goals
                 wait.Update();
             }
 
-            bool prevState = interrupt();
-
             bool beforeUsable = addonReader.UsableAction.Is(item);
             int beforeCastEventValue = playerReader.CastEvent.Value;
             int beforeSpellId = playerReader.CastSpellId.Value;
             int beforeCastCount = playerReader.CastCount;
 
             int pressMs = PressKeyAction(item);
-            int remainCastMs = playerReader.RemainCastMs;
 
-            if (item.SkipValidation)
+            if (item.BaseAction)
             {
-                if (item.Log)
+                if (Log && item.Log)
                     LogCastbarSkipValidation(logger, item.Name);
 
                 item.SetClicked();
                 return true;
             }
 
-            (bool inputTimeOut, double inputElapsedMs) = wait.Until(remainCastMs + pressMs + SpellQueueTimeMs + (2 * playerReader.NetworkLatency.Value),
+            (bool t, double e) = wait.Until(SpellQueueTimeMs + playerReader.NetworkLatency.Value,
                 interrupt: () =>
                 beforeCastEventValue != playerReader.CastEvent.Value ||
                 beforeSpellId != playerReader.CastSpellId.Value ||
                 beforeCastCount != playerReader.CastCount ||
-                prevState != interrupt()
+                interrupt()
                 );
 
-            if (item.Log)
-                LogCastbarInput(logger, item.Name, pressMs, !inputTimeOut, inputElapsedMs);
+            if (Log && item.Log)
+                LogCastbarInput(logger, item.Name, pressMs, !t, e);
 
-            if (inputTimeOut)
+            if (t)
                 return false;
 
-            if (item.Log)
+            if (Log && item.Log)
                 LogCastbarUsableChange(logger, item.Name, playerReader.IsCasting(), playerReader.CastCount, beforeUsable, addonReader.UsableAction.Is(item), ((UI_ERROR)beforeCastEventValue).ToStringF(), ((UI_ERROR)playerReader.CastEvent.Value).ToStringF());
 
-            item.SetClicked();
-
-            if (!CastSuccessful((UI_ERROR)playerReader.CastEvent.Value))
+            if (!CastSuccessful(playerReader.CastEvent.Value))
             {
-                ReactToLastCastingEvent(item, $"{item.Name}-{nameof(CastingHandler)}: CastCastbar");
+                react.Do(item, $"{item.Name}-{nameof(CastingHandler)}: {nameof(CastCastbar)}");
                 return false;
             }
+
+            playerReader.ReadLastCastGCD();
+            item.SetClicked();
 
             if (item.AfterCastWaitCastbar)
             {
                 if (playerReader.IsCasting())
                 {
-                    int remainMs = playerReader.RemainCastMs;
-                    remainMs -= (SpellQueueTimeMs / 2) + playerReader.NetworkLatency.Value;
+                    int remainMs = playerReader.RemainCastMs - SpellQueueTimeMs;
+                    if (Log && item.Log)
+                        LogVisibleAfterCastWaitCastbar(logger, item.Name, remainMs);
 
-                    if (item.Log)
-                        LogVisibleCastbarWaitForEnd(logger, item.Name, remainMs);
-
-                    wait.Until(remainMs, () => !playerReader.IsCasting() || prevState != interrupt(), RepeatPetAttack);
-                    if (prevState != interrupt())
+                    wait.Until(remainMs, () => !playerReader.IsCasting() || interrupt(), RepeatPetAttack);
+                    if (interrupt())
                     {
-                        if (item.Log)
-                            LogVisibleCastbarInterrupted(logger, item.Name);
+                        if (Log && item.Log)
+                            LogVisibleAfterCastWaitCastbarInterrupted(logger, item.Name);
 
                         return false;
                     }
@@ -217,16 +222,15 @@ namespace Core.Goals
                 {
                     beforeCastEventValue = playerReader.CastEvent.Value;
 
-                    int remain = playerReader.RemainCastMs - SpellQueueTimeMs - playerReader.NetworkLatency.Value;
+                    int remain = playerReader.RemainCastMs - SpellQueueTimeMs;
+                    if (Log && item.Log)
+                        LogHiddenAfterCastWaitCastbar(logger, item.Name, remain);
 
-                    if (item.Log)
-                        LogHiddenCastbarWaitForEnd(logger, item.Name, remain);
-
-                    wait.Until(remain, () => beforeCastEventValue != playerReader.CastEvent.Value || prevState != interrupt(), RepeatPetAttack);
-                    if (prevState != interrupt())
+                    wait.Until(remain, () => beforeCastEventValue != playerReader.CastEvent.Value || interrupt(), RepeatPetAttack);
+                    if (interrupt())
                     {
-                        if (item.Log)
-                            LogHiddenCastbarInterrupted(logger, item.Name);
+                        if (Log && item.Log)
+                            LogHiddenAfterCastWaitCastbarInterrupted(logger, item.Name);
 
                         return false;
                     }
@@ -238,7 +242,7 @@ namespace Core.Goals
 
         public bool CastIfReady(KeyAction item)
         {
-            return item.CanRun() && Cast(item, bits.HasTarget);
+            return item.CanRun() && Cast(item, playerReader.Bits.HasTarget);
         }
 
         public bool CastIfReady(KeyAction item, Func<bool> interrupt)
@@ -248,74 +252,69 @@ namespace Core.Goals
 
         public bool Cast(KeyAction item)
         {
-            return Cast(item, bits.HasTarget);
+            return Cast(item, playerReader.Bits.HasTarget);
         }
 
         public bool Cast(KeyAction item, Func<bool> interrupt)
         {
-            DateTime begin = DateTime.UtcNow;
+            bool prevState = interrupt();
+            bool Interrupt() => prevState != interrupt();
+
+            bool t = false;
+            double e = 0;
 
             if (item.HasFormRequirement && playerReader.Form != item.FormEnum)
             {
                 bool beforeUsable = addonReader.UsableAction.Is(item);
                 Form beforeForm = playerReader.Form;
 
-                if (!SwitchForm(beforeForm, item))
-                {
+                if (!SwitchForm(item))
                     return false;
-                }
 
-                if (beforeForm != playerReader.Form)
+                if (!WaitForGCD(item, Interrupt))
+                    return false;
+
+                //TODO: upon form change and GCD - have to check Usable state
+                if (!beforeUsable && !addonReader.UsableAction.Is(item))
                 {
-                    if (!WaitForGCD(item, interrupt))
-                        return false;
+                    if (Log && item.Log)
+                        LogAfterFormSwitchNotUsable(logger, item.Name, beforeForm.ToStringF(), playerReader.Form.ToStringF());
 
-                    wait.Update();
-
-                    //TODO: upon form change and GCD - have to check Usable state
-                    if (!beforeUsable && !addonReader.UsableAction.Is(item))
-                    {
-                        if (item.Log)
-                            LogAfterFormSwitchNotUsable(logger, item.Name, beforeForm.ToStringF(), playerReader.Form.ToStringF());
-
-                        return false;
-                    }
+                    return false;
                 }
             }
 
-            bool prevState = interrupt();
-
-            if (bits.SpellOn_Shoot())
+            if (playerReader.Bits.SpellOn_Shoot())
             {
                 input.StopAttack();
                 input.StopAttack();
 
                 int waitTime = Math.Max(playerReader.GCD.Value, playerReader.RemainCastMs) + (2 * playerReader.NetworkLatency.Value);
-                (bool gcdTimeout, double elapsedMs) = wait.Until(waitTime, () => prevState != interrupt());
-                logger.LogInformation($"Stop {nameof(bits.SpellOn_Shoot)} and wait {waitTime}ms | {elapsedMs}ms");
-                if (!gcdTimeout)
+                (t, e) = wait.Until(waitTime, Interrupt);
+                logger.LogInformation($"Stop {nameof(playerReader.Bits.SpellOn_Shoot)} and wait {waitTime}ms | {e}ms");
+                if (!t)
                 {
                     return false;
                 }
             }
 
-            if (item.WaitForGCD && !WaitForGCD(item, interrupt))
+            if (!WaitForGCD(item, Interrupt))
             {
                 return false;
             }
 
-            if (item.DelayBeforeCast > 0)
+            if (item.BeforeCastDelay > 0)
             {
-                if (item.StopBeforeCast || item.HasCastBar)
+                if (!playerReader.IsCasting() && (item.BeforeCastStop || item.HasCastBar))
                 {
                     stopMoving.Stop();
                     wait.Update();
                 }
 
-                if (item.Log)
-                    LogDelayBeforeCast(logger, item.Name, item.DelayBeforeCast);
+                if (Log && item.Log)
+                    LogBeforeCastDelay(logger, item.Name, item.BeforeCastDelay);
 
-                cts.Token.WaitHandle.WaitOne(item.DelayBeforeCast);
+                wait.Until(item.BeforeCastDelay, Interrupt);
             }
 
             int auraHash = playerReader.AuraCount.Hash;
@@ -334,10 +333,10 @@ namespace Core.Goals
             }
             else
             {
-                if (!CastCastbar(item, interrupt))
+                if (!CastCastbar(item, Interrupt))
                 {
                     // try again after reacted to UI_ERROR
-                    if (!CastCastbar(item, interrupt))
+                    if (!CastCastbar(item, Interrupt))
                     {
                         return false;
                     }
@@ -346,81 +345,118 @@ namespace Core.Goals
 
             if (item.AfterCastWaitBuff)
             {
-                // GCD means projectile travel time
-                int totalTime = Math.Max(playerReader.GCD.Value, playerReader.RemainCastMs) + 2 * SpellQueueTimeMs;
+                int totalTime = Math.Max(playerReader.GCD.Value, playerReader.RemainCastMs) + SpellQueueTimeMs;
 
-                (bool changeTimeOut, double elapsedMs) = wait.Until(totalTime, () => auraHash != playerReader.AuraCount.Hash);
-                if (item.Log)
-                    LogAfterCastWaitBuff(logger, item.Name, !changeTimeOut, playerReader.AuraCount.ToString(), elapsedMs);
+                (t, e) = wait.Until(totalTime, () =>
+                    auraHash != playerReader.AuraCount.Hash ||
+                    (MissType)addonReader.CombatLog.TargetMissType.Value != MissType.NONE ||
+                    Interrupt()
+                    );
+
+                if (Log && item.Log)
+                    LogAfterCastWaitBuff(logger, item.Name, !t, playerReader.AuraCount.ToString(), ((MissType)addonReader.CombatLog.TargetMissType.Value).ToStringF(), e);
             }
 
-            if (item.AfterCastWaitItem)
+            if (item.AfterCastAuraExpected)
+            {
+                wait.Update();
+
+                int delay = Math.Max(playerReader.RemainCastMs, item.Item ? 0 : playerReader.LastCastGCD) + SpellQueueTimeMs;
+
+                if (Log && item.Log)
+                    LogAfterCastAuraExpected(logger, item.Name, delay);
+
+                item.SetClicked(delay);
+            }
+
+            if (item.AfterCastWaitBag)
             {
                 int totalTime = Math.Max(playerReader.GCD.Value, playerReader.RemainCastMs) + SpellQueueTimeMs;
 
-                (bool changeTimeOut, double elapsedMs) = wait.Until(totalTime, () => bagHash != addonReader.BagReader.Hash);
-                if (item.Log)
-                    LogAfterCastWaitItem(logger, item.Name, !changeTimeOut, elapsedMs);
+                (t, e) = wait.Until(totalTime, () => bagHash != addonReader.BagReader.Hash || Interrupt());
+                if (Log && item.Log)
+                    LogAfterCastWaitBag(logger, item.Name, !t, e);
             }
 
-            if (item.DelayUntilCombat) // stop waiting if the mob is targetting me
+            if (item.AfterCastWaitCombat)
             {
-                stopMoving.Stop();
-                (bool timeout, double elapsedMs) = wait.Until(2 * item.DelayAfterCast, bits.TargetOfTargetIsPlayerOrPet); // possible travel speed projectile
+                (t, e) = wait.Until(2 * GCD, () => playerReader.Bits.PlayerInCombat() || Interrupt());
 
-                if (item.Log)
-                    LogDelayUntilCombat(logger, item.Name, !timeout, elapsedMs);
+                if (Log && item.Log)
+                    LogAfterCastWaitCombat(logger, item.Name, !t, e);
             }
 
-            if (item.DelayAfterCast != defaultKeyAction.DelayAfterCast && item.DelayAfterCast > 0)
+            if (item.AfterCastWaitMeleeRange)
             {
-                if (item.Log)
-                    LogDelayAfterCast(logger, item.Name, item.DelayAfterCast);
+                int lastKnownHealth = playerReader.HealthCurrent();
 
-                (bool delayTimeOut, double delayElapsedMs) = wait.Until(item.DelayAfterCast, () => prevState != interrupt());
-                if (item.Log)
-                {
-                    if (!delayTimeOut)
-                    {
-                        LogDelayAfterCastInterrupted(logger, item.Name, delayElapsedMs);
-                    }
-                }
+                if (Log && item.Log)
+                    LogAfterCastWaitMeleeRange(logger, item.Name);
+
+                wait.Until(MAX_WAIT_MELEE_RANGE,
+                    () =>
+                    playerReader.IsInMeleeRange() ||
+                    playerReader.IsTargetCasting() ||
+                    playerReader.HealthCurrent() < lastKnownHealth ||
+                    !playerReader.WithInPullRange() ||
+                    Interrupt()
+                    );
             }
 
-            if (item.StepBackAfterCast != 0)
+            if (item.AfterCastStepBack != 0)
             {
-                if (item.Log)
-                    LogStepBackAfterCast(logger, item.Name, item.StepBackAfterCast);
+                if (Log && item.Log)
+                    LogAfterCastStepBack(logger, item.Name, item.AfterCastStepBack);
 
                 input.Proc.SetKeyState(input.Proc.BackwardKey, true);
-
-                bool stepbackTimeOut = false;
-                double stepbackElapsedMs = 0;
 
                 if (Random.Shared.Next(3) == 0) // 33 %
                     input.Jump();
 
-                if (item.StepBackAfterCast == -1)
+                if (item.AfterCastStepBack == -1)
                 {
                     int waitAmount = playerReader.GCD.Value;
                     if (waitAmount == 0)
                     {
                         waitAmount = MIN_GCD - SpellQueueTimeMs;
                     }
-                    (stepbackTimeOut, stepbackElapsedMs) = wait.Until(waitAmount, () => prevState != interrupt());
+                    (t, e) = wait.Until(waitAmount, Interrupt);
                 }
                 else
                 {
-                    (stepbackTimeOut, stepbackElapsedMs) = wait.Until(item.StepBackAfterCast, () => prevState != interrupt());
+                    (t, e) = wait.Until(item.AfterCastStepBack, Interrupt);
                 }
 
-                if (item.Log)
-                    LogStepBackAfterCastInterrupted(logger, item.Name, !stepbackTimeOut, stepbackElapsedMs);
+                if (Log && item.Log)
+                    LogAfterCastStepBackInterrupted(logger, item.Name, !t, e);
 
                 input.Proc.SetKeyState(input.Proc.BackwardKey, false);
             }
 
-            UpdateSpellQueue(item, begin);
+            if (item.AfterCastWaitGCD)
+            {
+                if (Log && item.Log)
+                    LogAfterCastWaitGCD(logger, item.Name, playerReader.GCD.Value);
+
+                wait.Until(playerReader.GCD.Value, Interrupt);
+            }
+
+            if (item.AfterCastDelay > 0)
+            {
+                if (Log && item.Log)
+                    LogAfterCastDelay(logger, item.Name, item.AfterCastDelay);
+
+                (t, e) = wait.Until(item.AfterCastDelay, Interrupt);
+                if (Log && item.Log && !t)
+                {
+                    LogAfterCastDelayInterrupted(logger, item.Name, e);
+                }
+            }
+
+            int durationMs = UpdateGCD(false);
+
+            if (Log && item.Log)
+                LogWaitForGCD(logger, item.Name, playerReader.GCD.Value, playerReader.RemainCastMs, durationMs);
 
             item.ConsumeCharge();
             return true;
@@ -428,223 +464,65 @@ namespace Core.Goals
 
         private bool WaitForGCD(KeyAction item, Func<bool> interrupt)
         {
-            int totalTime = Math.Max(playerReader.GCD.Value, playerReader.RemainCastMs) - (SpellQueueTimeMs - playerReader.NetworkLatency.Value); //+ playerReader.NetworkLatency.Value
-            if (totalTime < 0)
+            int duration = Math.Max(playerReader.GCD.Value, playerReader.RemainCastMs) - (SpellQueueTimeMs - playerReader.NetworkLatency.Value); //+ playerReader.NetworkLatency.Value
+            if (duration < 0)
                 return true;
 
-            bool before = interrupt();
-            (bool timeout, double elapsedMs) = wait.Until(totalTime,
-                () => before != interrupt());
+            (bool t, double e) = wait.Until(duration, interrupt);
 
-            if (item.Log)
-                LogGCD(logger, item.Name, !timeout, addonReader.UsableAction.Is(item), totalTime, elapsedMs);
+            if (Log && item.Log)
+                LogGCD(logger, item.Name, !t, addonReader.UsableAction.Is(item), duration, e);
 
-            return !timeout || before == interrupt();
+            return !t;
         }
 
-        public bool SwitchForm(Form beforeForm, KeyAction item)
+        public int UpdateGCD(bool forced)
         {
-            int index = -1;
+            int durationMs;
+
+            if (SpellInQueue() && !forced)
+            {
+                durationMs = Math.Max(playerReader.LastCastGCD, playerReader.RemainCastMs)
+                    - SpellQueueTimeMs
+                    + playerReader.NetworkLatency.Value;
+            }
+            else
+            {
+                durationMs = Math.Max(playerReader.GCD.Value, playerReader.RemainCastMs)
+                    - SpellQueueTimeMs
+                    + playerReader.NetworkLatency.Value;
+            }
+
+            SpellQueueOpen = DateTime.UtcNow.AddMilliseconds(durationMs);
+            //logger.LogInformation($"Spell Queue window upens after {durationMs}");
+            return durationMs;
+        }
+
+        public bool SwitchForm(KeyAction item)
+        {
+            KeyAction? formAction = null;
             for (int i = 0; i < classConfig.Form.Length; i++)
             {
-                if (classConfig.Form[i].FormEnum == item.FormEnum)
+                formAction = classConfig.Form[i];
+                if (formAction.FormEnum == item.FormEnum)
                 {
-                    index = i;
                     break;
                 }
             }
-            if (index == -1)
+
+            if (formAction == null)
             {
                 logger.LogError($"Unable to find {nameof(KeyAction.Key)} in {nameof(ClassConfiguration.Form)} to transform into {item.FormEnum}");
                 return false;
             }
 
-            PressKeyAction(classConfig.Form[index]);
-
-            (bool changedTimeOut, double elapsedMs) = wait.Until(SpellQueueTimeMs + playerReader.NetworkLatency.Value, () => playerReader.Form == item.FormEnum);
-            if (item.Log)
-                LogFormChanged(logger, item.Name, !changedTimeOut, beforeForm.ToStringF(), playerReader.Form.ToStringF(), elapsedMs);
-
-            classConfig.Form[index].SetClicked();
-
-            return playerReader.Form == item.FormEnum;
-        }
-
-        private void UpdateSpellQueue(KeyAction item, DateTime begin)
-        {
-            int duration = Math.Max(playerReader.GCD.Value, playerReader.RemainCastMs)
-                - SpellQueueTimeMs
-                - (int)(DateTime.UtcNow - begin).TotalMilliseconds
-                + playerReader.NetworkLatency.Value; /* - (2 * playerReader.NetworkLatency.Value)*/;
-
-            SpellQueueOpen = DateTime.UtcNow.AddMilliseconds(duration);
-
-            if (item.Log)
-                LogWaitForGCD(logger, item.Name, playerReader.GCD.Value, playerReader.RemainCastMs, duration);
-        }
-
-        private void ReactToLastCastingEvent(KeyAction item, string source)
-        {
-            UI_ERROR value = (UI_ERROR)playerReader.CastEvent.Value;
-            switch (value)
-            {
-                case UI_ERROR.NONE:
-                case UI_ERROR.CAST_START:
-                case UI_ERROR.CAST_SUCCESS:
-                case UI_ERROR.SPELL_FAILED_TARGETS_DEAD:
-                    break;
-                case UI_ERROR.ERR_SPELL_FAILED_INTERRUPTED:
-                    item.SetClicked();
-                    break;
-                case UI_ERROR.SPELL_FAILED_NOT_READY:
-                /*
-                int waitTime = Math.Max(playerReader.GCD.Value, playerReader.RemainCastMs);
-                logger.LogInformation($"{source} React to {value.ToStringF()} -- wait for GCD {waitTime}ms");
-                if (waitTime > 0)
-                    wait.Fixed(waitTime);
-                break;
-                */
-                case UI_ERROR.ERR_SPELL_COOLDOWN:
-                    logger.LogInformation($"{source} React to {value.ToStringF()} -- wait until its ready");
-                    int waitTime = Math.Max(playerReader.GCD.Value, playerReader.RemainCastMs);
-                    bool before = addonReader.UsableAction.Is(item);
-                    wait.Until(waitTime, () => before != addonReader.UsableAction.Is(item) || addonReader.UsableAction.Is(item));
-                    break;
-                case UI_ERROR.ERR_SPELL_FAILED_STUNNED:
-                    int debuffCount = playerReader.AuraCount.PlayerDebuff;
-                    if (debuffCount != 0)
-                    {
-                        logger.LogInformation($"{source} -- React to {value.ToStringF()} -- Wait till losing debuff!");
-                        wait.While(() => debuffCount == playerReader.AuraCount.PlayerDebuff);
-                    }
-                    else
-                    {
-                        logger.LogInformation($"{source} -- Didn't know how to react {value.ToStringF()} when PlayerDebuffCount: {debuffCount}");
-                    }
-
-                    break;
-                case UI_ERROR.ERR_SPELL_OUT_OF_RANGE:
-
-                    if (!playerReader.Bits.HasTarget())
-                        return;
-
-                    if (playerReader.Class == PlayerClassEnum.Hunter && playerReader.IsInMeleeRange())
-                    {
-                        logger.LogInformation($"{source} -- As a Hunter didn't know how to react {value.ToStringF()}");
-                        return;
-                    }
-
-                    float minRange = playerReader.MinRange();
-                    if (bits.PlayerInCombat() && bits.HasTarget() && !playerReader.IsTargetCasting())
-                    {
-                        wait.Update();
-                        wait.Update();
-                        if (playerReader.TargetTarget == TargetTargetEnum.Me)
-                        {
-                            logger.LogInformation($"{source} -- React to {value.ToStringF()} -- Just wait for the target to get in range.");
-
-                            (bool timeout, double elapsedMs) = wait.Until(GCD,
-                                () => minRange != playerReader.MinRange() || playerReader.IsTargetCasting()
-                            );
-                        }
-                    }
-                    else
-                    {
-                        double beforeDirection = playerReader.Direction;
-                        input.Interact();
-                        input.StopAttack();
-                        stopMoving.Stop();
-                        wait.Update();
-
-                        if (beforeDirection != playerReader.Direction)
-                        {
-                            input.Interact();
-
-                            (bool timeout, double elapsedMs) = wait.Until(GCD,
-                                () => minRange != playerReader.MinRange());
-
-                            logger.LogInformation($"{source} -- React to {value.ToStringF()} -- Approached target {minRange}->{playerReader.MinRange()}");
-                        }
-                        else
-                        {
-                            logger.LogInformation($"{source} -- React to {value.ToStringF()} -- Start moving forward");
-                            input.Proc.SetKeyState(input.Proc.ForwardKey, true);
-                        }
-                    }
-                    break;
-                case UI_ERROR.ERR_BADATTACKFACING:
-                    if (playerReader.IsInMeleeRange())
-                    {
-                        logger.LogInformation($"{source} -- React to {value.ToStringF()} -- Interact!");
-                        input.Interact();
-                        stopMoving.Stop();
-                    }
-                    else
-                    {
-                        switch (playerReader.Class)
-                        {
-                            case PlayerClassEnum.None:
-                                break;
-                            case PlayerClassEnum.Monk:
-                            case PlayerClassEnum.DemonHunter:
-                            case PlayerClassEnum.Druid:
-                            case PlayerClassEnum.DeathKnight:
-                            case PlayerClassEnum.Warrior:
-                            case PlayerClassEnum.Paladin:
-                            case PlayerClassEnum.Rogue:
-                                logger.LogInformation($"{source} -- React to {value.ToStringF()} -- Interact!");
-                                input.Interact();
-                                stopMoving.Stop();
-                                break;
-                            case PlayerClassEnum.Hunter:
-                            case PlayerClassEnum.Priest:
-                            case PlayerClassEnum.Shaman:
-                            case PlayerClassEnum.Mage:
-                            case PlayerClassEnum.Warlock:
-                                stopMoving.Stop();
-                                logger.LogInformation($"{source} -- React to {value.ToStringF()} -- Turning 180!");
-                                float desiredDirection = playerReader.Direction + MathF.PI;
-                                desiredDirection = desiredDirection > MathF.PI * 2 ? desiredDirection - (MathF.PI * 2) : desiredDirection;
-                                direction.SetDirection(desiredDirection, Vector3.Zero);
-                                break;
-                        }
-
-                        wait.Update();
-                    }
-                    break;
-                case UI_ERROR.SPELL_FAILED_MOVING:
-                    logger.LogInformation($"{source} -- React to {value.ToStringF()} -- Stop moving!");
-                    wait.While(playerReader.Bits.IsFalling);
-                    stopMoving.Stop();
-                    wait.Update();
-                    break;
-                case UI_ERROR.ERR_SPELL_FAILED_ANOTHER_IN_PROGRESS:
-                    logger.LogInformation($"{source} -- React to {value.ToStringF()} -- Wait till casting!");
-                    wait.While(playerReader.IsCasting);
-                    break;
-                case UI_ERROR.ERR_BADATTACKPOS:
-                    if (bits.SpellOn_AutoAttack())
-                    {
-                        logger.LogInformation($"{source} -- React to {value.ToStringF()} -- Interact!");
-                        input.Interact();
-                        stopMoving.Stop();
-                        wait.Update();
-                    }
-                    else
-                    {
-                        logger.LogInformation($"{source} -- Didn't know how to React to {value.ToStringF()}");
-                    }
-                    break;
-                default:
-                    logger.LogInformation($"{source} -- Didn't know how to React to {value.ToStringF()}");
-                    break;
-            }
+            return CastInstant(formAction);
         }
 
         private void RepeatPetAttack()
         {
-            if (bits.PlayerInCombat() &&
-                bits.HasPet() &&
+            if (playerReader.Bits.PlayerInCombat() &&
+                playerReader.Bits.HasPet() &&
                 !playerReader.PetHasTarget &&
                 input.ClassConfig.PetAttack.GetCooldownRemaining() == 0)
             {
@@ -652,22 +530,13 @@ namespace Core.Goals
             }
         }
 
-        private void RepeatStayCloseToTarget()
-        {
-            if (classConfig.Approach.GetCooldownRemaining() == 0)
-            {
-                input.Approach();
-            }
-        }
-
-
         #region Logging
 
         [LoggerMessage(
             EventId = 70,
             Level = LogLevel.Information,
-            Message = "[{name}] waiting for next swing...")]
-        static partial void LogWaitNextSwing(ILogger logger, string name);
+            Message = "[{name}] ... AfterCastWaitSwing")]
+        static partial void LogAfterCastWaitSwing(ILogger logger, string name);
 
         [LoggerMessage(
             EventId = 71,
@@ -678,14 +547,14 @@ namespace Core.Goals
         [LoggerMessage(
             EventId = 72,
             Level = LogLevel.Information,
-            Message = "[{name}] instant input {pressTime} {register} {inputElapsedMs}ms")]
+            Message = "[{name}] instant input {pressTime}ms {register} {inputElapsedMs}ms")]
         static partial void LogInstantInput(ILogger logger, string name, int pressTime, bool register, double inputElapsedMs);
 
         [LoggerMessage(
             EventId = 73,
             Level = LogLevel.Information,
-            Message = "[{name}] ... usable: {beforeUsable}->{afterUsable} -- {beforeCastEvent}->{afterCastEvent} -- GCD: {gcd}")]
-        static partial void LogInstantUsableChange(ILogger logger, string name, bool beforeUsable, bool afterUsable, string beforeCastEvent, string afterCastEvent, int gcd);
+            Message = "[{name}] instant usable: {beforeUsable}->{afterUsable} -- {beforeCastEvent}->{afterCastEvent}")]
+        static partial void LogInstantUsableChange(ILogger logger, string name, bool beforeUsable, bool afterUsable, string beforeCastEvent, string afterCastEvent);
 
         [LoggerMessage(
             EventId = 74,
@@ -696,7 +565,7 @@ namespace Core.Goals
         [LoggerMessage(
             EventId = 75,
             Level = LogLevel.Information,
-            Message = "[{name}] ... castbar input {pressTime}ms {register} {inputElapsedMs}ms")]
+            Message = "[{name}] castbar input {pressTime}ms {register} {inputElapsedMs}ms")]
         static partial void LogCastbarInput(ILogger logger, string name, int pressTime, bool register, double inputElapsedMs);
 
         [LoggerMessage(
@@ -708,26 +577,26 @@ namespace Core.Goals
         [LoggerMessage(
             EventId = 77,
             Level = LogLevel.Information,
-            Message = "[{name}] waiting for visible cast bar finish {remain}ms or interrupt...")]
-        static partial void LogVisibleCastbarWaitForEnd(ILogger logger, string name, int remain);
+            Message = "[{name}] ... AfterCastWaitCastbar(V) {remain}ms or interrupt...")]
+        static partial void LogVisibleAfterCastWaitCastbar(ILogger logger, string name, int remain);
 
         [LoggerMessage(
             EventId = 78,
             Level = LogLevel.Warning,
-            Message = "[{name}] ... visible castbar interrupted!")]
-        static partial void LogVisibleCastbarInterrupted(ILogger logger, string name);
+            Message = "[{name}] ... AfterCastWaitCastbar(v) interrupted!")]
+        static partial void LogVisibleAfterCastWaitCastbarInterrupted(ILogger logger, string name);
 
         [LoggerMessage(
             EventId = 79,
             Level = LogLevel.Information,
-            Message = "[{name}] waiting for hidden cast bar finish {remain}ms or interrupt...")]
-        static partial void LogHiddenCastbarWaitForEnd(ILogger logger, string name, int remain);
+            Message = "[{name}] ... AfterCastWaitCastbar(h) {remain}ms or interrupt...")]
+        static partial void LogHiddenAfterCastWaitCastbar(ILogger logger, string name, int remain);
 
         [LoggerMessage(
             EventId = 80,
             Level = LogLevel.Warning,
-            Message = "[{name}] ... hidden castbar interrupted!")]
-        static partial void LogHiddenCastbarInterrupted(ILogger logger, string name);
+            Message = "[{name}] ... AfterCastWaitCastbar(h) interrupted!")]
+        static partial void LogHiddenAfterCastWaitCastbarInterrupted(ILogger logger, string name);
 
 
         [LoggerMessage(
@@ -739,50 +608,44 @@ namespace Core.Goals
         [LoggerMessage(
             EventId = 82,
             Level = LogLevel.Information,
-            Message = "[{name}] DelayBeforeCast {delayBeforeCast}ms")]
-        static partial void LogDelayBeforeCast(ILogger logger, string name, int delayBeforeCast);
+            Message = "[{name}] ... BeforeCastDelay {delayBeforeCast}ms")]
+        static partial void LogBeforeCastDelay(ILogger logger, string name, int delayBeforeCast);
 
         [LoggerMessage(
             EventId = 83,
             Level = LogLevel.Information,
-            Message = "[{name}] ... AfterCastWaitBuff | Buff: {changeTimeOut} | {auraCount} | {elapsedMs}ms")]
-        static partial void LogAfterCastWaitBuff(ILogger logger, string name, bool changeTimeOut, string auraCount, double elapsedMs);
+            Message = "[{name}] ... AfterCastWaitBuff | Buff: {changeTimeOut} | {auraCount} | miss: {missType} | {elapsedMs}ms")]
+        static partial void LogAfterCastWaitBuff(ILogger logger, string name, bool changeTimeOut, string auraCount, string missType, double elapsedMs);
 
         [LoggerMessage(
             EventId = 84,
             Level = LogLevel.Information,
-            Message = "[{name}] ... DelayUntilCombat ? {success} {delayAfterCast}ms")]
-        static partial void LogDelayUntilCombat(ILogger logger, string name, bool success, double delayAfterCast);
+            Message = "[{name}] ... AfterCastWaitCombat ? {success} {delayAfterCast}ms")]
+        static partial void LogAfterCastWaitCombat(ILogger logger, string name, bool success, double delayAfterCast);
 
         [LoggerMessage(
             EventId = 85,
             Level = LogLevel.Information,
-            Message = "[{name}] ... DelayAfterCast {delayAfterCast}ms")]
-        static partial void LogDelayAfterCast(ILogger logger, string name, int delayAfterCast);
+            Message = "[{name}] ... AfterCastDelay {delayAfterCast}ms")]
+        static partial void LogAfterCastDelay(ILogger logger, string name, int delayAfterCast);
 
         [LoggerMessage(
             EventId = 86,
             Level = LogLevel.Information,
-            Message = "[{name}] ... DelayAfterCast interrupted {delayElaspedMs}ms")]
-        static partial void LogDelayAfterCastInterrupted(ILogger logger, string name, double delayElaspedMs);
-
-        [LoggerMessage(
-            EventId = 87,
-            Level = LogLevel.Information,
-            Message = "[{name}] ... instant interrupt: {interrupt} | CanRun: {canRun} | {canRunElapsedMs}ms")]
-        static partial void LogWaitForInGameFeedback(ILogger logger, string name, bool interrupt, bool canRun, double canRunElapsedMs);
+            Message = "[{name}] ... AfterCastDelay interrupted {delayElaspedMs}ms")]
+        static partial void LogAfterCastDelayInterrupted(ILogger logger, string name, double delayElaspedMs);
 
         [LoggerMessage(
             EventId = 88,
             Level = LogLevel.Information,
-            Message = "[{name}] StepBackAfterCast {stepBackAfterCast}ms")]
-        static partial void LogStepBackAfterCast(ILogger logger, string name, int stepBackAfterCast);
+            Message = "[{name}] ... AfterCastStepBack {stepBackAfterCast}ms")]
+        static partial void LogAfterCastStepBack(ILogger logger, string name, int stepBackAfterCast);
 
         [LoggerMessage(
             EventId = 89,
             Level = LogLevel.Information,
-            Message = "[{name}] .... StepBackAfterCast interrupt: {interrupt} | {stepbackElapsedMs}ms")]
-        static partial void LogStepBackAfterCastInterrupted(ILogger logger, string name, bool interrupt, double stepbackElapsedMs);
+            Message = "[{name}] .... AfterCastStepBack interrupt: {interrupt} | {stepbackElapsedMs}ms")]
+        static partial void LogAfterCastStepBackInterrupted(ILogger logger, string name, bool interrupt, double stepbackElapsedMs);
 
         [LoggerMessage(
             EventId = 90,
@@ -799,14 +662,32 @@ namespace Core.Goals
         [LoggerMessage(
             EventId = 92,
             Level = LogLevel.Information,
-            Message = "[{name}] ... AfterCastWaitItem ? {changeTimeOut} | {elapsedMs}ms")]
-        static partial void LogAfterCastWaitItem(ILogger logger, string name, bool changeTimeOut, double elapsedMs);
+            Message = "[{name}] ... AfterCastWaitBag ? {changeTimeOut} | {elapsedMs}ms")]
+        static partial void LogAfterCastWaitBag(ILogger logger, string name, bool changeTimeOut, double elapsedMs);
 
         [LoggerMessage(
             EventId = 93,
             Level = LogLevel.Information,
-            Message = "[{name}] GCD: {gcd}ms | castRem: {remainCastMs} | Next Spell can be queued after {duration}ms")]
+            Message = "[{name}] GCD: {gcd}ms | Cast: {remainCastMs}ms | Next spell {duration}ms")]
         static partial void LogWaitForGCD(ILogger logger, string name, int gcd, int remainCastMs, double duration);
+
+        [LoggerMessage(
+            EventId = 94,
+            Level = LogLevel.Information,
+            Message = "[{name}] ... AfterCastAuraExpected {delay}ms")]
+        static partial void LogAfterCastAuraExpected(ILogger logger, string name, int delay);
+
+        [LoggerMessage(
+            EventId = 95,
+            Level = LogLevel.Information,
+            Message = "[{name}] ... AfterCastWaitGCD {gcd}ms")]
+        static partial void LogAfterCastWaitGCD(ILogger logger, string name, int gcd);
+
+        [LoggerMessage(
+            EventId = 96,
+            Level = LogLevel.Information,
+            Message = "[{name}] ... AfterCastWaitMeleeRange")]
+        static partial void LogAfterCastWaitMeleeRange(ILogger logger, string name);
 
         #endregion
     }

--- a/Core/GoalsComponent/MountHandler.cs
+++ b/Core/GoalsComponent/MountHandler.cs
@@ -51,51 +51,47 @@ namespace Core
         {
             if (playerReader.Class == PlayerClassEnum.Druid)
             {
-                int index = -1;
+                KeyAction? keyAction = null;
                 for (int i = 0; i < classConfig.Form.Length; i++)
                 {
-                    if (classConfig.Form[i].FormEnum is Form.Druid_Flight or Form.Druid_Travel)
+                    keyAction = classConfig.Form[i];
+                    if (keyAction.FormEnum is Form.Druid_Flight or Form.Druid_Travel)
                     {
-                        index = i;
                         break;
                     }
                 }
 
-                if (index > -1 &&
-                    castingHandler.SwitchForm(playerReader.Form, classConfig.Form[index]))
+                if (keyAction != null && castingHandler.SwitchForm(keyAction))
                 {
                     return;
                 }
             }
 
-            if (playerReader.Bits.IsFalling())
-            {
-                wait.While(playerReader.Bits.IsFalling);
-            }
+            wait.While(playerReader.Bits.IsFalling);
 
             stopMoving.Stop();
             wait.Update();
 
             input.Mount();
 
-            (bool timeOut, double elapsedMs) =
+            (bool t, double e) =
                 wait.Until(CastingHandler.SpellQueueTimeMs + playerReader.NetworkLatency.Value, CastDetected);
-            Log($"Cast started ? {!timeOut} {elapsedMs}ms");
+            Log($"Cast started ? {!t} {e}ms");
 
             if (!playerReader.Bits.IsMounted())
             {
                 wait.Update();
 
-                (timeOut, elapsedMs) =
+                (t, e) =
                     wait.Until(playerReader.RemainCastMs + playerReader.NetworkLatency.Value, MountedOrNotCastingOrValidTargetOrEnteredCombat);
-                Log($"Cast ended ? {!timeOut} {elapsedMs}ms");
+                Log($"Cast ended ? {!t} {e}ms");
 
                 if (!HasValidTarget())
                 {
-                    (timeOut, elapsedMs) =
+                    (t, e) =
                         wait.Until(CastingHandler.SpellQueueTimeMs + playerReader.NetworkLatency.Value, playerReader.Bits.IsMounted);
 
-                    Log($"Mounted ? {playerReader.Bits.IsMounted()} {elapsedMs}ms");
+                    Log($"Mounted ? {playerReader.Bits.IsMounted()} {e}ms");
                 }
 
                 if (playerReader.Bits.PlayerInCombat() && playerReader.Bits.HasTarget() && !playerReader.Bits.TargetOfTargetIsPlayerOrPet())

--- a/Core/GoalsComponent/ReactCastError.cs
+++ b/Core/GoalsComponent/ReactCastError.cs
@@ -1,0 +1,188 @@
+﻿using Core.Goals;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Numerics;
+
+namespace Core
+{
+    public class ReactCastError
+    {
+        private readonly ILogger logger;
+        private readonly AddonReader addonReader;
+        private readonly PlayerReader playerReader;
+        private readonly Wait wait;
+        private readonly ConfigurableInput input;
+        private readonly StopMoving stopMoving;
+        private readonly PlayerDirection direction;
+
+        public ReactCastError(ILogger logger, AddonReader addonReader, Wait wait, ConfigurableInput input, StopMoving stopMoving, PlayerDirection direction)
+        {
+            this.logger = logger;
+            this.addonReader = addonReader;
+            this.playerReader = addonReader.PlayerReader;
+            this.wait = wait;
+            this.input = input;
+            this.stopMoving = stopMoving;
+            this.direction = direction;
+        }
+
+        public void Do(KeyAction item, string source)
+        {
+            UI_ERROR value = (UI_ERROR)playerReader.CastEvent.Value;
+            switch (value)
+            {
+                case UI_ERROR.NONE:
+                case UI_ERROR.CAST_START:
+                case UI_ERROR.CAST_SUCCESS:
+                case UI_ERROR.SPELL_FAILED_TARGETS_DEAD:
+                    break;
+                case UI_ERROR.ERR_SPELL_FAILED_INTERRUPTED:
+                    item.SetClicked();
+                    break;
+                case UI_ERROR.SPELL_FAILED_NOT_READY:
+                /*
+                int waitTime = Math.Max(playerReader.GCD.Value, playerReader.RemainCastMs);
+                logger.LogInformation($"{source} React to {value.ToStringF()} -- wait for GCD {waitTime}ms");
+                if (waitTime > 0)
+                    wait.Fixed(waitTime);
+                break;
+                */
+                case UI_ERROR.ERR_SPELL_COOLDOWN:
+                    logger.LogInformation($"{source} React to {value.ToStringF()} -- wait until its ready");
+                    int waitTime = Math.Max(playerReader.GCD.Value, playerReader.RemainCastMs);
+                    bool before = addonReader.UsableAction.Is(item);
+                    wait.Until(waitTime, () => before != addonReader.UsableAction.Is(item) || addonReader.UsableAction.Is(item));
+                    break;
+                case UI_ERROR.ERR_ATTACK_PACIFIED:
+                case UI_ERROR.ERR_SPELL_FAILED_STUNNED:
+                    int debuffCount = playerReader.AuraCount.PlayerDebuff;
+                    if (debuffCount != 0)
+                    {
+                        logger.LogInformation($"{source} -- React to {value.ToStringF()} -- Wait till losing debuff!");
+                        wait.While(() => debuffCount == playerReader.AuraCount.PlayerDebuff);
+                    }
+                    else
+                    {
+                        logger.LogInformation($"{source} -- Didn't know how to react {value.ToStringF()} when PlayerDebuffCount: {debuffCount}");
+                    }
+
+                    break;
+                case UI_ERROR.ERR_SPELL_OUT_OF_RANGE:
+
+                    if (!playerReader.Bits.HasTarget())
+                        return;
+
+                    if (playerReader.Class == PlayerClassEnum.Hunter && playerReader.IsInMeleeRange())
+                    {
+                        logger.LogInformation($"{source} -- As a Hunter didn't know how to react {value.ToStringF()}");
+                        return;
+                    }
+
+                    float minRange = playerReader.MinRange();
+                    if (playerReader.Bits.PlayerInCombat() && playerReader.Bits.HasTarget() && !playerReader.IsTargetCasting())
+                    {
+                        wait.Update();
+                        wait.Update();
+                        if (playerReader.TargetTarget == TargetTargetEnum.Me)
+                        {
+                            logger.LogInformation($"{source} -- React to {value.ToStringF()} -- Just wait for the target to get in range.");
+
+                            (bool t, double e) = wait.Until(CastingHandler.GCD,
+                                () => minRange != playerReader.MinRange() || playerReader.IsTargetCasting()
+                            );
+                        }
+                    }
+                    else
+                    {
+                        double beforeDirection = playerReader.Direction;
+                        input.Interact();
+                        input.StopAttack();
+                        stopMoving.Stop();
+                        wait.Update();
+
+                        if (beforeDirection != playerReader.Direction)
+                        {
+                            input.Interact();
+
+                            (bool t, double e) = wait.Until(CastingHandler.GCD, () => minRange != playerReader.MinRange());
+
+                            logger.LogInformation($"{source} -- React to {value.ToStringF()} -- Approached target {minRange}->{playerReader.MinRange()}");
+                        }
+                        else
+                        {
+                            logger.LogInformation($"{source} -- React to {value.ToStringF()} -- Start moving forward");
+                            input.Proc.SetKeyState(input.Proc.ForwardKey, true);
+                        }
+                    }
+                    break;
+                case UI_ERROR.ERR_BADATTACKFACING:
+                    if (playerReader.IsInMeleeRange())
+                    {
+                        logger.LogInformation($"{source} -- React to {value.ToStringF()} -- Interact!");
+                        input.Interact();
+                        stopMoving.Stop();
+                    }
+                    else
+                    {
+                        switch (playerReader.Class)
+                        {
+                            case PlayerClassEnum.None:
+                                break;
+                            case PlayerClassEnum.Monk:
+                            case PlayerClassEnum.DemonHunter:
+                            case PlayerClassEnum.Druid:
+                            case PlayerClassEnum.DeathKnight:
+                            case PlayerClassEnum.Warrior:
+                            case PlayerClassEnum.Paladin:
+                            case PlayerClassEnum.Rogue:
+                                logger.LogInformation($"{source} -- React to {value.ToStringF()} -- Interact!");
+                                input.Interact();
+                                stopMoving.Stop();
+                                break;
+                            case PlayerClassEnum.Hunter:
+                            case PlayerClassEnum.Priest:
+                            case PlayerClassEnum.Shaman:
+                            case PlayerClassEnum.Mage:
+                            case PlayerClassEnum.Warlock:
+                                stopMoving.Stop();
+                                logger.LogInformation($"{source} -- React to {value.ToStringF()} -- Turning 180!");
+                                float desiredDirection = playerReader.Direction + MathF.PI;
+                                desiredDirection = desiredDirection > MathF.PI * 2 ? desiredDirection - (MathF.PI * 2) : desiredDirection;
+                                direction.SetDirection(desiredDirection, Vector3.Zero);
+                                break;
+                        }
+
+                        wait.Update();
+                    }
+                    break;
+                case UI_ERROR.SPELL_FAILED_MOVING:
+                    logger.LogInformation($"{source} -- React to {value.ToStringF()} -- Stop moving!");
+                    wait.While(playerReader.Bits.IsFalling);
+                    stopMoving.Stop();
+                    wait.Update();
+                    break;
+                case UI_ERROR.ERR_SPELL_FAILED_ANOTHER_IN_PROGRESS:
+                    logger.LogInformation($"{source} -- React to {value.ToStringF()} -- Wait till casting!");
+                    wait.While(playerReader.IsCasting);
+                    break;
+                case UI_ERROR.ERR_BADATTACKPOS:
+                    if (playerReader.Bits.SpellOn_AutoAttack())
+                    {
+                        logger.LogInformation($"{source} -- React to {value.ToStringF()} -- Interact!");
+                        input.Interact();
+                        stopMoving.Stop();
+                        wait.Update();
+                    }
+                    else
+                    {
+                        logger.LogInformation($"{source} -- Didn't know how to React to {value.ToStringF()}");
+                    }
+                    break;
+                default:
+                    logger.LogInformation($"{source} -- Didn't know how to React to {value.ToStringF()}");
+                    break;
+            }
+        }
+
+    }
+}

--- a/Core/GoalsFactory/GoalFactory.cs
+++ b/Core/GoalsFactory/GoalFactory.cs
@@ -55,6 +55,7 @@ namespace Core
             // Goals components
             services.AddSingleton<PlayerDirection>();
             services.AddSingleton<StopMoving>();
+            services.AddSingleton<ReactCastError>();
             services.AddSingleton<CastingHandler>();
             services.AddSingleton<StuckDetector>();
             services.AddSingleton<CombatUtil>();

--- a/Core/Requirement/RequirementFactory.cs
+++ b/Core/Requirement/RequirementFactory.cs
@@ -325,8 +325,8 @@ namespace Core
                 }
             }
 
-            AddConsumableRequirement("Water", item);
-            AddConsumableRequirement("Food", item);
+            if (item.Name is Drink or Food)
+                AddConsumableRequirement(item);
 
             InitPerKeyActionRequirements(item);
 
@@ -609,17 +609,16 @@ namespace Core
             }
         }
 
-        private static void AddConsumableRequirement(string name, KeyAction item)
+        private static void AddConsumableRequirement(KeyAction item)
         {
-            if (item.Name == name)
-            {
-                item.StopBeforeCast = true;
-                item.WhenUsable = true;
-                item.AfterCastWaitBuff = true;
+            item.BeforeCastStop = true;
+            item.WhenUsable = true;
+            item.AfterCastWaitBuff = true;
+            item.Item = true;
 
-                item.Requirements.Add("!Swimming");
-                item.Requirements.Add("!Falling");
-            }
+            item.Requirements.Add($"!{item.Name}");
+            item.Requirements.Add("!Swimming");
+            item.Requirements.Add("!Falling");
         }
 
         private void AddSpellSchoolRequirement(List<Requirement> RequirementObjects, KeyAction item)
@@ -705,7 +704,7 @@ namespace Core
         {
             string key = $"CD_{item.Name}";
             bool f() => UsableGCD(key);
-            string s() => $"CD {intVariables[key]() / 1000f:0.0}";
+            string s() => $"CD {intVariables[key]() / 1000f:F1}";
 
             return new Requirement
             {
@@ -717,7 +716,7 @@ namespace Core
 
         private bool UsableGCD(string key)
         {
-            return intVariables[key]() <= CastingHandler.SpellQueueTimeMs + playerReader.NetworkLatency.Value;
+            return intVariables[key]() <= CastingHandler.SpellQueueTimeMs - playerReader.NetworkLatency.Value;
         }
 
         private Requirement CreateTargetCastingSpell(string requirement)

--- a/Core/Requirement/RequirementFactory.cs
+++ b/Core/Requirement/RequirementFactory.cs
@@ -40,6 +40,8 @@ namespace Core
         private readonly Dictionary<string, Func<string, Requirement>> requirementMap;
 
         public const string AddVisible = "AddVisible";
+        public const string Drink = "Drink";
+        public const string Food = "Food";
 
         public RequirementFactory(ILogger logger, AddonReader addonReader, NpcNameFinder npcNameFinder, Dictionary<int, SchoolMask[]> immunityBlacklist)
         {
@@ -115,8 +117,8 @@ namespace Core
                 { "Casting", playerReader.IsCasting },
 
                 // General Buff Condition
-                { "Eating", playerReader.Buffs.Food },
-                { "Drinking", playerReader.Buffs.Drink },
+                { Food, playerReader.Buffs.Food },
+                { Drink, playerReader.Buffs.Drink },
                 { "Mana Regeneration", playerReader.Buffs.Mana_Regeneration },
                 { "Well Fed", playerReader.Buffs.Well_Fed },
                 { "Clearcasting", playerReader.Buffs.Clearcasting },
@@ -388,29 +390,28 @@ namespace Core
 
         public void InitUserDefinedIntVariables(Dictionary<string, int> intKeyValues)
         {
-            foreach (var kvp in intKeyValues)
+            foreach ((string key, int value) in intKeyValues)
             {
-                int v = kvp.Value;
-                int f() => v;
+                int f() => value;
 
-                if (!intVariables.TryAdd(kvp.Key, f))
+                if (!intVariables.TryAdd(key, f))
                 {
-                    throw new Exception($"Unable to add user defined variable to values. [{kvp.Key} -> {kvp.Value}]");
+                    throw new Exception($"Unable to add user defined variable to values. [{key} -> {value}]");
                 }
                 else
                 {
-                    if (kvp.Key.StartsWith("Buff_"))
+                    if (key.StartsWith("Buff_"))
                     {
-                        int l() => playerBuffTimeReader.GetRemainingTimeMs(v);
-                        intVariables.TryAdd($"{v}", l);
+                        int l() => playerBuffTimeReader.GetRemainingTimeMs(value);
+                        intVariables.TryAdd($"{value}", l);
                     }
-                    else if(kvp.Key.StartsWith("Debuff_"))
+                    else if (key.StartsWith("Debuff_"))
                     {
-                        int l() => targetDebuffTimeReader.GetRemainingTimeMs(v);
-                        intVariables.TryAdd($"{v}", l);
+                        int l() => targetDebuffTimeReader.GetRemainingTimeMs(value);
+                        intVariables.TryAdd($"{value}", l);
                     }
 
-                    LogUserDefinedValue(logger, nameof(RequirementFactory), kvp.Key, kvp.Value);
+                    LogUserDefinedValue(logger, nameof(RequirementFactory), key, value);
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -370,7 +370,9 @@ Gives the ability to the user to define global integer variables along the whole
 For example look at the Warlock profiles.
 ```json
 "IntVariables": {
-    "DOT_MIN_HEALTH%": 35
+    "DOT_MIN_HEALTH%": 35,
+    "Debuff_Frost Fever": 237522,   // iconId https://www.wowhead.com/icons
+    "Debuff_Blood Plague": 237514,  // iconId https://www.wowhead.com/icons
 }
 ```
 
@@ -391,50 +393,47 @@ Can specify conditions with [Requirement(s)](#Requirement) in order to create a 
 | Property Name | Description | Default value |
 | --- | --- | --- |
 | `"Name"` | Name of the KeyAction. For the `ActionBarPopulator`, lowercase means macro. | `""` |
-| `"HasCastBar"` | After key press cast bar is expected?<br>By default sets `StopBeforeCast`=`true` | `false` |
-| `"StopBeforeCast"` | Should stop moving before key press | `false` |
 | `"Key"` | Key to press (`ConsoleKey`) | `""` |
+| `"Cost"` | [Adhoc Goals](#Adhoc-Goals) or [NPC Goal](#NPC-Goals) only, priority | `18` |
+| `"PathFilename"` | [NPC Goal](#NPC-Goals) only, this is a short path to get close to the NPC to avoid walls etc. | `""` |
+| `"HasCastBar"` | After key press cast bar is expected?<br>By default sets `BeforeCastStop`=`true` | `false` |
+| `"InCombat"` | Should combat matter when attempt to cast?<br>Accepted values:<br>* `"any value for doesn't matter"`<br>* `"true"`<br>* `"false"` | `false` |
+| `"Item"` | Like on use Trinket, `Food`, `Drink`.<br>The following spells counts as Item, `Throw`, `Auto Shot`, `Shoot` | `false` |
 | `"PressDuration"` | How many milliseconds to hold the key press | `50` |
 | `"Form"` | Shapeshift/Stance form to be in to cast this spell<br>If setted, affects `WhenUsable` | `Form.None` |
-| `"Charge"` | How many consequent key press should happen before setting Cooldown | `1` |
 | `"Cooldown"` | **Note this is not the in-game cooldown!**<br>The time in milliseconds before KeyAction can be used again.<br>This property will be updated when the backend registers the `Key` press. It has no feedback from the game. | `400` |
+| `"Charge"` | How many consequent key press should happen before setting Cooldown | `1` |
 | `"School"` | Indicate what type of element the spell do. Accepted values:<br>* `SchoolMask.Physical`<br>* `SchoolMask.Holy`<br>* `SchoolMask.Fire`<br>* `SchoolMask.Nature`<br>* `SchoolMask.Frost`<br>* `SchoolMask.Shadow`<br>* `SchoolMask.Arcane` | `SchoolMask.None` |
 | --- | --- | --- |
-| --- | The Following `Min` prefixed values used by **ActionBarCost**. Do not use them directly! | --- |
-| `"MinMana"` | Minimum `Mana` [Requirement](#Requirement) | `0` |
-| `"MinRage"` | Minimum `Rage` [Requirement](#Requirement) | `0` |
-| `"MinEnergy"` | Minimum `Energy` [Requirement](#Requirement) | `0` |
-| `"MinComboPoints"` | The minimum combo points [Requirement](#Requirement) | `0` |
-| `"MinRunicPower"` | The minimum Runic Power [Requirement](#Requirement) | `0` |
-| `"MinRuneBlood"` | The minimum Blood Rune [Requirement](#Requirement) | `0` |
-| `"MinRuneFrost"` | The minimum Frost Rune [Requirement](#Requirement) | `0` |
-| `"MinRuneUnholy"` | The minimum Unholy Rune [Requirement](#Requirement) | `0` |
-| --- | --- | --- |
-| `"TotalRune"` | Accumlated available Rune count [Requirement](#Requirement) | `0` |
 | `"WhenUsable"` | Mapped to [IsUsableAction](https://wowwiki-archive.fandom.com/wiki/API_IsUsableAction) | `false` |
+| `"UseWhenTargetIsCasting"` | Checks for the target casting/channeling.<br>Accepted values:<br>* `null` -> ignore<br>* `false` -> when enemy not casting<br>* `true` -> when enemy casting | `null` |
 | `"Requirement"` | Single [Requirement](#Requirement) | `false` |
 | `"Requirements"` | List of [Requirement](#Requirement) | `false` |
-| `"WaitForWithinMeleeRange"` | [Pull Goal](#Pull-Goal) only<br>While the [Requirements](#Requirement) are met, keep repeating the KeyAction.<br>Interrupted either:<br>* target enters melee range<br>* target starts casting<br>* player receives damage | `false` |
-| `"WaitForGCD"` | Indicates should wait for the `GCD` | `true` |
-| `"SkipValidation"` | After key press, skip awaiting in-game effect, such as __(player debuff/buff or target debuff/buff)__ changed. | `false` |
 | `"ResetOnNewTarget"` | Reset the Cooldown if the target changes | `false` |
-| `"Log"` | KeyAction related events should appear in the log | `true` |
-| `"DelayBeforeCast"` | Delay in milliseconds before key press happens | `0` |
-| `"DelayAfterCast"` | Delay in milliseconds after the key press happened | `1450` |
-| `"DelayUntilCombat"` | After cast, waits until player enters combat, good for pulling. | `false` |
-| `"AfterCastWaitBuff"` | After a successful cast, should wait until __(player debuff/buff or target debuff/buff)__ changed. | `false` |
-| `"AfterCastWaitItem"` | After a successful cast, should wait until __(inventory change)__ changed. | `false` |
-| `"AfterCastWaitNextSwing"` | After cast wait for next melee swing happen. | `false` |
-| `"AfterCastWaitCastbar"` | After cast wait for the current castbar to finish. | `false` |
-| `"Cost"` | [Adhoc Goals](#Adhoc-Goals) or [NPC Goal](#NPC-Goals) only the priority | `18` |
-| `"InCombat"` | Should combat matter when attempt to cast?<br>Accepted values:<br>* `"any value for doesn't matter"`<br>* `"true"`<br>* `"false"` | `false` |
-| `"StepBackAfterCast"` | After successful cast, start backpedaling for milliseconds.<br> If value set to `-1` attempts to use the whole remaining GCD duration. | `0` |
-| `"PathFilename"` | [NPC Goal](#NPC-Goals) only, this is a short path to get close to the NPC to avoid walls etc. | `""` |
-| `"UseWhenTargetIsCasting"` | Checks for the target casting/channeling.<br>Accepted values:<br>* `null` -> ignore<br>* `false` -> when enemy not casting<br>* `true` -> when enemy casting | `null` |
+| `"Log"` | Related events should appear in the logs | `true` |
+| --- | Before keypress cast, ... | --- |
+| `"BeforeCastStop"` | stop moving. | `false` |
+| `"BeforeCastDelay"` | delay in milliseconds | `0` |
+| --- | After Successful cast, ... | --- |
+| `"AfterCastWaitSwing"` | wait for next melee swing to land.<br>Blocks **CastingHandler**. | `false` |
+| `"AfterCastWaitCastbar"` | wait for the castbar to finish, `SpellQueueTimeMs` excluded.<br>Blocks **CastingHandler**. | `false` |
+| `"AfterCastWaitBuff"` | wait for Aura=__(player-target debuff/buff)__ count changes.<br>Only works properly, when the Aura **count** changes.<br>Not suitable for refreshing already existing Aura<br>Blocks **CastingHandler**. | `false` |
+| `"AfterCastAuraExpected"` | refreshing Aura=__(player-target debuff/buff)__<br>Just adds an extra(`SpellQueueTimeMs`) Cooldown to the action, so it wont repeat itself.<br>Not blocking  **CastingHandler**. | `false` |
+| `"AfterCastWaitBag"` | wait for inventory, bag change.<br>Blocks **CastingHandler**. | `false` |
+| `"AfterCastWaitCombat"` | wait for player entering combat.<br>Blocks **CastingHandler**. | `false` |
+| `"AfterCastWaitMeleeRange"` | wait for interrupted either:<br>* target enters melee range<br>* target starts casting<br>* player receives damage<br>Blocks **CastingHandler**. | `false` |
+| `"AfterCastStepBack"` | start backpedaling for milliseconds.<br>If value set to `-1` attempts to use the whole remaining GCD duration.<br>Blocks **CastingHandler**. | `0` |
+| `"AfterCastWaitGCD"` | the Global cooldown fully expire.<br>Blocks **CastingHandler**. | `0` |
+| `"AfterCastDelay"` | delay in milliseconds.<br>Blocks **CastingHandler**. | `0` |
+| --- | --- | --- |
 
-Some of these properties are optional and not required to be specified. However can create pretty complex conditions and branches to suit the situation.
+Some of these properties are optional and not required to be specified.
 
-e.g. - bare minimum for a spell which has castbar. **Note:** _there are some spells which dosen't have visible castbar. like `"Throw"`, `"Shoot"`, `"Auto Shot"`_
+However you can create complex conditions and branches to suit the situation.
+
+Important, the `AfterCast` prefixed conditions order as is its shows up the the table above.
+
+e.g. - bare minimum for a spell which has castbar.
 ```json
 {
     "Name": "Frostbolt",
@@ -451,11 +450,23 @@ e.g. - bare minimum for a spell which is instant (no castbar)
 }
 ```
 
-Theres are only two specially named KeyAction `Food` and `Water` which is reserved for eating and drinking.
+e.g. for Rogue ability
+```json
+{
+    "Name": "Slice and Dice",
+    "Key": "3",
+    "Requirements": [
+        "!Slice and Dice",
+        "Combo Point > 1"
+    ]
+}
+```
+
+Theres are few specially named KeyAction such as `Food` and `Drink` which is reserved for eating and drinking.
 
 They already have some prebaked `Requirement` conditions in order to avoid mistype the definition. 
 
-The bare minimum for `Food` and `Water` is looks something like this.
+The bare minimum for `Food` and `Drink` is looks something like this.
 ```json
 {
     "Name": "Food",
@@ -463,23 +474,21 @@ The bare minimum for `Food` and `Water` is looks something like this.
     "Requirement": "Health% < 50"
 },
 {
-    "Name": "Water",
+    "Name": "Drink",
     "Key": "=",
     "Requirement": "Mana% < 50"
 }
 ```
+---
 
-e.g. for Rogue ability
-```json
-{
-    "Name": "Slice And Dice",
-    "Key": "3",
-    "MinEnergy": 25,
-    "MinComboPoints": 2,
-    "Cooldown": 3000,
-    "Requirement": "!Slice And Dice"
-}
-```
+### Casting Handler
+
+**CastingHandler** is a component which responsible for handling player spell casting, 
+let it be using an item from the inventory, casting an instant spell or casting a spell which has castbar.
+
+From Addon version **1.5.5** it has been significantly changed to the point where it no longer blocks the execution until the castbar fully finishes, but rather gives back the control to the parent Goal such as [Adhoc Goals](#Adhoc-Goals) or [Pull Goal](#Pull-Goal) or [Combat Goal](#Combat-Goal) to give more time to find the best suitable action for the given moment.
+
+As a result in order to execute the [Pull Goal](#Pull-Goal) sequence in respect, have to combine its `KeyAction(s)` with `AfterCast` prefixed conditions.
 
 ---
 ### Pull Goal
@@ -493,7 +502,7 @@ e.g.
         {
             "Name": "Concussive Shot",
             "Key": "9",
-            "StopBeforeCast": true,
+            "BeforeCastStop": true,
             "Requirements": ["HasRangedWeapon", "!InMeleeRange", "HasAmmo"]
         }
     ]
@@ -516,7 +525,6 @@ e.g.
             "Name": "Fireball",
             "Key": "2",
             "HasCastBar": true,
-            "MinMana": 30,
             "Requirement": "TargetHealth% > 20"
         },
         {
@@ -542,7 +550,6 @@ e.g.
         {
             "Name": "Frost Armor",
             "Key": "3",
-            "MinMana": 60,
             "Requirement": "!Frost Armor"
         },
         {
@@ -551,7 +558,7 @@ e.g.
             "Requirement": "Health% < 30"
         },
         {
-            "Name": "Water",
+            "Name": "Drink",
             "Key": "-",
             "Requirement": "Mana% < 30"
         }
@@ -565,7 +572,7 @@ These `Sequence` of `KeyAction(s)` are done when not in combat and are not on co
 
 The keypresses happens simultaneously on all `KeyAction(s)` which mets the `Requirement`.
 
-Suitable for `Food` and `Water`.
+Suitable for `Food` and `Drink`.
 
 e.g.
 ```json
@@ -577,7 +584,7 @@ e.g.
             "Requirement": "Health% < 50"
         },
         {
-            "Name": "Water",
+            "Name": "Drink",
             "Key": "-",
             "Requirement": "Mana% < 50"
         }
@@ -664,7 +671,7 @@ A requirement is something that must be evaluated to be `true` for the `KeyActio
 Not all `KeyAction` requires requirement(s), some rely on
 * `Cooldown` - populated manually
 * `ActionBarCooldownReader` - populated automatically
-* `ActionBarCostReader` - populated automatically
+* `ActionBarCostReader` - populated automatically including (`MinMana`, `MinRage`, `MinEnergy`, `MinRunicPower`, `MinRuneBlood`, `MinRuneFrost`, `MinRuneUnholy`)
 
 Can specify `Requirements` for complex condition.
 
@@ -703,7 +710,7 @@ Formula: `[Negate keyword][requirement]`
 e.g.
 ```json
 "Requirement": "not Curse of Weakness"
-"Requirement": "!BagItem:6265:3"
+"Requirement": "!BagItem:Item_Soul_Shard:3"
 ```
 ---
 
@@ -832,8 +839,7 @@ e.g. for `CD_{KeyAction.Name}`: Where `Hammer of Justice` referencing the `Judge
     "Name": "Judgement",
     "Key": "1",
     "WhenUsable": true,
-    "Requirements": ["Seal of the Crusader", "!Judgement of the Crusader"],
-    "DelayAfterCast": 0
+    "Requirements": ["Seal of the Crusader", "!Judgement of the Crusader"]
 },
 {
     "Name": "Hammer of Justice",
@@ -867,7 +873,7 @@ Formula: `BagItem:[intVariableKey/itemid]:[count]`
 e.g.
 
 * `"Requirement": "BagItem:5175"` - Must have a [Earth Totem](https://tbc.wowhead.com/item=5175) in bag
-* `"Requirement": "BagItem:6265:3"` - Must have atleast [3x Soulshard](https://tbc.wowhead.com/item=6265) in bag
+* `"Requirement": "BagItem:Item_Soul_Shard:3"` - Must have atleast [3x Soulshard](https://tbc.wowhead.com/item=6265) in bag
 * `"Requirement": "not BagItem:19007:1"` - Must not have a [Lesser Healthstone](https://tbc.wowhead.com/item=19007) in bag
 * `"Requirement": "!BagItem:6265:3"` - Must not have [3x Soulshard](https://tbc.wowhead.com/item=6265) in bag
 * `"Requirement": "!BagItem:MyAwesomeIntVariable:69"`
@@ -1023,7 +1029,9 @@ e.g.
 ```json
 "IntVariables": {
     "Debuff_Blood Plague": 237514,
-    "Debuff_Frost Fever": 237522
+    "Debuff_Frost Fever": 237522,
+    "Item_Soul_Shard": 6265,
+    "Item_Healthstone": 22105,
 },
 ```
 


### PR DESCRIPTION
Breaking Changes:

Some of the `KeyAction` public properties has been renamed in order to have some consistency about when it happens during the execution. Here's a list of changed names:
* `StopBeforeCast` -> `BeforeCastStop`
* `DelayBeforeCast` -> `BeforeCastDelay`
* `WaitForWithinMeleeRange` -> `AfterCastWaitMeleeRange`
* `DelayAfterCast` ->`AfterCastDelay`
* `WaitForGCD` -> `AfterCastWaitGCD`
* Added `AfterCastWaitBag`
* Added `AfterCastWaitCastbar`
* Added `AfterCastAuraExpected`
* `AfterCastWaitNextSwing` -> `AfterCastWaitSwing`
* `DelayUntilCombat` -> `AfterCastWaitCombat`
* `StepBackAfterCast` -> `AfterCastStepBack`

You can find the respected documentation in the readme.

`PlayerReader` no longer holds `FormCost`. Since The Stance/Shapeshift/Aura/Presence action are bound to ActionBarButton, no longer needs to be hold them in a separate container, just have to match the `FormEnum` with the those actions which are marked with `FormAction=true`. The good thing is when the in game cost changes, it will automatically follows the changes.

`CastingHandler` has been improved utilize GCD and Spell Queue Window best as possible. As a result many `KeyAction` properties has been renamed in order to reflect when does it happen during the chain. Also fixing some reliability issues regarding detecting `InstantCast` spells and items, also some special spells such as `Throw`, `Auto Attack`, `Shoot`, `Auto Shot`. Shapeshifting should behave as consistently as InstantCast spell casting.

`PullTargetGoal` should no longer interrupt castbar based spell cast, near the end.

In summary this chunk of changes around KeyActions is meant to fix many reliability issues!