### PR TITLE
Feature: `AddonConfig` Allow `CELL_SIZE` change upon install.

### DIFF
--- a/Core/Addon/AddonConfig.cs
+++ b/Core/Addon/AddonConfig.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+
 using Newtonsoft.Json;
 
 namespace Core
@@ -15,6 +16,7 @@ namespace Core
 
         public string InstallPath { get; set; } = string.Empty;
         public string Author { get; set; } = string.Empty;
+        public string CellSize { get; set; } = "1";
         public string Title { get; set; } = string.Empty;
         public string Command { get; set; } = string.Empty;
 

--- a/Core/Configurator/AddonConfigurator.cs
+++ b/Core/Configurator/AddonConfigurator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Text.RegularExpressions;
 using Game;
 using WinAPI;
+using Core.Extensions;
 
 namespace Core
 {
@@ -92,6 +93,17 @@ namespace Core
             else
             {
                 logger.LogError($"{nameof(Config)}.{nameof(Config.Title)} - error - cannot be empty: '{Config.Title}'");
+                return false;
+            }
+
+            if (!int.TryParse(Config.CellSize, out int size))
+            {
+                logger.LogError($"{nameof(Config)}.{nameof(Config.CellSize)} - error - be a number: '{Config.CellSize}'");
+                return false;
+            }
+            else if (size < 1 || size > 9)
+            {
+                logger.LogError($"{nameof(Config)}.{nameof(Config.CellSize)} - error - must be, including between 1 and 9: '{Config.CellSize}'");
                 return false;
             }
 
@@ -204,6 +216,9 @@ namespace Core
                 .Replace(DefaultAddonName, Config.Title)
                 .Replace("dc", Config.Command)
                 .Replace("DC", Config.Command);
+
+            Regex cellSizeRegex = new(@"^local CELL_SIZE = (?<SIZE>[0-9]+)", RegexOptions.Multiline);
+            text = text.Replace(cellSizeRegex, "SIZE", Config.CellSize);
 
             File.WriteAllText(mainLuaPath, text);
         }

--- a/Core/Extensions/RegexExtension.cs
+++ b/Core/Extensions/RegexExtension.cs
@@ -1,0 +1,23 @@
+﻿using System.Text.RegularExpressions;
+
+namespace Core.Extensions
+{
+    public static class RegexExtension
+    {
+        public static string Replace(this string input, Regex regex, string groupName, string replacement)
+        {
+            return regex.Replace(input, m =>
+            {
+                return ReplaceNamedGroup(groupName, replacement, m);
+            });
+        }
+
+        private static string ReplaceNamedGroup(string groupName, string replacement, Match m)
+        {
+            string capture = m.Value;
+            capture = capture.Remove(m.Groups[groupName].Index - m.Index, m.Groups[groupName].Length);
+            capture = capture.Insert(m.Groups[groupName].Index - m.Index, replacement);
+            return capture;
+        }
+    }
+}


### PR DESCRIPTION
This comes handy when new addon update comes out, so It going to be enough to press `Install & Save`. The `CELL_SIZE` settings remains.

![addon_config](https://user-images.githubusercontent.com/367101/185243059-7004252c-0d90-485b-b0aa-b6762628cab0.png)

In order to change this value after install. First have to delete the current configuration at BlazoServer `Addon Config` tab, then the input field becomes editable. Finally press `Install & Save`

**Note:** If you already using a non **1** value for `CEL_SIZE`, the first time it going to replace that value to **1**. However you can redo the previously mentioned process in order to change it back.