### PR TITLE
Feature: (DXGI) DirectX based AddonData reader

### DIFF
--- a/BlazorServer/appsettings.json
+++ b/BlazorServer/appsettings.json
@@ -16,5 +16,8 @@
   },
   "Process": {
     "Id": -1
+  },
+  "Reader": {
+    "Type": "GDI" // from Win7 'GDI' - from Win8 'DGXI'
   }
 }

--- a/Core/Actionbar/ActionBarBits.cs
+++ b/Core/Actionbar/ActionBarBits.cs
@@ -14,7 +14,7 @@ namespace Core
             bits = new BitVector32[cells.Length];
         }
 
-        public void Update(AddonDataProvider reader)
+        public void Update(IAddonDataProvider reader)
         {
             for (int i = 0; i < bits.Length; i++)
             {

--- a/Core/Actionbar/ActionBarCooldownReader.cs
+++ b/Core/Actionbar/ActionBarCooldownReader.cs
@@ -31,7 +31,7 @@ namespace Core
             Reset();
         }
 
-        public void Read(AddonDataProvider reader)
+        public void Read(IAddonDataProvider reader)
         {
             // formula
             // MAX_ACTION_IDX * slot + (cooldown / MAX_VALUE_MUL)

--- a/Core/Actionbar/ActionBarCostReader.cs
+++ b/Core/Actionbar/ActionBarCostReader.cs
@@ -61,7 +61,7 @@ namespace Core
             Reset();
         }
 
-        public void Read(AddonDataProvider reader)
+        public void Read(IAddonDataProvider reader)
         {
             // formula
             // COST_MAX_COST_IDX * costNum + COST_MAX_POWER_TYPE * (type + offsetEnumPowerType) + slot

--- a/Core/Addon/AddonDataProviderDGXI.cs
+++ b/Core/Addon/AddonDataProviderDGXI.cs
@@ -1,0 +1,219 @@
+﻿using Game;
+using SharpGen.Runtime;
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Threading;
+using Vortice.Direct3D;
+using Vortice.Direct3D11;
+using Vortice.DXGI;
+
+namespace Core
+{
+    public sealed class AddonDataProviderDGXI : IAddonDataProvider, IDisposable
+    {
+        private readonly CancellationTokenSource cts;
+
+        private readonly WowScreen wowScreen;
+
+        private bool disposing;
+
+        //                                 B  G  R
+        private readonly byte[] fColor = { 0, 0, 0 };
+        private readonly byte[] lColor = { 129, 132, 30 };
+
+        private static readonly FeatureLevel[] s_featureLevels = new[]
+{
+            FeatureLevel.Level_12_1,
+            FeatureLevel.Level_12_0,
+            FeatureLevel.Level_11_0,
+        };
+
+        private readonly Vortice.RawRect bounds;
+
+        private readonly IDXGIAdapter adapter;
+        private readonly IDXGIOutput output;
+        private readonly IDXGIOutput1 output1;
+
+        private readonly IDXGIOutputDuplication duplication;
+        private readonly ID3D11Texture2D addonTexture;
+        private readonly ID3D11Device device;
+
+        private readonly Bitmap bitmap;
+        private readonly Rectangle rect;
+        private readonly int[] data;
+        private readonly DataFrame[] frames;
+
+        public AddonDataProviderDGXI(CancellationTokenSource cts, WowScreen wowScreen, DataFrame[] frames)
+        {
+            this.cts = cts;
+            this.wowScreen = wowScreen;
+
+            this.frames = frames;
+
+            data = new int[this.frames.Length];
+
+            for (int i = 0; i < this.frames.Length; i++)
+            {
+                if (frames[i].X > rect.Width)
+                    rect.Width = frames[i].X;
+
+                if (frames[i].Y > rect.Height)
+                    rect.Height = frames[i].Y;
+            }
+            rect.Width++;
+            rect.Height++;
+
+            bitmap = new(rect.Right, rect.Bottom, PixelFormat.Format32bppRgb);
+
+            int screenId = 0;
+
+            IDXGIFactory1 factory = DXGI.CreateDXGIFactory1<IDXGIFactory1>();
+            adapter = factory.GetAdapter(0);
+            output = adapter.GetOutput(screenId);
+            output1 = output.QueryInterface<IDXGIOutput1>();
+            D3D11.D3D11CreateDevice(adapter, DriverType.Unknown, DeviceCreationFlags.None, s_featureLevels, out ID3D11Device? d);
+
+            if (d == null)
+                throw new Exception("device is null");
+
+            device = d;
+
+            bounds = output1.Description.DesktopCoordinates;
+
+            duplication = output1.DuplicateOutput(device);
+
+            Texture2DDescription textureDesc = new()
+            {
+                CPUAccessFlags = CpuAccessFlags.Read,
+                BindFlags = BindFlags.None,
+                Format = Format.B8G8R8A8_UNorm,
+                Width = rect.Right,
+                Height = rect.Bottom,
+                //Width = bounds.Right - bounds.Left,
+                //Height = bounds.Bottom - bounds.Top,
+                MiscFlags = ResourceOptionFlags.None,
+                MipLevels = 1,
+                ArraySize = 1,
+                SampleDescription = { Count = 1, Quality = 0 },
+                Usage = ResourceUsage.Staging
+            };
+
+            addonTexture = device.CreateTexture2D(textureDesc);
+        }
+
+        public void Dispose()
+        {
+            if (disposing)
+                return;
+
+            disposing = true;
+
+            duplication.ReleaseFrame();
+            duplication.Dispose();
+
+            addonTexture.Dispose();
+            device.Dispose();
+            adapter.Dispose();
+            output1.Dispose();
+            output.Dispose();
+
+            bitmap.Dispose();
+        }
+
+        public void Update()
+        {
+            cts.Token.WaitHandle.WaitOne(1);
+
+            if (cts.IsCancellationRequested || disposing) return;
+
+            Point p = new();
+            wowScreen.GetPosition(ref p);
+
+            duplication.ReleaseFrame();
+            Result result = duplication.AcquireNextFrame(50, out OutduplFrameInfo frameInfo, out IDXGIResource? desktopResource);
+            if (!result.Success || disposing)
+                return;
+
+            const int bytesPerPixel = 4;
+
+            ID3D11Texture2D texture = desktopResource.QueryInterface<ID3D11Texture2D>();
+            device.ImmediateContext.CopySubresourceRegion(addonTexture, 0, 0, 0, 0, texture, 0,
+                new Vortice.Mathematics.Box(p.X, p.Y, 0, p.X + rect.Right, p.Y + rect.Bottom, 1));
+            MappedSubresource dataBox = device.ImmediateContext.Map(addonTexture, 0, MapMode.Read, Vortice.Direct3D11.MapFlags.None);
+
+            int sizeInBytesToCopy = rect.Right * bytesPerPixel;
+
+            BitmapData bd = bitmap.LockBits(rect, ImageLockMode.ReadWrite, bitmap.PixelFormat);
+            for (int y = 0; y < rect.Bottom; y++)
+            {
+                MemoryHelpers.CopyMemory(bd.Scan0 + y * bd.Stride, (dataBox.DataPointer + y * dataBox.RowPitch), sizeInBytesToCopy);
+            }
+            device.ImmediateContext.Unmap(addonTexture, 0);
+            texture.Dispose();
+
+            //bitmap.Save($"bitmap.bmp", ImageFormat.Bmp);
+            //Thread.Sleep(1000);
+
+            unsafe
+            {
+                byte* fLine = (byte*)bd.Scan0 + (frames[0].Y * bd.Stride);
+                int fx = frames[0].X * bytesPerPixel;
+
+                byte* lLine = (byte*)bd.Scan0 + (frames[^1].Y * bd.Stride);
+                int lx = frames[^1].X * bytesPerPixel;
+
+                for (int i = 0; i < 3; i++)
+                {
+                    if (fLine[fx + i] != fColor[i] || lLine[lx + i] != lColor[i])
+                        goto Unlock;
+                }
+
+                for (int i = 0; i < frames.Length; i++)
+                {
+                    fLine = (byte*)bd.Scan0 + (frames[i].Y * bd.Stride);
+                    fx = frames[i].X * bytesPerPixel;
+
+                    data[frames[i].Index] = (fLine[fx + 2] * 65536) + (fLine[fx + 1] * 256) + fLine[fx];
+                }
+
+            Unlock:
+                bitmap.UnlockBits(bd);
+            }
+        }
+
+        public void InitFrames(DataFrame[] frames) { }
+
+        public int GetInt(int index)
+        {
+            return data[index];
+        }
+
+        public float GetFixed(int index)
+        {
+            return GetInt(index) / 100000f;
+        }
+
+        public string GetString(int index)
+        {
+            int color = GetInt(index);
+            if (color != 0)
+            {
+                string colorString = color.ToString();
+                if (colorString.Length > 6) { return string.Empty; }
+                string colorText = "000000"[..(6 - colorString.Length)] + colorString;
+                return ToChar(colorText, 0) + ToChar(colorText, 2) + ToChar(colorText, 4);
+            }
+            else
+            {
+                return string.Empty;
+            }
+        }
+
+        private static string ToChar(string colorText, int start)
+        {
+            return ((char)int.Parse(colorText.Substring(start, 2))).ToString();
+        }
+    }
+}
+

--- a/Core/Addon/AddonDataProviderGDI.cs
+++ b/Core/Addon/AddonDataProviderGDI.cs
@@ -1,0 +1,140 @@
+﻿using Game;
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Threading;
+
+namespace Core
+{
+    public sealed class AddonDataProviderGDI : IAddonDataProvider, IDisposable
+    {
+        private readonly CancellationTokenSource cts;
+
+        private readonly int[] data;
+        private readonly DataFrame[] frames;
+
+        private readonly Rectangle rect;
+        private readonly Bitmap bitmap;
+        private readonly Graphics graphics;
+
+        private readonly WowScreen wowScreen;
+        private readonly int bytesPerPixel;
+
+        //                                 B  G  R
+        private readonly byte[] fColor = { 0, 0, 0 };
+        private readonly byte[] lColor = { 129, 132, 30 };
+
+        private const PixelFormat pixelFormat = PixelFormat.Format32bppPArgb;
+
+        private bool disposing;
+
+        public AddonDataProviderGDI(CancellationTokenSource cts, WowScreen wowScreen, DataFrame[] frames)
+        {
+            this.cts = cts;
+            this.wowScreen = wowScreen;
+            this.frames = frames;
+
+            data = new int[this.frames.Length];
+
+            for (int i = 0; i < this.frames.Length; i++)
+            {
+                if (frames[i].X > rect.Width)
+                    rect.Width = frames[i].X;
+
+                if (frames[i].Y > rect.Height)
+                    rect.Height = frames[i].Y;
+            }
+            rect.Width++;
+            rect.Height++;
+
+            bitmap = new(rect.Width, rect.Height, pixelFormat);
+            graphics = Graphics.FromImage(bitmap);
+
+            bytesPerPixel = Image.GetPixelFormatSize(pixelFormat) / 8;
+        }
+
+        public void Dispose()
+        {
+            if (disposing)
+                return;
+
+            disposing = true;
+
+            graphics.Dispose();
+            bitmap.Dispose();
+        }
+
+        public void Update()
+        {
+            cts.Token.WaitHandle.WaitOne(1);
+
+            if (cts.IsCancellationRequested || disposing) return;
+
+            Point p = new();
+            wowScreen.GetPosition(ref p);
+            graphics.CopyFromScreen(p, Point.Empty, rect.Size);
+
+            unsafe
+            {
+                BitmapData bd = bitmap.LockBits(rect, ImageLockMode.ReadOnly, pixelFormat);
+
+                byte* fLine = (byte*)bd.Scan0 + (frames[0].Y * bd.Stride);
+                int fx = frames[0].X * bytesPerPixel;
+
+                byte* lLine = (byte*)bd.Scan0 + (frames[^1].Y * bd.Stride);
+                int lx = frames[^1].X * bytesPerPixel;
+
+                for (int i = 0; i < 3; i++)
+                {
+                    if (fLine[fx + i] != fColor[i] || lLine[lx + i] != lColor[i])
+                        goto Exit;
+                }
+
+                for (int i = 0; i < frames.Length; i++)
+                {
+                    fLine = (byte*)bd.Scan0 + (frames[i].Y * bd.Stride);
+                    fx = frames[i].X * bytesPerPixel;
+
+                    data[frames[i].Index] = (fLine[fx + 2] * 65536) + (fLine[fx + 1] * 256) + fLine[fx];
+                }
+
+            Exit:
+                bitmap.UnlockBits(bd);
+            }
+        }
+
+        public void InitFrames(DataFrame[] frames) { }
+
+        public int GetInt(int index)
+        {
+            return data[index];
+        }
+
+        public float GetFixed(int index)
+        {
+            return GetInt(index) / 100000f;
+        }
+
+        public string GetString(int index)
+        {
+            int color = GetInt(index);
+            if (color != 0)
+            {
+                string colorString = color.ToString();
+                if (colorString.Length > 6) { return string.Empty; }
+                string colorText = "000000"[..(6 - colorString.Length)] + colorString;
+                return ToChar(colorText, 0) + ToChar(colorText, 2) + ToChar(colorText, 4);
+            }
+            else
+            {
+                return string.Empty;
+            }
+        }
+
+        private static string ToChar(string colorText, int start)
+        {
+            return ((char)int.Parse(colorText.Substring(start, 2))).ToString();
+        }
+    }
+}
+

--- a/Core/Addon/AddonDataProviderType.cs
+++ b/Core/Addon/AddonDataProviderType.cs
@@ -1,0 +1,9 @@
+﻿namespace Core
+{
+    public enum AddonDataProviderType
+    {
+        GDI,
+        DXGI,
+        GDIConfig
+    }
+}

--- a/Core/Addon/AddonReader.cs
+++ b/Core/Addon/AddonReader.cs
@@ -9,7 +9,7 @@ namespace Core
     public sealed class AddonReader : IAddonReader, IDisposable
     {
         private readonly ILogger logger;
-        private readonly AddonDataProvider reader;
+        private readonly IAddonDataProvider reader;
         private readonly AutoResetEvent autoResetEvent;
 
         public PlayerReader PlayerReader { get; }
@@ -58,16 +58,16 @@ namespace Core
         public string TargetName { get; private set; } = string.Empty;
 
         public double AvgUpdateLatency { private set; get; }
-        private int updateSum;
+        private double updateSum;
         private int updateIndex;
         private DateTime lastUpdate;
 
-        public AddonReader(ILogger logger, AddonDataProvider addonDataProvider,
+        public AddonReader(ILogger logger, IAddonDataProvider reader,
             AutoResetEvent autoResetEvent, AreaDB areaDB, WorldMapAreaDB worldMapAreaDB,
             ItemDB itemDB, CreatureDB creatureDB, SpellDB spellDB, TalentDB talentDB)
         {
             this.logger = logger;
-            this.reader = addonDataProvider;
+            this.reader = reader;
             this.autoResetEvent = autoResetEvent;
 
             this.AreaDb = areaDB;
@@ -87,7 +87,7 @@ namespace Core
 
             this.SpellBookReader = new(71, spellDB);
 
-            this.PlayerReader = new(addonDataProvider);
+            this.PlayerReader = new(reader);
             this.LevelTracker = new(this);
             this.TalentReader = new(72, PlayerReader, talentDB);
 
@@ -121,12 +121,12 @@ namespace Core
                     return;
                 }
 
-                updateSum += (int)(DateTime.UtcNow - lastUpdate).TotalMilliseconds;
+                updateSum += (DateTime.UtcNow - lastUpdate).TotalMilliseconds;
                 updateIndex++;
                 AvgUpdateLatency = updateSum / updateIndex;
                 lastUpdate = DateTime.UtcNow;
 
-                AddonDataProvider reader = this.reader;
+                IAddonDataProvider reader = this.reader;
 
                 CurrentAction.Update(reader);
                 UsableAction.Update(reader);

--- a/Core/Addon/AuraTimeReader.cs
+++ b/Core/Addon/AuraTimeReader.cs
@@ -29,7 +29,7 @@ namespace Core
             Reset();
         }
 
-        public void Read(AddonDataProvider reader)
+        public void Read(IAddonDataProvider reader)
         {
             int textureId = reader.GetInt(cTextureId);
             if (textureId == 0) return;

--- a/Core/Addon/ConfigAddonReader.cs
+++ b/Core/Addon/ConfigAddonReader.cs
@@ -25,23 +25,46 @@ namespace Core.Addon
 
         public RecordInt UIMapId => throw new NotImplementedException();
 
-#pragma warning disable CS0067 // The event is never used
         public event Action? AddonDataChanged;
+
+#pragma warning disable CS0067 // The event is never used
         public event Action? ZoneChanged;
         public event Action? PlayerDeath;
 #pragma warning restore CS0067
 
+        private readonly IAddonDataProvider reader;
+
+        public ConfigAddonReader(IAddonDataProvider reader)
+        {
+            this.reader = reader;
+        }
+
         public int GetInt(int index)
         {
-            throw new NotImplementedException();
+            return reader.GetInt(index);
         }
 
         public void FetchData()
         {
-            throw new NotImplementedException();
+            reader.Update();
         }
 
         public void FullReset()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Update()
+        {
+            FetchData();
+        }
+
+        public void UpdateUI()
+        {
+            AddonDataChanged?.Invoke();
+        }
+
+        public void SessionReset()
         {
             throw new NotImplementedException();
         }

--- a/Core/Addon/IAddonDataProvider.cs
+++ b/Core/Addon/IAddonDataProvider.cs
@@ -1,0 +1,14 @@
+﻿namespace Core
+{
+    public interface IAddonDataProvider
+    {
+        void Update();
+        void InitFrames(DataFrame[] frames);
+
+        int GetInt(int index);
+        float GetFixed(int index);
+        string GetString(int index);
+
+        void Dispose();
+    }
+}

--- a/Core/Addon/IAddonReader.cs
+++ b/Core/Addon/IAddonReader.cs
@@ -39,6 +39,10 @@ namespace Core
         void FetchData();
         void FullReset();
 
+        void Update();
+        void UpdateUI();
+        void SessionReset();
+
         int GetInt(int index);
     }
 }

--- a/Core/Addon/PlayerReader.cs
+++ b/Core/Addon/PlayerReader.cs
@@ -6,8 +6,9 @@ namespace Core
 {
     public partial class PlayerReader
     {
-        private readonly AddonDataProvider reader;
-        public PlayerReader(AddonDataProvider reader)
+        private readonly IAddonDataProvider reader;
+
+        public PlayerReader(IAddonDataProvider reader)
         {
             this.reader = reader;
             Bits = new(8, 9);
@@ -159,7 +160,7 @@ namespace Core
             _ => false
         };
 
-        public void Update(AddonDataProvider reader)
+        public void Update(IAddonDataProvider reader)
         {
             Bits.Update(reader);
             SpellInRange.Update(reader);

--- a/Core/Addon/SpellBookReader.cs
+++ b/Core/Addon/SpellBookReader.cs
@@ -20,7 +20,7 @@ namespace Core
             this.SpellDB = spellDB;
         }
 
-        public void Read(AddonDataProvider reader)
+        public void Read(IAddonDataProvider reader)
         {
             int spellId = reader.GetInt(cSpellId);
             if (spellId == 0) return;

--- a/Core/AddonComponent/AddonBits.cs
+++ b/Core/AddonComponent/AddonBits.cs
@@ -16,7 +16,7 @@ namespace Core
             this.cell2 = cell2;
         }
 
-        public void Update(AddonDataProvider reader)
+        public void Update(IAddonDataProvider reader)
         {
             v1 = new(reader.GetInt(cell1));
             v2 = new(reader.GetInt(cell2));

--- a/Core/AddonComponent/AuraCount.cs
+++ b/Core/AddonComponent/AuraCount.cs
@@ -8,7 +8,7 @@
         public int TargetDebuff { get; }
         public int TargetBuff { get; }
 
-        public AuraCount(AddonDataProvider reader, int cell)
+        public AuraCount(IAddonDataProvider reader, int cell)
         {
             Hash = TargetBuff = reader.GetInt(cell);
 

--- a/Core/AddonComponent/BuffStatus.cs
+++ b/Core/AddonComponent/BuffStatus.cs
@@ -13,7 +13,7 @@ namespace Core
             this.cell = cell;
         }
 
-        public void Update(AddonDataProvider reader)
+        public void Update(IAddonDataProvider reader)
         {
             v = new(reader.GetInt(cell));
         }

--- a/Core/AddonComponent/CombatLog.cs
+++ b/Core/AddonComponent/CombatLog.cs
@@ -44,7 +44,7 @@ namespace Core
             TargetDodge.Reset();
         }
 
-        public void Update(AddonDataProvider reader, bool playerInCombat)
+        public void Update(IAddonDataProvider reader, bool playerInCombat)
         {
             if (TargetMissType.Updated(reader) && (MissType)TargetMissType.Value == MissType.DODGE)
             {

--- a/Core/AddonComponent/RecordInt.cs
+++ b/Core/AddonComponent/RecordInt.cs
@@ -19,7 +19,7 @@ namespace Core
             this.cell = cell;
         }
 
-        public bool Updated(AddonDataProvider reader)
+        public bool Updated(IAddonDataProvider reader)
         {
             int temp = Value;
             Value = reader.GetInt(cell);
@@ -34,14 +34,14 @@ namespace Core
             return false;
         }
 
-        public bool UpdatedNoEvent(AddonDataProvider reader)
+        public bool UpdatedNoEvent(IAddonDataProvider reader)
         {
             int temp = Value;
             Value = reader.GetInt(cell);
             return temp != Value;
         }
 
-        public void Update(AddonDataProvider reader)
+        public void Update(IAddonDataProvider reader)
         {
             int temp = Value;
             Value = reader.GetInt(cell);

--- a/Core/AddonComponent/SpellInRange.cs
+++ b/Core/AddonComponent/SpellInRange.cs
@@ -15,7 +15,7 @@ namespace Core
             this.cell = cell;
         }
 
-        public void Update(AddonDataProvider reader)
+        public void Update(IAddonDataProvider reader)
         {
             b = new(reader.GetInt(cell));
         }

--- a/Core/AddonComponent/Stance.cs
+++ b/Core/AddonComponent/Stance.cs
@@ -11,7 +11,7 @@
             this.cell = cell;
         }
 
-        public void Update(AddonDataProvider reader)
+        public void Update(IAddonDataProvider reader)
         {
             value = reader.GetInt(cell);
         }

--- a/Core/AddonComponent/TargetDebuffStatus.cs
+++ b/Core/AddonComponent/TargetDebuffStatus.cs
@@ -13,7 +13,7 @@ namespace Core
             this.cell = cell;
         }
 
-        public void Update(AddonDataProvider reader)
+        public void Update(IAddonDataProvider reader)
         {
             v = new(reader.GetInt(cell));
         }

--- a/Core/Bag/BagReader.cs
+++ b/Core/Bag/BagReader.cs
@@ -55,7 +55,7 @@ namespace Core
             this.equipmentReader.OnEquipmentChanged -= OnEquipmentChanged;
         }
 
-        public void Read(AddonDataProvider reader)
+        public void Read(IAddonDataProvider reader)
         {
             ReadBagMeta(reader, out bool metaChanged);
 
@@ -74,7 +74,7 @@ namespace Core
             }
         }
 
-        private void ReadBagMeta(AddonDataProvider reader, out bool changed)
+        private void ReadBagMeta(IAddonDataProvider reader, out bool changed)
         {
             changed = false;
 
@@ -114,7 +114,7 @@ namespace Core
             }
         }
 
-        private void ReadInventory(AddonDataProvider reader, out bool hasChanged)
+        private void ReadInventory(IAddonDataProvider reader, out bool hasChanged)
         {
             hasChanged = false;
 

--- a/Core/BotController.cs
+++ b/Core/BotController.cs
@@ -150,7 +150,6 @@ namespace Core
             while (!cts.IsCancellationRequested)
             {
                 AddonReader.Update();
-                cts.Token.WaitHandle.WaitOne(1);
             }
             logger.LogWarning("Addon thread stoppped!");
         }

--- a/Core/ConfigBotController.cs
+++ b/Core/ConfigBotController.cs
@@ -3,12 +3,14 @@ using System;
 using System.Collections.Generic;
 using Core.Session;
 using Game;
+using System.Threading;
+using Microsoft.Extensions.Logging;
 
 namespace Core
 {
-    public class ConfigBotController : IBotController
+    public class ConfigBotController : IBotController, IDisposable
     {
-        public AddonReader AddonReader => throw new NotImplementedException();
+        public IAddonReader AddonReader { get; }
         public GoapAgent? GoapAgent => throw new NotImplementedException();
         public RouteInfo? RouteInfo => throw new NotImplementedException();
         public WowScreen WowScreen => throw new NotImplementedException();
@@ -23,12 +25,62 @@ namespace Core
         public double AvgScreenLatency => throw new NotImplementedException();
         public double AvgNPCLatency => throw new NotImplementedException();
 
+        AddonReader IBotController.AddonReader => throw new NotImplementedException();
+
         public event Action? ProfileLoaded;
         public event Action? StatusChanged;
 
+        private readonly ILogger logger;
+        private readonly CancellationTokenSource cts;
+
+        private readonly Thread addonThread;
+
+        private readonly Thread? frontendThread;
+        private const int frontendTickMs = 250;
+
+        public ConfigBotController(ILogger logger, CancellationTokenSource cts, IAddonReader addonReader)
+        {
+            this.logger = logger;
+            this.cts = cts;
+            this.AddonReader = addonReader;
+
+            addonThread = new(AddonThread);
+            addonThread.Start();
+
+            frontendThread = new(FrontendThread);
+            frontendThread.Start();
+        }
+
+        public void Dispose()
+        {
+            cts.Cancel();
+        }
+
+        private void FrontendThread()
+        {
+            while (!cts.IsCancellationRequested)
+            {
+                AddonReader.UpdateUI();
+                cts.Token.WaitHandle.WaitOne(frontendTickMs);
+            }
+
+            if (logger.IsEnabled(LogLevel.Debug))
+                logger.LogDebug("Frontend thread stopped!");
+        }
+
+        private void AddonThread()
+        {
+            while (!cts.IsCancellationRequested)
+            {
+                AddonReader.Update();
+            }
+            logger.LogWarning("Addon thread stoppped!");
+        }
+
+
         public void Shutdown()
         {
-
+            cts.Cancel();
         }
 
         public void MinimapNodeFound()

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -36,6 +36,7 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
     <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+    <PackageReference Include="Vortice.Direct3D11" Version="2.1.19" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Core/DataFrame/FrameConfig.cs
+++ b/Core/DataFrame/FrameConfig.cs
@@ -37,9 +37,12 @@ namespace Core
 
         public static DataFrame[] LoadFrames()
         {
-            var config = JsonConvert.DeserializeObject<DataFrameConfig>(File.ReadAllText(FrameConfigMeta.DefaultFilename));
-            if (config.Version == FrameConfigMeta.Version)
-                return config.frames;
+            if (Exists())
+            {
+                var config = JsonConvert.DeserializeObject<DataFrameConfig>(File.ReadAllText(FrameConfigMeta.DefaultFilename));
+                if (config.Version == FrameConfigMeta.Version)
+                    return config.frames;
+            }
 
             return Array.Empty<DataFrame>();
         }

--- a/Core/Equipments/EquipmentReader.cs
+++ b/Core/Equipments/EquipmentReader.cs
@@ -29,7 +29,7 @@ namespace Core
             }
         }
 
-        public void Read(AddonDataProvider reader)
+        public void Read(IAddonDataProvider reader)
         {
             int index = reader.GetInt(cSlotNum);
             if (index < MAX_EQUIPMENT_COUNT && index >= 0)

--- a/Core/Gossip/GossipReader.cs
+++ b/Core/Gossip/GossipReader.cs
@@ -31,7 +31,7 @@ namespace Core
             this.cGossip = cGossip;
         }
 
-        public void Read(AddonDataProvider reader)
+        public void Read(IAddonDataProvider reader)
         {
             data = reader.GetInt(cGossip);
 

--- a/Core/StartupConfig/StartupConfigReader.cs
+++ b/Core/StartupConfig/StartupConfigReader.cs
@@ -1,0 +1,13 @@
+﻿namespace Core
+{
+    public class StartupConfigReader
+    {
+        public const string Position = "Reader";
+
+        public StartupConfigReader() { }
+
+        public string Type { get; set; } = string.Empty;
+
+        public AddonDataProviderType ReaderType => System.Enum.TryParse(Type, out AddonDataProviderType m) ? m : AddonDataProviderType.GDI;
+    }
+}

--- a/Frontend/Pages/FrameConfiguration.razor
+++ b/Frontend/Pages/FrameConfiguration.razor
@@ -5,6 +5,7 @@
 @inject AddonConfigurator addonConfigurator
 @inject FrameConfigurator frameConfigurator
 @inject DataConfig dataConfig
+@inject IAddonDataProvider reader
 
 @implements IDisposable
 
@@ -24,13 +25,26 @@
         <h1>Frame configuration not found !</h1>
     }
 
-    @if (FrameConfig.Exists())
-    {
-        <hr />
-        <h4 class="text-warning">Tinkering with the following fields are not recommend! Unless experinecing strange behaviours then repeat the Frame Configuration process!</h4>
-    }
-
     <div class="card-deck mb-3 text-center">
+
+        @if (FrameConfig.Exists())
+        {
+            <div class="card mb-4 box-shadow">
+                <div class="card-header">
+                    <h4 class="my-0 font-weight-normal">Delete</h4>
+                </div>
+                <div class="card-body">
+                    <ul class="list-unstyled mt-1 mb-1">
+                        <li>Experiencing troubles?</li>
+                        <li>Delete current config and do it again!</li>
+                    </ul>
+                    <button class="btn btn-lg btn-block btn-danger" @onclick="DeleteCurrentConfig">
+                        <span>Delete</span>
+                    </button>
+                </div>
+            </div>
+        }
+
         <div class="card mb-4 box-shadow">
             <div class="card-header">
                 <h4 class="my-0 font-weight-normal">Auto</h4>
@@ -40,7 +54,7 @@
                     <li>1-Click</li>
                     <li>Recommended in general</li>
                 </ul>
-                <button class="btn btn-lg btn-block btn-primary" @onclick="StartAutoConfigure" disabled="@manual">
+                <button class="btn btn-lg btn-block btn-primary" @onclick="StartAutoConfigure" disabled="@(manual || disabled)">
                     <span>Start</span>
                 </button>
             </div>
@@ -55,7 +69,9 @@
                     <li>Follow few steps</li>
                     <li>Recommended for troubleshooting</li>
                 </ul>
-                <button type="button" class="btn btn-lg btn-block @manualButtonStyle" @onclick="ToggleManualConfig">@manualButtonText</button>
+                <button type="button" class="btn btn-lg btn-block @manualButtonStyle" @onclick="ToggleManualConfig" disabled="@disabled">
+                    @manualButtonText
+                </button>
             </div>
         </div>
     </div>
@@ -142,6 +158,7 @@
 
     private AddonConfig addonConfig = null!;
 
+    private bool disabled = true;
     private bool saved = false;
     private bool manual { get; set; } = false;
     private string manualButtonText { get; set; } = "Start";
@@ -152,6 +169,9 @@
     {
         addonConfig = addonConfigurator.Config;
         frameConfigurator.OnUpdate += OnUpdate;
+
+        if (reader is AddonDataProviderGDIConfig)
+            disabled = false;
     }
 
     public void Dispose()
@@ -165,7 +185,7 @@
     {
         if (frameConfigurator.TryResolveRaceAndClass(out RaceEnum race, out PlayerClassEnum @class))
         {
-            playerClass = race.ToStringF() + " " + @class.ToStringF();
+            playerClass = $"{race.ToStringF()} {@class.ToStringF()}";
         }
         else
         {
@@ -199,9 +219,16 @@
             NavigationManager.NavigateTo("/RestartServer");
     }
 
-    public void StartAutoConfigure()
+    public async void StartAutoConfigure()
     {
+        await Task.Delay(1);
         if (frameConfigurator.StartAutoConfig())
             NavigationManager.NavigateTo("/RestartServer");
+    }
+
+    public void DeleteCurrentConfig()
+    {
+        FrameConfigurator.DeleteConfig();
+        NavigationManager.NavigateTo("/RestartServer");
     }
 }

--- a/Frontend/Pages/LogComponent.razor
+++ b/Frontend/Pages/LogComponent.razor
@@ -37,6 +37,7 @@
         @for(int i=LoggerSink.Log.Count()-1; i >= 0; i--)
         {
             var evt = LoggerSink.Log.PeekAt(i);
+            if (evt == null) continue;
             <tr class="@logLevelColor[evt.Level]">
                 <td class="log">@evt.Timestamp.ToString("HH:mm:ss")</td>
                 <td class="log">@evt.RenderMessage()</td>

--- a/HeadlessServer/RunOptions.cs
+++ b/HeadlessServer/RunOptions.cs
@@ -8,17 +8,14 @@ namespace HeadlessServer
         [Value(0,
             MetaName = "ClassConfig file",
             Required = true,
-            HelpText = "ClassConfiguration file example: Warrior_1.json")]
+            HelpText = "ClassConfiguration file found in 'Json\\class\\'\nexample: Warrior_1.json")]
         public string? ClassConfig { get; set; }
 
         [Option('m',
             "mode",
             Required = false,
             Default = nameof(StartupConfigPathing.Types.Local),
-            HelpText = $@"PPather service: 
-                {nameof(StartupConfigPathing.Types.Local)} | 
-                {nameof(StartupConfigPathing.Types.RemoteV1)} | 
-                {nameof(StartupConfigPathing.Types.RemoteV3)}")]
+            HelpText = $"Navigation services: \n{nameof(StartupConfigPathing.Types.Local)}\n{nameof(StartupConfigPathing.Types.RemoteV1)}\n{nameof(StartupConfigPathing.Types.RemoteV3)}")]
         public string? Mode { get; set; }
 
         [Option('p',
@@ -28,28 +25,35 @@ namespace HeadlessServer
             HelpText = $"World of Warcraft Process Id")]
         public int Pid { get; set; }
 
+        [Option('r',
+            "reader",
+            Required = false,
+            Default = "GDI",
+            HelpText = $"Screen reader backend.\n'{nameof(AddonDataProviderType.GDI)}': is the default, compatible from Win7.\n'{nameof(AddonDataProviderType.DXGI)}': DirectX based works from Win8.")]
+        public AddonDataProviderType? Reader { get; set; }
+
         [Option("hostv1",
             Required = false,
             Default = "localhost",
-            HelpText = $"PPather Remote V1 host")]
+            HelpText = $"Navigation Remote V1 host")]
         public string? Hostv1 { get; set; }
 
         [Option("portv1",
             Required = false,
             Default = 5001,
-            HelpText = $"PPather Remote V1 port")]
+            HelpText = $"Navigation Remote V1 port")]
         public int Portv1 { get; set; }
 
         [Option("hostv3",
             Required = false,
             Default = "127.0.0.1",
-            HelpText = $"PPather Remote V3 host")]
+            HelpText = $"Navigation Remote V3 host")]
         public string? Hostv3 { get; set; }
 
         [Option("portv3",
             Required = false,
             Default = 47111,
-            HelpText = $"PPather Remote V3 port")]
+            HelpText = $"Navigation Remote V3 port")]
         public int Portv3 { get; set; }
     }
 }


### PR DESCRIPTION
Changes:

Added `DXGI` based screen capturer, should reduce the latency of how often can capture frames from the game compare to `GDI` version. `DXGI` should be feature equivalent with the existing one. 

DirectX `DXGI` supported from windows 8. While the `GDI` version is from Windows 7.

`DXGI` uses GPU to capture addon frame so in theory consume less CPU time. 
![compare](https://user-images.githubusercontent.com/367101/181952260-4e8f8121-226d-4f58-85a0-f71698ec8ee8.png)

Both `BlazorServer` and `HeadlessServer` capable of running both reader.

`FrameConfiguration` process is now restricted to Configuration mode. So in order to redo the process, first have to delete the existing one.

`HeadlessServer` is now having the same guard as `BlazorServer` at startup. Validating config files integrity with the screen size.

 