### PR TITLE
Addon: [1.6.3] - Feature: Tracking Target buffs duration - `AuraTimeReader` keep tracks of unlimited duration times as well.

### DIFF
--- a/Addons/DataToColor/Collections.lua
+++ b/Addons/DataToColor/Collections.lua
@@ -93,6 +93,12 @@ function struct:getForced()
     end
 end
 
+function struct:forcedReset()
+    for _, v in pairs(self) do
+        v.value = GetTime()
+    end
+end
+
 function struct:value(key)
     return self[key].value
 end

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -3,7 +3,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors
-## Version: 1.6.2
+## Version: 1.6.3
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/Query.lua
+++ b/Addons/DataToColor/Query.lua
@@ -162,25 +162,14 @@ function DataToColor:Set(trigger, input)
     end
 end
 
-function DataToColor:getAuraMaskForClass(func, unitId, table, queue)
+function DataToColor:getAuraMaskForClass(func, unitId, table)
     local num = 0
     for k, v in pairs(table) do
         for i = 1, 16 do
-            local name, texture, _, _, _, expirationTime, source = func(unitId, i)
+            local name, texture = func(unitId, i)
             if name == nil then
                 break
             end
-
-            if expirationTime > 0 then
-                if not queue:exists(texture) then
-                    queue:set(texture, expirationTime)
-                    --DataToColor:Print(texture, " added ", expirationTime)
-                elseif queue:value(texture) < expirationTime then
-                    queue:set(texture, expirationTime)
-                    --DataToColor:Print(texture, " updated ", expirationTime)
-                end
-            end
-
             if v[texture] or find(name, v[1]) then
                 num = num + base2(1, k)
                 break
@@ -188,6 +177,27 @@ function DataToColor:getAuraMaskForClass(func, unitId, table, queue)
         end
     end
     return num
+end
+
+function DataToColor:populateAuraTimer(func, unitId, queue)
+    for i = 1, 40 do
+        local name, texture, _, _, duration, expirationTime = func(unitId, i)
+        if name == nil then
+            break
+        end
+
+        if duration == 0 then
+            expirationTime = GetTime() + 14400 -- 4 hours - anything above considered unlimited duration
+        end
+
+        if not queue:exists(texture) then
+            queue:set(texture, expirationTime)
+            --DataToColor:Print(texture, " aura added ", expirationTime)
+        elseif not queue:isDirty(texture) and queue:value(texture) < expirationTime then
+            queue:set(texture, expirationTime)
+            --DataToColor:Print(texture, " aura updated ", expirationTime)
+        end
+    end
 end
 
 -- player debuffs cant be higher than 16!

--- a/Core/Addon/AddonReader.cs
+++ b/Core/Addon/AddonReader.cs
@@ -27,6 +27,8 @@ namespace Core
 
         public AuraTimeReader TargetDebuffTimeReader { get; }
 
+        public AuraTimeReader TargetBuffTimeReader { get; }
+
         public ActionBarBits CurrentAction { get; }
         public ActionBarBits UsableAction { get; }
 
@@ -96,6 +98,7 @@ namespace Core
 
             this.PlayerBuffTimeReader = new(79, 80);
             this.TargetDebuffTimeReader = new(81, 82);
+            this.TargetBuffTimeReader = new(83, 84);
 
             lastUpdate = DateTime.UtcNow;
         }
@@ -156,6 +159,7 @@ namespace Core
 
                 PlayerBuffTimeReader.Read(reader);
                 TargetDebuffTimeReader.Read(reader);
+                TargetBuffTimeReader.Read(reader);
 
                 if (UIMapId.Updated(reader))
                 {
@@ -191,6 +195,7 @@ namespace Core
 
             PlayerBuffTimeReader.Reset();
             TargetDebuffTimeReader.Reset();
+            TargetBuffTimeReader.Reset();
 
             SessionReset();
         }

--- a/Core/Addon/AuraTimeReader.cs
+++ b/Core/Addon/AuraTimeReader.cs
@@ -17,6 +17,8 @@ namespace Core
             }
         }
 
+        private const int UNLIMITED = 14400; // 4 hours - anything above considered unlimited duration
+
         private readonly int cTextureId;
         private readonly int cDurationSec;
 
@@ -46,7 +48,7 @@ namespace Core
         public int GetRemainingTimeMs(int textureId)
         {
             return data.TryGetValue(textureId, out Data d) ?
-                Math.Max(0, (int)(d.StartTime.AddSeconds(d.DurationSec) - DateTime.UtcNow).TotalMilliseconds)
+                Math.Max(0, d.DurationSec >= UNLIMITED ? 1 : (int)(d.StartTime.AddSeconds(d.DurationSec) - DateTime.UtcNow).TotalMilliseconds)
                 : 0;
         }
 

--- a/Core/ClassConfig/ClassConfiguration.cs
+++ b/Core/ClassConfig/ClassConfiguration.cs
@@ -117,7 +117,7 @@ namespace Core
 
         public void Initialise(DataConfig dataConfig, AddonReader addonReader, RequirementFactory requirementFactory, ILogger logger, string? overridePathProfileFile)
         {
-            requirementFactory.InitUserDefinedIntVariables(IntVariables, addonReader.PlayerBuffTimeReader, addonReader.TargetDebuffTimeReader);
+            requirementFactory.InitUserDefinedIntVariables(IntVariables, addonReader.PlayerBuffTimeReader, addonReader.TargetDebuffTimeReader, addonReader.TargetBuffTimeReader);
 
             Jump.Key = JumpKey;
             Jump.Name = nameof(Jump);

--- a/Core/Requirement/RequirementFactory.cs
+++ b/Core/Requirement/RequirementFactory.cs
@@ -299,6 +299,7 @@ namespace Core
                 //"Cost_{KeyAction.Name}"
                 //"Buff_{textureId}"
                 //"Debuff_{textureId}"
+                //"TBuff_{textureId}"
                 { "MainHandSpeed", playerReader.MainHandSpeedMs },
                 { "MainHandSwing", () => Math.Clamp(playerReader.MainHandSwing.ElapsedMs() - playerReader.MainHandSpeedMs(), -playerReader.MainHandSpeedMs(), 0) },
                 { "CurGCD", playerReader.GCD._Value },
@@ -384,7 +385,9 @@ namespace Core
             item.RequirementsRuntime = requirements.ToArray();
         }
 
-        public void InitUserDefinedIntVariables(Dictionary<string, int> intKeyValues, AuraTimeReader playerBuffTimeReader, AuraTimeReader targetDebuffTimeReader)
+        public void InitUserDefinedIntVariables(Dictionary<string, int> intKeyValues,
+            AuraTimeReader playerBuffTimeReader, AuraTimeReader targetDebuffTimeReader,
+            AuraTimeReader targetBuffTimeReader)
         {
             foreach ((string key, int value) in intKeyValues)
             {
@@ -404,6 +407,11 @@ namespace Core
                     else if (key.StartsWith("Debuff_"))
                     {
                         int l() => targetDebuffTimeReader.GetRemainingTimeMs(value);
+                        intVariables.TryAdd($"{value}", l);
+                    }
+                    else if (key.StartsWith("TBuff_"))
+                    {
+                        int l() => targetBuffTimeReader.GetRemainingTimeMs(value);
                         intVariables.TryAdd($"{value}", l);
                     }
 

--- a/README.md
+++ b/README.md
@@ -996,9 +996,9 @@ e.g.
 ---
 ### **Player Buff remaining time requirements**
 
-First in the `IntVariables` have to mention the buff icon id such as `Buff_{you fancy name}: {icon_id}`.
+First in the `IntVariables` have to mention the buff icon id such as `Buff_{your fancy name}: {icon_id}`.
 
-It is important, thee addon keeps track of the **icon_id**! Not **spell_id**
+It is important, the addon keeps track of the **icon_id**! Not **spell_id**
 
 e.g.
 ```json
@@ -1027,17 +1027,15 @@ e.g.
 ---
 ### **Target Debuff remaining time requirements**
 
-First in the `IntVariables` have to mention the buff icon id such as `Debuff_{you fancy name}: {icon_id}`
+First in the `IntVariables` have to mention the buff icon id such as `Debuff_{your fancy name}: {icon_id}`
 
-It is important, thee addon keeps track of the **icon_id**! Not **spell_id**
+It is important, the addon keeps track of the **icon_id**! Not **spell_id**
 
 e.g.
 ```json
 "IntVariables": {
     "Debuff_Blood Plague": 237514,
-    "Debuff_Frost Fever": 237522,
-    "Item_Soul_Shard": 6265,
-    "Item_Healthstone": 22105,
+    "Debuff_Frost Fever": 237522
 },
 ```
 
@@ -1054,6 +1052,19 @@ e.g.
         "InMeleeRange"                                                                                // and their duration less then 2 seconds
     ]
 }
+```
+---
+### **Target Buff remaining time requirements**
+
+First in the `IntVariables` have to mention the buff icon id such as `TBuff_{your fancy name}: {icon_id}`
+
+It is important, the addon keeps track of the **icon_id**! Not **spell_id**
+
+e.g.
+```json
+"IntVariables": {
+    "TBuff_Battle Shout": 132333,
+},
 ```
 ---
 ### **Trigger requirements**


### PR DESCRIPTION
Added new Requirement `"TBuff_{fancy name}": textureId`