### PR TITLE
Addon: [1.7.35] - Addon: update bag inventory for 10.0 - Core: Dependency Injection for BlazorServer

### DIFF
--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -76,8 +76,12 @@ local GetMoney = GetMoney
 local GetContainerNumSlots = DataToColor.GetContainerNumSlots
 local GetComboPoints = GetComboPoints
 
+local NUM_BAG_SLOTS = NUM_BAG_SLOTS
+
+local ContainerIDToInventoryID = DataToColor.ContainerIDToInventoryID
 local GetContainerItemLink = DataToColor.GetContainerItemLink
 local PickupContainerItem = DataToColor.PickupContainerItem
+local GetInventoryItemLink = GetInventoryItemLink
 local DeleteCursorItem = DeleteCursorItem
 local GetMerchantItemLink = GetMerchantItemLink
 local GetItemInfo = GetItemInfo
@@ -309,8 +313,15 @@ function DataToColor:InitUpdateQueues()
 end
 
 function DataToColor:InitEquipmentQueue()
-    for eqNum = 0, 23 do
+    -- ammo slot till tabard
+    for eqNum = 0, 19 do
         DataToColor.equipmentQueue:push(eqNum)
+    end
+
+    -- backpacks
+    for i = 1, NUM_BAG_SLOTS do
+        local invID = ContainerIDToInventoryID(i)
+        DataToColor.equipmentQueue:push(invID)
     end
 end
 
@@ -535,9 +546,17 @@ function DataToColor:CreateFrames(n)
 
                 -- 23 24
                 local equipmentSlot = DataToColor.equipmentQueue:shift() or 0
-                Pixel(int, equipmentSlot, 23)
-                Pixel(int, DataToColor:equipSlotItemId(equipmentSlot), 24)
-                --DataToColor:Print("equipmentQueue ", equipmentSlot, " -> ", itemId)
+
+                -- TODO map new slot to old
+                -- should be calculated
+                local slot = equipmentSlot
+                if slot >= 30 then
+                    slot = slot - 11
+                end
+                Pixel(int, slot, 23)
+                local itemId = DataToColor:equipSlotItemId(equipmentSlot)
+                Pixel(int, itemId, 24)
+                --DataToColor:Print("equipmentQueue ", equipmentSlot, " slot -> ", slot, " -> ", itemId)
             end
 
             Pixel(int, DataToColor:isCurrentAction(1, 24), 25)

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -3,7 +3,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors
-## Version: 1.7.34
+## Version: 1.7.35
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/EventHandlers.lua
+++ b/Addons/DataToColor/EventHandlers.lua
@@ -30,6 +30,9 @@ local RepopMe = RepopMe
 local RetrieveCorpse = RetrieveCorpse
 local GetCorpseRecoveryDelay = GetCorpseRecoveryDelay
 
+local ContainerIDToInventoryID = DataToColor.ContainerIDToInventoryID
+local NUM_BAG_SLOTS = NUM_BAG_SLOTS
+
 local CAST_START = 999998
 local CAST_SUCCESS = 999999
 
@@ -434,12 +437,14 @@ function DataToColor:OnLootClosed(event)
 end
 
 function DataToColor:OnBagUpdate(event, containerID)
-    if containerID >= 0 and containerID <= 4 then
+    if containerID >= 0 and containerID <= NUM_BAG_SLOTS then
         DataToColor.bagQueue:push(containerID)
         DataToColor:InitInventoryQueue(containerID)
 
         if containerID >= 1 then
-            DataToColor.equipmentQueue:push(19 + containerID) -- from tabard
+            local invID = ContainerIDToInventoryID(containerID)
+            --DataToColor:Print("OnBagUpdate "..containerID.." invID "..invID)
+            DataToColor.equipmentQueue:push(invID)
         end
     end
     --DataToColor:Print("OnBagUpdate "..containerID)

--- a/Addons/DataToColor/Versions.lua
+++ b/Addons/DataToColor/Versions.lua
@@ -46,17 +46,18 @@ local TBC252 = DataToColor.IsClassic_BCC() and select(4, GetBuildInfo()) >= 2050
 local Wrath340 = DataToColor.IsClassic_BCC() and select(4, GetBuildInfo()) >= 30400
 
 if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then
-	DataToColor.ClientVersion = 1
+  DataToColor.ClientVersion = 1
 elseif WOW_PROJECT_ID == WOW_PROJECT_WRATH_CLASSIC then
   DataToColor.ClientVersion = 4
 elseif WOW_PROJECT_ID == WOW_PROJECT_BURNING_CRUSADE_CLASSIC then
-	if LE_EXPANSION_LEVEL_CURRENT == LE_EXPANSION_NORTHREND or LE_EXPANSION_LEVEL_CURRENT == LE_EXPANSION_WRATH_OF_THE_LICH_KING then
-		DataToColor.ClientVersion = 4
-	elseif LE_EXPANSION_LEVEL_CURRENT == LE_EXPANSION_BURNING_CRUSADE then
-		DataToColor.ClientVersion = 3
-	end
+  if LE_EXPANSION_LEVEL_CURRENT == LE_EXPANSION_NORTHREND or
+      LE_EXPANSION_LEVEL_CURRENT == LE_EXPANSION_WRATH_OF_THE_LICH_KING then
+    DataToColor.ClientVersion = 4
+  elseif LE_EXPANSION_LEVEL_CURRENT == LE_EXPANSION_BURNING_CRUSADE then
+    DataToColor.ClientVersion = 3
+  end
 elseif WOW_PROJECT_ID == WOW_PROJECT_CLASSIC then
-	DataToColor.ClientVersion = 2
+  DataToColor.ClientVersion = 2
 end
 
 if DataToColor.IsRetail() or TBC253 or DataToColor.IsClassic_Wrath() then
@@ -106,8 +107,15 @@ end
 -- bag changes from 10.0
 
 DataToColor.GetContainerNumSlots = GetContainerNumSlots or C_Container.GetContainerNumSlots
-DataToColor.GetContainerItemInfo = GetContainerItemInfo or C_Container.GetContainerItemInfo
+DataToColor.GetContainerItemInfo = GetContainerItemInfo or
+    function(bagID, slot)
+      local o = C_Container.GetContainerItemInfo(bagID, slot)
+      if o == nil then return nil end
+      return o.iconFileID, o.stackCount, o.isLocked, o.quality, o.isReadable, o.hasLoot, o.hyperlink, o.isFiltered, o.hasNoValue, o.itemID, o.isBound
+    end
+
 DataToColor.GetContainerNumFreeSlots = GetContainerNumFreeSlots or C_Container.GetContainerNumFreeSlots
 DataToColor.GetContainerItemLink = GetContainerItemLink or C_Container.GetContainerItemLink
 DataToColor.PickupContainerItem = PickupContainerItem or C_Container.PickupContainerItem
 DataToColor.UseContainerItem = UseContainerItem or C_Container.UseContainerItem
+DataToColor.ContainerIDToInventoryID = ContainerIDToInventoryID or C_Container.ContainerIDToInventoryID

--- a/BlazorServer/Startup.cs
+++ b/BlazorServer/Startup.cs
@@ -9,7 +9,6 @@ using BlazorTable;
 using Core;
 using Core.Addon;
 using Core.Database;
-using Core.Environment;
 using Core.Session;
 
 using Game;
@@ -20,6 +19,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -129,8 +129,6 @@ public sealed class Startup
         services.AddSingleton<DataFrame[]>(x => FrameConfig.LoadFrames());
         services.AddSingleton<FrameConfigurator>();
 
-        services.AddSingleton<IEnvironment, BlazorFrontend>();
-
         if (AddonConfig.Exists() && FrameConfig.Exists())
         {
             services.AddSingleton<MinimapNodeFinder>();
@@ -171,6 +169,9 @@ public sealed class Startup
             services.AddSingleton<IBotController, ConfigBotController>();
             services.AddSingleton<IAddonReader, ConfigAddonReader>();
         }
+
+        services.AddSingleton<WApi>();
+        services.AddSingleton<FrontendUpdate>();
 
         services.AddMatBlazor();
         services.AddRazorPages();

--- a/Core/ConfigBotController.cs
+++ b/Core/ConfigBotController.cs
@@ -35,10 +35,7 @@ public sealed class ConfigBotController : IBotController, IDisposable
 
     private readonly Thread addonThread;
 
-    private readonly Thread? frontendThread;
-    private const int frontendTickMs = 250;
-
-    public ConfigBotController(ILogger logger, CancellationTokenSource cts, IAddonReader addonReader)
+    public ConfigBotController(ILogger logger, IAddonReader addonReader, CancellationTokenSource cts)
     {
         this.logger = logger;
         this.cts = cts;
@@ -46,26 +43,11 @@ public sealed class ConfigBotController : IBotController, IDisposable
 
         addonThread = new(AddonThread);
         addonThread.Start();
-
-        frontendThread = new(FrontendThread);
-        frontendThread.Start();
     }
 
     public void Dispose()
     {
         cts.Cancel();
-    }
-
-    private void FrontendThread()
-    {
-        while (!cts.IsCancellationRequested)
-        {
-            AddonReader.UpdateUI();
-            cts.Token.WaitHandle.WaitOne(frontendTickMs);
-        }
-
-        if (logger.IsEnabled(LogLevel.Debug))
-            logger.LogDebug("Frontend thread stopped!");
     }
 
     private void AddonThread()

--- a/Core/Environment/BlazorFrontend.cs
+++ b/Core/Environment/BlazorFrontend.cs
@@ -1,5 +1,0 @@
-﻿namespace Core.Environment;
-
-public sealed class BlazorFrontend : IEnvironment
-{
-}

--- a/Core/Environment/FrontendUpdate.cs
+++ b/Core/Environment/FrontendUpdate.cs
@@ -1,0 +1,37 @@
+﻿using System.Threading;
+
+using Microsoft.Extensions.Logging;
+
+namespace Core;
+
+public sealed class FrontendUpdate
+{
+    private readonly ILogger logger;
+    private readonly IAddonReader addonReader;
+    private readonly CancellationToken ct;
+
+    private readonly Thread thread;
+    private const int tickMs = 250;
+
+    public FrontendUpdate(ILogger logger, IAddonReader addonReader, CancellationTokenSource cts)
+    {
+        this.logger = logger;
+        this.addonReader = addonReader;
+        this.ct = cts.Token;
+
+        thread = new(Update);
+        thread.Start();
+    }
+
+    private void Update()
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            addonReader.UpdateUI();
+            ct.WaitHandle.WaitOne(tickMs);
+        }
+
+        if (logger.IsEnabled(LogLevel.Debug))
+            logger.LogDebug("Frontend thread stopped!");
+    }
+}

--- a/Core/Environment/Headless.cs
+++ b/Core/Environment/Headless.cs
@@ -1,5 +1,0 @@
-﻿namespace Core.Environment;
-
-public sealed class Headless : IEnvironment
-{
-}

--- a/Core/Environment/IEnvironment.cs
+++ b/Core/Environment/IEnvironment.cs
@@ -1,5 +1,0 @@
-﻿namespace Core.Environment;
-
-public interface IEnvironment
-{
-}

--- a/Core/WowheadAPI/WApi.cs
+++ b/Core/WowheadAPI/WApi.cs
@@ -3,51 +3,41 @@ using System.Xml;
 
 namespace Core;
 
-public static class WApi
+public sealed class WApi
 {
-    public static ClientVersion Version
+    private readonly string BaseUrl;
+
+    public WApi(StartupClientVersion scv)
     {
-        set
+        BaseUrl = scv.Version switch
         {
-            switch (value)
-            {
-                case ClientVersion.SoM:
-                    BaseUrl = "https://classic.wowhead.com";
-                    break;
-                case ClientVersion.TBC:
-                    BaseUrl = "https://tbc.wowhead.com";
-                    break;
-                case ClientVersion.Wrath:
-                    BaseUrl = "https://www.wowhead.com/wotlk";
-                    break;
-                default:
-                case ClientVersion.Retail:
-                    BaseUrl = "https://www.wowhead.com";
-                    break;
-            }
-        }
+            ClientVersion.SoM => "https://classic.wowhead.com",
+            ClientVersion.TBC => "https://tbc.wowhead.com",
+            ClientVersion.Wrath => "https://www.wowhead.com/wotlk",
+            _ => "https://www.wowhead.com",
+        };
     }
 
-    public static string BaseUrl { get; set; } = "https://www.wowhead.com";
-
-    public static string NpcId => $"{BaseUrl}/npc=";
-    public static string ItemId => $"{BaseUrl}/item=";
-    public static string SpellId => $"{BaseUrl}/spell=";
+    public string NpcId => $"{BaseUrl}/npc=";
+    public string ItemId => $"{BaseUrl}/item=";
+    public string SpellId => $"{BaseUrl}/spell=";
 
     public const string TinyIconUrl = "https://wow.zamimg.com/images/wow/icons/tiny/{0}.gif";
     public const string MedIconUrl = "https://wow.zamimg.com/images/wow/icons/medium/{0}.jpg";
 
-    public static async Task<string> FetchItemIconName(int itemId)
+    private static readonly XmlReaderSettings iconSettings = new() { Async = true, LineNumberOffset = 14 };
+    private const string ICON = "icon";
+
+    public async Task<string> FetchItemIconName(int itemId)
     {
         try
         {
-            using XmlReader reader = XmlReader.Create($"{ItemId}{itemId}&xml", new XmlReaderSettings { Async = true, LineNumberOffset = 14 });
-            while (await reader.ReadAsync())
+            using XmlReader xml = XmlReader.Create($"{ItemId}{itemId}&xml", iconSettings);
+            while (await xml.ReadAsync())
             {
-                if (reader.NodeType == XmlNodeType.Element && reader.Name.Contains("icon"))
+                if (xml.NodeType == XmlNodeType.Element && xml.Name.Contains(ICON))
                 {
-                    await reader.ReadAsync();
-                    return reader.Value;
+                    return await xml.ReadElementContentAsStringAsync();
                 }
             }
         }

--- a/Frontend/Pages/BagItemComponent.razor
+++ b/Frontend/Pages/BagItemComponent.razor
@@ -1,4 +1,6 @@
-﻿<a href="@($"{WApi.ItemId}{BagItem.ItemId}")" target="_blank" data-wowhead="item=@BagItem.ItemId" class="small" style="text-decoration:none">
+﻿@inject WApi api
+
+<a href="@($"{api.ItemId}{BagItem.ItemId}")" target="_blank" data-wowhead="item=@BagItem.ItemId" class="small" style="text-decoration:none">
     <b>
         <span style="color:@BagItemColour(BagItem.Item);font-weight:normal">
             @if (BagItem.Count > 1)
@@ -58,7 +60,7 @@
             return;
         }
 
-        iconName = await WApi.FetchItemIconName(BagItem.ItemId);
+        iconName = await api.FetchItemIconName(BagItem.ItemId);
         icons.TryAdd(BagItem.ItemId, iconName);
     }
 

--- a/Frontend/Pages/BotHeader.razor
+++ b/Frontend/Pages/BotHeader.razor
@@ -2,6 +2,7 @@
 
 @inject IAddonReader addonReader
 @inject IBotController botController
+@inject WApi api
 
 @implements IDisposable
 
@@ -32,7 +33,7 @@
                 <td>
                     @if (addonReader.PlayerReader.Bits.HasTarget())
                     {
-                        <a href="@($"{WApi.NpcId}{playerReader.TargetId}")" target="_blank">
+                        <a href="@($"{api.NpcId}{playerReader.TargetId}")" target="_blank">
                             <div>
                                 @addonReader.TargetName<br />
                                 (@playerReader.TargetLevel) @((int)playerReader.TargetHealthPercentage()) %<br />

--- a/Frontend/Pages/EquipmentComponent.razor
+++ b/Frontend/Pages/EquipmentComponent.razor
@@ -1,4 +1,6 @@
-﻿<a href="@($"{WApi.ItemId}{Item.Entry}")" target="_blank" data-wowhead="item=@Item.Entry" class="small" style="text-decoration:none">
+﻿@inject WApi api
+
+<a href="@($"{api.ItemId}{Item.Entry}")" target="_blank" data-wowhead="item=@Item.Entry" class="small" style="text-decoration:none">
     <img src="@imgLink" />
 </a>
 
@@ -32,7 +34,7 @@
             return;
         }
 
-        iconName = await WApi.FetchItemIconName(Item.Entry);
+        iconName = await api.FetchItemIconName(Item.Entry);
         icons.TryAdd(Item.Entry, iconName);
     }
 

--- a/Frontend/Pages/Index.razor
+++ b/Frontend/Pages/Index.razor
@@ -5,6 +5,7 @@
 @inject IBotController botController
 @inject IJSRuntime JSRuntime
 @inject AddonConfigurator addonConfigurator
+@inject FrontendUpdate updater // TODO: this is a hack to instantiate this class
 
 @implements IDisposable
 

--- a/Frontend/Pages/Swag.razor
+++ b/Frontend/Pages/Swag.razor
@@ -3,6 +3,7 @@
 @inject IAddonReader addonReader
 @inject IBotController botController
 @inject IJSRuntime JSRuntime
+@inject WApi api
 
 @implements IDisposable
 
@@ -38,7 +39,7 @@
                     @foreach (var bag in bagReader.Bags.Reverse())
                     {
                         <th>
-                            <a href="@($"{WApi.ItemId}{bag.ItemId}")" target="_blank">@bag.Name</a>
+                            <a href="@($"{api.ItemId}{bag.ItemId}")" target="_blank">@bag.Name</a>
                         </th>
                     }
                 </tr>

--- a/Frontend/Pages/TalentTreeComponent.razor
+++ b/Frontend/Pages/TalentTreeComponent.razor
@@ -1,6 +1,7 @@
 ﻿@using Core.Talents
 
 @inject IAddonReader addonReader
+@inject WApi api
 
 <div class="card mt-1">
     <div class="card-header">
@@ -40,7 +41,7 @@
                                         <td>
                                             @if (talentReader.Spells.TryGetValue(talent.Key, out int spellId))
                                             {
-                                                <a href="@($"{WApi.SpellId}{@spellId}")" target="_blank" data-wowhead="item=@spellId" class="small" style="text-decoration:none">
+                                                <a href="@($"{api.SpellId}{@spellId}")" target="_blank" data-wowhead="item=@spellId" class="small" style="text-decoration:none">
                                                     @DisplayName(talent.Value)
                                                 </a>
                                             }

--- a/HeadlessServer/Program.cs
+++ b/HeadlessServer/Program.cs
@@ -8,7 +8,6 @@ using Serilog;
 using Serilog.Events;
 using Serilog.Extensions.Logging;
 using CommandLine;
-using Core.Environment;
 using WinAPI;
 using System.Drawing;
 using SharedLib;
@@ -93,8 +92,6 @@ internal sealed class Program
             return false;
 
         services.AddSingleton<CancellationTokenSource>();
-
-        services.AddSingleton<IEnvironment, Headless>();
 
         services.AddSingleton<WowProcess>(x => new(options.Value.Pid));
         services.AddSingleton<StartupClientVersion>();


### PR DESCRIPTION
Issue:
* Since 10.0 patch, many old API has been [changed](https://wowpedia.fandom.com/wiki/Patch_10.0.2/API_changes)

Fix:
* Inventory and bag info should be obtained properly, and BlazorServer Frontend should show up the values correctly

Changes:
* BlazorServer: `FrontendUpdate` only runs when the app started from BlazorServer
* Core: `WApi`: No longer static class and instantiated by DI

Tested:
* Classic Wrath PTR **3.4.1.47720**
* Classic Wrath **3.4.1.47720**
* Classic Era **1.14.3.46575**
* Classic Vanilla **1.14.0.40618**
* Classic BC **2.5.2.40892**