### PR TITLE
Refactor: PPather reduce allocations

### DIFF
--- a/PPather/Graph/Path.cs
+++ b/PPather/Graph/Path.cs
@@ -23,13 +23,11 @@ namespace PPather.Graph
 {
     public sealed class Path
     {
-        public List<Vector3> locations { get; set; } = new();
+        public List<Vector3> locations { get; } = new();
 
         public int Count => locations.Count;
 
         public Vector3 GetLast => locations[^1];
-
-        public Vector3 this[int index] => locations[index];
 
         public Path(List<Spot> steps)
         {

--- a/PPather/Graph/PathGraph.cs
+++ b/PPather/Graph/PathGraph.cs
@@ -61,7 +61,7 @@ namespace PPather.Graph
 
         public Path lastReducedPath;
 
-        public static float IsCloseToModelRange = 2;
+        public const float IsCloseToModelRange = 2;
 
         /*
 		public const float IndoorsWantedStepLength = 1.5f;
@@ -253,9 +253,10 @@ namespace PPather.Graph
                     float mid_x = (s.Loc.X + cs.Loc.X) / 2;
                     float mid_y = (s.Loc.Y + cs.Loc.Y) / 2;
                     float mid_z = (s.Loc.Z + cs.Loc.Z) / 2;
-                    float stand_z;
-                    int flags;
-                    if (triangleWorld.FindStandableAt(mid_x, mid_y, mid_z - WantedStepLength * .75f, mid_z + WantedStepLength * .75f, out stand_z, out flags, toonHeight, toonSize))
+
+                    if (triangleWorld.FindStandableAt(mid_x, mid_y,
+                        mid_z - WantedStepLength * .75f, mid_z + WantedStepLength * .75f,
+                        out _, out _, toonHeight, toonSize))
                     {
                         s.AddPathTo(cs);
                         cs.AddPathTo(s);
@@ -664,7 +665,7 @@ namespace PPather.Graph
             float H_Score = spotLinkedToCurrent.GetDistanceTo2D(destinationSpot) * heuristicsFactor;// the estimated movement cost to move from that given square on the grid to the final destination, point B. This is often referred to as the heuristic, which can be a bit confusing. The reason why it is called that is because it is a guess. We really don�t know the actual distance until we find the path, because all sorts of things can be in the way (walls, water, etc.). You are given one way to calculate H in this tutorial, but there are many others that you can find in other articles on the web.
             float F_Score = G_Score + H_Score;
 
-            if (spotLinkedToCurrent.IsFlagSet(Spot.FLAG_WATER)) { F_Score += 30; }
+            if (spotLinkedToCurrent.IsFlagSet(Spot.FLAG_WATER)) { F_Score += 50; }
 
             if (!spotLinkedToCurrent.SearchScoreIsSet(currentSearchID) || F_Score < spotLinkedToCurrent.SearchScoreGet(currentSearchID))
             {
@@ -683,7 +684,7 @@ namespace PPather.Graph
             float H_Score = spotLinkedToCurrent.GetDistanceTo2D(destinationSpot) * heuristicsFactor;// the estimated movement cost to move from that given square on the grid to the final destination, point B. This is often referred to as the heuristic, which can be a bit confusing. The reason why it is called that is because it is a guess. We really don�t know the actual distance until we find the path, because all sorts of things can be in the way (walls, water, etc.). You are given one way to calculate H in this tutorial, but there are many others that you can find in other articles on the web.
             float F_Score = G_Score + H_Score;
 
-            if (spotLinkedToCurrent.IsFlagSet(Spot.FLAG_WATER)) { F_Score += 30; }
+            if (spotLinkedToCurrent.IsFlagSet(Spot.FLAG_WATER)) { F_Score += 50; }
 
             int score = GetTriangleClosenessScore(spotLinkedToCurrent.Loc);
             score += GetTriangleGradiantScore(spotLinkedToCurrent.Loc, gradiantMax);
@@ -707,7 +708,7 @@ namespace PPather.Graph
             float new_score = currentSearchSpotScore + currentSearchSpot.GetDistanceTo(spotLinkedToCurrent) + TurnCost(currentSearchSpot, spotLinkedToCurrent);
 
             if (locationHeuristics != null) { new_score += locationHeuristics.Score(currentSearchSpot.Loc.X, currentSearchSpot.Loc.Y, currentSearchSpot.Loc.Z); }
-            if (spotLinkedToCurrent.IsFlagSet(Spot.FLAG_WATER)) { new_score += 30; }
+            if (spotLinkedToCurrent.IsFlagSet(Spot.FLAG_WATER)) { new_score += 50; }
 
             if (spotLinkedToCurrent.SearchScoreIsSet(currentSearchID))
             {
@@ -758,7 +759,8 @@ namespace PPather.Graph
                 } // TODO: this is slow
 
                 // check we can stand at this new location
-                if (!triangleWorld.FindStandableAt(nx, ny, currentSearchSpot.Loc.Z - WantedStepLength * .75f, currentSearchSpot.Loc.Z + WantedStepLength * .75f, out float new_z, out int flags, toonHeight, toonSize))
+                if (!triangleWorld.FindStandableAt(nx, ny, currentSearchSpot.Loc.Z - WantedStepLength * .75f,
+                    currentSearchSpot.Loc.Z + WantedStepLength * .75f, out float new_z, out TriangleType flags, toonHeight, toonSize))
                 {
                     continue;
                 }
@@ -781,11 +783,11 @@ namespace PPather.Graph
                 //PeekSpot = newSpot;
 
                 //check flags return by triangleWorld.FindStandableA
-                if ((flags & ChunkedTriangleCollection.TriangleFlagDeepWater) != 0)
+                if ((flags & TriangleType.Water) != 0)
                 {
                     newSpot.SetFlag(Spot.FLAG_WATER, true);
                 }
-                if (((flags & ChunkedTriangleCollection.TriangleFlagModel) != 0) || ((flags & ChunkedTriangleCollection.TriangleFlagObject) != 0))
+                if (((flags & TriangleType.Model) != 0) || ((flags & TriangleType.Object) != 0))
                 {
                     newSpot.SetFlag(Spot.FLAG_INDOORS, true);
                 }
@@ -824,9 +826,9 @@ namespace PPather.Graph
 
         public bool IsUnderwaterOrInAir(Vector3 l)
         {
-            if (triangleWorld.FindStandableAt(l.X, l.Y, l.Z - 50.0f, l.Z + 5.0f, out _, out int flags, toonHeight, toonSize))
+            if (triangleWorld.FindStandableAt(l.X, l.Y, l.Z - 50.0f, l.Z + 5.0f, out _, out TriangleType flags, toonHeight, toonSize))
             {
-                if ((flags & ChunkedTriangleCollection.TriangleFlagDeepWater) != 0)
+                if ((flags & TriangleType.Water) != 0)
                     return true;
                 else
                     return false;

--- a/PPather/Search/MeshFactory.cs
+++ b/PPather/Search/MeshFactory.cs
@@ -1,6 +1,7 @@
-﻿using System.Linq;
-using WowTriangles;
+﻿using WowTriangles;
 using System.Numerics;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 namespace PPather
 {
@@ -9,39 +10,29 @@ namespace PPather
         public static Vector3[] CreatePoints(TriangleCollection collection)
         {
             Vector3[] points = new Vector3[collection.VertexCount];
-            for (int i = 0; i < collection.VertexCount; i++)
+            var span = CollectionsMarshal.AsSpan(collection.Vertecies);
+            for (int i = 0; i < span.Length; i++)
             {
-                collection.GetVertex(i, out float x, out float y, out float z);
-                points[i] = new(x, y, z);
+                points[i] = span[i];
             }
 
             return points;
         }
 
-        public static int[] CreateTriangles(int modelType, TriangleCollection tc)
+        public static IEnumerable<int> CreateTriangles(TriangleType modelType, TriangleCollection tc)
         {
-            int[] triangles = new int[tc.TriangleCount * 3];
-            int triangleNumber = 0;
-            int vertexOffset = 0;
+            List<int> triangles = new();
             for (int i = 0; i < tc.TriangleCount; i++)
             {
-                tc.GetTriangle(i, out int v0, out int v1, out int v2, out int flags, out _);
-                if (flags == modelType)
-                {
-                    triangles[(triangleNumber * 3) + 0] = v0 + vertexOffset;
-                    triangles[(triangleNumber * 3) + 1] = v1 + vertexOffset;
-                    triangles[(triangleNumber * 3) + 2] = v2 + vertexOffset;
-                }
-                else
-                {
-                    triangles[(triangleNumber * 3) + 0] = -1;
-                    triangles[(triangleNumber * 3) + 1] = -1;
-                    triangles[(triangleNumber * 3) + 2] = -1;
-                }
-                triangleNumber++;
+                tc.GetTriangle(i, out int v0, out int v1, out int v2, out TriangleType flags);
+                if (flags != modelType)
+                    continue;
+
+                triangles.Add(v0);
+                triangles.Add(v1);
+                triangles.Add(v2);
             }
-            vertexOffset += tc.VertexCount;
-            return triangles.Where(t => t != -1).ToArray();
+            return triangles;
         }
     }
 }

--- a/PPather/Search/Search.cs
+++ b/PPather/Search/Search.cs
@@ -32,19 +32,15 @@ namespace PPather
 
         public Vector4 CreateWorldLocation(float x, float y, float z, int mapId)
         {
-            float zTerrain = GetZValueAt(x, y, z,
-                new int[] { ChunkedTriangleCollection.TriangleTerrain });
-
-            float zWater = GetZValueAt(x, y, z,
-                new int[] { ChunkedTriangleCollection.TriangleFlagDeepWater });
+            float zTerrain = GetZValueAt(x, y, z, TriangleType.Terrain);
+            float zWater = GetZValueAt(x, y, z, TriangleType.Water);
 
             if (zWater > zTerrain)
             {
                 return new Vector4(x, y, zWater, mapId);
             }
 
-            float zModel = GetZValueAt(x, y, z,
-            new int[] { ChunkedTriangleCollection.TriangleFlagModel, ChunkedTriangleCollection.TriangleFlagObject });
+            float zModel = GetZValueAt(x, y, z, TriangleType.Model | TriangleType.Object);
 
             if (zModel != float.MinValue)
             {
@@ -61,7 +57,7 @@ namespace PPather
             return new Vector4(x, y, zTerrain, mapId);
         }
 
-        private float GetZValueAt(float x, float y, float z, int[] allowedModels)
+        private float GetZValueAt(float x, float y, float z, TriangleType allowedFlags)
         {
             float min = -1000;
             float max = 2000;
@@ -72,7 +68,7 @@ namespace PPather
                 max = z + 2000;
             }
 
-            if (PathGraph.triangleWorld.FindStandableAt1(x, y, min, max, out float z1, out int flags1, toonHeight, toonSize, true, allowedModels))
+            if (PathGraph.triangleWorld.FindStandableAt1(x, y, min, max, out float z1, out _, toonHeight, toonSize, true, allowedFlags))
             {
                 return z1;
             }
@@ -104,6 +100,10 @@ namespace PPather
             {
                 logger.LogError(ex.Message);
                 return null;
+            }
+            finally
+            {
+                PathGraph.SearchEnabled = false;
             }
         }
     }

--- a/PPather/Triangles/Data/QuadArray.cs
+++ b/PPather/Triangles/Data/QuadArray.cs
@@ -2,8 +2,8 @@
 {
     public readonly struct QuadArray
     {
-        private const int Q = 5;
-        private const int SIZE = 512 * Q; // Max size if SIZE*SIZE = 16M
+        private const int Q = 4;
+        private const int SIZE = 256 * Q; // Max size if SIZE*SIZE = 16M
 
         // Jagged array
         // pointer chasing FTL
@@ -18,37 +18,41 @@
 
         private static void getIndices(int index, out int i0, out int i1)
         {
-            i1 = index % SIZE; index /= SIZE;
+            i1 = index % SIZE;
+            index /= SIZE;
             i0 = index % SIZE;
         }
 
-        private void allocateAt(int i0, int i1)
+        private void allocateAt(int i0)
         {
             int[] a1 = arrays[i0];
-            if (a1 == null) { a1 = new int[SIZE * Q]; arrays[i0] = a1; }
+            if (a1 == null)
+            {
+                a1 = new int[SIZE * Q];
+                arrays[i0] = a1;
+            }
         }
 
         public void SetSize(int new_size)
         {
-            getIndices(new_size, out int i0, out int i1);
+            getIndices(new_size, out int i0, out _);
             for (int i = i0 + 1; i < SIZE; i++)
                 arrays[i] = null;
         }
 
-        public void Set(int index, int x, int y, int z, int w, int sequence)
+        public void Set(int index, int x, int y, int z, int flags)
         {
             getIndices(index, out int i0, out int i1);
-            allocateAt(i0, i1);
+            allocateAt(i0);
             int[] innermost = arrays[i0];
             i1 *= Q;
             innermost[i1 + 0] = x;
             innermost[i1 + 1] = y;
             innermost[i1 + 2] = z;
-            innermost[i1 + 3] = w;
-            innermost[i1 + 4] = sequence;
+            innermost[i1 + 3] = flags;
         }
 
-        public void Get(int index, out int x, out int y, out int z, out int w, out int sequence)
+        public void Get(int index, out int x, out int y, out int z, out int flags)
         {
             getIndices(index, out int i0, out int i1);
 
@@ -58,8 +62,7 @@
                 x = default;
                 y = default;
                 z = default;
-                w = default;
-                sequence = default;
+                flags = default;
                 return;
             }
 
@@ -68,8 +71,7 @@
             x = innermost[i1 + 0];
             y = innermost[i1 + 1];
             z = innermost[i1 + 2];
-            w = innermost[i1 + 3];
-            sequence = innermost[i1 + 4];
+            flags = innermost[i1 + 3];
         }
     }
 }

--- a/PPather/Triangles/Data/Triangle.cs
+++ b/PPather/Triangles/Data/Triangle.cs
@@ -1,0 +1,26 @@
+﻿namespace PPather.Triangles
+{
+    public readonly struct Triangle<T>
+    {
+        private readonly T v0;
+        private readonly T v1;
+        private readonly T v2;
+        private readonly TriangleType Flags;
+
+        public Triangle(T v0, T v1, T v2, TriangleType flags)
+        {
+            this.v0 = v0;
+            this.v1 = v1;
+            this.v2 = v2;
+            Flags = flags;
+        }
+
+        public void Deconstruct(out T v0, out T v1, out T v2, out TriangleType flags)
+        {
+            v0 = this.v0;
+            v1 = this.v1;
+            v2 = this.v2;
+            flags = Flags;
+        }
+    }
+}

--- a/PPather/Triangles/Data/TriangleType.cs
+++ b/PPather/Triangles/Data/TriangleType.cs
@@ -1,0 +1,20 @@
+﻿namespace PPather
+{
+    [System.Flags]
+    public enum TriangleType : byte
+    {
+        Terrain = 0,
+        Water = 1,
+        Object = 2,
+        Model = 4,
+    }
+
+    public static class TriangleType_Ext
+    {
+        public static bool Has(this TriangleType flags, TriangleType flag)
+        {
+            return (flags & flag) != 0;
+        }
+    }
+
+}

--- a/PPather/Triangles/TriangleCollection.cs
+++ b/PPather/Triangles/TriangleCollection.cs
@@ -4,11 +4,13 @@
  *
  */
 
+using System.Collections.Generic;
 using System.Numerics;
 
 using Microsoft.Extensions.Logging;
 
-using PPather.Triangles.Data;
+using PPather;
+using PPather.Triangles;
 
 namespace WowTriangles
 {
@@ -18,8 +20,8 @@ namespace WowTriangles
     public sealed class TriangleCollection
     {
         private readonly ILogger logger;
-        private readonly TrioArray vertices;
-        private readonly QuadArray triangles;
+        public List<Vector3> Vertecies { get; }
+        public List<Triangle<int>> Triangles { get; }
 
         private TriangleMatrix matrix;
 
@@ -37,29 +39,18 @@ namespace WowTriangles
         private Vector3 limit_min = new(-1E30f, -1E30f, -1E30f);
 
         private int triangleCount;
-        public int TriangleCount => triangleCount;
+        public int TriangleCount => Triangles.Count;
 
-        private int vertexCount;
-        public int VertexCount => vertexCount;
+        public int VertexCount { get; private set; }
 
         public TriangleCollection(ILogger logger)
         {
             this.logger = logger;
-
-            vertices = new TrioArray();
-            triangles = new QuadArray();
+            Vertecies = new(65536); // terrain mesh
+            Triangles = new(128);
         }
 
         public bool HasTriangleMatrix => matrix != null;
-
-        public void Clear()
-        {
-            vertices.SetSize(0);
-            triangles.SetSize(0);
-
-            triangleCount = 0;
-            vertexCount = 0;
-        }
 
         public TriangleMatrix GetTriangleMatrix()
         {
@@ -67,48 +58,6 @@ namespace WowTriangles
                 matrix = new TriangleMatrix(this, logger);
 
             return matrix;
-        }
-
-        public void CompactVertices()
-        {
-            bool[] used_indices = new bool[vertexCount];
-            int[] old_to_new = new int[vertexCount];
-
-            // check what vertives are used
-            for (int i = 0; i < triangleCount; i++)
-            {
-                GetTriangle(i, out int v0, out int v1, out int v2);
-                used_indices[v0] = true;
-                used_indices[v1] = true;
-                used_indices[v2] = true;
-            }
-
-            // figure out new indices and move
-            int sum = 0;
-            for (int i = 0; i < used_indices.Length; i++)
-            {
-                if (used_indices[i])
-                {
-                    old_to_new[i] = sum;
-                    vertices.Get(i, out float x, out float y, out float z);
-                    vertices.Set(sum, x, y, z);
-                    sum++;
-                }
-                else
-                {
-                    old_to_new[i] = -1;
-                }
-            }
-
-            vertices.SetSize(sum);
-
-            // Change all triangles
-            for (int i = 0; i < triangleCount; i++)
-            {
-                GetTriangle(i, out int v0, out int v1, out int v2, out int flags, out int sequence);
-                triangles.Set(i, old_to_new[v0], old_to_new[v1], old_to_new[v2], flags, sequence);
-            }
-            vertexCount = sum;
         }
 
         public void SetLimits(float min_x, float min_y, float min_z,
@@ -120,32 +69,26 @@ namespace WowTriangles
 
         public int AddVertex(float x, float y, float z)
         {
-            vertices.Set(vertexCount, x, y, z);
-            return vertexCount++;
+            VerticesSet(VertexCount, x, y, z);
+            return VertexCount++;
         }
 
         // big list if triangles (3 vertice IDs per triangle)
-        public int AddTriangle(int v0, int v1, int v2, int flags, int sequence)
+        public void AddTriangle(int v0, int v1, int v2, TriangleType flags)
         {
             // check limits
             if (!CheckVertexLimits(v0) &&
                 !CheckVertexLimits(v1) &&
                 !CheckVertexLimits(v2))
-                return -1;
+                return;
 
             // Create new
             SetMinMax(v0);
             SetMinMax(v1);
             SetMinMax(v2);
 
-            triangles.Set(triangleCount, v0, v1, v2, flags, sequence);
-            return triangleCount++;
-        }
-
-        // big list if triangles (3 vertice IDs per triangle)
-        public int AddTriangle(int v0, int v1, int v2)
-        {
-            return AddTriangle(v0, v1, v2, 0, 0);
+            TrianglesSet(triangleCount, v0, v1, v2, flags);
+            triangleCount++;
         }
 
         private void SetMinMax(int v)
@@ -181,66 +124,67 @@ namespace WowTriangles
 
         public void GetVertex(int i, out float x, out float y, out float z)
         {
-            vertices.Get(i, out x, out y, out z);
+            VerticesGet(i, out x, out y, out z);
         }
 
-        public void GetTriangle(int i, out int v0, out int v1, out int v2)
+        public void GetTriangle(int i,
+            out int v0, out int v1, out int v2, out TriangleType flags)
         {
-            triangles.Get(i, out v0, out v1, out v2, out _, out _);
-        }
-
-        public void GetTriangle(int i, out int v0, out int v1, out int v2, out int flags, out int sequence)
-        {
-            triangles.Get(i, out v0, out v1, out v2, out flags, out sequence);
+            TrianglesGet(i, out v0, out v1, out v2, out flags);
         }
 
         public void GetTriangleVertices(int i,
                                         out float x0, out float y0, out float z0,
                                         out float x1, out float y1, out float z1,
-                                        out float x2, out float y2, out float z2, out int flags, out int sequence)
+                                        out float x2, out float y2, out float z2, out TriangleType flags)
         {
-            triangles.Get(i, out int v0, out int v1, out int v2, out flags, out sequence);
-            vertices.Get(v0, out x0, out y0, out z0);
-            vertices.Get(v1, out x1, out y1, out z1);
-            vertices.Get(v2, out x2, out y2, out z2);
+            TrianglesGet(i, out int v0, out int v1, out int v2, out flags);
+
+            VerticesGet(v0, out x0, out y0, out z0);
+            VerticesGet(v1, out x1, out y1, out z1);
+            VerticesGet(v2, out x2, out y2, out z2);
         }
 
+        [System.Runtime.CompilerServices.SkipLocalsInit]
         public void GetTriangleVertices(int i,
                                         out float x0, out float y0, out float z0,
                                         out float x1, out float y1, out float z1,
                                         out float x2, out float y2, out float z2)
         {
-            triangles.Get(i, out int v0, out int v1, out int v2, out _, out _);
-            vertices.Get(v0, out x0, out y0, out z0);
-            vertices.Get(v1, out x1, out y1, out z1);
-            vertices.Get(v2, out x2, out y2, out z2);
+            TrianglesGet(i, out int v0, out int v1, out int v2, out _);
+
+            VerticesGet(v0, out x0, out y0, out z0);
+            VerticesGet(v1, out x1, out y1, out z1);
+            VerticesGet(v2, out x2, out y2, out z2);
         }
 
-        public float[] GetFlatVertices()
+        [System.Runtime.CompilerServices.SkipLocalsInit]
+        private void VerticesGet(int index, out float x, out float y, out float z)
         {
-            float[] flat = new float[VertexCount * 3];
-            for (int i = 0; i < VertexCount; i++)
-            {
-                int off = i * 3;
-                vertices.Get(i, out flat[off], out flat[off + 1], out flat[off + 2]);
-            }
-            return flat;
+            var local = Vertecies;
+            Vector3 v = local[index];
+            x = v.X;
+            y = v.Y;
+            z = v.Z;
         }
 
-        public void AddAllTrianglesFrom(TriangleCollection set)
+        private void VerticesSet(int index, float x, float y, float z)
         {
-            for (int i = 0; i < set.TriangleCount; i++)
-            {
-                set.GetTriangleVertices(i,
-                    out float v0x, out float v0y, out float v0z,
-                    out float v1x, out float v1y, out float v1z,
-                    out float v2x, out float v2y, out float v2z);
+            Vertecies.Insert(index, new(x, y, z));
+        }
 
-                int v0 = AddVertex(v0x, v0y, v0z);
-                int v1 = AddVertex(v1x, v1y, v1z);
-                int v2 = AddVertex(v2x, v2y, v2z);
-                AddTriangle(v0, v1, v2);
-            }
+
+        [System.Runtime.CompilerServices.SkipLocalsInit]
+        private void TrianglesGet(int index, out int v0, out int v1, out int v2, out TriangleType flags)
+        {
+            var local = Triangles;
+            Triangle<int> t = local[index];
+            (v0, v1, v2, flags) = t;
+        }
+
+        private void TrianglesSet(int index, int v0, int v1, int v2, TriangleType flags)
+        {
+            Triangles.Insert(index, new(v0, v1, v2, flags));
         }
     }
 }

--- a/PPather/Triangles/TriangleMatrix.cs
+++ b/PPather/Triangles/TriangleMatrix.cs
@@ -20,15 +20,14 @@ namespace WowTriangles
 {
     public sealed class TriangleMatrix
     {
-        private const float resolution = 2.0f;
+        private const float resolution = 6.0f;
         private readonly SparseFloatMatrix2D<List<int>> matrix;
 
         public TriangleMatrix(TriangleCollection tc, ILogger logger)
         {
             DateTime pre = DateTime.UtcNow;
 
-            int capacity = (int)(tc.TriangleCount / (resolution * 150)); // 150 - 2
-            matrix = new SparseFloatMatrix2D<List<int>>(resolution, capacity);
+            matrix = new SparseFloatMatrix2D<List<int>>(resolution);
 
             Vector3 vertex0;
             Vector3 vertex1;
@@ -90,7 +89,7 @@ namespace WowTriangles
             }
 
             if (logger.IsEnabled(LogLevel.Trace))
-                logger.LogTrace($"Build hash for {tc.TriangleCount} triangles - {maxAtOne} -- cap: {capacity} - c: {listCount} - time {(DateTime.UtcNow - pre).TotalMilliseconds}ms");
+                logger.LogTrace($"Build hash for {tc.TriangleCount} triangles - {maxAtOne} - c: {listCount} - time {(DateTime.UtcNow - pre).TotalMilliseconds}ms");
         }
 
         public ArraySegment<int> GetAllCloseTo(float x, float y, float distance)

--- a/PPather/Triangles/Utils.cs
+++ b/PPather/Triangles/Utils.cs
@@ -27,12 +27,11 @@ namespace WowTriangles
 {
     public static class Utils
     {
+        [System.Runtime.CompilerServices.SkipLocalsInit]
         public static bool SegmentTriangleIntersect(in Vector3 p0, in Vector3 p1,
                                                     in Vector3 t0, in Vector3 t1, in Vector3 t2,
                                                     out Vector3 I)
         {
-            I = new();
-
             Vector3 u = Subtract(t1, t0); // triangle vector 1
             Vector3 v = Subtract(t2, t0); // triangle vector 2
             Vector3 n = Cross(u, v); // triangle normal
@@ -41,12 +40,24 @@ namespace WowTriangles
             Vector3 w0 = Subtract(p0, t0);
             float a = -Dot(n, w0);
             float b = Dot(n, dir);
-            if (Abs(b) < float.Epsilon) return false; // parallel
+            if (Abs(b) < float.Epsilon)
+            {
+                I = new();
+                return false; // parallel
+            }
 
             // get intersect point of ray with triangle plane
             float r = a / b;
-            if (r < 0.0f) return false; // "before" p0
-            if (r > 1.0f) return false; // "after" p1
+            if (r < 0.0f)
+            {
+                I = new();
+                return false; // "before" p0
+            }
+            if (r > 1.0f)
+            {
+                I = new();
+                return false; // "after" p1
+            }
 
             Vector3 M = Multiply(dir, r);
             I = Add(p0, M);// intersect point of line and plane
@@ -144,6 +155,7 @@ namespace WowTriangles
 
         // From the book "Real-Time Collision Detection" by Christer Ericson, page 169
         // See also the published Errata at http://realtimecollisiondetection.net/books/rtcd/errata/
+        [System.Runtime.CompilerServices.SkipLocalsInit]
         public static bool TestTriangleBoxIntersect(in Vector3 a, in Vector3 b, in Vector3 c, in Vector3 boxCenter, in Vector3 boxExtents)
         {
             // Translate triangle as conceptually moving AABB to origin

--- a/PathingAPI/Pages/Index.razor
+++ b/PathingAPI/Pages/Index.razor
@@ -8,7 +8,7 @@
         display: flex;
         flex-direction: column;
         overflow-y: scroll;
-        max-height: 72px;
+        max-height: 60px;
     }
 </style>
 

--- a/PathingAPI/Pages/SearchParameters.razor
+++ b/PathingAPI/Pages/SearchParameters.razor
@@ -3,7 +3,7 @@
 
 @inject IJSRuntime jsRuntime
 
-<span class="form-inline">
+<span class="form-inline px-4">
 
     <!-- Continent Combo -->
     <label>Continent:</label>

--- a/PathingAPI/Pages/Watch.razor
+++ b/PathingAPI/Pages/Watch.razor
@@ -22,7 +22,7 @@
     <span>Reset</span>
 </button>
 *@
-<div id="canvasText" style="position: relative; z-index: 2; left: 0px;padding-left:10px; top: 20px; height:30px; background-color: black;color:white">
+<div id="canvasText" style="position: relative; z-index: 2; left: 0px;padding-left:10px; height:30px; background-color: black;color:white">
     ...
 </div>
 <canvas id="renderCanvas" style="background:black">
@@ -37,6 +37,8 @@
     private Thread thread;
     private CancellationTokenSource cts;
     private JsonSerializerOptions options;
+
+    private Queue<ChunkEventArgs> chunkEventArgs = new();
 
     private Vector4 lastFrom;
     private Vector4 lastTo;
@@ -155,6 +157,11 @@
     {
         if (spotPath != null)
         {
+            while (chunkEventArgs.TryDequeue(out var e))
+            {
+                await DequeueChunkEvent(e);
+            }
+
             await jsRuntime.InvokeVoidAsync("removeMeshes", Name);
             await jsRuntime.InvokeVoidAsync("drawPath",
                 JsonSerializer.Serialize(spotPath.locations, options), PathColour, Name);
@@ -182,16 +189,22 @@
             JsonSerializer.Serialize(e.Locations, options), e.Colour, e.Name);
     }
 
-    private async void OnChunkAdded(ChunkEventArgs e)
+    private /*async*/ void OnChunkAdded(ChunkEventArgs e)
+    {
+        chunkEventArgs.Enqueue(e);
+        //_ = DequeueChunkEvent(e);
+    }
+
+    private async ValueTask DequeueChunkEvent(ChunkEventArgs e)
     {
         TriangleCollection chunks = pPatherService.GetChunkAt(e.GridX, e.GridY);
 
         int i = 0;
-        int[][] models = new int[4][];
-        models[i++] = MeshFactory.CreateTriangles(0, chunks);
-        models[i++] = MeshFactory.CreateTriangles(1, chunks);
-        models[i++] = MeshFactory.CreateTriangles(2, chunks);
-        models[i++] = MeshFactory.CreateTriangles(4, chunks);
+        IEnumerable<int>[] models = new IEnumerable<int>[4];
+        models[i++] = MeshFactory.CreateTriangles(TriangleType.Terrain, chunks);
+        models[i++] = MeshFactory.CreateTriangles(TriangleType.Water, chunks);
+        models[i++] = MeshFactory.CreateTriangles(TriangleType.Object, chunks);
+        models[i++] = MeshFactory.CreateTriangles(TriangleType.Model, chunks);
 
         Vector3[] positions = MeshFactory.CreatePoints(chunks);
 

--- a/PathingAPI/Shared/MainLayout.razor
+++ b/PathingAPI/Shared/MainLayout.razor
@@ -5,7 +5,7 @@
 </div>
 
 <div class="main">
-    <div class="content px-4">
+    <div class="content">
         @Body
     </div>
 </div>

--- a/PathingAPI/wwwroot/css/site.css
+++ b/PathingAPI/wwwroot/css/site.css
@@ -168,8 +168,9 @@ app {
     }
 
     .main > div {
-        padding-left: 2rem !important;
-        padding-right: 1.5rem !important;
+        /*padding-left: 2rem !important;
+        padding-right: 1.5rem !important;*/
+        padding-top: 0;
     }
 
     .navbar-toggler {


### PR DESCRIPTION
Changes: 
* Utilizing `ArrayPools` when its possible.
* Storing `Triangle<T>` data more efficiently.
* Using `List` over old custom array allocator for `Triangle`.
* TriangleMatrix: reduce resolution from 2 to 6. Should gain 4x speed up 🤞
* Utils: Hot path function `SkipLocalInit` applied.
* Increase cost of crossing water terrain type from 30 -> 50