### PR TITLE
Feature: Rework `NpcNameFinder` - More reliable mouse targeting and skinning due `Interact with Mouseover`

### DIFF
--- a/Core/ClassConfig/ClassConfiguration.cs
+++ b/Core/ClassConfig/ClassConfiguration.cs
@@ -73,6 +73,9 @@ namespace Core
         public KeyAction Interact { get; } = new();
         public string InteractKey { get; init; } = "I";
 
+        public KeyAction InteractMouseOver { get; } = new();
+        public string InteractMouseOverKey { get; init; } = "J";
+
         public KeyAction Approach { get; } = new();
         public KeyAction AutoAttack { get; } = new();
 
@@ -201,6 +204,13 @@ namespace Core
             Interact.PressDuration = 30;
             Interact.BaseAction = true;
             Interact.Initialise(this, addonReader, requirementFactory, logger, Log);
+
+            InteractMouseOver.Key = InteractMouseOverKey;
+            InteractMouseOver.Name = nameof(InteractMouseOver);
+            InteractMouseOver.Cooldown = 0;
+            InteractMouseOver.PressDuration = 10;
+            InteractMouseOver.BaseAction = true;
+            InteractMouseOver.Initialise(this, addonReader, requirementFactory, logger, Log);
 
             Approach.Key = InteractKey;
             Approach.Name = nameof(Approach);

--- a/Core/GoalsComponent/TargetFinder.cs
+++ b/Core/GoalsComponent/TargetFinder.cs
@@ -9,13 +9,14 @@ namespace Core.Goals
         private readonly ConfigurableInput input;
         private readonly ClassConfiguration classConfig;
         private readonly PlayerReader playerReader;
-
+        private readonly Wait wait;
         private readonly NpcNameTargeting npcNameTargeting;
 
-        public TargetFinder(ConfigurableInput input, ClassConfiguration classConfig, PlayerReader playerReader, NpcNameTargeting npcNameTargeting)
+        public TargetFinder(ConfigurableInput input, ClassConfiguration classConfig, Wait wait, PlayerReader playerReader, NpcNameTargeting npcNameTargeting)
         {
             this.classConfig = classConfig;
             this.input = input;
+            this.wait = wait;
             this.playerReader = playerReader;
             this.npcNameTargeting = npcNameTargeting;
         }
@@ -42,7 +43,8 @@ namespace Core.Goals
                 npcNameTargeting.ChangeNpcType(target);
                 if (!ct.IsCancellationRequested && npcNameTargeting.NpcCount > 0)
                 {
-                    npcNameTargeting.TargetingAndClickNpc(true, ct);
+                    if (npcNameTargeting.InteractFirst(ct))
+                        wait.Update();
                 }
             }
 

--- a/Core/Input/ConfigurableInput.cs
+++ b/Core/Input/ConfigurableInput.cs
@@ -19,6 +19,9 @@ namespace Core
             wowProcessInput.BackwardKey = classConfig.BackwardKey;
             wowProcessInput.TurnLeftKey = classConfig.TurnLeftKey;
             wowProcessInput.TurnRightKey = classConfig.TurnRightKey;
+
+            wowProcessInput.InteractMouseover = classConfig.InteractMouseOver.ConsoleKey;
+            wowProcessInput.InteractMouseoverPress = classConfig.InteractMouseOver.PressDuration;
         }
 
         public void Stop()

--- a/CoreTests/NpcNameFinder/MockWoWProcess.cs
+++ b/CoreTests/NpcNameFinder/MockWoWProcess.cs
@@ -19,5 +19,10 @@ namespace CoreTests
         {
             throw new System.NotImplementedException();
         }
+
+        public void InteractMouseOver()
+        {
+            throw new System.NotImplementedException();
+        }
     }
 }

--- a/CoreTests/NpcNameFinder/Test_NpcNameFinder.cs
+++ b/CoreTests/NpcNameFinder/Test_NpcNameFinder.cs
@@ -7,6 +7,8 @@ using System.Threading;
 using System.Text;
 using System.Diagnostics;
 using System.Linq;
+using WowheadDB;
+using Core.Extensions;
 
 #pragma warning disable 0162
 
@@ -16,6 +18,9 @@ namespace CoreTests
     {
         private const bool saveImage = true;
         private const bool LogEachUpdate = true;
+
+        private const bool debugTargeting = false;
+        private const bool debugSkinning = false;
 
         private readonly ILogger logger;
         private readonly NpcNameFinder npcNameFinder;
@@ -106,17 +111,39 @@ namespace CoreTests
             {
                 paint.DrawRectangle(whitePen, npcNameFinder.Area);
 
-                int i = 0;
-                foreach (var n in npcNameFinder.Npcs)
+                int j = 0;
+                foreach (var npc in npcNameFinder.Npcs)
                 {
-                    foreach (var l in npcNameTargeting.locTargetingAndClickNpc)
+                    if (debugTargeting)
                     {
-                        paint.DrawEllipse(whitePen, l.X + n.ClickPoint.X, l.Y + n.ClickPoint.Y, 5, 5);
+                        foreach (var l in npcNameTargeting.locTargeting)
+                        {
+                            paint.DrawEllipse(whitePen, l.X + npc.ClickPoint.X, l.Y + npc.ClickPoint.Y, 5, 5);
+                        }
                     }
 
-                    paint.DrawRectangle(whitePen, n.Rect);
-                    paint.DrawString(i.ToString(), font, brush, new PointF(n.Left - 20f, n.Top));
-                    i++;
+                    if (debugSkinning)
+                    {
+                        int c = npcNameTargeting.locFindBy.Length;
+                        int e = 3;
+                        Point[] attemptPoints = new Point[c + (c * e)];
+                        for (int i = 0; i < c; i += e)
+                        {
+                            Point p = npcNameTargeting.locFindBy[i];
+                            attemptPoints[i] = p;
+                            attemptPoints[i + c] = new Point(npc.Width / 2, p.Y).Scale(npcNameFinder.ScaleToRefWidth, npcNameFinder.ScaleToRefHeight);
+                            attemptPoints[i + c + 1] = new Point(-npc.Width / 2, p.Y).Scale(npcNameFinder.ScaleToRefWidth, npcNameFinder.ScaleToRefHeight);
+                        }
+
+                        foreach (var l in attemptPoints)
+                        {
+                            paint.DrawEllipse(whitePen, l.X + npc.ClickPoint.X, l.Y + npc.ClickPoint.Y, 5, 5);
+                        }
+                    }
+
+                    paint.DrawRectangle(whitePen, npc.Rect);
+                    paint.DrawString(j.ToString(), font, brush, new PointF(npc.Left - 20f, npc.Top));
+                    j++;
                 }
             }
 

--- a/CoreTests/Program.cs
+++ b/CoreTests/Program.cs
@@ -37,7 +37,7 @@ namespace CoreTests
             //NpcNames types = NpcNames.Friendly | NpcNames.Neutral;
 
             Test_NpcNameFinder test = new(logger, types);
-            int count = 100;
+            int count = 2;
             int i = 0;
 
             Stopwatch stopwatch = new();

--- a/Game/Input/IMouseInput.cs
+++ b/Game/Input/IMouseInput.cs
@@ -9,5 +9,7 @@ namespace Game
         void RightClickMouse(Point p);
 
         void LeftClickMouse(Point p);
+
+        void InteractMouseOver();
     }
 }

--- a/Game/Input/WowProcessInput.cs
+++ b/Game/Input/WowProcessInput.cs
@@ -1,8 +1,10 @@
 ﻿using Microsoft.Extensions.Logging;
+
 using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Threading;
+
 using WinAPI;
 
 #pragma warning disable 162
@@ -29,6 +31,8 @@ namespace Game
         public ConsoleKey BackwardKey { get; set; }
         public ConsoleKey TurnLeftKey { get; set; }
         public ConsoleKey TurnRightKey { get; set; }
+        public ConsoleKey InteractMouseover { get; set; }
+        public int InteractMouseoverPress { get; set; } = 10;
 
         public WowProcessInput(ILogger logger, CancellationTokenSource cts, WowProcess wowProcess)
         {
@@ -130,7 +134,7 @@ namespace Game
             keyDownDict[key] = true;
             int totalElapsedMs = nativeInput.KeyPress((int)key, milliseconds);
             keyDownDict[key] = false;
-            
+
             if (LogInput)
             {
                 LogKeyPress(logger, key, totalElapsedMs);
@@ -180,6 +184,11 @@ namespace Game
         public void LeftClickMouse(Point p)
         {
             nativeInput.LeftClickMouse(p);
+        }
+
+        public void InteractMouseOver()
+        {
+            KeyPress(InteractMouseover, InteractMouseoverPress);
         }
 
         [LoggerMessage(

--- a/README.md
+++ b/README.md
@@ -279,18 +279,17 @@ To change the default movement keys to `WASD` in the ClassConfiguration file or 
 ```
 
 `Targeting`:
+
 | In-Game | Key | ClassConfiguration KeyAction Name | Desciption |
 | ---- | ---- | ---- | ---- |
 | Target Nearest Enemy | Tab | TargetNearestTargetKey | ---- |
 | Target Pet | Multiply | TargetPetKey | Only pet based class |
-| Target Last Target | G | TargetLastTargetKey | ---- |
-| Interact With Target | I | InteractKey | ---- |
+| Target Last Target | G | TargetLastTargetKey | Loot last target |
+| Interact With Mouseover | J | InteractMouseOverKey | Mouse based actions |
+| Interact With Target | I | InteractKey | Targeting and combat |
 | Assist Target | F | TargetTargetOfTargetKey | ---- |
 | Pet attack | Subtract | PetAttackKey | Only pet based class |
 | Target Focus | PageUp | TargetFocusKey | Only for `"AssistFocus"` Mode |
-
-The `"Interact with Target"` keybind is super important as it allows the bot to turn towards and approach the target.
-The `"Target Last Target"` keybind helps with looting.
 
 ## 10.1. Actionbar Key Bindings:
 

--- a/SharedLib/Extensions/RectangleExt.cs
+++ b/SharedLib/Extensions/RectangleExt.cs
@@ -8,6 +8,10 @@ namespace SharedLib.Extensions
         {
             return new Point(r.Left + r.Width / 2, r.Top + r.Height / 2);
         }
+        public static Point Max(this Rectangle r)
+        {
+            return new Point(r.Left + r.Width, r.Top + r.Height);
+        }
 
         public static Point BottomCentre(this Rectangle r)
         {

--- a/SharedLib/NpcFinder/LineOfNpcName.cs
+++ b/SharedLib/NpcFinder/LineOfNpcName.cs
@@ -8,7 +8,6 @@
 
         public bool IsInAgroup;
 
-        public int Length => XEnd - XStart + 1;
         public int X => XStart + ((XEnd - XStart) / 2);
 
         public LineOfNpcName(int xStart, int xend, int y)

--- a/SharedLib/NpcFinder/NpcPosition.cs
+++ b/SharedLib/NpcFinder/NpcPosition.cs
@@ -1,9 +1,12 @@
 ﻿using System.Drawing;
+using System;
 
 namespace SharedLib.NpcFinder
 {
-    public readonly struct NpcPosition
+    public readonly struct NpcPosition : IEquatable<NpcPosition>
     {
+        public static readonly NpcPosition Empty = new(Point.Empty, Point.Empty, 0, 0, 0);
+
         public readonly int Left => Rect.Left;
         public readonly int Top => Rect.Top;
         public readonly int Height => Rect.Height;
@@ -32,6 +35,26 @@ namespace SharedLib.NpcFinder
 
             IsAdd = (ClickPoint.X < screenMid - screenTargetBuffer && ClickPoint.X > screenMid - screenAddBuffer) ||
             (ClickPoint.X > screenMid + screenTargetBuffer && ClickPoint.X < screenMid + screenAddBuffer);
+        }
+
+        public NpcPosition(Rectangle rect, NpcPosition other, float yOffset, float heightMul)
+        {
+            Rect = rect;
+
+            screenMid = other.screenMid;
+            screenMidBuffer = other.screenMidBuffer;
+            screenTargetBuffer = other.screenTargetBuffer;
+            screenAddBuffer = other.screenAddBuffer;
+
+            ClickPoint = new(rect.Left + (rect.Width / 2), (int)(rect.Bottom + yOffset + (rect.Height * heightMul)));
+
+            IsAdd = (ClickPoint.X < screenMid - screenTargetBuffer && ClickPoint.X > screenMid - screenAddBuffer) ||
+            (ClickPoint.X > screenMid + screenTargetBuffer && ClickPoint.X < screenMid + screenAddBuffer);
+        }
+
+        public bool Equals(NpcPosition other)
+        {
+            return Rect == other.Rect;
         }
     }
 }


### PR DESCRIPTION
Bugfix for #378 by pre allocating the array, thus avoiding resize.

**Breaking Change**:
* It is **mandatory** to bind `Interact with Mouseover` hotkey in order to **mouse** based interactions to work!
* Please look at [9. Configure the Wow Client - Key Bindings](https://github.com/Xian55/WowClassicGrindBot#9-configure-the-wow-client---key-bindings)  `Targeting` section.

Key Changes:
* Mouse based interaction should be way more reliable then before, more quicker search action, and upon missing there going to be no more **miss clicks**, there are no more click actions!

updated corpse hitbox estimation:
![unknown](https://user-images.githubusercontent.com/367101/184282578-09e27717-8521-4146-9c90-2e0f239d78d6.png)

![image](https://user-images.githubusercontent.com/367101/184283484-02d6b284-16ce-486b-99a4-5a70a1454dc4.png)
