### PR TITLE
Addon: [1.6.31] - Feature: Obtain target `UnitClassification`

### DIFF
--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -434,7 +434,8 @@ function DataToColor:CreateFrames(n)
 
             Pixel(float, GetPlayerFacing() or 0, 3)
             Pixel(int, DataToColor.map or 0, 4) -- MapUIId
-            Pixel(int, UnitLevel(DataToColor.C.unitPlayer), 5)
+            local playerLevel = UnitLevel(DataToColor.C.unitPlayer)
+            Pixel(int, playerLevel, 5)
 
             local cx, cy = DataToColor:GetCorpsePosition()
             Pixel(float, cx * 10, 6)
@@ -595,7 +596,11 @@ function DataToColor:CreateFrames(n)
             DataToColor:populateAuraTimer(UnitDebuff, DataToColor.C.unitTarget, DataToColor.targetDebuffTime)
             DataToColor:populateAuraTimer(UnitBuff, DataToColor.C.unitTarget, DataToColor.targetBuffTime)
 
-            Pixel(int, UnitLevel(DataToColor.C.unitTarget), 43)
+            local targetLevel = UnitLevel(DataToColor.C.unitTarget)
+            if targetLevel == -1 then
+                targetLevel = playerLevel + 10
+            end
+            Pixel(int, targetLevel * 100 + DataToColor.unitClassification[UnitClassification(DataToColor.C.unitTarget)], 43)
 
             -- Amount of money in coppers
             Pixel(int, GetMoney() % 1000000, 44) -- Represents amount of money held (in copper)

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -3,7 +3,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors
-## Version: 1.6.3
+## Version: 1.6.31
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/Query.lua
+++ b/Addons/DataToColor/Query.lua
@@ -75,6 +75,16 @@ local GetPetHappiness = GetPetHappiness
 
 local ammoSlot = GetInventorySlotInfo("AmmoSlot")
 
+DataToColor.unitClassification = {
+    ["normal"] = 1,
+    ["trivial"] = 2,
+    ["minus"] = 4,
+    ["rare"] = 8,
+    ["elite"] = 16,
+    ["rareelite"] = 32,
+    ["worldboss"] = 64
+}
+
 -- Use Astrolabe function to get current player position
 function DataToColor:GetPosition()
     if DataToColor.map ~= nil then
@@ -124,7 +134,7 @@ function DataToColor:Bits1()
         base2(IsMounted() and 1 or 0, 18) +
         base2(IsAutoRepeatSpell(DataToColor.C.Spell.ShootId) and 1 or 0, 19) +
         base2(IsCurrentSpell(DataToColor.C.Spell.AttackId) and 1 or 0, 20) +
-        base2(DataToColor:targetIsNormal(), 21) +
+        base2(UnitIsPlayer(DataToColor.C.unitTarget) and 1 or 0, 21) +
         base2(UnitIsTapDenied(DataToColor.C.unitTarget) and 1 or 0, 22) +
         base2(IsFalling() and 1 or 0, 23)
 end
@@ -142,7 +152,8 @@ function DataToColor:Bits2()
         base2(DataToColor:isHostile(DataToColor.C.unitFocusTarget), 7) +
         base2(UnitExists(DataToColor.C.unitFocusTarget) and CheckInteractDistance(DataToColor.C.unitFocusTarget, 2) and 1 or 0, 8) +
         base2(UnitIsDead(DataToColor.C.unitPetTarget) and 1 or 0, 9) +
-        base2(IsStealthed() and 1 or 0, 10)
+        base2(IsStealthed() and 1 or 0, 10) +
+        base2(UnitIsTrivial(DataToColor.C.unitTarget) and 1 or 0, 11)
 end
 
 function DataToColor:CustomTrigger(t)
@@ -466,24 +477,6 @@ end
 -- Only put functions here that are part of a boolean sequence --
 -- Sew BELOW for examples ---------------------------------------
 -----------------------------------------------------------------
-
-function DataToColor:targetIsNormal()
-    local classification = UnitClassification(DataToColor.C.unitTarget)
-    if classification == DataToColor.C.unitNormal then
-        if (UnitIsPlayer(DataToColor.C.unitTarget)) then
-            return 0
-        end
-
-        if UnitName(DataToColor.C.unitPet) == UnitName(DataToColor.C.unitTarget) then
-            return 0
-        end
-
-        return 1
-        -- if target is not in combat, return 1 for bitmask
-    else
-        return 0
-    end
-end
 
 function DataToColor:shapeshiftForm()
     local index = GetShapeshiftForm(false)

--- a/Core/Addon/PlayerReader.cs
+++ b/Core/Addon/PlayerReader.cs
@@ -70,7 +70,9 @@ namespace Core
         public BuffStatus Buffs { get; }
         public TargetDebuffStatus TargetDebuffs { get; }
 
-        public int TargetLevel => reader.GetInt(43);
+        public int TargetLevel => reader.GetInt(43) / 100;
+
+        public UnitClassification TargetClassification => (UnitClassification)(reader.GetInt(43) % 100);
 
         public int Gold => reader.GetInt(44) + (reader.GetInt(45) * 1000000);
 
@@ -148,16 +150,6 @@ namespace Core
 
         public int FocusGuid => reader.GetInt(77);
         public int FocusTargetGuid => reader.GetInt(78);
-
-        // https://wowpedia.fandom.com/wiki/Mob_experience
-        public bool TargetYieldXP() => Level.Value switch
-        {
-            int n when n < 5 => true,
-            int n when n is >= 6 and <= 39 => TargetLevel > (Level.Value - MathF.Floor(Level.Value / 10f) - 5),
-            int n when n is >= 40 and <= 59 => TargetLevel > (Level.Value - MathF.Floor(Level.Value / 5f) - 5),
-            int n when n is >= 60 and <= 80 => TargetLevel > Level.Value - 9,
-            _ => false
-        };
 
         public void Update(IAddonDataProvider reader)
         {

--- a/Core/AddonComponent/AddonBits.cs
+++ b/Core/AddonComponent/AddonBits.cs
@@ -44,7 +44,7 @@ namespace Core
         public bool IsMounted() => v1[Mask._18];
         public bool SpellOn_Shoot() => v1[Mask._19];
         public bool SpellOn_AutoAttack() => v1[Mask._20];
-        public bool TargetIsNormal() => v1[Mask._21];
+        public bool TargetIsPlayer() => v1[Mask._21];
         public bool IsTagged() => v1[Mask._22];
         public bool IsFalling() => v1[Mask._23];
 
@@ -70,5 +70,9 @@ namespace Core
         public bool PetTargetIsDead() => v2[Mask._9];
 
         public bool IsStealthed() => v2[Mask._10];
+
+        public bool TargetIsTrivial() => v2[Mask._11];
+
+        public bool TargetIsNotTrivial() => !v2[Mask._11];
     }
 }

--- a/Core/AddonComponent/UnitClassification.cs
+++ b/Core/AddonComponent/UnitClassification.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+using Newtonsoft.Json;
+
+namespace Core
+{
+    [Flags]
+    [JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    public enum UnitClassification
+    {
+        None = 0,
+        Normal = 1,
+        Trivial = 2,
+        Minus = 4,
+        Rare = 8,
+        Elite = 16,
+        RareElite = 32,
+        WorldBoss = 64
+    }
+
+    public static class UnitClassification_Extension
+    {
+        public static string ToStringF(this UnitClassification value) => value switch
+        {
+            UnitClassification.None => nameof(UnitClassification.None),
+            UnitClassification.Normal => nameof(UnitClassification.Normal),
+            UnitClassification.Trivial => nameof(UnitClassification.Trivial),
+            UnitClassification.Minus => nameof(UnitClassification.Minus),
+            UnitClassification.Rare => nameof(UnitClassification.Rare),
+            UnitClassification.Elite => nameof(UnitClassification.Elite),
+            UnitClassification.RareElite => nameof(UnitClassification.RareElite),
+            UnitClassification.WorldBoss => nameof(UnitClassification.WorldBoss),
+            _ => throw new ArgumentOutOfRangeException()
+        };
+    }
+}

--- a/Core/ClassConfig/ClassConfiguration.cs
+++ b/Core/ClassConfig/ClassConfiguration.cs
@@ -48,7 +48,7 @@ namespace Core
 
         public int NPCMaxLevels_Above { get; set; } = 1;
         public int NPCMaxLevels_Below { get; set; } = 7;
-
+        public UnitClassification TargetMask { get; set; } = UnitClassification.Normal | UnitClassification.Trivial | UnitClassification.Rare;
         public bool CheckTargetGivesExp { get; set; }
         public string[] Blacklist { get; init; } = Array.Empty<string>();
 

--- a/Core/Requirement/RequirementFactory.cs
+++ b/Core/Requirement/RequirementFactory.cs
@@ -81,7 +81,7 @@ namespace Core
             boolVariables = new()
             {
                 // Target Based
-                { "TargetYieldXP", playerReader.TargetYieldXP },
+                { "TargetYieldXP", playerReader.Bits.TargetIsNotTrivial },
                 { "TargetsMe", playerReader.TargetsMe },
                 { "TargetsPet", playerReader.TargetsPet },
                 { "TargetsNone", playerReader.TargetsNone },

--- a/Frontend/Pages/BotHeader.razor
+++ b/Frontend/Pages/BotHeader.razor
@@ -38,11 +38,7 @@
                                 (@playerReader.TargetLevel) @((int)playerReader.TargetHealthPercentage()) %<br />
                                 GUID: @playerReader.TargetGuid
 
-                                @if (!playerReader.Bits.TargetIsNormal())
-                                {
-                                    <div>NOT NORMAL</div>
-                                }
-                                else if (playerReader.ComboPoints() > 0)
+                                @if (playerReader.ComboPoints() > 0)
                                 {
                                     <div>Combo Points: @playerReader.ComboPoints()</div>
                                 }

--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ Take a look at the class files in `/Json/class` for examples of what you can do.
 | `"NPCMaxLevels_Below"` | Maximum allowed level below difference to the player | true | `7` |
 | `"CheckTargetGivesExp"` | Only engage the target if it yields experience | true | `false` |
 | `"Blacklist"` | List of names or sub names which must be avoid engaging | true | `[""]` |
+| `"TargetMask"` | [UnitClassification](https://wowpedia.fandom.com/wiki/API_UnitClassification) types that allowed to engage with. | true | `"Normal, Trivial, Rare"` |
 | `"ImmunityBlacklist"` | List of Npc ids which have some sort of `School` immunities | true | `""` |
 | `"IntVariables"` | List of user defined `integer` variables | true | `[]` |
 | --- | --- | --- | --- |
@@ -351,6 +352,21 @@ Take a look at the class files in `/Json/class` for examples of what you can do.
 | `"BackwardKey"` | `Consolekey` to be pressed to move backward | true | `"DownArrow"` |
 | `"TurnLeftKey"` | `Consolekey` to be pressed to turn left | true | `"LeftArrow"` |
 | `"TurnRightKey"` | `Consolekey` to be pressed to turn right | true | `"RightArrow"` |
+
+### TargetMask
+
+Based of [UnitClassification](https://wowpedia.fandom.com/wiki/API_UnitClassification) API.
+
+Valid Values: `"Normal", "Trivial", "Minus", "Rare", "Elite", "RareElite", "WorldBoss"`
+
+The mentioned values can be combined together like:
+
+e.g.
+```json
+"TargetMask": "Normal, Trivial, Rare, Elite, RareElite",
+```
+
+Where `Elite` and `RareElite` has been included compare to default.
 
 ### KeyboardOnly
 

--- a/SharedLib/Extensions/EnumExtension.cs
+++ b/SharedLib/Extensions/EnumExtension.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SharedLib.Extensions
+{
+    public static class EnumExtensions
+    {
+        public static IEnumerable<Enum> GetFlags(this Enum value)
+        {
+            return GetFlags(value, Enum.GetValues(value.GetType()).Cast<Enum>().ToArray());
+        }
+
+        public static IEnumerable<Enum> GetIndividualFlags(this Enum value)
+        {
+            return GetFlags(value, GetFlagValues(value.GetType()).ToArray());
+        }
+
+        private static IEnumerable<Enum> GetFlags(Enum value, Enum[] values)
+        {
+            ulong bits = Convert.ToUInt64(value);
+            List<Enum> results = new List<Enum>();
+            for (int i = values.Length - 1; i >= 0; i--)
+            {
+                ulong mask = Convert.ToUInt64(values[i]);
+                if (i == 0 && mask == 0L)
+                    break;
+                if ((bits & mask) == mask)
+                {
+                    results.Add(values[i]);
+                    bits -= mask;
+                }
+            }
+            if (bits != 0L)
+                return Enumerable.Empty<Enum>();
+            if (Convert.ToUInt64(value) != 0L)
+                return results.Reverse<Enum>();
+            if (bits == Convert.ToUInt64(value) && values.Length > 0 && Convert.ToUInt64(values[0]) == 0L)
+                return values.Take(1);
+            return Enumerable.Empty<Enum>();
+        }
+
+        private static IEnumerable<Enum> GetFlagValues(Type enumType)
+        {
+            ulong flag = 0x1;
+            foreach (var value in Enum.GetValues(enumType).Cast<Enum>())
+            {
+                ulong bits = Convert.ToUInt64(value);
+                if (bits == 0L)
+                    //yield return value;
+                    continue; // skip the zero value
+                while (flag < bits) flag <<= 1;
+                if (flag == bits)
+                    yield return value;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Key Changes:
* Using [UnitClassification](https://wowpedia.fandom.com/wiki/API_UnitClassification) API to get target type such as `Elite`
* ClassConfig: Allow whitelist `UnitClassification` of target units to engage with. Default `"Normal, Trivial, Rare"`
* using [UnitIsTrivial](https://wowpedia.fandom.com/wiki/API_UnitIsTrivial) to check `CheckTargetGivesExp` or `TargetYieldXP`

Bug Fix:
* world boss or units that's 10lvl higher than player, the reported level was `-1`

Successor of #381 