### PR TITLE
Core: `CombatLog`: On attacking a mob which Evades notify the `TargetBlacklist`.

### DIFF
--- a/Core/AddonComponent/CombatLog.cs
+++ b/Core/AddonComponent/CombatLog.cs
@@ -8,6 +8,7 @@ namespace Core
         private bool wasInCombat;
 
         public event Action? KillCredit;
+        public event Action? TargetEvade;
 
         public HashSet<int> DamageDone { get; } = new();
         public HashSet<int> DamageTaken { get; } = new();
@@ -46,9 +47,17 @@ namespace Core
 
         public void Update(IAddonDataProvider reader, bool playerInCombat)
         {
-            if (TargetMissType.Updated(reader) && (MissType)TargetMissType.Value == MissType.DODGE)
+            if (TargetMissType.Updated(reader))
             {
-                TargetDodge.UpdateTime();
+                switch ((MissType)TargetMissType.Value)
+                {
+                    case MissType.DODGE:
+                        TargetDodge.UpdateTime();
+                        break;
+                    case MissType.EVADE:
+                        TargetEvade?.Invoke();
+                        break;
+                }
             }
 
             if (playerInCombat && DamageTakenGuid.Updated(reader) && DamageTakenGuid.Value > 0)


### PR DESCRIPTION
Note: the evading npc remains blacklisted during the rest of the session!

As of now there's no way to make difference between these two scenarios:
* NPC actually spawned a location which makes it invincible. 
* Another player aggroed the currently selected target, the other player moved out of aggro range, and the NPC runs back to the spawn location, during this time it is invincible.