### PR TITLE
Refactor: Core: `RequirementFactory`: use `ReadOnlySpan` for parsing `Requirement`

### DIFF
--- a/Core/Actionbar/ActionBarCostReader.cs
+++ b/Core/Actionbar/ActionBarCostReader.cs
@@ -90,7 +90,7 @@ namespace Core
             OnActionCostReset?.Invoke();
         }
 
-        public ActionBarCost GetCostByActionBarSlot(KeyAction keyAction, int costIndex = 0)
+        public ActionBarCost Get(KeyAction keyAction, int costIndex = 0)
         {
             int slotIdx = keyAction.SlotIndex;
             return data[slotIdx][costIndex];

--- a/Core/ClassConfig/KeyAction.cs
+++ b/Core/ClassConfig/KeyAction.cs
@@ -1,4 +1,4 @@
-using Core.Goals;
+﻿using Core.Goals;
 
 using Microsoft.Extensions.Logging;
 
@@ -300,7 +300,7 @@ namespace Core
         {
             for (int i = 0; i < ActionBar.NUM_OF_COST; i++)
             {
-                ActionBarCost abc = actionBarCostReader.GetCostByActionBarSlot(this, i);
+                ActionBarCost abc = actionBarCostReader.Get(this, i);
                 if (abc.Cost == 0)
                     continue;
 

--- a/Json/class/Rogue_20.json
+++ b/Json/class/Rogue_20.json
@@ -18,7 +18,7 @@
         "Key": 6,
         "WhenUsable": true,
         "UseWhenTargetIsCasting": true
-        //"Requirement": "TargetCastingSpell:9053|11443"
+        //"Requirement": "TargetCastingSpell:9053,11443"
       },
       {
         "Name": "Evasion",

--- a/README.md
+++ b/README.md
@@ -1507,7 +1507,7 @@ Combined with the `KeyAction.UseWhenTargetIsCasting` property, this requirement 
 
 Firstly `"TargetCastingSpell"` as it is without mentioning any spellID. Simply tells if the target is doing any cast at all.
 
-Secondly can specify the following Format `"TargetCastingSpell:spellID1|spellID2|..."` which translates to "if Target is casting spellID1 OR spellID2 OR ...".
+Secondly can specify the following Format `"TargetCastingSpell:spellID1,spellID2,..."` which translates to "if Target is casting spellID1 OR spellID2 OR ...".
 
 e.g. Rogue_20.json
 ```json
@@ -1522,7 +1522,7 @@ e.g. Rogue_20.json
 {
     "Name": "Kick",
     "UseWhenTargetIsCasting": true,
-    "Requirement": "TargetCastingSpell:9053|11443"
+    "Requirement": "TargetCastingSpell:9053,11443"
 },
 {
     "Name": "Kick",


### PR DESCRIPTION
Breaking Change:
* For `TargetCastingSpell` Requirement the separator character has been changed from `|` -> `,` as it remained in infinite loop while parsing `InfixToPostFix` ...
* Should no longer allocate an extra array while parsing Requirement values.