### PR TITLE
Refactor: `Adhoc` and `Parallel` goals awaiting logic has been replaced with `WaitGoal`

### DIFF
--- a/Core/ClassConfig/ClassConfiguration.cs
+++ b/Core/ClassConfig/ClassConfiguration.cs
@@ -65,7 +65,7 @@ namespace Core
         public KeyActions Adhoc { get; } = new();
         public KeyActions Parallel { get; } = new();
         public KeyActions NPC { get; } = new();
-        public KeyActions Wait { get; } = new();
+        public WaitKeyActions Wait { get; } = new();
 
         public KeyAction[] Form { get; init; } = Array.Empty<KeyAction>();
         public KeyAction[] GatherFindKeyConfig { get; set; } = Array.Empty<KeyAction>();

--- a/Core/ClassConfig/KeyActions.cs
+++ b/Core/ClassConfig/KeyActions.cs
@@ -3,11 +3,11 @@ using System;
 
 namespace Core
 {
-    public sealed partial class KeyActions : IDisposable
+    public partial class KeyActions : IDisposable
     {
-        public KeyAction[] Sequence { get; init; } = Array.Empty<KeyAction>();
+        public KeyAction[] Sequence { get; set; } = Array.Empty<KeyAction>();
 
-        public void PreInitialise(string prefix, RequirementFactory requirementFactory, ILogger logger)
+        public virtual void PreInitialise(string prefix, RequirementFactory requirementFactory, ILogger logger)
         {
             if (Sequence.Length > 0)
             {
@@ -22,7 +22,7 @@ namespace Core
             }
         }
 
-        public void Initialise(string prefix, ClassConfiguration config, AddonReader addonReader, RequirementFactory requirementFactory, ILogger logger, bool globalLog)
+        public virtual void Initialise(string prefix, ClassConfiguration config, AddonReader addonReader, RequirementFactory requirementFactory, ILogger logger, bool globalLog)
         {
             if (Sequence.Length > 0)
             {
@@ -47,13 +47,13 @@ namespace Core
             EventId = 10,
             Level = LogLevel.Information,
             Message = "[{prefix}] CreateDynamicBindings.")]
-        static partial void LogDynamicBinding(ILogger logger, string prefix);
+        protected static partial void LogDynamicBinding(ILogger logger, string prefix);
 
         [LoggerMessage(
             EventId = 11,
             Level = LogLevel.Information,
             Message = "[{prefix}] Initialise KeyActions.")]
-        static partial void LogInitKeyActions(ILogger logger, string prefix);
+        protected static partial void LogInitKeyActions(ILogger logger, string prefix);
 
     }
 }

--- a/Core/ClassConfig/WaitKeyActions.cs
+++ b/Core/ClassConfig/WaitKeyActions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+
 using System;
 
 namespace Core
@@ -7,6 +8,8 @@ namespace Core
     {
         public float FoodDrinkCost { get; set; } = 5f;
 
+        public bool AutoGenerateWaitForFoodAndDrink { get; set; } = true;
+
         public override void PreInitialise(string prefix, RequirementFactory requirementFactory, ILogger logger)
         {
             base.PreInitialise(prefix, requirementFactory, logger);
@@ -14,7 +17,8 @@ namespace Core
 
         public override void Initialise(string prefix, ClassConfiguration config, AddonReader addonReader, RequirementFactory requirementFactory, ILogger logger, bool globalLog)
         {
-            AddWaitKeyActionsForFoodOrDrink(logger, config);
+            if (AutoGenerateWaitForFoodAndDrink)
+                AddWaitKeyActionsForFoodOrDrink(logger, config);
 
             base.Initialise(prefix, config, addonReader, requirementFactory, logger, globalLog);
         }

--- a/Core/ClassConfig/WaitKeyActions.cs
+++ b/Core/ClassConfig/WaitKeyActions.cs
@@ -1,0 +1,97 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+
+namespace Core
+{
+    public sealed partial class WaitKeyActions : KeyActions
+    {
+        public float FoodDrinkCost { get; set; } = 5f;
+
+        public override void PreInitialise(string prefix, RequirementFactory requirementFactory, ILogger logger)
+        {
+            base.PreInitialise(prefix, requirementFactory, logger);
+        }
+
+        public override void Initialise(string prefix, ClassConfiguration config, AddonReader addonReader, RequirementFactory requirementFactory, ILogger logger, bool globalLog)
+        {
+            AddWaitKeyActionsForFoodOrDrink(logger, config);
+
+            base.Initialise(prefix, config, addonReader, requirementFactory, logger, globalLog);
+        }
+
+        private void AddWaitKeyActionsForFoodOrDrink(ILogger logger, ClassConfiguration classConfig)
+        {
+            bool foodExists = false;
+            bool drinkExists = false;
+
+            for (int i = 0; i < classConfig.Adhoc.Sequence.Length; i++)
+            {
+                KeyAction action = classConfig.Adhoc.Sequence[i];
+                if (action.Name.Contains(RequirementFactory.Food, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    foodExists = true;
+                }
+                else if (action.Name.Contains(RequirementFactory.Drink, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    drinkExists = true;
+                }
+            }
+
+            for (int i = 0; i < classConfig.Parallel.Sequence.Length; i++)
+            {
+                KeyAction action = classConfig.Parallel.Sequence[i];
+                if (action.Name.Contains(RequirementFactory.Food, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    foodExists = true;
+                }
+                else if (action.Name.Contains(RequirementFactory.Drink, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    drinkExists = true;
+                }
+            }
+
+            if (foodExists)
+            {
+                KeyAction foodWaitAction = new()
+                {
+                    Cost = FoodDrinkCost,
+                    Name = "Eating",
+                    Requirement = $"{RequirementFactory.Food} && {RequirementFactory.HealthP} < 99"
+                };
+
+                KeyAction[] keyActions = Sequence;
+
+                int newSize = keyActions.Length + 1;
+                Array.Resize(ref keyActions, newSize);
+
+                keyActions[^1] = foodWaitAction;
+
+                Sequence = keyActions;
+
+                logger.LogInformation($"[{nameof(WaitKeyActions)}] Added awaiting action for {RequirementFactory.Food}");
+            }
+
+            if (drinkExists)
+            {
+                KeyAction drinkWaitAction = new()
+                {
+                    Cost = FoodDrinkCost,
+                    Name = "Drinking",
+                    Requirement = $"{RequirementFactory.Drink} && {RequirementFactory.ManaP} < 99"
+                };
+
+                KeyAction[] keyActions = Sequence;
+
+                int newSize = keyActions.Length + 1;
+                Array.Resize(ref keyActions, newSize);
+
+                keyActions[^1] = drinkWaitAction;
+
+                Sequence = keyActions;
+
+                logger.LogInformation($"[{nameof(WaitKeyActions)}] Added awaiting action for {RequirementFactory.Drink}");
+            }
+        }
+
+    }
+}

--- a/Core/Goals/AdhocGoal.cs
+++ b/Core/Goals/AdhocGoal.cs
@@ -22,8 +22,6 @@ namespace Core.Goals
 
         private readonly bool? combatMatters;
 
-        //private bool castSuccess;
-
         public AdhocGoal(KeyAction key, ILogger logger, ConfigurableInput input, Wait wait, AddonReader addonReader, StopMoving stopMoving, CastingHandler castingHandler, MountHandler mountHandler)
             : base(nameof(AdhocGoal))
         {

--- a/Core/Goals/AdhocGoal.cs
+++ b/Core/Goals/AdhocGoal.cs
@@ -22,7 +22,7 @@ namespace Core.Goals
 
         private readonly bool? combatMatters;
 
-        private bool castSuccess;
+        //private bool castSuccess;
 
         public AdhocGoal(KeyAction key, ILogger logger, ConfigurableInput input, Wait wait, AddonReader addonReader, StopMoving stopMoving, CastingHandler castingHandler, MountHandler mountHandler)
             : base(nameof(AdhocGoal))
@@ -59,11 +59,6 @@ namespace Core.Goals
             castingHandler.UpdateGCD(true);
         }
 
-        public override void OnExit()
-        {
-            castSuccess = false;
-        }
-
         public override void Update()
         {
             if (castingHandler.SpellInQueue())
@@ -72,7 +67,7 @@ namespace Core.Goals
                 return;
             }
 
-            if (!castSuccess || (key.Charge > 1 && key.CanRun()))
+            if ((key.Charge >= 1 && key.CanRun()))
             {
                 Cast();
                 wait.Update();
@@ -88,50 +83,7 @@ namespace Core.Goals
 
         private void Cast()
         {
-            if (!castingHandler.CastIfReady(key, Interrupt))
-            {
-                if (Interrupt())
-                {
-                    castSuccess = true;
-                }
-
-                return;
-            }
-
-            bool wasDrinkingOrEating = playerReader.Buffs.Drink() || playerReader.Buffs.Food();
-
-            DateTime startTime = DateTime.UtcNow;
-
-            while ((playerReader.Buffs.Drink() || playerReader.Buffs.Food() || playerReader.IsCasting()) && !Interrupt())
-            {
-                wait.Update();
-
-                if (playerReader.Buffs.Drink())
-                {
-                    if (playerReader.ManaPercentage() > 98) { break; }
-                }
-                else if (playerReader.Buffs.Food() && !key.Requirements.Contains("Well Fed"))
-                {
-                    if (playerReader.HealthPercent() > 98) { break; }
-                }
-                else if (!key.CanRun())
-                {
-                    break;
-                }
-
-                if ((DateTime.UtcNow - startTime).TotalSeconds > 30)
-                {
-                    logger.LogInformation($"Waited (30s) long enough for {key.Name}");
-                    break;
-                }
-            }
-
-            if (wasDrinkingOrEating)
-            {
-                input.Stop();
-            }
-
-            castSuccess = true;
+            castingHandler.CastIfReady(key, Interrupt);
         }
     }
 }

--- a/Core/Goals/ParallelGoal.cs
+++ b/Core/Goals/ParallelGoal.cs
@@ -91,41 +91,6 @@ namespace Core.Goals
         private void Cast()
         {
             Parallel.For(0, Keys.Length, Execute);
-
-            if (castSuccess)
-            {
-                bool wasDrinkingOrEating = playerReader.Buffs.Drink() || playerReader.Buffs.Food();
-
-                DateTime startTime = DateTime.UtcNow;
-                while ((playerReader.Buffs.Drink() || playerReader.Buffs.Food() || playerReader.IsCasting()) && !playerReader.Bits.PlayerInCombat())
-                {
-                    wait.Update();
-
-                    if (playerReader.Buffs.Drink() && playerReader.Buffs.Food())
-                    {
-                        if (playerReader.ManaPercentage() > 98 && playerReader.HealthPercent() > 98) { break; }
-                    }
-                    else if (playerReader.Buffs.Drink())
-                    {
-                        if (playerReader.ManaPercentage() > 98) { break; }
-                    }
-                    else if (playerReader.Buffs.Food())
-                    {
-                        if (playerReader.HealthPercent() > 98) { break; }
-                    }
-
-                    if ((DateTime.UtcNow - startTime).TotalSeconds > 30)
-                    {
-                        logger.LogInformation($"Waited (30s) long enough for {Name}");
-                        break;
-                    }
-                }
-
-                if (wasDrinkingOrEating)
-                {
-                    input.StandUp();
-                }
-            }
         }
 
         private void Execute(int i)

--- a/Core/Requirement/RequirementFactory.cs
+++ b/Core/Requirement/RequirementFactory.cs
@@ -44,6 +44,9 @@ namespace Core
         public const string Drink = "Drink";
         public const string Food = "Food";
 
+        public const string HealthP = "Health%";
+        public const string ManaP = "Mana%";
+
         public RequirementFactory(ILogger logger, AddonReader addonReader,
             NpcNameFinder npcNameFinder, Dictionary<int, SchoolMask[]> immunityBlacklist)
         {
@@ -290,10 +293,10 @@ namespace Core
 
             intVariables = new Dictionary<string, Func<int>>
             {
-                { "Health%", playerReader.HealthPercent },
+                { HealthP, playerReader.HealthPercent },
                 { "TargetHealth%", playerReader.TargetHealthPercentage },
                 { "PetHealth%", playerReader.PetHealthPercentage },
-                { "Mana%", playerReader.ManaPercentage },
+                { ManaP, playerReader.ManaPercentage },
                 { "Mana", playerReader.ManaCurrent },
                 { "Energy", playerReader.PTCurrent },
                 { "Rage", playerReader.PTCurrent },

--- a/README.md
+++ b/README.md
@@ -546,6 +546,29 @@ The bare minimum for `Food` and `Drink` is looks something like this.
     "Requirement": "Mana% < 50"
 }
 ```
+
+When any of these KeyActions detected, by default, it going to be awaited with a predefined [Wait Goal](#wait-goals) logic.
+
+Should see something like this, you can override any of the following values.
+
+```json
+"Wait": {
+    "AutoGenerateWaitForFoodAndDrink": true,    // should generate 'Eating' and 'Drinking' KeyActions
+    "FoodDrinkCost": 5,                         // can override the Cost of awaiting Eating and Drinking
+    "Sequence": {
+    {
+        "Name": "Eating",
+        "Cost": "FoodDrinkCost",
+        "Requirement": "Food && Health% < 99"
+    },
+    {
+        "Name": "Drinking",
+        "Cost": "FoodDrinkCost",
+        "Requirement": "Drink && Mana% < 99"
+    },
+    }
+},
+```
 ---
 
 ### Casting Handler


### PR DESCRIPTION
```json
{
    "Name": "Food",
    "Key": "-",
    "Requirement": "Health% < 50"
},
{
    "Name": "Drink",
    "Key": "=",
    "Requirement": "Mana% < 50"
}
```

When any of these KeyActions detected, by default, it going to be awaited with a predefined Wait Goal logic.

Should see something like this, you can override any of the following values.

```json
"Wait": {
    "AutoGenerateWaitForFoodAndDrink": true,    // should generate 'Eating' and 'Drinking' KeyActions
    "FoodDrinkCost": 5,                         // can override the Cost of awaiting Eating and Drinking
    "Sequence": {
    {
        "Name": "Eating",
        "Cost": "FoodDrinkCost",
        "Requirement": "Food && Health% < 99"
    },
    {
        "Name": "Drinking",
        "Cost": "FoodDrinkCost",
        "Requirement": "Drink && Mana% < 99"
    },
    }
},
```