### PR TITLE
replacing GetTempFileName with fixed name

### DIFF
--- a/PPather/Triangles/MPQTriangleSupplier.cs
+++ b/PPather/Triangles/MPQTriangleSupplier.cs
@@ -47,7 +47,7 @@ namespace WowTriangles
             this.logger = logger;
             this.mapId = mapId;
 
-            archive = new StormDll.ArchiveSet(this.logger, GetArchiveNames(dataConfig));
+            archive = new StormDll.ArchiveSet(this.logger, GetArchiveNames(dataConfig), dataConfig);
             modelmanager = new ModelManager(archive, 160, dataConfig);
             wmomanager = new WMOManager(archive, modelmanager, 120, dataConfig);
 

--- a/PPather/Triangles/StormDll.cs
+++ b/PPather/Triangles/StormDll.cs
@@ -106,7 +106,7 @@ namespace StormDll
     {
         private Archive[] archives;
 
-        public ArchiveSet(ILogger logger, string[] files)
+        public ArchiveSet(ILogger logger, string[] files, DataConfig dataConfig)
         {
             archives = new Archive[files.Length];
 
@@ -116,7 +116,7 @@ namespace StormDll
                     OpenArchive.MPQ_OPEN_NO_LISTFILE |
                     OpenArchive.MPQ_OPEN_NO_ATTRIBUTES |
                     OpenArchive.MPQ_OPEN_NO_HEADER_SEARCH |
-                    OpenArchive.MPQ_OPEN_READ_ONLY);
+                    OpenArchive.MPQ_OPEN_READ_ONLY, dataConfig);
 
                 if (open && a.IsOpen())
                 {
@@ -159,7 +159,7 @@ namespace StormDll
 
         private readonly System.Collections.Generic.HashSet<string> fileList = new(StringComparer.InvariantCultureIgnoreCase);
 
-        public Archive(string file, out bool open, uint Prio, OpenArchive Flags)
+        public Archive(string file, out bool open, uint Prio, OpenArchive Flags, DataConfig dataConfig)
         {
             open = Environment.Is64BitProcess
                 ? StormDllx64.SFileOpenArchive(file, Prio, Flags, out handle)
@@ -167,13 +167,25 @@ namespace StormDll
 
             if (open)
             {
-                string temp = Path.GetTempFileName();
+                string tempfolder = dataConfig.PPather;
+                if (!Directory.Exists(tempfolder))
+                {
+                    Directory.CreateDirectory(tempfolder);
+                }
 
-                bool extracted = Environment.Is64BitProcess
-                ? StormDllx64.SFileExtractFile(handle, "(listfile)", temp, OpenFile.SFILE_OPEN_FROM_MPQ)
-                : StormDllx86.SFileExtractFile(handle, "(listfile)", temp, OpenFile.SFILE_OPEN_FROM_MPQ);
+                FileInfo fi = new FileInfo(file);
+                string temp = Path.Combine(tempfolder, fi.Name + ".listfile.tmp");// Path.GetTempFileName(); we should be very careful to use the GetTempFileName
 
-                if (extracted && File.Exists(temp))
+                bool extracted = File.Exists(temp);
+                if (!extracted)
+                {
+                   extracted = Environment.Is64BitProcess
+                                ? StormDllx64.SFileExtractFile(handle, "(listfile)", temp, OpenFile.SFILE_OPEN_FROM_MPQ)
+                                : StormDllx86.SFileExtractFile(handle, "(listfile)", temp, OpenFile.SFILE_OPEN_FROM_MPQ);
+                }
+
+
+                if (extracted)
                 {
                     foreach (string line in File.ReadLines(temp))
                     {


### PR DESCRIPTION
The current StormDll.cs extract the list file to the system temp folder, and generate temp names, 
1) it requires user access and would crash due to not sufficient access if you run it through IIS
2) it extract the same list file many times and generate enough garbage
So saving it to a fixed filename same as all the rest tmp files to PPather Folder is better.

