### PR TITLE
Fix divide 0 crash

### DIFF
--- a/Addons/DataToColor/Query.lua
+++ b/Addons/DataToColor/Query.lua
@@ -485,7 +485,7 @@ function DataToColor:getAvgEquipmentDurability()
         c = c + (cc or 0)
         m = m + (mm or 0)
     end
-    return max(0, floor(c * 100 / m) - 1) -- 0-99
+    return max(0, floor((c + 1)* 100 / (m + 1)) - 1) -- 0-99
 end
 
 -----------------------------------------------------------------


### PR DESCRIPTION
Client: 3.4.0 45043 
Class: Mage
Addon Version: 1.7.13
Error happened after entering deadmine
![image](https://user-images.githubusercontent.com/10232727/184800149-24957f7d-a44c-4486-8828-e9a55ac9eb4e.png)


Update, if i'm naked the error keeps raising.
![image](https://user-images.githubusercontent.com/10232727/184803238-d6272a7d-7179-47db-9117-e964ebf2b865.png)
