### PR TITLE
Fix: Loot prematurely marked success because of late inventory change

### DIFF
--- a/Core/Bag/BagReader.cs
+++ b/Core/Bag/BagReader.cs
@@ -1,4 +1,4 @@
-﻿using Core.Database;
+using Core.Database;
 
 using SharedLib;
 
@@ -27,6 +27,7 @@ namespace Core
         public event Action? DataChanged;
 
         public int Hash { private set; get; }
+        public int HashNewOrStackGain { private set; get; }
 
         private bool changedFromEvent;
 
@@ -149,6 +150,9 @@ namespace Core
 
                         if (existingItem.Count != itemCount)
                         {
+                            if (existingItem.Count < itemCount)
+                                HashNewOrStackGain++;
+
                             existingItem.UpdateCount(itemCount);
                             hasChanged = true;
                         }
@@ -162,10 +166,12 @@ namespace Core
                     if (ItemDB.Items.TryGetValue(itemId, out var item))
                     {
                         BagItems.Add(new BagItem(bag, slot, itemId, itemCount, item));
+                        HashNewOrStackGain++;
                     }
                     else
                     {
                         BagItems.Add(new BagItem(bag, slot, itemId, itemCount, new Item() { Entry = itemId, Name = "Unknown" }));
+                        HashNewOrStackGain++;
                     }
                 }
             }

--- a/Core/Goals/LootGoal.cs
+++ b/Core/Goals/LootGoal.cs
@@ -38,7 +38,7 @@ namespace Core.Goals
 
         private bool gatherCorpse;
         private int targetId;
-        private int bagHash;
+        private int bagHashNewOrStackGain;
         private int money;
 
         public LootGoal(ILogger logger, ConfigurableInput input, Wait wait,
@@ -72,7 +72,7 @@ namespace Core.Goals
 
             wait.While(LootReset);
 
-            bagHash = bagReader.Hash;
+            bagHashNewOrStackGain = bagReader.HashNewOrStackGain;
             money = playerReader.Money;
 
             if (bagReader.BagsFull())
@@ -213,7 +213,7 @@ namespace Core.Goals
 
         private bool LootWindowClosedOrBagOrMoneyChanged()
         {
-            return bagHash != bagReader.Hash ||
+            return bagHashNewOrStackGain != bagReader.HashNewOrStackGain ||
                 money != playerReader.Money ||
                 (LootStatus)playerReader.LootEvent.Value is
                 LootStatus.CLOSED;

--- a/Core/Goals/SkinningGoal.cs
+++ b/Core/Goals/SkinningGoal.cs
@@ -28,7 +28,7 @@ namespace Core.Goals
         private readonly GoapAgentState state;
 
         private bool canRun;
-        private int bagHash;
+        private int bagHashNewOrStackGain;
 
         private readonly List<SkinCorpseEvent> corpses = new();
 
@@ -91,7 +91,7 @@ namespace Core.Goals
                 return;
             }
 
-            bagHash = bagReader.Hash;
+            bagHashNewOrStackGain = bagReader.HashNewOrStackGain;
 
             wait.Fixed(playerReader.NetworkLatency.Value);
 
@@ -315,7 +315,7 @@ namespace Core.Goals
 
         private bool LootWindowClosedOrBagChanged()
         {
-            return bagHash != bagReader.Hash ||
+            return bagHashNewOrStackGain != bagReader.HashNewOrStackGain ||
                 (LootStatus)playerReader.LootEvent.Value is
                 LootStatus.CLOSED;
         }

--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ Can specify conditions with [Requirement(s)](#Requirement) in order to create a 
 | `"AfterCastWaitCastbar"` | wait for the castbar to finish, `SpellQueueTimeMs` excluded.<br>Blocks **CastingHandler**. | `false` |
 | `"AfterCastWaitBuff"` | wait for Aura=__(player-target debuff/buff)__ count changes.<br>Only works properly, when the Aura **count** changes.<br>Not suitable for refreshing already existing Aura<br>Blocks **CastingHandler**. | `false` |
 | `"AfterCastAuraExpected"` | refreshing Aura=__(player-target debuff/buff)__<br>Just adds an extra(`SpellQueueTimeMs`) Cooldown to the action, so it wont repeat itself.<br>Not blocking  **CastingHandler**. | `false` |
-| `"AfterCastWaitBag"` | wait for inventory, bag change.<br>Blocks **CastingHandler**. | `false` |
+| `"AfterCastWaitBag"` | wait for any inventory, bag change.<br>Blocks **CastingHandler**. | `false` |
 | `"AfterCastWaitCombat"` | wait for player entering combat.<br>Blocks **CastingHandler**. | `false` |
 | `"AfterCastWaitMeleeRange"` | wait for interrupted either:<br>* target enters melee range<br>* target starts casting<br>* player receives damage<br>Blocks **CastingHandler**. | `false` |
 | `"AfterCastStepBack"` | start backpedaling for milliseconds.<br>If value set to `-1` attempts to use the whole remaining GCD duration.<br>Blocks **CastingHandler**. | `0` |


### PR DESCRIPTION
Scenario: 
* After killing a mob, there could be a short amount of time window when prematurely marking `LootGoal` as success because of losing an item from the inventory. 

Example: 
* hunter ammo decrement
* warlock soul shard usage