### PR TITLE
Addon: [1.7.12] - Feature: Blacklist rules for `mouseover`

### DIFF
--- a/Addons/DataToColor/Constants.lua
+++ b/Addons/DataToColor/Constants.lua
@@ -16,6 +16,8 @@ DataToColor.C.unitFocusTarget = "focustarget"
 DataToColor.C.unitPetTarget = "pettarget"
 DataToColor.C.unitTargetTarget = "targettarget"
 DataToColor.C.unitNormal = "normal"
+DataToColor.C.unitmouseover = "mouseover"
+DataToColor.C.unitmouseovertarget = "mouseovertarget"
 
 -- Character's name
 DataToColor.C.CHARACTER_NAME = UnitName(DataToColor.C.unitPlayer)

--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -619,13 +619,16 @@ function DataToColor:CreateFrames(n)
             Pixel(int, min(16, playerDebuffCount) * 1000000 + playerBuffCount * 10000 + targetDebuffCount * 100 + targetBuffCount, 55)
 
             if DataToColor.targetChanged then
-                Pixel(int, DataToColor:targetNpcId(), 56) -- target id
+                Pixel(int, DataToColor:NpcId(DataToColor.C.unitTarget), 56) -- target id
                 Pixel(int, DataToColor:getGuidFromUnit(DataToColor.C.unitTarget), 57)
             end
 
             Pixel(int, DataToColor:CastingInfoSpellId(DataToColor.C.unitTarget), 58) -- SpellId being cast by target
 
-            Pixel(int, DataToColor:TargetOfTargetAsNumber(), 59)
+            Pixel(int,
+                10 * DataToColor:UnitsTargetAsNumber(DataToColor.C.unitmouseover, DataToColor.C.unitmouseovertarget) +
+                DataToColor:UnitsTargetAsNumber(DataToColor.C.unitTarget, DataToColor.C.unitTargetTarget),
+                59)
 
             Pixel(int, DataToColor.lastAutoShot, 60)
             Pixel(int, DataToColor.lastMainHandMeleeSwing, 61)
@@ -737,8 +740,18 @@ function DataToColor:CreateFrames(n)
                     Pixel(int, 0, 83)
                     Pixel(int, 0, 84)
                 end
-
             end
+
+            local mouseoverLevel = UnitLevel(DataToColor.C.unitmouseover)
+            if mouseoverLevel == -1 then
+                mouseoverLevel = playerLevel + 10
+            end
+            Pixel(int, mouseoverLevel * 100 + DataToColor.unitClassification[UnitClassification(DataToColor.C.unitmouseover)], 85)
+
+            Pixel(int, DataToColor:NpcId(DataToColor.C.unitmouseover), 86)
+            Pixel(int, DataToColor:getGuidFromUnit(DataToColor.C.unitmouseover), 87)
+
+            -- 88
 
             -- 94 last cast GCD
             Pixel(int, DataToColor.lastCastGCD, 94)

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -3,7 +3,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors
-## Version: 1.7.11
+## Version: 1.7.12
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Core/Addon/AddonReader.cs
+++ b/Core/Addon/AddonReader.cs
@@ -1,6 +1,9 @@
 using Core.Database;
+
 using Microsoft.Extensions.Logging;
+
 using SharedLib;
+
 using System;
 using System.Threading;
 
@@ -57,6 +60,9 @@ namespace Core
 
         private int lastTargetId = -1;
         public string TargetName { get; private set; } = string.Empty;
+
+        private int lastMouseOverId = -1;
+        public string MouseOverName { get; private set; } = string.Empty;
 
         public double AvgUpdateLatency { private set; get; }
         private double updateSum;
@@ -141,6 +147,12 @@ namespace Core
 
                     TargetName = CreatureDb.Entries.TryGetValue(PlayerReader.TargetId, out Creature creature)
                     ? creature.Name : reader.GetString(16) + reader.GetString(17);
+                }
+
+                if (lastMouseOverId != PlayerReader.MouseOverId)
+                {
+                    MouseOverName = CreatureDb.Entries.TryGetValue(PlayerReader.MouseOverId, out Creature creature)
+                        ? creature.Name : string.Empty;
                 }
 
                 CombatLog.Update(reader, PlayerReader.Bits.PlayerInCombat());

--- a/Core/Addon/IMouseOverReader.cs
+++ b/Core/Addon/IMouseOverReader.cs
@@ -1,0 +1,10 @@
+﻿namespace Core
+{
+    public interface IMouseOverReader
+    {
+        int MouseOverLevel { get; }
+        UnitClassification MouseOverClassification { get; }
+        int MouseOverId { get; }
+        int MouseOverGuid { get; }
+    }
+}

--- a/Core/Addon/PlayerReader.cs
+++ b/Core/Addon/PlayerReader.cs
@@ -1,10 +1,9 @@
-﻿using System;
-using System.Collections.Specialized;
+﻿using System.Collections.Specialized;
 using System.Numerics;
 
 namespace Core
 {
-    public partial class PlayerReader
+    public partial class PlayerReader : IMouseOverReader
     {
         private readonly IAddonDataProvider reader;
 
@@ -114,10 +113,12 @@ namespace Core
         public int SpellBeingCastByTarget => reader.GetInt(58);
         public bool IsTargetCasting() => SpellBeingCastByTarget != 0;
 
-        public TargetTargetEnum TargetTarget => (TargetTargetEnum)reader.GetInt(59);
-        public bool TargetsMe() => TargetTarget == TargetTargetEnum.Me;
-        public bool TargetsPet() => TargetTarget == TargetTargetEnum.Pet;
-        public bool TargetsNone() => TargetTarget == TargetTargetEnum.None;
+        // 10 * MouseOverTarget + TargetTarget
+        public UnitsTarget MouseOverTarget => (UnitsTarget)(reader.GetInt(59) / 10 % 10);
+        public UnitsTarget TargetTarget => (UnitsTarget)(reader.GetInt(59) % 10);
+        public bool TargetsMe() => TargetTarget == UnitsTarget.Me;
+        public bool TargetsPet() => TargetTarget == UnitsTarget.Pet;
+        public bool TargetsNone() => TargetTarget == UnitsTarget.None;
 
         public RecordInt AutoShot { get; } = new(60);
         public RecordInt MainHandSwing { get; } = new(61);
@@ -137,6 +138,14 @@ namespace Core
         public int OffHandSpeed => reader.GetInt(75) / 10000 * 10;
 
         public int RemainCastMs => reader.GetInt(76);
+
+
+        // MouseOverLevel * 100 + MouseOverClassification
+        public int MouseOverLevel => reader.GetInt(85) / 100;
+        public UnitClassification MouseOverClassification => (UnitClassification)(reader.GetInt(85) % 100);
+        public int MouseOverId => reader.GetInt(86);
+        public int MouseOverGuid => reader.GetInt(87);
+
 
         public int LastCastGCD { get; set; }
         public void ReadLastCastGCD()

--- a/Core/AddonComponent/AddonBits.cs
+++ b/Core/AddonComponent/AddonBits.cs
@@ -26,15 +26,15 @@ namespace Core
         public bool TargetInCombat() => v1[Mask._0];
         public bool TargetIsDead() => v1[Mask._1];
         public bool TargetIsNotDead() => !v1[Mask._1];
-        public bool DeadStatus() => v1[Mask._2];
-        public bool TalentPoints() => v1[Mask._3];
-        // 4 unused
+        public bool IsDead() => v1[Mask._2];
+        public bool HasTalentPoint() => v1[Mask._3];
+        public bool HasMouseOver() => v1[Mask._4];
         public bool TargetCanBeHostile() => v1[Mask._5];
         public bool HasPet() => v1[Mask._6];
-        public bool MainHandEnchant_Active() => v1[Mask._7];
-        public bool OffHandEnchant_Active() => v1[Mask._8];
+        public bool HasMainHandTempEnchant() => v1[Mask._7];
+        public bool HasOffHandTempEnchant() => v1[Mask._8];
         public bool ItemsAreBroken() => v1[Mask._9];
-        public bool IsFlying() => v1[Mask._10];
+        public bool PlayerOnTaxi() => v1[Mask._10];
         public bool IsSwimming() => v1[Mask._11];
         public bool PetHappy() => v1[Mask._12];
         public bool HasAmmo() => v1[Mask._13];
@@ -46,34 +46,28 @@ namespace Core
         public bool SpellOn_Shoot() => v1[Mask._19];
         public bool SpellOn_AutoAttack() => v1[Mask._20];
         public bool TargetIsPlayer() => v1[Mask._21];
-        public bool IsTagged() => v1[Mask._22];
+        public bool TargetIsTagged() => v1[Mask._22];
         public bool IsFalling() => v1[Mask._23];
 
         // -- value2 based flags
         public bool IsDrowning() => v2[Mask._0];
-
-        public bool IsCorpseInRange() => v2[Mask._1];
-
+        public bool CorpseInRange() => v2[Mask._1];
         public bool IsIndoors() => v2[Mask._2];
-
         public bool HasFocus() => v2[Mask._3];
-
         public bool FocusInCombat() => v2[Mask._4];
-
         public bool FocusHasTarget() => v2[Mask._5];
-
         public bool FocusTargetInCombat() => v2[Mask._6];
-
         public bool FocusTargetCanBeHostile() => v2[Mask._7];
-
-        // 8 unused
-
+        public bool MouseOverIsDead() => v2[Mask._8];
         public bool PetTargetIsDead() => v2[Mask._9];
-
         public bool IsStealthed() => v2[Mask._10];
-
         public bool TargetIsTrivial() => v2[Mask._11];
-
         public bool TargetIsNotTrivial() => !v2[Mask._11];
+        public bool MouseOverIsTrivial() => v2[Mask._12];
+        public bool MouseOverIsNotTrivial() => !v2[Mask._12];
+        public bool MouseOverIsTagged() => v2[Mask._13];
+        public bool MouseOverCanBeHostile() => v2[Mask._14];
+        public bool MouseOverIsPlayer() => v2[Mask._15];
+        public bool MouseOverTargetIsPlayerOrPet() => v2[Mask._16];
     }
 }

--- a/Core/AddonComponent/UnitsTarget.cs
+++ b/Core/AddonComponent/UnitsTarget.cs
@@ -1,6 +1,6 @@
 ﻿namespace Core
 {
-    public enum TargetTargetEnum
+    public enum UnitsTarget
     {
         Self = 0,
         Me = 1,

--- a/Core/BotController.cs
+++ b/Core/BotController.cs
@@ -138,7 +138,7 @@ namespace Core
             logger.LogDebug($"Woohoo, I have read the player class. You are a {AddonReader.PlayerReader.Race.ToStringF()} {AddonReader.PlayerReader.Class.ToStringF()}.");
 
             npcNameFinder = new(logger, WowScreen, npcNameFinderEvent);
-            npcNameTargeting = new(logger, cts, WowScreen, npcNameFinder, wowProcessInput);
+            npcNameTargeting = new(logger, cts, WowScreen, npcNameFinder, wowProcessInput, addonReader.PlayerReader, new NoBlacklist(), wait);
             WowScreen.AddDrawAction(npcNameFinder.ShowNames);
             WowScreen.AddDrawAction(npcNameTargeting.ShowClickPositions);
 

--- a/Core/ClassConfig/ClassConfiguration.cs
+++ b/Core/ClassConfig/ClassConfiguration.cs
@@ -208,7 +208,7 @@ namespace Core
             InteractMouseOver.Key = InteractMouseOverKey;
             InteractMouseOver.Name = nameof(InteractMouseOver);
             InteractMouseOver.Cooldown = 0;
-            InteractMouseOver.PressDuration = 10;
+            InteractMouseOver.PressDuration = 15;
             InteractMouseOver.BaseAction = true;
             InteractMouseOver.Initialise(this, addonReader, requirementFactory, logger, Log);
 

--- a/Core/GOAP/GoapAgent.cs
+++ b/Core/GOAP/GoapAgent.cs
@@ -203,9 +203,9 @@ namespace Core.GOAP
                 { GoapKey.pethastarget, playerReader.PetHasTarget && !playerReader.Bits.PetTargetIsDead() },
                 { GoapKey.targetisalive, playerReader.Bits.HasTarget() && !playerReader.Bits.TargetIsDead() },
                 { GoapKey.targettargetsus, (playerReader.Bits.HasTarget() && playerReader.TargetHealthPercentage() < 30) || playerReader.TargetTarget is // hacky way to keep attacking fleeing humanoids
-                    TargetTargetEnum.Me or
-                    TargetTargetEnum.Pet or
-                    TargetTargetEnum.PartyOrPet },
+                    UnitsTarget.Me or
+                    UnitsTarget.Pet or
+                    UnitsTarget.PartyOrPet },
                 { GoapKey.incombat, playerReader.Bits.PlayerInCombat() },
                 { GoapKey.ismounted,
                     (playerReader.Class == UnitClass.Druid &&
@@ -214,7 +214,7 @@ namespace Core.GOAP
                 { GoapKey.withinpullrange, playerReader.WithInPullRange() },
                 { GoapKey.incombatrange, playerReader.WithInCombatRange() },
                 { GoapKey.pulled, false },
-                { GoapKey.isdead, playerReader.Bits.DeadStatus() },
+                { GoapKey.isdead, playerReader.Bits.IsDead() },
                 { GoapKey.isswimming, playerReader.Bits.IsSwimming() },
                 { GoapKey.itemsbroken, playerReader.Bits.ItemsAreBroken() },
                 { GoapKey.producedcorpse, State.LastCombatKillCount > 0 },

--- a/Core/Goals/ApproachTargetGoal.cs
+++ b/Core/Goals/ApproachTargetGoal.cs
@@ -21,7 +21,7 @@ namespace Core.Goals
         private readonly PlayerReader playerReader;
         private readonly StopMoving stopMoving;
         private readonly CombatUtil combatUtil;
-        private readonly IBlacklist blacklist;
+        private readonly IBlacklist targetBlacklist;
 
         private DateTime approachStart;
 
@@ -44,7 +44,7 @@ namespace Core.Goals
             this.playerReader = addonReader.PlayerReader;
             this.stopMoving = stopMoving;
             this.combatUtil = combatUtil;
-            this.blacklist = blacklist;
+            this.targetBlacklist = blacklist;
 
             AddPrecondition(GoapKey.hastarget, true);
             AddPrecondition(GoapKey.targetisalive, true);
@@ -154,7 +154,7 @@ namespace Core.Goals
 
                 if (playerReader.TargetGuid != initialTargetGuid)
                 {
-                    if (playerReader.Bits.HasTarget() && !blacklist.IsTargetBlacklisted()) // blacklist
+                    if (playerReader.Bits.HasTarget() && !targetBlacklist.Is()) // blacklist
                     {
                         if (playerReader.MinRange() < initialTargetMinRange)
                         {

--- a/Core/Goals/BlacklistTargetGoal.cs
+++ b/Core/Goals/BlacklistTargetGoal.cs
@@ -6,19 +6,19 @@
 
         private readonly PlayerReader playerReader;
         private readonly ConfigurableInput input;
-        private readonly IBlacklist blacklist;
+        private readonly IBlacklist targetBlacklist;
 
         public BlacklistTargetGoal(PlayerReader playerReader, ConfigurableInput input, IBlacklist blacklist)
             : base(nameof(BlacklistTargetGoal))
         {
             this.playerReader = playerReader;
             this.input = input;
-            this.blacklist = blacklist;
+            this.targetBlacklist = blacklist;
         }
 
         public override bool CanRun()
         {
-            return playerReader.Bits.HasTarget() && blacklist.IsTargetBlacklisted();
+            return playerReader.Bits.HasTarget() && targetBlacklist.Is();
         }
 
         public override void OnEnter()

--- a/Core/Goals/FollowRouteGoal.cs
+++ b/Core/Goals/FollowRouteGoal.cs
@@ -30,7 +30,7 @@ namespace Core.Goals
         private readonly MountHandler mountHandler;
         private readonly Navigation navigation;
 
-        private readonly IBlacklist blacklist;
+        private readonly IBlacklist targetBlacklist;
         private readonly TargetFinder targetFinder;
         private const int minMs = 500, maxMs = 1000;
         private const NpcNames NpcNameToFind = NpcNames.Enemy | NpcNames.Neutral;
@@ -84,7 +84,7 @@ namespace Core.Goals
             this.npcNameFinder = npcNameFinder;
             this.mountHandler = mountHandler;
             this.targetFinder = targetFinder;
-            this.blacklist = blacklist;
+            this.targetBlacklist = blacklist;
 
             this.navigation = navigation;
             navigation.OnPathCalculated += Navigation_OnPathCalculated;
@@ -138,7 +138,7 @@ namespace Core.Goals
 
         private void Abort()
         {
-            if (!blacklist.IsTargetBlacklisted())
+            if (!targetBlacklist.Is())
                 navigation.StopMovement();
 
             navigation.Stop();

--- a/Core/Goals/PullTargetGoal.cs
+++ b/Core/Goals/PullTargetGoal.cs
@@ -20,7 +20,7 @@ namespace Core.Goals
         private readonly CastingHandler castingHandler;
         private readonly MountHandler mountHandler;
         private readonly CombatUtil combatUtil;
-        private readonly IBlacklist blacklist;
+        private readonly IBlacklist targetBlacklist;
 
         private readonly KeyAction? approachKey;
         private readonly Action approachAction;
@@ -45,7 +45,7 @@ namespace Core.Goals
             this.npcNameTargeting = npcNameTargeting;
             this.stuckDetector = stuckDetector;
             this.combatUtil = combatUtil;
-            this.blacklist = blacklist;
+            this.targetBlacklist = blacklist;
 
             Keys = input.ClassConfig.Pull.Sequence;
 
@@ -222,9 +222,9 @@ namespace Core.Goals
                 addonReader.DamageDoneCount() > 0 ||
                 addonReader.DamageTakenCount() > 0 ||
                 playerReader.TargetTarget is
-                TargetTargetEnum.Me or
-                TargetTargetEnum.Pet or
-                TargetTargetEnum.PartyOrPet;
+                UnitsTarget.Me or
+                UnitsTarget.Pet or
+                UnitsTarget.PartyOrPet;
         }
 
         private void DefaultApproach()
@@ -263,21 +263,21 @@ namespace Core.Goals
         private bool SuccessfulPull()
         {
             return playerReader.TargetTarget is
-                        TargetTargetEnum.Me or
-                        TargetTargetEnum.Pet or
-                        TargetTargetEnum.PartyOrPet ||
+                        UnitsTarget.Me or
+                        UnitsTarget.Pet or
+                        UnitsTarget.PartyOrPet ||
                         addonReader.CombatLog.DamageDoneGuid.ElapsedMs() < CastingHandler.GCD ||
                         playerReader.IsInMeleeRange();
         }
 
         private bool PullPrevention()
         {
-            return blacklist.IsTargetBlacklisted() &&
+            return targetBlacklist.Is() &&
                 playerReader.TargetTarget is not
-                TargetTargetEnum.None or
-                TargetTargetEnum.Me or
-                TargetTargetEnum.Pet or
-                TargetTargetEnum.PartyOrPet;
+                UnitsTarget.None or
+                UnitsTarget.Me or
+                UnitsTarget.Pet or
+                UnitsTarget.PartyOrPet;
         }
 
         private void Log(string text)

--- a/Core/Goals/WalkToCorpseGoal.cs
+++ b/Core/Goals/WalkToCorpseGoal.cs
@@ -99,7 +99,7 @@ namespace Core.Goals
 
         public override void Update()
         {
-            if (!playerReader.Bits.IsCorpseInRange())
+            if (!playerReader.Bits.CorpseInRange())
             {
                 navigation.Update();
             }

--- a/Core/GoalsComponent/Blacklist/IBlacklist.cs
+++ b/Core/GoalsComponent/Blacklist/IBlacklist.cs
@@ -2,6 +2,6 @@
 {
     public interface IBlacklist
     {
-        bool IsTargetBlacklisted();
+        bool Is();
     }
 }

--- a/Core/GoalsComponent/Blacklist/MouseOverBlacklist.cs
+++ b/Core/GoalsComponent/Blacklist/MouseOverBlacklist.cs
@@ -1,0 +1,202 @@
+﻿using Microsoft.Extensions.Logging;
+
+using System;
+
+using SharedLib.Extensions;
+
+namespace Core
+{
+    public partial class MouseOverBlacklist : IBlacklist
+    {
+        private readonly string[] blacklist;
+
+        private readonly AddonReader addonReader;
+        private readonly PlayerReader playerReader;
+        private readonly ILogger logger;
+        private readonly int above;
+        private readonly int below;
+        private readonly bool checkMouseOverGivesExp;
+        private readonly UnitClassification mask;
+
+        private int lastGuid;
+
+        public MouseOverBlacklist(ILogger logger, AddonReader addonReader, ClassConfiguration classConfig)
+        {
+            this.addonReader = addonReader;
+            playerReader = addonReader.PlayerReader;
+            this.logger = logger;
+            this.above = classConfig.NPCMaxLevels_Above;
+            this.below = classConfig.NPCMaxLevels_Below;
+
+            this.checkMouseOverGivesExp = classConfig.CheckTargetGivesExp;
+            this.mask = classConfig.TargetMask;
+
+            this.blacklist = classConfig.Blacklist;
+
+            logger.LogInformation($"[{nameof(MouseOverBlacklist)}] {nameof(classConfig.TargetMask)}: {string.Join(", ", mask.GetIndividualFlags())}");
+
+            if (blacklist.Length > 0)
+                logger.LogInformation($"[{nameof(MouseOverBlacklist)}] Name: {string.Join(", ", blacklist)}");
+        }
+
+        public bool Is()
+        {
+            if (!playerReader.Bits.HasMouseOver())
+            {
+                lastGuid = 0;
+                return false;
+            }
+            else if (addonReader.CombatLog.DamageTaken.Contains(playerReader.MouseOverGuid))
+            {
+                return false;
+            }
+
+            if (playerReader.PetHasTarget && playerReader.MouseOverGuid == playerReader.PetGuid)
+            {
+                return true;
+            }
+
+            // it is trying to kill me
+            if (playerReader.Bits.MouseOverTargetIsPlayerOrPet())
+            {
+                return false;
+            }
+
+            if (!mask.HasFlag(playerReader.MouseOverClassification))
+            {
+                if (lastGuid != playerReader.MouseOverGuid)
+                {
+                    LogClassification(logger, playerReader.MouseOverId, playerReader.MouseOverGuid, addonReader.MouseOverName, playerReader.MouseOverClassification.ToStringF());
+                    lastGuid = playerReader.MouseOverGuid;
+                }
+
+                return true; // ignore non white listed unit classification
+            }
+
+            if (playerReader.Bits.MouseOverIsPlayer())
+            {
+                if (lastGuid != playerReader.MouseOverGuid)
+                {
+                    LogPlayer(logger, playerReader.MouseOverId, playerReader.MouseOverGuid, addonReader.MouseOverName);
+                    lastGuid = playerReader.MouseOverGuid;
+                }
+
+                return true; // ignore players
+            }
+
+            if (!playerReader.Bits.MouseOverIsDead() && playerReader.Bits.MouseOverIsTagged())
+            {
+                if (lastGuid != playerReader.MouseOverGuid)
+                {
+                    LogTagged(logger, playerReader.MouseOverId, playerReader.MouseOverGuid, addonReader.MouseOverName);
+                    lastGuid = playerReader.MouseOverGuid;
+                }
+
+                return true; // ignore tagged mobs
+            }
+
+
+            if (playerReader.Bits.MouseOverCanBeHostile() && playerReader.MouseOverLevel > playerReader.Level.Value + above)
+            {
+                if (lastGuid != playerReader.MouseOverGuid)
+                {
+                    LogLevelHigh(logger, playerReader.MouseOverId, playerReader.MouseOverGuid, addonReader.MouseOverName);
+                    lastGuid = playerReader.MouseOverGuid;
+                }
+
+                return true; // ignore if current level + 2
+            }
+
+            if (checkMouseOverGivesExp)
+            {
+                if (playerReader.Bits.MouseOverIsTrivial())
+                {
+                    if (lastGuid != playerReader.MouseOverGuid)
+                    {
+                        LogNoExperienceGain(logger, playerReader.MouseOverId, playerReader.MouseOverGuid, addonReader.MouseOverName);
+                        lastGuid = playerReader.MouseOverGuid;
+                    }
+                    return true;
+                }
+            }
+            else if (playerReader.Bits.MouseOverCanBeHostile() && playerReader.MouseOverLevel < playerReader.Level.Value - below)
+            {
+                if (lastGuid != playerReader.MouseOverGuid)
+                {
+                    LogLevelLow(logger, playerReader.MouseOverId, playerReader.MouseOverGuid, addonReader.MouseOverName);
+                    lastGuid = playerReader.MouseOverGuid;
+                }
+                return true; // ignore if current level - 7
+            }
+
+            if (blacklist.Length > 0 && Contains())
+            {
+                if (lastGuid != playerReader.MouseOverGuid)
+                {
+                    LogNameMatch(logger, playerReader.MouseOverId, playerReader.MouseOverGuid, addonReader.MouseOverName);
+                    lastGuid = playerReader.MouseOverGuid;
+                }
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool Contains()
+        {
+            for (int i = 0; i < blacklist.Length; i++)
+            {
+                if (addonReader.MouseOverName.Contains(blacklist[i], StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+
+            return false;
+        }
+
+        #region logging
+
+        [LoggerMessage(
+            EventId = 60,
+            Level = LogLevel.Warning,
+            Message = "MouseOverBlacklist ({id},{guid},{name}) is player!")]
+        static partial void LogPlayer(ILogger logger, int id, int guid, string name);
+
+        [LoggerMessage(
+            EventId = 61,
+            Level = LogLevel.Warning,
+            Message = "MouseOverBlacklist ({id},{guid},{name}) is tagged!")]
+        static partial void LogTagged(ILogger logger, int id, int guid, string name);
+
+        [LoggerMessage(
+            EventId = 62,
+            Level = LogLevel.Warning,
+            Message = "MouseOverBlacklist ({id},{guid},{name}) too high level!")]
+        static partial void LogLevelHigh(ILogger logger, int id, int guid, string name);
+
+        [LoggerMessage(
+            EventId = 63,
+            Level = LogLevel.Warning,
+            Message = "MouseOverBlacklist ({id},{guid},{name}) too low level!")]
+        static partial void LogLevelLow(ILogger logger, int id, int guid, string name);
+
+        [LoggerMessage(
+            EventId = 64,
+            Level = LogLevel.Warning,
+            Message = "MouseOverBlacklist ({id},{guid},{name}) not yield experience!")]
+        static partial void LogNoExperienceGain(ILogger logger, int id, int guid, string name);
+
+        [LoggerMessage(
+            EventId = 65,
+            Level = LogLevel.Warning,
+            Message = "MouseOverBlacklist ({id},{guid},{name}) name match!")]
+        static partial void LogNameMatch(ILogger logger, int id, int guid, string name);
+
+        [LoggerMessage(
+            EventId = 66,
+            Level = LogLevel.Warning,
+            Message = "MouseOverBlacklist ({id},{guid},{name},{classification}) not defined in the TargetMask!")]
+        static partial void LogClassification(ILogger logger, int id, int guid, string name, string classification);
+
+        #endregion
+    }
+}

--- a/Core/GoalsComponent/Blacklist/NoBlacklist.cs
+++ b/Core/GoalsComponent/Blacklist/NoBlacklist.cs
@@ -2,6 +2,6 @@
 {
     public class NoBlacklist : IBlacklist
     {
-        public bool IsTargetBlacklisted() => false;
+        public bool Is() => false;
     }
 }

--- a/Core/GoalsComponent/Blacklist/TargetBlacklist.cs
+++ b/Core/GoalsComponent/Blacklist/TargetBlacklist.cs
@@ -6,7 +6,7 @@ using SharedLib.Extensions;
 
 namespace Core
 {
-    public partial class Blacklist : IBlacklist
+    public partial class TargetBlacklist : IBlacklist
     {
         private readonly string[] blacklist;
 
@@ -20,7 +20,7 @@ namespace Core
 
         private int lastGuid;
 
-        public Blacklist(ILogger logger, AddonReader addonReader, ClassConfiguration classConfig)
+        public TargetBlacklist(ILogger logger, AddonReader addonReader, ClassConfiguration classConfig)
         {
             this.addonReader = addonReader;
             playerReader = addonReader.PlayerReader;
@@ -33,13 +33,13 @@ namespace Core
 
             this.blacklist = classConfig.Blacklist;
 
-            logger.LogInformation($"[{nameof(Blacklist)}] {nameof(classConfig.TargetMask)}: {string.Join(", ", targetMask.GetIndividualFlags())}");
+            logger.LogInformation($"[{nameof(TargetBlacklist)}] {nameof(classConfig.TargetMask)}: {string.Join(", ", targetMask.GetIndividualFlags())}");
 
             if (blacklist.Length > 0)
-                logger.LogInformation($"[{nameof(Blacklist)}] Name: {string.Join(", ", blacklist)}");
+                logger.LogInformation($"[{nameof(TargetBlacklist)}] Name: {string.Join(", ", blacklist)}");
         }
 
-        public bool IsTargetBlacklisted()
+        public bool Is()
         {
             if (!playerReader.Bits.HasTarget())
             {
@@ -84,7 +84,7 @@ namespace Core
                 return true; // ignore players
             }
 
-            if (!playerReader.Bits.TargetIsDead() && playerReader.Bits.IsTagged())
+            if (!playerReader.Bits.TargetIsDead() && playerReader.Bits.TargetIsTagged())
             {
                 if (lastGuid != playerReader.TargetGuid)
                 {

--- a/Core/GoalsComponent/CombatUtil.cs
+++ b/Core/GoalsComponent/CombatUtil.cs
@@ -61,7 +61,7 @@ namespace Core
                 {
                     input.TargetPet();
                     Log($"Pets target {playerReader.TargetTarget}");
-                    if (playerReader.TargetTarget == TargetTargetEnum.PetHasATarget)
+                    if (playerReader.TargetTarget == UnitsTarget.PetHasATarget)
                     {
                         Log($"{nameof(AquiredTarget)}: Found target by pet");
                         input.TargetOfTarget();

--- a/Core/GoalsComponent/MountHandler.cs
+++ b/Core/GoalsComponent/MountHandler.cs
@@ -20,7 +20,7 @@ namespace Core
         private readonly PlayerReader playerReader;
         private readonly CastingHandler castingHandler;
         private readonly StopMoving stopMoving;
-        private readonly IBlacklist blacklist;
+        private readonly IBlacklist targetBlacklist;
 
         public MountHandler(ILogger logger, ConfigurableInput input, ClassConfiguration classConfig, Wait wait, AddonReader addonReader, CastingHandler castingHandler, StopMoving stopMoving, IBlacklist blacklist)
         {
@@ -32,7 +32,7 @@ namespace Core
             this.playerReader = addonReader.PlayerReader;
             this.castingHandler = castingHandler;
             this.stopMoving = stopMoving;
-            this.blacklist = blacklist;
+            this.targetBlacklist = blacklist;
         }
 
         public bool CanMount()
@@ -144,7 +144,7 @@ namespace Core
 
         private bool MountedOrNotCastingOrValidTargetOrEnteredCombat() => playerReader.Bits.IsMounted() || !playerReader.IsCasting() || HasValidTarget() || playerReader.Bits.PlayerInCombat();
 
-        private bool HasValidTarget() => playerReader.Bits.HasTarget() && !blacklist.IsTargetBlacklisted() && playerReader.MinRange() < MIN_DISTANCE_TO_INTERRUPT_CAST;
+        private bool HasValidTarget() => playerReader.Bits.HasTarget() && !targetBlacklist.Is() && playerReader.MinRange() < MIN_DISTANCE_TO_INTERRUPT_CAST;
 
         private void Log(string text)
         {

--- a/Core/GoalsComponent/ReactCastError.cs
+++ b/Core/GoalsComponent/ReactCastError.cs
@@ -83,7 +83,7 @@ namespace Core
                     {
                         wait.Update();
                         wait.Update();
-                        if (playerReader.TargetTarget == TargetTargetEnum.Me)
+                        if (playerReader.TargetTarget == UnitsTarget.Me)
                         {
                             logger.LogInformation($"{source} -- React to {value.ToStringF()} -- Just wait for the target to get in range.");
 

--- a/Core/GoalsComponent/TargetFinder.cs
+++ b/Core/GoalsComponent/TargetFinder.cs
@@ -9,14 +9,12 @@ namespace Core.Goals
         private readonly ConfigurableInput input;
         private readonly ClassConfiguration classConfig;
         private readonly PlayerReader playerReader;
-        private readonly Wait wait;
         private readonly NpcNameTargeting npcNameTargeting;
 
-        public TargetFinder(ConfigurableInput input, ClassConfiguration classConfig, Wait wait, PlayerReader playerReader, NpcNameTargeting npcNameTargeting)
+        public TargetFinder(ConfigurableInput input, ClassConfiguration classConfig, PlayerReader playerReader, NpcNameTargeting npcNameTargeting)
         {
             this.classConfig = classConfig;
             this.input = input;
-            this.wait = wait;
             this.playerReader = playerReader;
             this.npcNameTargeting = npcNameTargeting;
         }
@@ -24,6 +22,7 @@ namespace Core.Goals
         public void Reset()
         {
             npcNameTargeting.ChangeNpcType(NpcNames.None);
+            npcNameTargeting.Reset();
         }
 
         public bool Search(NpcNames target, Func<bool> validTarget, CancellationToken ct)
@@ -43,8 +42,7 @@ namespace Core.Goals
                 npcNameTargeting.ChangeNpcType(target);
                 if (!ct.IsCancellationRequested && npcNameTargeting.NpcCount > 0)
                 {
-                    if (npcNameTargeting.InteractFirst(ct))
-                        wait.Update();
+                    npcNameTargeting.AquireNonBlacklisted(ct);
                 }
             }
 

--- a/Core/GoalsFactory/GoalFactory.cs
+++ b/Core/GoalsFactory/GoalFactory.cs
@@ -48,7 +48,8 @@ namespace Core
             }
             else
             {
-                services.AddSingleton<IBlacklist, Blacklist>();
+                services.AddSingleton<MouseOverBlacklist, MouseOverBlacklist>();
+                services.AddSingleton<IBlacklist, TargetBlacklist>();
                 services.AddSingleton<GoapGoal, BlacklistTargetGoal>();
             }
 
@@ -145,6 +146,8 @@ namespace Core
 
             ServiceProvider provider = services.BuildServiceProvider(
                 new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true });
+
+            npcNameTargeting.UpdateBlacklist(provider.GetService<MouseOverBlacklist>() ?? provider.GetService<IBlacklist>()!);
 
             IEnumerable<GoapGoal> goals = provider.GetServices<GoapGoal>();
             IEnumerable<IRouteProvider> pathProviders = goals.OfType<IRouteProvider>();

--- a/Core/Requirement/RequirementFactory.cs
+++ b/Core/Requirement/RequirementFactory.cs
@@ -105,8 +105,8 @@ namespace Core
                 { "AutoShot", playerReader.Bits.SpellOn_AutoShot },
                 
                 // Temporary Enchants
-                { "HasMainHandEnchant", playerReader.Bits.MainHandEnchant_Active },
-                { "HasOffHandEnchant", playerReader.Bits.OffHandEnchant_Active },
+                { "HasMainHandEnchant", playerReader.Bits.HasMainHandTempEnchant },
+                { "HasOffHandEnchant", playerReader.Bits.HasOffHandTempEnchant },
                 
                 // Equipment - Bag
                 { "Items Broken", playerReader.Bits.ItemsAreBroken },

--- a/CoreTests/NpcNameFinder/MockMouseOverReader.cs
+++ b/CoreTests/NpcNameFinder/MockMouseOverReader.cs
@@ -1,0 +1,15 @@
+﻿using Core;
+
+namespace CoreTests
+{
+    public class MockMouseOverReader : IMouseOverReader
+    {
+        public int MouseOverLevel => throw new System.NotImplementedException();
+
+        public UnitClassification MouseOverClassification => throw new System.NotImplementedException();
+
+        public int MouseOverId => throw new System.NotImplementedException();
+
+        public int MouseOverGuid => throw new System.NotImplementedException();
+    }
+}

--- a/CoreTests/NpcNameFinder/Test_NpcNameFinder.cs
+++ b/CoreTests/NpcNameFinder/Test_NpcNameFinder.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Diagnostics;
 using System.Linq;
 using SharedLib.Extensions;
+using Core;
 
 #pragma warning disable 0162
 
@@ -49,7 +50,8 @@ namespace CoreTests
 
             MockWoWProcess mockWoWProcess = new();
             MockWoWScreen mockWoWScreen = new();
-            npcNameTargeting = new(logger, new(), mockWoWScreen, npcNameFinder, mockWoWProcess);
+            MockMouseOverReader mouseOverReader = new();
+            npcNameTargeting = new(logger, new(), mockWoWScreen, npcNameFinder, mockWoWProcess, mouseOverReader, new NoBlacklist(), null);
 
             npcNameFinder.ChangeNpcType(types);
 

--- a/Game/Input/WowProcessInput.cs
+++ b/Game/Input/WowProcessInput.cs
@@ -32,7 +32,7 @@ namespace Game
         public ConsoleKey TurnLeftKey { get; set; }
         public ConsoleKey TurnRightKey { get; set; }
         public ConsoleKey InteractMouseover { get; set; }
-        public int InteractMouseoverPress { get; set; } = 10;
+        public int InteractMouseoverPress { get; set; } = 15;
 
         public WowProcessInput(ILogger logger, CancellationTokenSource cts, WowProcess wowProcess)
         {


### PR DESCRIPTION
Prevent targeting the `mouseover` when it determined as blacklisted.

Improvements: 
* Incase the closest `NPCName` is blacklisted, skip it, and try the next one until running out of `NpcName`s