### PR TITLE
Addon: [1.7.32] - Feature: `KeyAction` custom interrupt in `CombatGoal` - Ranged weapon speed and swing timer

### DIFF
--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -771,7 +771,9 @@ function DataToColor:CreateFrames(n)
             Pixel(int, DataToColor:NpcId(DataToColor.C.unitmouseover), 86)
             Pixel(int, DataToColor:getGuidFromUnit(DataToColor.C.unitmouseover), 87)
 
-            -- 88
+            Pixel(int, DataToColor:getUnitRangedDamage(DataToColor.C.unitPlayer), 88)
+
+            -- 89 empty
 
             -- 94 last cast GCD
             Pixel(int, DataToColor.lastCastGCD, 94)

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -3,7 +3,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors
-## Version: 1.7.31
+## Version: 1.7.32
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/Query.lua
+++ b/Addons/DataToColor/Query.lua
@@ -47,6 +47,7 @@ local GetSkillLineInfo = GetSkillLineInfo
 local UnitIsGhost = UnitIsGhost
 local C_DeathInfo = C_DeathInfo
 local UnitAttackSpeed = UnitAttackSpeed
+local UnitRangedDamage = UnitRangedDamage
 
 -- bits
 
@@ -448,6 +449,11 @@ end
 function DataToColor:getMeleeAttackSpeed(unit)
     local main, off = UnitAttackSpeed(unit)
     return 10000 * floor((off or 0) * 100) + floor((main or 0) * 100)
+end
+
+function DataToColor:getUnitRangedDamage(unit)
+    local speed = UnitRangedDamage(unit)
+    return floor((speed or 0) * 100)
 end
 
 function DataToColor:getAvgEquipmentDurability()

--- a/Core/Addon/PlayerReader.cs
+++ b/Core/Addon/PlayerReader.cs
@@ -181,6 +181,8 @@ namespace Core
         public int FocusGuid => reader.GetInt(77);
         public int FocusTargetGuid => reader.GetInt(78);
 
+        public int RangedSpeedMs() => reader.GetInt(88) * 10;
+
         public void Update(IAddonDataProvider reader)
         {
             if (UIMapId.Updated(reader) && UIMapId.Value != 0)

--- a/Core/AddonComponent/AddonBits.cs
+++ b/Core/AddonComponent/AddonBits.cs
@@ -26,6 +26,7 @@ namespace Core
         public bool TargetInCombat() => v1[Mask._0];
         public bool TargetIsDead() => v1[Mask._1];
         public bool TargetIsNotDead() => !v1[Mask._1];
+        public bool TargetAlive() => HasTarget() && TargetIsNotDead();
         public bool IsDead() => v1[Mask._2];
         public bool HasTalentPoint() => v1[Mask._3];
         public bool HasMouseOver() => v1[Mask._4];

--- a/Core/ClassConfig/KeyAction.cs
+++ b/Core/ClassConfig/KeyAction.cs
@@ -45,6 +45,10 @@ namespace Core
         public List<string> Requirements { get; } = new();
         public Requirement[] RequirementsRuntime { get; set; } = Array.Empty<Requirement>();
 
+        public string Interrupt { get; set; } = string.Empty;
+        public List<string> Interrupts { get; } = new();
+        public Requirement[] InterruptsRuntime { get; set; } = Array.Empty<Requirement>();
+
         public bool WhenUsable { get; set; }
 
         public bool ResetOnNewTarget { get; set; }
@@ -133,6 +137,11 @@ namespace Core
             if (!string.IsNullOrEmpty(Requirement))
             {
                 Requirements.Add(Requirement);
+            }
+
+            if (!string.IsNullOrEmpty(Interrupt))
+            {
+                Interrupts.Add(Interrupt);
             }
 
             HasFormRequirement = !string.IsNullOrEmpty(Form);
@@ -265,6 +274,18 @@ namespace Core
             }
 
             return canRun = true;
+        }
+
+        public bool CanBeInterrupted()
+        {
+            var array = InterruptsRuntime;
+            for (int i = 0; i < array.Length; i++)
+            {
+                if (!array[i].HasRequirement())
+                    return false;
+            }
+
+            return true;
         }
 
         private void InitMinPowerType(ActionBarCostReader actionBarCostReader)

--- a/Core/Goals/AdhocGoal.cs
+++ b/Core/Goals/AdhocGoal.cs
@@ -67,7 +67,7 @@ namespace Core.Goals
 
             if ((key.Charge >= 1 && key.CanRun()))
             {
-                Cast();
+                castingHandler.CastIfReady(key, Interrupt);
                 wait.Update();
             }
         }
@@ -77,11 +77,6 @@ namespace Core.Goals
             return combatMatters.HasValue
                 ? combatMatters.Value == addonReader.PlayerReader.Bits.PlayerInCombat() && addonReader.DamageTakenCount() > 0
                 : addonReader.DamageTakenCount() > 0;
-        }
-
-        private void Cast()
-        {
-            castingHandler.CastIfReady(key, Interrupt);
         }
     }
 }

--- a/Core/Goals/CombatGoal.cs
+++ b/Core/Goals/CombatGoal.cs
@@ -76,12 +76,6 @@ namespace Core.Goals
             }
         }
 
-        private bool ValidTarget()
-        {
-            return playerReader.Bits.HasTarget() &&
-                playerReader.Bits.TargetIsNotDead();
-        }
-
         public override void OnEnter()
         {
             if (mountHandler.IsMounted())
@@ -141,7 +135,10 @@ namespace Core.Goals
                         continue;
                     }
 
-                    if (ValidTarget() && castingHandler.CastIfReady(keyAction, ValidTarget))
+                    if (playerReader.Bits.TargetAlive() && castingHandler.CastIfReady(keyAction,
+                        keyAction.Interrupts.Count > 0
+                        ? keyAction.CanBeInterrupted
+                        : playerReader.Bits.TargetAlive))
                     {
                         break;
                     }

--- a/Core/GoalsComponent/CastingHandler.cs
+++ b/Core/GoalsComponent/CastingHandler.cs
@@ -256,19 +256,9 @@ namespace Core.Goals
             return true;
         }
 
-        public bool CastIfReady(KeyAction item)
-        {
-            return item.CanRun() && Cast(item, playerReader.Bits.HasTarget);
-        }
-
         public bool CastIfReady(KeyAction item, Func<bool> interrupt)
         {
             return item.CanRun() && Cast(item, interrupt);
-        }
-
-        public bool Cast(KeyAction item)
-        {
-            return Cast(item, playerReader.Bits.HasTarget);
         }
 
         public bool Cast(KeyAction item, Func<bool> interrupt)

--- a/Json/class/Hunter_1.json
+++ b/Json/class/Hunter_1.json
@@ -7,6 +7,8 @@
       {
         "Name": "Auto Shot",
         "Key": "3",
+        "BeforeCastStop": true,
+        "AfterCastWaitCombat": true,
         "Item": true,
         "Requirements": [
           "HasRangedWeapon",
@@ -23,12 +25,25 @@
         "Name": "Auto Shot",
         "Key": "3",
         "Item": true,
+        "BeforeCastStop": true,
         "Requirements": [
           "HasRangedWeapon",
           "!InMeleeRange",
           "!AutoShot",
           "HasAmmo"
         ]
+      },
+      {
+        "Name": "Stepback",
+        "Key": "S",
+        "PressDuration": 3000,
+        "BaseAction": true,
+        "Requirements": [
+          "LastAutoShotMs < 400",
+          "!InMeleeRange",
+          "AutoShot"
+        ],
+        "Interrupt": "RangedSwing < -500 && TargetAlive"
       },
       {
         "Name": "Raptor Strike",
@@ -46,6 +61,12 @@
         "Requirements": [
           "InMeleeRange",
           "!AutoAttacking"
+        ]
+      },
+      {
+        "Name": "Approach",
+        "Requirements": [
+          "InMeleeRange"
         ]
       }
     ]

--- a/Json/class/Hunter_4.json
+++ b/Json/class/Hunter_4.json
@@ -7,6 +7,7 @@
         "Name": "Serpent Sting",
         "Key": "2",
         "BeforeCastStop": true,
+        "AfterCastAuraExpected": true,
         "Requirements": [
           "HasRangedWeapon",
           "HasAmmo",
@@ -18,6 +19,7 @@
         "Name": "Auto Shot",
         "Key": "3",
         "Item": true,
+        "AfterCastWaitCombat": true,
         "Requirements": [
           "HasRangedWeapon",
           "HasAmmo",
@@ -33,12 +35,25 @@
         "Name": "Auto Shot",
         "Key": "3",
         "Item": true,
+        "BeforeCastStop": true,
         "Requirements": [
           "HasRangedWeapon",
           "HasAmmo",
           "!InMeleeRange",
           "!AutoShot"
         ]
+      },
+      {
+        "Name": "Stepback",
+        "Key": "S",
+        "PressDuration": 3000,
+        "BaseAction": true,
+        "Requirements": [
+          "LastAutoShotMs < 400",
+          "!InMeleeRange",
+          "AutoShot"
+        ],
+        "Interrupt": "RangedSwing < -500 && TargetAlive"
       },
       {
         "Name": "Raptor Strike",
@@ -55,8 +70,13 @@
         "Name": "AutoAttack",
         "Requirements": [
           "InMeleeRange",
-          "!AutoShot",
           "!AutoAttacking"
+        ]
+      },
+      {
+        "Name": "Approach",
+        "Requirements": [
+          "InMeleeRange"
         ]
       }
     ]

--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ The path that the class follows is a `json` file in `/Json/path/` which contains
 "PathThereAndBack": true,                   // if true walks the path and the walks it backwards.
 "PathReduceSteps": true,                    // uses every other coordinate.
 ```
-### **KeyAction** - Commands
+### KeyAction
 
 Each `KeyAction` has its own properties to describe what the action is all about. 
 
@@ -475,6 +475,8 @@ Can specify conditions with [Requirement(s)](#Requirement) in order to create a 
 | `"UseWhenTargetIsCasting"` | Checks for the target casting/channeling.<br>Accepted values:<br>* `null` -> ignore<br>* `false` -> when enemy not casting<br>* `true` -> when enemy casting | `null` |
 | `"Requirement"` | Single [Requirement](#Requirement) | `false` |
 | `"Requirements"` | List of [Requirement](#Requirement) | `false` |
+| `"Interrupt"` | Single [Requirement](#Requirement) | `false` |
+| `"Interrupts"` | List of [Requirement](#Requirement) | `false` |
 | `"ResetOnNewTarget"` | Reset the Cooldown if the target changes | `false` |
 | `"Log"` | Related events should appear in the logs | `true` |
 | --- | Before keypress cast, ... | --- |
@@ -529,7 +531,7 @@ e.g. for Rogue ability
 }
 ```
 
-Theres are few specially named KeyAction such as `Food` and `Drink` which is reserved for eating and drinking.
+Theres are few specially named [KeyAction](#KeyAction) such as `Food` and `Drink` which is reserved for eating and drinking.
 
 They already have some prebaked `Requirement` conditions in order to avoid mistype the definition. 
 
@@ -547,7 +549,7 @@ The bare minimum for `Food` and `Drink` is looks something like this.
 }
 ```
 
-When any of these KeyActions detected, by default, it going to be awaited with a predefined [Wait Goal](#wait-goals) logic.
+When any of these [KeyAction(s)](#KeyAction) detected, by default, it going to be awaited with a predefined [Wait Goal](#wait-goals) logic.
 
 Should see something like this, you can override any of the following values.
 
@@ -578,12 +580,15 @@ let it be using an item from the inventory, casting an instant spell or casting 
 
 From Addon version **1.6.0** it has been significantly changed to the point where it no longer blocks the execution until the castbar fully finishes, but rather gives back the control to the parent Goal such as [Adhoc Goals](#Adhoc-Goals) or [Pull Goal](#Pull-Goal) or [Combat Goal](#Combat-Goal) to give more time to find the best suitable action for the given moment.
 
-As a result in order to execute the [Pull Goal](#Pull-Goal) sequence in respect, have to combine its `KeyAction(s)` with `AfterCast` prefixed conditions.
+As a result in order to execute the [Pull Goal](#Pull-Goal) sequence in respect, have to combine its [KeyAction(s)](#KeyAction) with `AfterCast` prefixed conditions.
 
 ---
+
+## Goal Groups
+
 ### Pull Goal
 
-This is the `Sequence` of `KeyAction(s)` that are used when pulling a mob.
+This is the `Sequence` of [KeyAction(s)](#KeyAction) that are used when pulling a mob.
 
 e.g.
 ```json
@@ -605,7 +610,7 @@ e.g.
 
 ### Combat Goal
 
-The `Sequence` of `KeyAction(s)` that are used when in combat and trying to kill a mob. 
+The `Sequence` of [KeyAction(s)](#KeyAction) that are used when in combat and trying to kill a mob. 
 
 The combat goal does the first available command on the list. 
 
@@ -635,7 +640,7 @@ e.g.
 
 ### Adhoc Goals
 
-These `Sequence` of `KeyAction(s)` are done when not in combat and are not on cooldown. Suitable for personal buffs.
+These `Sequence` of [KeyAction(s)](#KeyAction) are done when not in combat and are not on cooldown. Suitable for personal buffs.
 
 e.g.
 ```json
@@ -662,9 +667,9 @@ e.g.
 
 ### Parallel Goals
 
-These `Sequence` of `KeyAction(s)` are done when not in combat and are not on cooldown. 
+These `Sequence` of [KeyAction(s)](#KeyAction) are done when not in combat and are not on cooldown. 
 
-The keypresses happens simultaneously on all `KeyAction(s)` which mets the `Requirement`.
+The keypresses happens simultaneously on all [KeyAction(s)](#KeyAction) which mets the `Requirement`.
 
 Suitable for `Food` and `Drink`.
 
@@ -780,9 +785,9 @@ In theory if there is a repeatable quest to collect items, you could set up a NP
 
 # Requirement
 
-A requirement is something that must be evaluated to be `true` for the `KeyAction` to run. 
+A requirement is something that must be evaluated to be `true` for the [KeyAction](#KeyAction) to run. 
 
-Not all `KeyAction` requires requirement(s), some rely on
+Not all [KeyAction](#KeyAction) requires requirement(s), some rely on
 * `Cooldown` - populated manually
 * `ActionBarCooldownReader` - populated automatically
 * `ActionBarCostReader` - populated automatically including (`MinMana`, `MinRage`, `MinEnergy`, `MinRunicPower`, `MinRuneBlood`, `MinRuneFrost`, `MinRuneUnholy`)
@@ -832,7 +837,7 @@ e.g.
 
 Two or more Requirement can be merged into a single Requirement object. 
 
-By default every Requirement is concataneted with `[and]` operator which means in order to execute the `KeyAction`, every member in the `RequirementsObject` must be evaluated to `true`. However this consctruct allows to concatanete with `[or]`. Nesting parenthesis are also supported.
+By default every Requirement is concataneted with `[and]` operator which means in order to execute the [KeyAction](#KeyAction), every member in the `RequirementsObject` must be evaluated to `true`. However this consctruct allows to concatanete with `[or]`. Nesting parenthesis are also supported.
 
 Formula: `[Requirement1] [Operator] [RequirementN]`
 
@@ -890,7 +895,9 @@ Formula: `[Keyword] [Operator] [Numeric integer value]`
 | `LastMainHandMs` | Time since last detected Main Hand Melee swing happened in milliseconds |
 | `MainHandSpeed` | Returns the player Main hand attack speed in milliseconds |
 | `MainHandSwing` | Returns the player predicted next main hand swing time |
-| `CD` | Returns the context KeyAction **in-game** cooldown in milliseconds |
+| `RangedSpeed` | Returns the player ranged weapon attack speed in milliseconds |
+| `RangedSwing` | Returns the player predicted next ranged weapon swing time |
+| `CD` | Returns the context [KeyAction](#KeyAction) **in-game** cooldown in milliseconds |
 | `CD_{KeyAction.Name}` | Returns the given `{KeyAction.Name}` **in-game** cooldown in milliseconds |
 | `Cost_{KeyAction.Name}` | Returns the given `{KeyAction.Name}` cost value |
 | `Buff_{IntVariable_Name}` | Returns the given `{IntVariable_Name}` remaining player buff up time |
@@ -908,7 +915,7 @@ For the `MinRange` and `MaxRange` gives an approximation range distance between 
 | 0 | 5 | "InMeleeRange" |
 | 5 | 15 | "IsInDeadZoneRange" |
 
-Its worth mention that `CD_{KeyAction.Name}` is a dynamic value.<br>Each `KeyAction` has its own `in-game Cooldown` which is not the same as `KeyAction.Cooldown`!
+Its worth mention that `CD_{KeyAction.Name}` is a dynamic value.<br>Each [KeyAction](#KeyAction) has its own `in-game Cooldown` which is not the same as `KeyAction.Cooldown`!
 
 e.g. Single Requirement
 ```json
@@ -1123,7 +1130,7 @@ e.g.
 },
 ```
 
-Then in **KeyAction** you can use the following requirement:
+Then in [KeyAction](#KeyAction) you can use the following requirement:
 
 e.g.
 ```json
@@ -1155,7 +1162,7 @@ e.g.
 },
 ```
 
-Then in **KeyAction** you can use the following requirement:
+Then in [KeyAction](#KeyAction) you can use the following requirement:
 
 e.g.
 ```json
@@ -1255,7 +1262,9 @@ Allow requirements about what buffs/debuffs you have or the target has or in gen
 | `"Items Broken"` | Has any broken(red) worn item |
 | `"HasRangedWeapon"` | Has equipped ranged weapon (wand/crossbow/bow/gun) |
 | `"HasAmmo"` | AmmoSlot has equipped ammo and count is greater than zero |
-| `"IsCasting"` | The player is currently casting any spell. |
+| `"Casting"` | The player is currently casting any spell. |
+| `"HasTarget"` | The player currently has a target. |
+| `"TargetAlive"` | The player currently has an alive target. |
 | `"InMeleeRange"` | Target is approximately 0-5 yard range |
 | `"InCloseMeleeRange"` | Target is approximately 0-2 yard range |
 | `"InDeadZoneRange"` | Target is approximately 5-11 yard range |
@@ -1520,6 +1529,44 @@ e.g. Rogue_20.json
 }
 ```
 
+# Interrupt Requirement
+
+Every [KeyAction](#KeyAction) has individual Interrupt(s) condition(s) which are [Requirement(s)](#Requirement) to stop execution before fully finishing it.
+
+As of now every [Goal groups](#Goal-groups) has a default Interrupt.
+* [Combat Goal](#Combat-Goal) based [KeyAction(s)](#KeyAction) interrupted once the target dies and the player loses the target.
+* [Parallel Goal](#Parallel-Goals) based [KeyAction(s)](#KeyAction) has **No** interrupt conditions.
+* [Adhoc Goals](#Adhoc-Goals) based [KeyAction(s)](#KeyAction) depends on `KeyAction.InCombat` flag.
+
+Here's and example for low level Hunters, while playing without a pet companion take advantage of interrupt.
+
+It attempts to step back for a maximum **3000**ms duration however this can be interrupted either
+* losing the current target
+* the next Auto Shot coming in **500**ms
+
+This **500**ms duration is the reload animation time, while the player has to stay still.
+
+```json
+"Combat": {
+    "Sequence": [
+        //...
+        {
+        "Name": "Stepback",
+        "Key": "S",
+        "PressDuration": 3000,
+        "BaseAction": true,
+        "Requirements": [
+            "LastAutoShotMs < 400",
+            "!InMeleeRange",
+            "AutoShot"
+        ],
+        "Interrupt": "RangedSwing < -500 && TargetAlive"
+        },
+        //...
+    ]
+}
+```
+---
 # Modes
 
 The default mode for the bot is to grind, but there are other modes. The mode is set in the root of the class file.
@@ -1591,7 +1638,7 @@ Pathed routes are shown in Green.
 
 ![Pathed route](images/PathedRoute.png)
 
-### Goals
+### Goal
 
 This component contains a button to allow the bot to be enabled and disabled.
 


### PR DESCRIPTION
Changes:
* `CombatGoal` goal based `KeyAction` can utilize the newly added `KeyActions.Interrupts` Requirements.
* Obtained Ranged weapon speed

Example can be found at `Hunter_1.json` and `Hunter_4.json` profiles.