### PR TITLE
Core: `BeforeCastDismount` option added for KeyAction

### DIFF
--- a/Core/ClassConfig/KeyAction.cs
+++ b/Core/ClassConfig/KeyAction.cs
@@ -17,6 +17,7 @@ namespace Core
         public int Slot { get; set; }
         public int SlotIndex { get; private set; }
         public int PressDuration { get; set; } = 50;
+        public bool AllowMounted { get; set; } = false;
         public string Form { get; set; } = string.Empty;
         public Form FormEnum { get; set; } = Core.Form.None;
         public bool FormAction { get; private set; }

--- a/Core/ClassConfig/KeyAction.cs
+++ b/Core/ClassConfig/KeyAction.cs
@@ -17,7 +17,6 @@ namespace Core
         public int Slot { get; set; }
         public int SlotIndex { get; private set; }
         public int PressDuration { get; set; } = 50;
-        public bool AllowMounted { get; set; } = false;
         public string Form { get; set; } = string.Empty;
         public Form FormEnum { get; set; } = Core.Form.None;
         public bool FormAction { get; private set; }
@@ -57,6 +56,7 @@ namespace Core
 
         public int BeforeCastDelay { get; set; }
         public bool BeforeCastStop { get; set; }
+        public bool BeforeCastDismount { get; set; } = true;
 
         public int AfterCastDelay { get; set; }
         public bool AfterCastWaitMeleeRange { get; set; }

--- a/Core/Goals/AdhocGoal.cs
+++ b/Core/Goals/AdhocGoal.cs
@@ -50,7 +50,7 @@ namespace Core.Goals
 
         public override void OnEnter()
         {
-            if (mountHandler.IsMounted())
+            if (mountHandler.IsMounted() && !key.AllowMounted)
             {
                 mountHandler.Dismount();
                 wait.Update();

--- a/Core/Goals/AdhocGoal.cs
+++ b/Core/Goals/AdhocGoal.cs
@@ -50,7 +50,7 @@ namespace Core.Goals
 
         public override void OnEnter()
         {
-            if (mountHandler.IsMounted() && !key.AllowMounted)
+            if (key.BeforeCastDismount && mountHandler.IsMounted())
             {
                 mountHandler.Dismount();
                 wait.Update();

--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ Can specify conditions with [Requirement(s)](#Requirement) in order to create a 
 | `"Name"` | Name of the KeyAction. For the `ActionBarPopulator`, lowercase means macro. | `""` |
 | `"Key"` | Key to press (`ConsoleKey`) | `""` |
 | `"Cost"` | [Adhoc Goals](#Adhoc-Goals) or [NPC Goal](#NPC-Goals) only, priority | `18` |
+| `"AllowMounted"` | [Adhoc Goals](#Adhoc-Goals) only, indicate whether the action could be used while mounted (like Paladin Crusader Aura) | `false` |
 | `"PathFilename"` | [NPC Goal](#NPC-Goals) only, this is a short path to get close to the NPC to avoid walls etc. | `""` |
 | `"HasCastBar"` | After key press cast bar is expected?<br>By default sets `BeforeCastStop`=`true` | `false` |
 | `"InCombat"` | Should combat matter when attempt to cast?<br>Accepted values:<br>* `"any value for doesn't matter"`<br>* `"true"`<br>* `"false"` | `false` |

--- a/README.md
+++ b/README.md
@@ -435,7 +435,6 @@ Can specify conditions with [Requirement(s)](#Requirement) in order to create a 
 | `"Name"` | Name of the KeyAction. For the `ActionBarPopulator`, lowercase means macro. | `""` |
 | `"Key"` | Key to press (`ConsoleKey`) | `""` |
 | `"Cost"` | [Adhoc Goals](#Adhoc-Goals) or [NPC Goal](#NPC-Goals) only, priority | `18` |
-| `"AllowMounted"` | [Adhoc Goals](#Adhoc-Goals) only, indicate whether the action could be used while mounted (like Paladin Crusader Aura) | `false` |
 | `"PathFilename"` | [NPC Goal](#NPC-Goals) only, this is a short path to get close to the NPC to avoid walls etc. | `""` |
 | `"HasCastBar"` | After key press cast bar is expected?<br>By default sets `BeforeCastStop`=`true` | `false` |
 | `"InCombat"` | Should combat matter when attempt to cast?<br>Accepted values:<br>* `"any value for doesn't matter"`<br>* `"true"`<br>* `"false"` | `false` |
@@ -455,6 +454,7 @@ Can specify conditions with [Requirement(s)](#Requirement) in order to create a 
 | --- | Before keypress cast, ... | --- |
 | `"BeforeCastStop"` | stop moving. | `false` |
 | `"BeforeCastDelay"` | delay in milliseconds | `0` |
+| `"BeforeCastDismount"` | should dismount. [Adhoc Goals](#Adhoc-Goals) only. | `true` |
 | --- | After Successful cast, ... | --- |
 | `"AfterCastWaitSwing"` | wait for next melee swing to land.<br>Blocks **CastingHandler**. | `false` |
 | `"AfterCastWaitCastbar"` | wait for the castbar to finish, `SpellQueueTimeMs` excluded.<br>Blocks **CastingHandler**. | `false` |


### PR DESCRIPTION
Allow adhoc goals to be dealt mounted. Could be somehow extended to other goals.
Not really tested yet. I don't really have a paladin character, help is apprieciated.
Should fix #413

Signed-off-by: AsterNighT <asternight@outlook.com>