### PR TITLE
Addon: [1.7.1] - Simplify: Math formulas - Cost and Cooldown minor fixes - Wrath Cat Actionbar - Added unit based Range checks

### DIFF
--- a/Addons/DataToColor/Constants.lua
+++ b/Addons/DataToColor/Constants.lua
@@ -23,10 +23,6 @@ DataToColor.C.CHARACTER_GUID = UnitGUID(DataToColor.C.unitPlayer)
 _, DataToColor.C.CHARACTER_CLASS, DataToColor.C.CHARACTER_CLASS_ID = UnitClass(DataToColor.C.unitPlayer)
 _, _, DataToColor.C.CHARACTER_RACE_ID = UnitRace(DataToColor.C.unitPlayer)
 
--- Actionbar power cost
-DataToColor.C.COST_MAX_COST_IDX = 100000
-DataToColor.C.COST_MAX_POWER_TYPE = 1000
-
 -- Spells
 DataToColor.C.Spell.AutoShotId = 75
 DataToColor.C.Spell.ShootId = 5019

--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -27,6 +27,7 @@ local strjoin = strjoin
 local strfind = strfind
 local debugstack = debugstack
 local ceil = ceil
+local floor = floor
 local GetTime = GetTime
 
 local UIParent = UIParent
@@ -566,19 +567,17 @@ function DataToColor:CreateFrames(n)
                 Pixel(int, costMeta or 0, 35)
                 Pixel(int, costValue or 0, 36)
 
-                local actionCDSlot, actionCDExpireTime = DataToColor.actionBarCooldownQueue:get()
-                if actionCDSlot then
-                    DataToColor.actionBarCooldownQueue:setDirty(actionCDSlot)
+                local slot, expireTime = DataToColor.actionBarCooldownQueue:get()
+                if slot then
+                    DataToColor.actionBarCooldownQueue:setDirty(slot)
 
-                    local duration = max(0, ceil(actionCDExpireTime - GetTime()))
-                    local valueMs = duration * 100
-
-                    --DataToColor:Print("actionBarCooldownQueue: ", actionCDSlot, " ", valueMs)
-                    Pixel(int, actionCDSlot * 100000 + valueMs, 37)
+                    local duration = max(0, floor((expireTime - GetTime()) * 10))
+                    --DataToColor:Print("actionBarCooldownQueue: ", slot, " ", duration, " ", expireTime - GetTime())
+                    Pixel(int, slot * 100000 + duration, 37)
 
                     if duration == 0 then
-                        DataToColor.actionBarCooldownQueue:remove(actionCDSlot)
-                        --DataToColor:Print("actionBarCooldownQueue: expired ", actionCDSlot, " ", valueMs)
+                        DataToColor.actionBarCooldownQueue:remove(slot)
+                        --DataToColor:Print("actionBarCooldownQueue: expired ", slot)
                     end
                 else
                     Pixel(int, 0, 37)

--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -382,7 +382,7 @@ function DataToColor:InitTalentQueue()
                 --                     1-3 +         1-11 +          1-4 +         1-5
                 local hash = tab * 1000000 + tier * 10000 + column * 10 + currentRank
                 DataToColor.talentQueue:push(hash)
-                --DataToColor:Print("talentQueue tab:"..tab.." | tier: "..tier.." | column: "..column.." | rank: "..currentRank)
+                --DataToColor:Print("talentQueue tab: ", tab, " | tier: ", tier, " | column: ", column, " | rank: ", currentRank, " | hash: ", hash)
             end
         end
     end
@@ -663,7 +663,7 @@ function DataToColor:CreateFrames(n)
             if globalCounter % GOSSIP_ITERATION_FRAME_CHANGE_RATE == 0 then
                 local gossipNum = DataToColor.gossipQueue:shift()
                 if gossipNum then
-                    --DataToColor:Print("gossipQueue:" .. gossipNum)
+                    --DataToColor:Print("gossipQueue: ", gossipNum)
                     Pixel(int, gossipNum, 73)
                 end
             end

--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -222,7 +222,8 @@ function DataToColor:SetupRequirements()
 end
 
 function DataToColor:Reset()
-    DataToColor.S.playerSpellBook = {}
+    DataToColor.S.playerSpellBookName = {}
+    DataToColor.S.playerSpellBookId = {}
 
     DataToColor.playerGUID = UnitGUID(DataToColor.C.unitPlayer)
     DataToColor.petGUID = UnitGUID(DataToColor.C.unitPet)
@@ -365,7 +366,8 @@ function DataToColor:InitSpellBookQueue()
         end
 
         local texture = GetSpellBookItemTexture(num, type)
-        DataToColor.S.playerSpellBook[texture] = name
+        DataToColor.S.playerSpellBookName[texture] = name
+        DataToColor.S.playerSpellBookId[id] = true
 
         DataToColor.spellBookQueue:push(id)
         num = num + 1
@@ -502,13 +504,9 @@ function DataToColor:CreateFrames(n)
                 local bagNum = DataToColor.bagQueue:shift()
                 if bagNum then
                     local freeSlots, bagType = GetContainerNumFreeSlots(bagNum)
-                    if not bagType then
-                        bagType = 0
-                    end
-
                     -- BagType + Index + FreeSpace + BagSlots
-                    Pixel(int, bagType * 1000000 + bagNum * 100000 + freeSlots * 1000 + GetContainerNumSlots(bagNum), 20)
-                    --DataToColor:Print("bagQueue bagType:", bagType, " | bagNum: ", bagNum, " | freeSlots: ", freeSlots, " | BagSlots: ", GetContainerNumSlots(bagNum))
+                    Pixel(int, (bagType or 0) * 1000000 + bagNum * 100000 + freeSlots * 1000 + GetContainerNumSlots(bagNum), 20)
+                    --DataToColor:Print("bagQueue bagType:", bagType or 0, " | bagNum: ", bagNum, " | freeSlots: ", freeSlots, " | BagSlots: ", GetContainerNumSlots(bagNum))
                 else
                     Pixel(int, 0, 20)
                 end
@@ -522,18 +520,12 @@ function DataToColor:CreateFrames(n)
 
                     local _, itemCount, _, _, _, _, _, _, _, itemID = GetContainerItemInfo(bagNum, bagSlotNum)
 
-                    if itemID == nil then
-                        itemCount = 0
-                        itemID = 0
-                    end
-
-                    --DataToColor:Print("inventoryQueue: "..bagNum.. " "..bagSlotNum.." -> id:"..itemID.." c:"..itemCount)
-
+                    --DataToColor:Print("inventoryQueue: ", bagNum, " ", bagSlotNum, " -> id: ", itemID or 0, " c:", itemCount or 0)
                     -- 0-4 bagNum + 1-21 itenNum + 1-1000 quantity
-                    Pixel(int, bagNum * 1000000 + bagSlotNum * 10000 + itemCount, 21)
+                    Pixel(int, bagNum * 1000000 + bagSlotNum * 10000 + (itemCount or 0), 21)
 
                     -- itemId 1-999999
-                    Pixel(int, itemID, 22)
+                    Pixel(int, itemID or 0, 22)
                 else
                     Pixel(int, 0, 21)
                     Pixel(int, 0, 22)
@@ -543,7 +535,7 @@ function DataToColor:CreateFrames(n)
                 local equipmentSlot = DataToColor.equipmentQueue:shift()
                 Pixel(int, equipmentSlot or 0, 23)
                 Pixel(int, DataToColor:equipSlotItemId(equipmentSlot), 24)
-                --DataToColor:Print("equipmentQueue "..equipmentSlot.." -> "..itemId)
+                --DataToColor:Print("equipmentQueue ", equipmentSlot, " -> ", itemId)
             end
 
             Pixel(int, DataToColor:isCurrentAction(1, 24), 25)
@@ -572,12 +564,14 @@ function DataToColor:CreateFrames(n)
                     DataToColor.actionBarCooldownQueue:setDirty(slot)
 
                     local duration = max(0, floor((expireTime - GetTime()) * 10))
-                    --DataToColor:Print("actionBarCooldownQueue: ", slot, " ", duration, " ", expireTime - GetTime())
+                    --if duration > 0 then
+                    --    DataToColor:Print("actionBarCooldownQueue: ", slot, " ", duration, " ", expireTime - GetTime())
+                    --end
                     Pixel(int, slot * 100000 + duration, 37)
 
                     if duration == 0 then
                         DataToColor.actionBarCooldownQueue:remove(slot)
-                        --DataToColor:Print("actionBarCooldownQueue: expired ", slot)
+                        --DataToColor:Print("actionBarCooldownQueue: ", slot, " expired")
                     end
                 else
                     Pixel(int, 0, 37)

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -3,7 +3,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors
-## Version: 1.7.0
+## Version: 1.7.1
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/Query.lua
+++ b/Addons/DataToColor/Query.lua
@@ -120,7 +120,7 @@ function DataToColor:Bits1()
         base2(UnitIsDead(DataToColor.C.unitTarget) and 1 or 0, 1) +
         base2(UnitIsDeadOrGhost(DataToColor.C.unitPlayer) and 1 or 0, 2) +
         base2(UnitCharacterPoints(DataToColor.C.unitPlayer) > 0 and 1 or 0, 3) +
-        base2(UnitExists(DataToColor.C.unitTarget) and CheckInteractDistance(DataToColor.C.unitTarget, 2) and 1 or 0, 4) +
+        -- 4 unused
         base2(DataToColor:isHostile(DataToColor.C.unitTarget), 5) +
         base2(UnitIsVisible(DataToColor.C.unitPet) and not UnitIsDead(DataToColor.C.unitPet) and 1 or 0, 6) +
         base2(mainHandEnchant and 1 or 0, 7) +
@@ -153,7 +153,7 @@ function DataToColor:Bits2()
         base2(UnitExists(DataToColor.C.unitFocusTarget) and 1 or 0, 5) +
         base2(UnitAffectingCombat(DataToColor.C.unitFocusTarget) and 1 or 0, 6) +
         base2(DataToColor:isHostile(DataToColor.C.unitFocusTarget), 7) +
-        base2(UnitExists(DataToColor.C.unitFocusTarget) and CheckInteractDistance(DataToColor.C.unitFocusTarget, 2) and 1 or 0, 8) +
+        -- 8 unused
         base2(UnitIsDead(DataToColor.C.unitPetTarget) and 1 or 0, 9) +
         base2(IsStealthed() and 1 or 0, 10) +
         base2(UnitIsTrivial(DataToColor.C.unitTarget) and 1 or 0, 11)
@@ -397,6 +397,15 @@ function DataToColor:areSpellsInRange()
             inRange = inRange + (2 ^ (i - 1))
         end
     end
+
+    local c = #DataToColor.S.interactInRangeList
+    for i = 1, c do
+        local data = DataToColor.S.interactInRangeList[i]
+        if CheckInteractDistance(data[1], data[2]) then
+            inRange = inRange + (2 ^ (24 - c + i - 1))
+        end
+    end
+
     return inRange
 end
 

--- a/Addons/DataToColor/Query.lua
+++ b/Addons/DataToColor/Query.lua
@@ -391,16 +391,23 @@ end
 
 function DataToColor:areSpellsInRange()
     local inRange = 0
-    for i = 1, #DataToColor.S.spellInRangeList, 1 do
-        local isInRange = IsSpellInRange(GetSpellInfo(DataToColor.S.spellInRangeList[i]), DataToColor.C.unitTarget)
-        if isInRange == 1 then
+    local targetCount = #DataToColor.S.spellInRangeTarget
+    for i = 1, targetCount do
+        if IsSpellInRange(GetSpellInfo(DataToColor.S.spellInRangeTarget[i]), DataToColor.C.unitTarget) == 1 then
             inRange = inRange + (2 ^ (i - 1))
         end
     end
 
-    local c = #DataToColor.S.interactInRangeList
+    for i = 1, #DataToColor.S.spellInRangeUnit do
+        local data = DataToColor.S.spellInRangeUnit[i]
+        if IsSpellInRange(GetSpellInfo(data[1]), data[2]) == 1 then
+            inRange = inRange + (2 ^ (targetCount + i - 1))
+        end
+    end
+
+    local c = #DataToColor.S.interactInRangeUnit
     for i = 1, c do
-        local data = DataToColor.S.interactInRangeList[i]
+        local data = DataToColor.S.interactInRangeUnit[i]
         if CheckInteractDistance(data[1], data[2]) then
             inRange = inRange + (2 ^ (24 - c + i - 1))
         end

--- a/Addons/DataToColor/Query.lua
+++ b/Addons/DataToColor/Query.lua
@@ -6,6 +6,8 @@ local bit = bit
 local band = bit.band
 local date = date
 
+local floor = math.floor
+
 local tonumber = tonumber
 local sub = string.sub
 local gsub = string.gsub
@@ -304,14 +306,8 @@ function DataToColor:isHostile(unit)
 end
 
 function DataToColor:getRange()
-    if UnitExists(DataToColor.C.unitTarget) then
-        local min, max = Range:GetRange(DataToColor.C.unitTarget)
-        if max == nil then
-            max = 99
-        end
-        return min * 100000 + max * 100
-    end
-    return 0
+    local min, max = Range:GetRange(DataToColor.C.unitTarget)
+    return (max or 0) * 1000 + (min or 0)
 end
 
 function DataToColor:targetNpcId()
@@ -459,15 +455,8 @@ function DataToColor:GetCorpsePosition()
 end
 
 function DataToColor:getMeleeAttackSpeed(unit)
-    local mainHand, offHand = UnitAttackSpeed(unit)
-    if not mainHand then
-        mainHand = 0
-    end
-
-    if not offHand then
-        offHand = 0
-    end
-    return 10000 * math.floor(mainHand * 100) + math.floor(offHand * 100)
+    local main, off = UnitAttackSpeed(unit)
+    return 10000 * floor((off or 0) * 100) + floor((main or 0) * 100)
 end
 
 -----------------------------------------------------------------

--- a/Addons/DataToColor/Query.lua
+++ b/Addons/DataToColor/Query.lua
@@ -354,28 +354,26 @@ end
 
 local offsetEnumPowerType = 2
 function DataToColor:populateActionbarCost(slot)
-    if slot == nil then
-        return
-    end
     local actionType, id = GetActionInfo(slot)
     if actionType == DataToColor.C.ActionType.Macro then
         id = GetMacroSpell(id)
     end
+
     if id and actionType == DataToColor.C.ActionType.Spell or actionType == DataToColor.C.ActionType.Macro then
         local costTable = GetSpellPowerCost(id)
         if costTable ~= nil then
-            for index, costInfo in ipairs(costTable) do
-                --print(slot, actionType, index, costInfo.type, costInfo.cost, GetSpellLink(id))
-
+            for order, costInfo in ipairs(costTable) do
                 -- cost negative means it produces that type of powertype...
-                if(costInfo.cost > 0) then
-                    DataToColor.actionBarCostQueue:set(DataToColor.C.COST_MAX_COST_IDX * index + DataToColor.C.COST_MAX_POWER_TYPE * (costInfo.type + offsetEnumPowerType) + slot, costInfo.cost)
+                if costInfo.cost > 0 then
+                    local meta = 100000 * slot + 10000 * order + costInfo.type + offsetEnumPowerType
+                    --print(slot, actionType, order, costInfo.type, costInfo.cost, GetSpellLink(id), meta)
+                    DataToColor.actionBarCostQueue:set(meta, costInfo.cost)
                 end
             end
         end
     end
     -- default value mana with zero cost
-    DataToColor.actionBarCostQueue:set((offsetEnumPowerType * DataToColor.C.COST_MAX_POWER_TYPE) + slot, 0)
+    DataToColor.actionBarCostQueue:set(100000 * slot + 10000 + offsetEnumPowerType, 0)
 end
 
 function DataToColor:equipSlotItemId(slot)

--- a/Addons/DataToColor/Storage.lua
+++ b/Addons/DataToColor/Storage.lua
@@ -8,7 +8,8 @@ DataToColor.S.targetDebuffs = {}
 
 DataToColor.S.playerAuraMap = {}
 
-DataToColor.S.playerSpellBook = {}
+DataToColor.S.playerSpellBookName = {}
+DataToColor.S.playerSpellBookId = {}
 
 function DataToColor:InitStorage()
     CreateSpellInRangeList()

--- a/Addons/DataToColor/Storage.lua
+++ b/Addons/DataToColor/Storage.lua
@@ -1,8 +1,9 @@
 local Load = select(2, ...)
 local DataToColor = unpack(Load)
 
-DataToColor.S.spellInRangeList = {}
-DataToColor.S.interactInRangeList = {}
+DataToColor.S.spellInRangeTarget = {}
+DataToColor.S.spellInRangeUnit = {}
+DataToColor.S.interactInRangeUnit = {}
 
 DataToColor.S.playerBuffs = {}
 DataToColor.S.targetDebuffs = {}
@@ -13,7 +14,9 @@ DataToColor.S.playerSpellBookName = {}
 DataToColor.S.playerSpellBookId = {}
 
 function DataToColor:InitStorage()
-    CreateSpellInRangeList()
+    CreateSpellInRangeTarget()
+    CreateSpellInRangeUnit()
+
     CreateInteractInRangeList()
 
     CreatePlayerBuffList()
@@ -21,29 +24,29 @@ function DataToColor:InitStorage()
     CreatePlayerAuraMap()
 end
 
-function CreateSpellInRangeList()
+function CreateSpellInRangeTarget()
     if DataToColor.C.CHARACTER_CLASS == "ROGUE" then
-        DataToColor.S.spellInRangeList = {
+        DataToColor.S.spellInRangeTarget = {
             1752, -- "Sinister Strike"
             2764, -- "Throw"
             3018, -- "Shoot" for classic -> 7918, -- "Shoot Gun"
         }
     elseif DataToColor.C.CHARACTER_CLASS == "DRUID" then
-        DataToColor.S.spellInRangeList = {
+        DataToColor.S.spellInRangeTarget = {
             5176, -- "Wrath"
             5211, -- "Bash"
             1079, -- "Rip"
             6807 -- "Maul"
         }
     elseif DataToColor.C.CHARACTER_CLASS == "WARRIOR" then
-        DataToColor.S.spellInRangeList = {
+        DataToColor.S.spellInRangeTarget = {
             100, -- "Charge"
             772, -- "Rend"
             3018, -- "Shoot" for classic -> 7918, -- "Shoot Gun"
             2764 -- "Throw"
         }
     elseif DataToColor.C.CHARACTER_CLASS == "PRIEST" then
-        DataToColor.S.spellInRangeList = {
+        DataToColor.S.spellInRangeTarget = {
             589, -- "Shadow Word: Pain"
             5019, -- "Shoot"
             15407, -- "Mind Flay"
@@ -51,11 +54,11 @@ function CreateSpellInRangeList()
             585 -- "Smite"
         }
     elseif DataToColor.C.CHARACTER_CLASS == "PALADIN" then
-        DataToColor.S.spellInRangeList = {
+        DataToColor.S.spellInRangeTarget = {
             20271 -- "Judgement"
         }
     elseif DataToColor.C.CHARACTER_CLASS == "MAGE" then
-        DataToColor.S.spellInRangeList = {
+        DataToColor.S.spellInRangeTarget = {
             133, -- "Fireball"
             5019, -- "Shoot"
             11366, -- "Pyroblast"
@@ -63,23 +66,23 @@ function CreateSpellInRangeList()
             2136 -- "Fire Blast"
         }
     elseif DataToColor.C.CHARACTER_CLASS == "HUNTER" then
-        DataToColor.S.spellInRangeList = {
+        DataToColor.S.spellInRangeTarget = {
             2973, -- "Raptor Strike"
             75, -- "Auto Shot"
             1978 -- "Serpent Sting"
         }
     elseif DataToColor.C.CHARACTER_CLASS == "WARLOCK" then
-        DataToColor.S.spellInRangeList = {
+        DataToColor.S.spellInRangeTarget = {
             686, -- "Shadow Bolt",
             5019 -- "Shoot"
         }
     elseif DataToColor.C.CHARACTER_CLASS == "SHAMAN" then
-        DataToColor.S.spellInRangeList = {
+        DataToColor.S.spellInRangeTarget = {
             403, -- "Lightning Bolt",
             8042 -- "Earth Shock"
         }
     elseif DataToColor.C.CHARACTER_CLASS == "DEATHKNIGHT" then
-        DataToColor.S.spellInRangeList = {
+        DataToColor.S.spellInRangeTarget = {
             49903, -- "Icy Touch"
             49893, -- "Death Coil"
             49576, -- "Death Grip"
@@ -89,23 +92,35 @@ function CreateSpellInRangeList()
     end
 end
 
+function CreateSpellInRangeUnit()
+    if DataToColor.C.CHARACTER_CLASS == "HUNTER" then
+        DataToColor.S.spellInRangeUnit = {
+            { 6991, DataToColor.C.unitPet } -- "Feed pet"
+        }
+    elseif DataToColor.C.CHARACTER_CLASS == "WARLOCK" then
+        DataToColor.S.spellInRangeUnit = {
+            { 27259, DataToColor.C.unitPet }, -- "Health Funnel"
+        }
+    end
+end
+
 function CreateInteractInRangeList()
-    DataToColor.S.interactInRangeList = {}
-    DataToColor.S.interactInRangeList[1] = { DataToColor.C.unitFocusTarget, 1 }
-    DataToColor.S.interactInRangeList[2] = { DataToColor.C.unitFocusTarget, 2 }
-    DataToColor.S.interactInRangeList[3] = { DataToColor.C.unitFocusTarget, 3 }
+    DataToColor.S.interactInRangeUnit = {}
+    DataToColor.S.interactInRangeUnit[1] = { DataToColor.C.unitFocusTarget, 1 }
+    DataToColor.S.interactInRangeUnit[2] = { DataToColor.C.unitFocusTarget, 2 }
+    DataToColor.S.interactInRangeUnit[3] = { DataToColor.C.unitFocusTarget, 3 }
 
-    DataToColor.S.interactInRangeList[4] = { DataToColor.C.unitFocus, 1 }
-    DataToColor.S.interactInRangeList[5] = { DataToColor.C.unitFocus, 2 }
-    DataToColor.S.interactInRangeList[6] = { DataToColor.C.unitFocus, 3 }
+    DataToColor.S.interactInRangeUnit[4] = { DataToColor.C.unitFocus, 1 }
+    DataToColor.S.interactInRangeUnit[5] = { DataToColor.C.unitFocus, 2 }
+    DataToColor.S.interactInRangeUnit[6] = { DataToColor.C.unitFocus, 3 }
 
-    DataToColor.S.interactInRangeList[7] = { DataToColor.C.unitPet, 1 }
-    DataToColor.S.interactInRangeList[8] = { DataToColor.C.unitPet, 2 }
-    DataToColor.S.interactInRangeList[9] = { DataToColor.C.unitPet, 3 }
+    DataToColor.S.interactInRangeUnit[7] = { DataToColor.C.unitPet, 1 }
+    DataToColor.S.interactInRangeUnit[8] = { DataToColor.C.unitPet, 2 }
+    DataToColor.S.interactInRangeUnit[9] = { DataToColor.C.unitPet, 3 }
 
-    DataToColor.S.interactInRangeList[10] = { DataToColor.C.unitTarget, 1 }
-    DataToColor.S.interactInRangeList[11] = { DataToColor.C.unitTarget, 2 }
-    DataToColor.S.interactInRangeList[12] = { DataToColor.C.unitTarget, 3 }
+    DataToColor.S.interactInRangeUnit[10] = { DataToColor.C.unitTarget, 1 }
+    DataToColor.S.interactInRangeUnit[11] = { DataToColor.C.unitTarget, 2 }
+    DataToColor.S.interactInRangeUnit[12] = { DataToColor.C.unitTarget, 3 }
 end
 
 function CreatePlayerBuffList()

--- a/Addons/DataToColor/Storage.lua
+++ b/Addons/DataToColor/Storage.lua
@@ -2,6 +2,7 @@ local Load = select(2, ...)
 local DataToColor = unpack(Load)
 
 DataToColor.S.spellInRangeList = {}
+DataToColor.S.interactInRangeList = {}
 
 DataToColor.S.playerBuffs = {}
 DataToColor.S.targetDebuffs = {}
@@ -13,6 +14,7 @@ DataToColor.S.playerSpellBookId = {}
 
 function DataToColor:InitStorage()
     CreateSpellInRangeList()
+    CreateInteractInRangeList()
 
     CreatePlayerBuffList()
     CreateTargetDebuffList()
@@ -85,6 +87,25 @@ function CreateSpellInRangeList()
             46584 -- "Raise Dead"
         }
     end
+end
+
+function CreateInteractInRangeList()
+    DataToColor.S.interactInRangeList = {}
+    DataToColor.S.interactInRangeList[1] = { DataToColor.C.unitFocusTarget, 1 }
+    DataToColor.S.interactInRangeList[2] = { DataToColor.C.unitFocusTarget, 2 }
+    DataToColor.S.interactInRangeList[3] = { DataToColor.C.unitFocusTarget, 3 }
+
+    DataToColor.S.interactInRangeList[4] = { DataToColor.C.unitFocus, 1 }
+    DataToColor.S.interactInRangeList[5] = { DataToColor.C.unitFocus, 2 }
+    DataToColor.S.interactInRangeList[6] = { DataToColor.C.unitFocus, 3 }
+
+    DataToColor.S.interactInRangeList[7] = { DataToColor.C.unitPet, 1 }
+    DataToColor.S.interactInRangeList[8] = { DataToColor.C.unitPet, 2 }
+    DataToColor.S.interactInRangeList[9] = { DataToColor.C.unitPet, 3 }
+
+    DataToColor.S.interactInRangeList[10] = { DataToColor.C.unitTarget, 1 }
+    DataToColor.S.interactInRangeList[11] = { DataToColor.C.unitTarget, 2 }
+    DataToColor.S.interactInRangeList[12] = { DataToColor.C.unitTarget, 3 }
 end
 
 function CreatePlayerBuffList()

--- a/Core/Actionbar/ActionBar.cs
+++ b/Core/Actionbar/ActionBar.cs
@@ -8,5 +8,7 @@
         public const int NUM_OF_COST = 4;
 
         public const int MAIN_ACTIONBAR_SLOT = 12;
+
+        public const int ACTION_SLOT_MUL = 100000;
     }
 }

--- a/Core/Actionbar/ActionBarCooldownReader.cs
+++ b/Core/Actionbar/ActionBarCooldownReader.cs
@@ -6,18 +6,17 @@ namespace Core
     {
         private readonly struct Data
         {
-            public int DurationSec { get; }
+            public float DurationSec { get; }
             public DateTime StartTime { get; }
 
-            public Data(int duration, DateTime startTime)
+            public Data(float duration, DateTime startTime)
             {
                 DurationSec = duration;
                 StartTime = startTime;
             }
         }
 
-        private const float MAX_ACTION_IDX = 100000f;
-        private const float MAX_VALUE_MUL = 100f;
+        private const float FRACTION_PART = 10f;
 
         private readonly int cActionbarNum;
 
@@ -33,20 +32,14 @@ namespace Core
 
         public void Read(IAddonDataProvider reader)
         {
-            // formula
-            // MAX_ACTION_IDX * slot + (cooldown / MAX_VALUE_MUL)
-            float durationSec = reader.GetInt(cActionbarNum);
-            if (durationSec == 0 || durationSec < MAX_ACTION_IDX) return;
+            int value = reader.GetInt(cActionbarNum);
+            if (value == 0 || value < ActionBar.ACTION_SLOT_MUL) return;
 
-            int slot = (int)(durationSec / MAX_ACTION_IDX);
-            durationSec -= (int)MAX_ACTION_IDX * slot;
-            durationSec /= MAX_VALUE_MUL;
+            int slot = value / ActionBar.ACTION_SLOT_MUL;
+            float durationSec = value % ActionBar.ACTION_SLOT_MUL / FRACTION_PART;
 
             int index = slot - 1;
-            if (index < 0)
-                return;
-
-            data[index] = new((int)durationSec, DateTime.UtcNow);
+            data[index] = new(durationSec, DateTime.UtcNow);
         }
 
         public void Reset()
@@ -60,10 +53,7 @@ namespace Core
         public int GetRemainingCooldown(KeyAction keyAction)
         {
             int index = keyAction.SlotIndex;
-            return data[index].DurationSec > 0
-                ? Math.Clamp((int)(data[index].StartTime.AddSeconds(data[index].DurationSec) - DateTime.UtcNow).TotalMilliseconds, 0, int.MaxValue)
-                : 0;
+            return Math.Clamp((int)(data[index].StartTime.AddSeconds(data[index].DurationSec) - DateTime.UtcNow).TotalMilliseconds, 0, int.MaxValue);
         }
-
     }
 }

--- a/Core/Actionbar/ActionBarCooldownReader.cs
+++ b/Core/Actionbar/ActionBarCooldownReader.cs
@@ -33,13 +33,13 @@ namespace Core
         public void Read(IAddonDataProvider reader)
         {
             int value = reader.GetInt(cActionbarNum);
-            if (value == 0 || value < ActionBar.ACTION_SLOT_MUL) return;
+            if (value == 0 || value < ActionBar.ACTION_SLOT_MUL)
+                return;
 
-            int slot = value / ActionBar.ACTION_SLOT_MUL;
+            int slotIdx = (value / ActionBar.ACTION_SLOT_MUL) - 1;
             float durationSec = value % ActionBar.ACTION_SLOT_MUL / FRACTION_PART;
 
-            int index = slot - 1;
-            data[index] = new(durationSec, DateTime.UtcNow);
+            data[slotIdx] = new(durationSec, DateTime.UtcNow);
         }
 
         public void Reset()

--- a/Core/Addon/AddonReader.cs
+++ b/Core/Addon/AddonReader.cs
@@ -40,7 +40,6 @@ namespace Core
         public LevelTracker LevelTracker { get; }
 
         public event Action? AddonDataChanged;
-        public event Action? ZoneChanged;
         public event Action? PlayerDeath;
 
         private readonly WorldMapAreaDB WorldMapAreaDb;
@@ -162,10 +161,7 @@ namespace Core
                 TargetBuffTimeReader.Read(reader);
 
                 if (UIMapId.Updated(reader))
-                {
                     AreaDb.Update(WorldMapAreaDb.GetAreaId(UIMapId.Value));
-                    ZoneChanged?.Invoke();
-                }
 
                 autoResetEvent.Set();
             }

--- a/Core/Addon/ConfigAddonReader.cs
+++ b/Core/Addon/ConfigAddonReader.cs
@@ -29,7 +29,6 @@ namespace Core.Addon
         public event Action? AddonDataChanged;
 
 #pragma warning disable CS0067 // The event is never used
-        public event Action? ZoneChanged;
         public event Action? PlayerDeath;
 #pragma warning restore CS0067
 

--- a/Core/Addon/IAddonReader.cs
+++ b/Core/Addon/IAddonReader.cs
@@ -33,7 +33,6 @@ namespace Core
         RecordInt UIMapId { get; }
 
         event Action? AddonDataChanged;
-        event Action? ZoneChanged;
         event Action? PlayerDeath;
 
         void FetchData();

--- a/Core/Addon/PlayerReader.cs
+++ b/Core/Addon/PlayerReader.cs
@@ -89,7 +89,7 @@ namespace Core
         public int MaxRange() => reader.GetInt(49) / 1000 % 1000;
 
         public bool IsInMeleeRange() => MinRange() == 0 && MaxRange() != 0 && MaxRange() <= 5;
-        public bool IsInDeadZone() => MinRange() >= 5 && Bits.TargetInTradeRange(); // between 5-8 yard - hunter and warrior
+        public bool IsInDeadZone() => MinRange() >= 5 && SpellInRange.Target_Trade; // between 5-8 yard - hunter and warrior
 
         public RecordInt PlayerXp { get; } = new(50);
 

--- a/Core/Addon/PlayerReader.cs
+++ b/Core/Addon/PlayerReader.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Specialized;
 using System.Numerics;
 
@@ -36,15 +36,15 @@ namespace Core
 
         public int HealthMax() => reader.GetInt(10);
         public int HealthCurrent() => reader.GetInt(11);
-        public int HealthPercent() => HealthMax() == 0 || HealthCurrent() == 1 ? 0 : HealthCurrent() * 100 / HealthMax();
+        public int HealthPercent() => HealthCurrent() * 100 / HealthMax();
 
         public int PTMax() => reader.GetInt(12); // Maximum amount of Power Type (dynamic)
         public int PTCurrent() => reader.GetInt(13); // Current amount of Power Type (dynamic)
-        public int PTPercentage() => PTMax() == 0 ? 0 : PTCurrent() * 100 / PTMax(); // Power Type (dynamic) in terms of a percentage
+        public int PTPercentage() => PTCurrent() * 100 / PTMax(); // Power Type (dynamic) in terms of a percentage
 
         public int ManaMax() => reader.GetInt(14);
         public int ManaCurrent() => reader.GetInt(15);
-        public int ManaPercentage() => ManaMax() == 0 ? 0 : ManaCurrent() * 100 / ManaMax();
+        public int ManaPercentage() => (1 + ManaCurrent()) * 100 / (1 + ManaMax());
 
         public int MaxRune() => reader.GetInt(14);
 
@@ -54,12 +54,11 @@ namespace Core
 
         public int TargetMaxHealth() => reader.GetInt(18);
         public int TargetHealth() => reader.GetInt(19);
-        public int TargetHealthPercentage() => TargetMaxHealth() == 0 || TargetHealth() == 1 ? 0 : TargetHealth() * 100 / TargetMaxHealth();
-
+        public int TargetHealthPercentage() => (1 + TargetHealth()) * 100 / (1 + TargetMaxHealth());
 
         public int PetMaxHealth() => reader.GetInt(38);
         public int PetHealth() => reader.GetInt(39);
-        public int PetHealthPercentage() => PetMaxHealth() == 0 || PetHealth() == 1 ? 0 : PetHealth() * 100 / PetMaxHealth();
+        public int PetHealthPercentage() => (1 + PetHealth()) * 100 / (1 + PetMaxHealth());
 
 
         public SpellInRange SpellInRange { get; }
@@ -95,7 +94,7 @@ namespace Core
         public RecordInt PlayerXp { get; } = new(50);
 
         public int PlayerMaxXp => reader.GetInt(51);
-        public int PlayerXpPercentage => PlayerXp.Value * 100 / (PlayerMaxXp == 0 ? 1 : PlayerMaxXp);
+        public int PlayerXpPercentage => PlayerXp.Value * 100 / PlayerMaxXp;
 
         private UI_ERROR UIError => (UI_ERROR)reader.GetInt(52);
         public UI_ERROR LastUIError { get; set; }

--- a/Core/Addon/PlayerReader.cs
+++ b/Core/Addon/PlayerReader.cs
@@ -83,7 +83,7 @@ namespace Core
         // 47 empty
 
         public Stance Stance { get; }
-        public Form Form => Stance.Get(Class, Bits.IsStealthed());
+        public Form Form => Stance.Get(Class, Bits.IsStealthed(), Version);
 
         public int MinRange() => reader.GetInt(49) % 1000;
         public int MaxRange() => reader.GetInt(49) / 1000 % 1000;

--- a/Core/Addon/PlayerReader.cs
+++ b/Core/Addon/PlayerReader.cs
@@ -70,14 +70,15 @@ namespace Core
         public BuffStatus Buffs { get; }
         public TargetDebuffStatus TargetDebuffs { get; }
 
+        // TargetLevel * 100 + TargetClass
         public int TargetLevel => reader.GetInt(43) / 100;
-
         public UnitClassification TargetClassification => (UnitClassification)(reader.GetInt(43) % 100);
 
         public int Gold => reader.GetInt(44) + (reader.GetInt(45) * 1000000);
 
-        public UnitRace Race => (UnitRace)(reader.GetInt(46) / 10_000);
-        public UnitClass Class => (UnitClass)(reader.GetInt(46) % 10_000 / 100);
+        // RACE_ID * 10000 + CLASS_ID * 100 + ClientVersion
+        public UnitRace Race => (UnitRace)(reader.GetInt(46) / 10000);
+        public UnitClass Class => (UnitClass)(reader.GetInt(46) / 100 % 100);
         public ClientVersion Version => (ClientVersion)(reader.GetInt(46) % 10);
 
         // 47 empty

--- a/Core/Addon/PlayerReader.cs
+++ b/Core/Addon/PlayerReader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Specialized;
 using System.Numerics;
 
@@ -86,8 +86,8 @@ namespace Core
         public Stance Stance { get; }
         public Form Form => Stance.Get(Class, Bits.IsStealthed());
 
-        public int MinRange() => (int)(reader.GetInt(49) / 100000f);
-        public int MaxRange() => (int)((reader.GetInt(49) - (MinRange() * 100000f)) / 100f);
+        public int MinRange() => reader.GetInt(49) % 1000;
+        public int MaxRange() => reader.GetInt(49) / 1000 % 1000;
 
         public bool IsInMeleeRange() => MinRange() == 0 && MaxRange() != 0 && MaxRange() <= 5;
         public bool IsInDeadZone() => MinRange() >= 5 && Bits.TargetInTradeRange(); // between 5-8 yard - hunter and warrior
@@ -131,9 +131,9 @@ namespace Core
 
         public BitVector32 CustomTrigger1;
 
-        public int MainHandSpeedMs() => (int)(reader.GetInt(75) / 10000f) * 10;
-
-        public int OffHandSpeed => (int)(reader.GetInt(75) - (MainHandSpeedMs() * 1000f));  // supposed to be 10000f - but theres a 10x
+        // 10000 * off * 100 + main * 100
+        public int MainHandSpeedMs() => reader.GetInt(75) % 10000 * 10;
+        public int OffHandSpeed => reader.GetInt(75) / 10000 * 10;
 
         public int RemainCastMs => reader.GetInt(76);
 

--- a/Core/AddonComponent/AddonBits.cs
+++ b/Core/AddonComponent/AddonBits.cs
@@ -27,7 +27,7 @@ namespace Core
         public bool TargetIsDead() => v1[Mask._1];
         public bool DeadStatus() => v1[Mask._2];
         public bool TalentPoints() => v1[Mask._3];
-        public bool TargetInTradeRange() => v1[Mask._4];
+        // 4 unused
         public bool TargetCanBeHostile() => v1[Mask._5];
         public bool HasPet() => v1[Mask._6];
         public bool MainHandEnchant_Active() => v1[Mask._7];
@@ -65,7 +65,7 @@ namespace Core
 
         public bool FocusTargetCanBeHostile() => v2[Mask._7];
 
-        public bool FocusTargetInTradeRange() => v2[Mask._8];
+        // 8 unused
 
         public bool PetTargetIsDead() => v2[Mask._9];
 

--- a/Core/AddonComponent/SpellInRange.cs
+++ b/Core/AddonComponent/SpellInRange.cs
@@ -74,6 +74,24 @@ namespace Core
         public bool DeathKnight_DarkCommand => b[Mask._3];
         public bool DeathKnight_RaiseDead => b[Mask._4];
 
+
+        // Unit based Non spell Ranges
+        public bool FocusTarget_Inspect => b[Mask._12];
+        public bool FocusTarget_Trade => b[Mask._13];
+        public bool FocusTarget_Duel => b[Mask._14];
+
+        public bool Focus_Inspect => b[Mask._15];
+        public bool Focus_Trade => b[Mask._16];
+        public bool Focus_Duel => b[Mask._17];
+
+        public bool Pet_Inspect => b[Mask._18];
+        public bool Pet_Trade => b[Mask._19];
+        public bool Pet_Duel => b[Mask._20];
+
+        public bool Target_Inspect => b[Mask._21];
+        public bool Target_Trade => b[Mask._22];
+        public bool Target_Duel => b[Mask._23];
+
         public bool WithinPullRange(PlayerReader playerReader, UnitClass @class) => @class switch
         {
             UnitClass.Warrior => (playerReader.Level.Value >= 4 && Warrior_Charge) || playerReader.IsInMeleeRange(),

--- a/Core/AddonComponent/SpellInRange.cs
+++ b/Core/AddonComponent/SpellInRange.cs
@@ -58,10 +58,12 @@ namespace Core
         public bool Hunter_RaptorStrike => b[Mask._0];
         public bool Hunter_AutoShoot => b[Mask._1];
         public bool Hunter_SerpentSting => b[Mask._2];
+        public bool Hunter_FeedPet => b[Mask._3];
 
         // Warlock
         public bool Warlock_ShadowBolt => b[Mask._0];
         public bool Warlock_Shoot => b[Mask._1];
+        public bool Warlock_HealthFunnel => b[Mask._2];
 
         // Shaman
         public bool Shaman_LightningBolt => b[Mask._0];

--- a/Core/AddonComponent/Stance.cs
+++ b/Core/AddonComponent/Stance.cs
@@ -16,12 +16,12 @@
             value = reader.GetInt(cell);
         }
 
-        public Form Get(UnitClass @class, bool stealth) => value == 0 ? Form.None : @class switch
+        public Form Get(UnitClass @class, bool stealth, ClientVersion version) => value == 0 ? Form.None : @class switch
         {
             UnitClass.Warrior => Form.Warrior_BattleStance + value - 1,
             UnitClass.Rogue => Form.Rogue_Stealth + value - 1,
             UnitClass.Priest => Form.Priest_Shadowform + value - 1,
-            UnitClass.Druid => stealth ? Form.Druid_Cat_Prowl : Form.Druid_Bear + value - 1,
+            UnitClass.Druid => version == ClientVersion.Wrath ? Form.Druid_Bear + value - 1 : (stealth ? Form.Druid_Cat_Prowl : Form.Druid_Bear + value - 1),
             UnitClass.Paladin => Form.Paladin_Devotion_Aura + value - 1,
             UnitClass.Shaman => Form.Shaman_GhostWolf + value - 1,
             UnitClass.DeathKnight => Form.DeathKnight_Blood_Presence + value - 1,

--- a/Core/BotController.cs
+++ b/Core/BotController.cs
@@ -265,6 +265,7 @@ namespace Core
             (RouteInfo routeInfo, IEnumerable<GoapGoal> availableActions) =
                 GoalFactory.CreateGoals(logger, AddonReader, configInput, dataConfig, npcNameFinder, npcNameTargeting, pather, execGameCommand, config, goapAgentState, cts, wait);
 
+            RouteInfo?.Dispose();
             RouteInfo = routeInfo;
 
             GoapAgent?.Dispose();
@@ -288,6 +289,7 @@ namespace Core
         {
             cts.Cancel();
             ClassConfig?.Dispose();
+            RouteInfo?.Dispose();
             GoapAgent?.Dispose();
 
             npcNameFinderEvent.Dispose();

--- a/Core/Configurator/FrameConfigurator.cs
+++ b/Core/Configurator/FrameConfigurator.cs
@@ -345,9 +345,12 @@ namespace Core
 
         public bool TryResolveRaceAndClass(out UnitRace race, out UnitClass @class, out ClientVersion version)
         {
-            race = (UnitRace)(reader.GetInt(46) / 10_000);
-            @class = (UnitClass)(reader.GetInt(46) % 10_000 / 100);
-            version = (ClientVersion)(reader.GetInt(46) % 10);
+            int value = reader.GetInt(46);
+
+            // RACE_ID * 10000 + CLASS_ID * 100 + ClientVersion
+            race = (UnitRace)(value / 10000);
+            @class = (UnitClass)(value / 100 % 100);
+            version = (ClientVersion)(value % 10);
 
             return Enum.IsDefined(race) && Enum.IsDefined(@class) && Enum.IsDefined(version);
         }

--- a/Core/DataFrame/FrameConfig.cs
+++ b/Core/DataFrame/FrameConfig.cs
@@ -74,23 +74,15 @@ namespace Core
 
         public static DataFrameMeta GetMeta(Color color)
         {
-            int data, hash;
-            data = hash = color.R * 65536 + color.G * 256 + color.B;
-
+            int hash = color.R * 65536 + color.G * 256 + color.B;
             if (hash == 0)
                 return DataFrameMeta.Empty;
 
             // CELL_SPACING * 10000000 + CELL_SIZE * 100000 + 1000 * FRAME_ROWS + NUMBER_OF_FRAMES
-            int spacing = (int)(data / 10000000f);
-            data -= (10000000 * spacing);
-
-            int size = (int)(data / 100000f);
-            data -= (100000 * size);
-
-            int rows = (int)(data / 1000f);
-            data -= (1000 * rows);
-
-            int count = data;
+            int spacing = hash / 10000000;
+            int size = hash / 100000 % 100;
+            int rows = hash / 1000 % 100;
+            int count = hash % 1000;
 
             return new DataFrameMeta(hash, spacing, size, rows, count);
         }

--- a/Core/Database/WorldMapAreaDB.cs
+++ b/Core/Database/WorldMapAreaDB.cs
@@ -22,12 +22,7 @@ namespace Core.Database
 
         public int GetAreaId(int uiMapId)
         {
-            if (areas.TryGetValue(uiMapId, out var map))
-            {
-                return map.AreaID;
-            }
-
-            return -1;
+            return areas.TryGetValue(uiMapId, out WorldMapArea map) ? map.AreaID : -1;
         }
 
         public Vector3 ToWorld(int uiMapId, Vector3 local, bool flipXY)

--- a/Core/Goals/FollowFocusGoal.cs
+++ b/Core/Goals/FollowFocusGoal.cs
@@ -33,7 +33,8 @@ namespace Core.Goals
                 wait.Update();
             }
 
-            input.FollowTarget();
+            if (playerReader.SpellInRange.Focus_Inspect)
+                input.FollowTarget();
 
             wait.Update();
         }

--- a/Core/Goals/TargetFocusTargetGoal.cs
+++ b/Core/Goals/TargetFocusTargetGoal.cs
@@ -43,7 +43,7 @@ namespace Core.Goals
                     wait.Update();
                 }
             }
-            else if (playerReader.Bits.FocusTargetInTradeRange())
+            else if (playerReader.SpellInRange.FocusTarget_Trade)
             {
                 input.TargetFocus();
                 input.TargetOfTarget();

--- a/Core/GoalsComponent/CastingHandler.cs
+++ b/Core/GoalsComponent/CastingHandler.cs
@@ -304,7 +304,7 @@ namespace Core.Goals
                 }
             }
 
-            if (!WaitForGCD(item, true, Interrupt))
+            if (!item.BaseAction && !WaitForGCD(item, true, Interrupt))
             {
                 return false;
             }

--- a/Core/GoalsFactory/GoalFactory.cs
+++ b/Core/GoalsFactory/GoalFactory.cs
@@ -149,7 +149,7 @@ namespace Core
             IEnumerable<GoapGoal> goals = provider.GetServices<GoapGoal>();
             IEnumerable<IRouteProvider> pathProviders = goals.OfType<IRouteProvider>();
 
-            RouteInfo routeInfo = new(route, pathProviders, addonReader);
+            RouteInfo routeInfo = new(route, pathProviders, addonReader.PlayerReader, addonReader.AreaDb);
 
             pather.DrawLines(new()
             {

--- a/Core/Gossip/GossipReader.cs
+++ b/Core/Gossip/GossipReader.cs
@@ -52,19 +52,11 @@ namespace Core
 
             // formula
             // 10000 * count + 100 * index + value
-            int count = (int)(data / 10000f);
-            data -= 10000 * count;
+            Count = data / 10000;
+            int order = data / 100 % 100;
+            Gossip gossip = (Gossip)(data % 100);
 
-            int order = (int)(data / 100f);
-            data -= 100 * order;
-
-            Count = count;
-
-            if (!Gossips.ContainsKey((Gossip)data))
-            {
-                Gossips.Add((Gossip)data, order);
-            }
+            Gossips[gossip] = order;
         }
-
     }
 }

--- a/Core/Path/RouteInfo.cs
+++ b/Core/Path/RouteInfo.cs
@@ -139,7 +139,7 @@ namespace Core
                 return;
 
             PoiList.Clear();
-
+            /*
             // Visualize the zone pois
             for (int i = 0; i < areaDB.CurrentArea.vendor?.Count; i++)
             {
@@ -164,6 +164,7 @@ namespace Core
                 NPC npc = areaDB.CurrentArea.flightmaster[i];
                 PoiList.Add(new RouteInfoPoi(npc, "orange"));
             }
+            */
         }
 
         private void CalculateDiffs()

--- a/Core/Path/RouteInfo.cs
+++ b/Core/Path/RouteInfo.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using System.Text;
+
+using Core.Database;
+
 using WowheadDB;
 
 namespace Core
@@ -32,7 +35,7 @@ namespace Core
         }
     }
 
-    public class RouteInfo
+    public class RouteInfo : IDisposable
     {
         public Vector3[] Route { get; private set; }
 
@@ -49,7 +52,8 @@ namespace Core
         }
 
         private readonly IEnumerable<IRouteProvider> pathedRoutes;
-        private readonly AddonReader addonReader;
+        private readonly AreaDB areaDB;
+        private readonly PlayerReader playerReader;
 
         public List<RouteInfoPoi> PoiList { get; } = new();
 
@@ -66,18 +70,23 @@ namespace Core
 
         private const int dSize = 2;
 
-        public RouteInfo(Vector3[] route, IEnumerable<IRouteProvider> pathedRoutes, AddonReader addonReader)
+        public RouteInfo(Vector3[] route, IEnumerable<IRouteProvider> pathedRoutes, PlayerReader playerReader, AreaDB areaDB)
         {
             this.Route = route;
-
             this.pathedRoutes = pathedRoutes;
-            this.addonReader = addonReader;
 
-            //addonReader.UIMapId.Changed -= OnZoneChanged;
-            //addonReader.UIMapId.Changed += OnZoneChanged;
-            //OnZoneChanged(this, EventArgs.Empty);
+            this.playerReader = playerReader;
+            this.areaDB = areaDB;
+
+            this.areaDB.Changed += OnZoneChanged;
+            OnZoneChanged();
 
             CalculateDiffs();
+        }
+
+        public void Dispose()
+        {
+            areaDB.Changed -= OnZoneChanged;
         }
 
         public void UpdateRoute(IEnumerable<Vector3> newRoute)
@@ -124,16 +133,36 @@ namespace Core
             return value / 100f * pointToGrid;
         }
 
-        private void OnZoneChanged(object sender, EventArgs e)
+        private void OnZoneChanged()
         {
-            if (addonReader.AreaDb.CurrentArea != null)
+            if (areaDB.CurrentArea == null)
+                return;
+
+            PoiList.Clear();
+
+            // Visualize the zone pois
+            for (int i = 0; i < areaDB.CurrentArea.vendor?.Count; i++)
             {
-                PoiList.Clear();
-                // Visualize the zone pois
-                addonReader.AreaDb.CurrentArea.vendor?.ForEach(x => PoiList.Add(new RouteInfoPoi(x, "green")));
-                addonReader.AreaDb.CurrentArea.repair?.ForEach(x => PoiList.Add(new RouteInfoPoi(x, "purple")));
-                addonReader.AreaDb.CurrentArea.innkeeper?.ForEach(x => PoiList.Add(new RouteInfoPoi(x, "blue")));
-                addonReader.AreaDb.CurrentArea.flightmaster?.ForEach(x => PoiList.Add(new RouteInfoPoi(x, "orange")));
+                NPC npc = areaDB.CurrentArea.vendor[i];
+                PoiList.Add(new RouteInfoPoi(npc, "green"));
+            }
+
+            for (int i = 0; i < areaDB.CurrentArea.repair?.Count; i++)
+            {
+                NPC npc = areaDB.CurrentArea.repair[i];
+                PoiList.Add(new RouteInfoPoi(npc, "purple"));
+            }
+
+            for (int i = 0; i < areaDB.CurrentArea.innkeeper?.Count; i++)
+            {
+                NPC npc = areaDB.CurrentArea.innkeeper[i];
+                PoiList.Add(new RouteInfoPoi(npc, "blue"));
+            }
+
+            for (int i = 0; i < areaDB.CurrentArea.flightmaster?.Count; i++)
+            {
+                NPC npc = areaDB.CurrentArea.flightmaster[i];
+                PoiList.Add(new RouteInfoPoi(npc, "orange"));
             }
         }
 
@@ -148,7 +177,7 @@ namespace Core
             var pois = PoiList.Select(p => p.Location);
             allPoints.AddRange(pois);
 
-            allPoints.Add(addonReader.PlayerReader.PlayerLocation);
+            allPoints.Add(playerReader.PlayerLocation);
 
             var maxX = allPoints.Max(s => s.X);
             var minX = allPoints.Min(s => s.X);
@@ -217,7 +246,7 @@ namespace Core
             Vector3 pt = NextPoint();
             if (pt == Vector3.Zero)
                 return string.Empty;
-                
+
             return $"<circle cx = '{ToCanvasPointX(pt.X)}' cy = '{ToCanvasPointY(pt.Y)}'r = '{dSize + 1}' />";
         }
 

--- a/Core/Talents/TalentReader.cs
+++ b/Core/Talents/TalentReader.cs
@@ -25,27 +25,23 @@ namespace Core
 
         public void Read(IAddonDataProvider reader)
         {
-            int data = reader.GetInt(cTalent);
-            if (data == 0 || Talents.ContainsKey(data)) return;
+            int hash = reader.GetInt(cTalent);
+            if (hash == 0 || Talents.ContainsKey(hash)) return;
 
-            int hash = data;
+            //           1-3 +         1-11 +         1-4 +         1-5
+            // tab * 1000000 + tier * 10000 + column * 10 + currentRank
+            int tab = hash / 1000000;
+            int tier = hash / 10000 % 100;
+            int column = hash / 10 % 10;
+            int rank = hash % 10;
 
-            int tab = (int)(data / 1000000f);
-            data -= 1000000 * tab;
-
-            int tier = (int)(data / 10000f);
-            data -= 10000 * tier;
-
-            int column = (int)(data / 10f);
-            data -= 10 * column;
-
-            var talent = new Talent
+            Talent talent = new()
             {
                 Hash = hash,
                 TabNum = tab,
                 TierNum = tier,
                 ColumnNum = column,
-                CurrentRank = data
+                CurrentRank = rank
             };
 
             if (talentDB.Update(ref talent, playerReader.Class, out int id))

--- a/Frontend/Pages/RouteComponent.razor
+++ b/Frontend/Pages/RouteComponent.razor
@@ -7,7 +7,8 @@
 @inject IAddonReader addonReader
 @inject IBotController botController
 @inject IJSRuntime JSRuntime
-@inject WorldMapAreaDB worldmapAreaDB 
+@inject WorldMapAreaDB worldmapAreaDB
+@inject AreaDB areaDB
 
 @implements IDisposable
 
@@ -115,7 +116,7 @@
     {
         botController.ProfileLoaded += OnProfileLoaded;
         addonReader.AddonDataChanged += OnAddonDataChanged;
-        addonReader.ZoneChanged += OnZoneChanged;
+        areaDB.Changed += OnZoneChanged;
         addonReader.PlayerDeath += OnPlayerDeath;
 
         UpdateZoneName();
@@ -129,7 +130,7 @@
 
         botController.ProfileLoaded -= OnProfileLoaded;
         addonReader.AddonDataChanged -= OnAddonDataChanged;
-        addonReader.ZoneChanged -= OnZoneChanged;
+        areaDB.Changed -= OnZoneChanged;
         addonReader.PlayerDeath -= OnPlayerDeath;
     }
 

--- a/README.md
+++ b/README.md
@@ -1383,8 +1383,10 @@ Formula: `SpellInRange:[Numeric integer value]`
 | Hunter | Raptor Strike | 0 |
 | Hunter | Auto Shot | 1 |
 | Hunter | Serpent Sting | 2 |
+| Hunter | Feed Pet | 3 |
 | Warlock | Shadow Bolt | 0 |
 | Warlock | Shoot | 1 |
+| Warlock | Health Funnel | 2 |
 | Shaman | Lightning Bolt | 0 |
 | Shaman | Earth Shock | 1 |
 | Death Knight | Icy Touch | 0 |

--- a/README.md
+++ b/README.md
@@ -1393,6 +1393,23 @@ Formula: `SpellInRange:[Numeric integer value]`
 | Death Knight | Dark Command | 3 |
 | Death Knight | Raise Dead | 4 |
 
+Shared [CheckInteractDistance](https://wowwiki-archive.fandom.com/wiki/API_CheckInteractDistance) API
+
+| Unit | id |
+| --- | --- |
+| focustarget Inspect | 12 |
+| focustarget Trade | 13 |
+| focustarget Duel | 14 |
+| focus Inspect | 15 |
+| focus Trade | 16 |
+| focus Duel | 17 |
+| pet Inspect | 18 |
+| pet Trade | 19 |
+| pet Duel | 20 |
+| target Inspect | 21 |
+| target Trade | 22 |
+| target Duel | 23 |
+
 e.g.
 ```json
 "Requirement": "SpellInRange:4"


### PR DESCRIPTION
Key Changes:
* Simplify cell math formulas using modulo over specific division.
* CooldownReader: Added extra 10th resolution
* CooldownReader: below GCD cooldowns durations were getting properly ignored
* CostReader: Using the same formula as in Cooldown
* `Wrath`: Adjust cat action bar during Prowl
* Obtain `focustarget`, `focus`, `pet` and `target` -> `Inspect`, `Trade` and `Duel` distance in ranges under `SpellInRange`.
* Added Hunter `Feed Pet` to SpellInRange respect to pet
* Added Warlock `Health Funnel` to SpellInRange respect to pet
* AddonReader: `ZoneChanged` event relocated to AreaDB. AreaDB no longer deserialize json on AddonReader thread!
* RouteInfo: Release event in Dispose

Bug fix:
* CastingHandler: `KeyAction.BaseAction` should not be blocked by `WaitForGCD`!


