### PR TITLE
Core: ScreenCapture: Capture screen when its requested.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -275,6 +275,9 @@ Json/PPather/*.tmp
 Json/class/_
 Json/path/_
 
+# ScreenCaptures
+Json/cap/*.jpg
+
 # Configs
 **/frame_config.json
 **/addon_config.json

--- a/BlazorServer/Startup.cs
+++ b/BlazorServer/Startup.cs
@@ -133,6 +133,20 @@ public sealed class Startup
         {
             services.AddSingleton<MinimapNodeFinder>();
 
+            StartupConfigDiagnostics StartupDiagnostics = new();
+            Configuration.GetSection(StartupConfigDiagnostics.Position).Bind(StartupDiagnostics);
+
+            if (StartupDiagnostics.Enabled)
+            {
+                services.AddSingleton<IScreenCapture, ScreenCapture>();
+                Log.Information($"[{nameof(Startup)}] {nameof(ScreenCapture)}");
+            }
+            else
+            {
+                services.AddSingleton<IScreenCapture, NoScreenCapture>();
+                Log.Information($"[{nameof(Startup)}] {nameof(NoScreenCapture)}");
+            }
+
             services.AddSingleton<IGrindSessionDAO, LocalGrindSessionDAO>();
             services.AddSingleton<WorldMapAreaDB>();
             services.AddSingleton<IPPather>(x =>

--- a/BlazorServer/appsettings.json
+++ b/BlazorServer/appsettings.json
@@ -19,5 +19,8 @@
   },
   "Reader": {
     "Type": "GDI" // from Win7 'GDI' - from Win8 'DXGI'
+  },
+  "Diagnostics": {
+    "Enabled": false
   }
 }

--- a/Core/AddonDataProvider/AddonDataProviderGDIConfig.cs
+++ b/Core/AddonDataProvider/AddonDataProviderGDIConfig.cs
@@ -11,7 +11,7 @@ namespace Core;
 public sealed class AddonDataProviderGDIConfig : IAddonDataProvider, IDisposable
 {
     private readonly CancellationToken ct;
-    private readonly ManualResetEvent manualReset = new(true);
+    private readonly ManualResetEventSlim manualReset = new(true);
     private readonly WowScreen wowScreen;
 
     private readonly StringBuilder sb = new(3);
@@ -45,7 +45,7 @@ public sealed class AddonDataProviderGDIConfig : IAddonDataProvider, IDisposable
 
     public void Update()
     {
-        manualReset.WaitOne();
+        manualReset.Wait();
         ct.WaitHandle.WaitOne(25);
 
         if (ct.IsCancellationRequested ||

--- a/Core/BotController.cs
+++ b/Core/BotController.cs
@@ -33,6 +33,7 @@ public sealed partial class BotController : IBotController, IDisposable
     private readonly AutoResetEvent npcNameFinderEvent;
     private readonly NpcNameFinder npcNameFinder;
     private readonly NpcNameTargeting npcNameTargeting;
+    private readonly IScreenCapture screenCapture;
 
     private readonly Thread addonThread;
 
@@ -67,7 +68,7 @@ public sealed partial class BotController : IBotController, IDisposable
         IPPather pather, IGrindSessionDAO grindSessionDAO, DataConfig dataConfig,
         WowProcess wowProcess, WowScreen wowScreen, WowProcessInput wowProcessInput,
         ExecGameCommand execGameCommand, Wait wait, IAddonReader addonReader,
-        MinimapNodeFinder minimapNodeFinder)
+        MinimapNodeFinder minimapNodeFinder, IScreenCapture screenCapture)
     {
         this.logger = logger;
         this.pather = pather;
@@ -80,6 +81,7 @@ public sealed partial class BotController : IBotController, IDisposable
         this.AddonReader = (addonReader as AddonReader)!;
         this.wait = wait;
         this.minimapNodeFinder = minimapNodeFinder;
+        this.screenCapture = screenCapture;
 
         this.cts = cts;
         npcNameFinderEvent = new(false);
@@ -248,7 +250,7 @@ public sealed partial class BotController : IBotController, IDisposable
         RouteInfo = routeInfo;
 
         GoapAgent?.Dispose();
-        GoapAgent = new(profileLoadedScope, dataConfig, GrindSessionDAO, WowScreen, routeInfo);
+        GoapAgent = new(profileLoadedScope, dataConfig, GrindSessionDAO, WowScreen, screenCapture, routeInfo);
     }
 
     private ClassConfiguration ReadClassConfiguration(string classFile, string? pathFile)

--- a/Core/GOAP/Events/ScreenCaptureEvent.cs
+++ b/Core/GOAP/Events/ScreenCaptureEvent.cs
@@ -1,0 +1,8 @@
+﻿namespace Core.GOAP;
+
+public sealed class ScreenCaptureEvent : GoapEventArgs
+{
+    public static readonly ScreenCaptureEvent Default = new();
+
+    private ScreenCaptureEvent() { }
+}

--- a/Core/Goals/FollowRouteGoal.cs
+++ b/Core/Goals/FollowRouteGoal.cs
@@ -33,7 +33,7 @@ public sealed class FollowRouteGoal : GoapGoal, IGoapEventListener, IRouteProvid
     private const int MIN_TIME_TO_START_CYCLE_PROFESSION = 5000;
     private const int CYCLE_PROFESSION_PERIOD = 8000;
 
-    private readonly ManualResetEvent sideActivityManualReset;
+    private readonly ManualResetEventSlim sideActivityManualReset;
     private readonly Thread? sideActivityThread;
     private CancellationTokenSource sideActivityCts;
 
@@ -189,7 +189,10 @@ public sealed class FollowRouteGoal : GoapGoal, IGoapEventListener, IRouteProvid
             wait.Update();
 
             if (playerReader.Bits.HasTarget())
-                LogWarning("Unable to clear target! Check Bindpad settings!");
+            {
+                SendGoapEvent(ScreenCaptureEvent.Default);
+                LogWarning($"Unable to clear target! Check Bindpad settings!");
+            }
         }
 
         if (playerReader.Bits.IsDrowning())
@@ -209,7 +212,7 @@ public sealed class FollowRouteGoal : GoapGoal, IGoapEventListener, IRouteProvid
 
     private void Thread_LookingForTarget()
     {
-        sideActivityManualReset.WaitOne();
+        sideActivityManualReset.Wait();
 
         while (!sideActivityCts.IsCancellationRequested)
         {
@@ -221,7 +224,7 @@ public sealed class FollowRouteGoal : GoapGoal, IGoapEventListener, IRouteProvid
             else
                 sideActivityCts.Token.WaitHandle.WaitOne(1);
 
-            sideActivityManualReset.WaitOne();
+            sideActivityManualReset.Wait();
         }
 
         if (logger.IsEnabled(LogLevel.Debug))
@@ -230,7 +233,7 @@ public sealed class FollowRouteGoal : GoapGoal, IGoapEventListener, IRouteProvid
 
     private void Thread_AttendedGather()
     {
-        sideActivityManualReset.WaitOne();
+        sideActivityManualReset.Wait();
 
         while (!sideActivityCts.IsCancellationRequested)
         {
@@ -239,7 +242,7 @@ public sealed class FollowRouteGoal : GoapGoal, IGoapEventListener, IRouteProvid
                 AlternateGatherTypes();
             }
             sideActivityCts.Token.WaitHandle.WaitOne(CYCLE_PROFESSION_PERIOD);
-            sideActivityManualReset.WaitOne();
+            sideActivityManualReset.Wait();
         }
 
         if (logger.IsEnabled(LogLevel.Debug))

--- a/Core/Goals/LootGoal.cs
+++ b/Core/Goals/LootGoal.cs
@@ -102,7 +102,15 @@ public sealed class LootGoal : GoapGoal, IGoapEventListener
         {
             (bool t, double e) = wait.Until(MAX_TIME_TO_DETECT_LOOT, LootWindowClosedOrBagOrMoneyChanged, input.ApproachOnCooldown);
             success = !t;
-            Log($"Loot {((success && !bagReader.BagsFull()) ? "Successful" : "Failed")} after {e}ms");
+            if (success && !bagReader.BagsFull())
+            {
+                Log($"Loot Successful after {e}ms");
+            }
+            else
+            {
+                SendGoapEvent(ScreenCaptureEvent.Default);
+                Log($"Loot Failed {e}ms");
+            }
 
             gatherCorpse &= success;
 
@@ -117,7 +125,8 @@ public sealed class LootGoal : GoapGoal, IGoapEventListener
         }
         else
         {
-            Log("Loot Failed, target not found!");
+            SendGoapEvent(ScreenCaptureEvent.Default);
+            Log($"Loot Failed, target not found!");
         }
 
         SendGoapEvent(new RemoveClosestPoi(CorpseEvent.NAME));
@@ -129,7 +138,10 @@ public sealed class LootGoal : GoapGoal, IGoapEventListener
             wait.Update();
 
             if (playerReader.Bits.HasTarget())
-                LogWarning("Unable to clear target! Check Bindpad settings!");
+            {
+                SendGoapEvent(ScreenCaptureEvent.Default);
+                LogWarning($"Unable to clear target! Check Bindpad settings!");
+            }
         }
 
         if (corpseLocations.Count > 0)

--- a/Core/Goals/SkinningGoal.cs
+++ b/Core/Goals/SkinningGoal.cs
@@ -142,6 +142,7 @@ public sealed class SkinningGoal : GoapGoal, IGoapEventListener, IDisposable
 
             if (!foundTarget)
             {
+                SendGoapEvent(ScreenCaptureEvent.Default);
                 LogWarning($"Unable to gather Target({playerReader.TargetId})!");
                 ExitInterruptOrFailed(false);
                 return;
@@ -229,7 +230,17 @@ public sealed class SkinningGoal : GoapGoal, IGoapEventListener, IDisposable
     private void ExitSuccess()
     {
         (bool t, double e) = wait.Until(MAX_TIME_TO_DETECT_LOOT, LootWindowClosedOrBagChanged);
-        Log($"Loot {((!t && !bagReader.BagsFull()) ? "Successful" : "Failed")} after {e}ms");
+
+        bool success = !t && !bagReader.BagsFull();
+        if (success)
+        {
+            Log($"Loot Successful after {e}ms");
+        }
+        else
+        {
+            SendGoapEvent(ScreenCaptureEvent.Default);
+            Log($"Loot Failed after {e}ms");
+        }
 
         SendGoapEvent(new RemoveClosestPoi(SkinCorpseEvent.NAME));
         state.GatherableCorpseCount = Math.Max(0, state.GatherableCorpseCount - 1);
@@ -253,7 +264,10 @@ public sealed class SkinningGoal : GoapGoal, IGoapEventListener, IDisposable
             wait.Update();
 
             if (playerReader.Bits.HasTarget())
-                LogWarning("Unable to clear target! Check Bindpad settings!");
+            {
+                SendGoapEvent(ScreenCaptureEvent.Default);
+                LogWarning($"Unable to clear target! Check Bindpad settings!");
+            }
         }
     }
 

--- a/Core/GoalsComponent/CastingHandlerInterruptWatchdog.cs
+++ b/Core/GoalsComponent/CastingHandlerInterruptWatchdog.cs
@@ -16,7 +16,7 @@ public sealed class CastingHandlerInterruptWatchdog : IDisposable
 
     private readonly Thread thread;
     private readonly CancellationTokenSource threadCts;
-    private readonly ManualResetEvent resetEvent;
+    private readonly ManualResetEventSlim resetEvent;
 
     private bool? initial;
     private Func<bool>? interrupt;
@@ -69,7 +69,7 @@ public sealed class CastingHandlerInterruptWatchdog : IDisposable
                 logger.LogWarning($"[{nameof(CastingHandlerInterruptWatchdog)}] waiting...");
 
             resetEvent.Reset();
-            resetEvent.WaitOne();
+            resetEvent.Wait();
         }
 
         if (logger.IsEnabled(LogLevel.Debug))

--- a/Core/GoalsComponent/Navigation.cs
+++ b/Core/GoalsComponent/Navigation.cs
@@ -64,7 +64,7 @@ public sealed partial class Navigation : IDisposable
 
     private readonly CancellationTokenSource _cts;
     private readonly Thread pathfinderThread;
-    private readonly ManualResetEvent manualReset;
+    private readonly ManualResetEventSlim manualReset;
 
     private int failedAttempt;
     private Vector3 lastFailedDestination;
@@ -404,7 +404,7 @@ public sealed partial class Navigation : IDisposable
                 }
                 pathRequests.Dequeue();
             }
-            manualReset.WaitOne();
+            manualReset.Wait();
         }
 
         if (logger.IsEnabled(LogLevel.Debug))

--- a/Core/Logging/LoggerSink.cs
+++ b/Core/Logging/LoggerSink.cs
@@ -1,6 +1,4 @@
-﻿using Serilog;
-using Serilog.Configuration;
-using Serilog.Core;
+﻿using Serilog.Core;
 using Serilog.Events;
 
 using System;

--- a/Core/ScreenCapture/IScreenCapture.cs
+++ b/Core/ScreenCapture/IScreenCapture.cs
@@ -1,0 +1,6 @@
+﻿namespace Core;
+
+public interface IScreenCapture
+{
+    void Request();
+}

--- a/Core/ScreenCapture/NoScreenCapture.cs
+++ b/Core/ScreenCapture/NoScreenCapture.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace Core;
+
+public sealed class NoScreenCapture : ScreenCaptureCleaner
+{
+    public NoScreenCapture(ILogger logger, DataConfig dataConfig)
+        : base(logger, dataConfig) { }
+
+    public override void Request() { }
+}

--- a/Core/ScreenCapture/ScreenCapture.cs
+++ b/Core/ScreenCapture/ScreenCapture.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Threading;
+
+using Game;
+
+using Microsoft.Extensions.Logging;
+
+namespace Core;
+
+public sealed partial class ScreenCapture : ScreenCaptureCleaner, IDisposable
+{
+    private readonly ILogger logger;
+    private readonly DataConfig dataConfig;
+    private readonly WowScreen wowScreen;
+    private readonly CancellationToken token;
+
+    private readonly ManualResetEventSlim manualReset;
+    private readonly Thread thread;
+
+    private readonly Bitmap bitmap;
+    private readonly Graphics graphics;
+
+    public ScreenCapture(ILogger logger, DataConfig dataConfig,
+        CancellationTokenSource cts, WowScreen wowScreen)
+        : base(logger, dataConfig)
+    {
+        this.logger = logger;
+        this.dataConfig = dataConfig;
+        this.token = cts.Token;
+        this.wowScreen = wowScreen;
+
+        bitmap = new(wowScreen.Rect.Width, wowScreen.Rect.Height);
+        graphics = Graphics.FromImage(bitmap);
+
+        manualReset = new(false);
+        thread = new(Thread);
+        thread.Start();
+    }
+
+    public void Dispose()
+    {
+        manualReset.Set();
+
+        graphics.Dispose();
+        bitmap.Dispose();
+    }
+
+    private void Thread()
+    {
+        manualReset.Wait();
+
+        while (!token.IsCancellationRequested)
+        {
+            manualReset.Reset();
+            try
+            {
+                string fileName = $"{DateTimeOffset.Now:MM_dd_HH_mm_ss_fff}.jpg";
+                LogScreenCapture(logger, fileName);
+
+                wowScreen.DrawBitmapTo(graphics);
+                bitmap.Save(Path.Join(dataConfig.Screenshot, fileName), ImageFormat.Jpeg);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, ex.Message);
+            }
+            manualReset.Wait();
+        }
+
+        if (logger.IsEnabled(LogLevel.Debug))
+            logger.LogDebug($"{nameof(ScreenCapture)} thread stopped!");
+    }
+
+    public override void Request()
+    {
+        manualReset.Set();
+    }
+
+
+    #region Logging 
+
+    [LoggerMessage(
+        EventId = 111,
+        Level = LogLevel.Information,
+        Message = "[ScreenCapture] {fileName}")]
+    static partial void LogScreenCapture(ILogger logger, string fileName);
+
+    #endregion
+}

--- a/Core/ScreenCapture/ScreenCaptureCleaner.cs
+++ b/Core/ScreenCapture/ScreenCaptureCleaner.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.IO;
+
+using Microsoft.Extensions.Logging;
+
+namespace Core;
+
+public abstract class ScreenCaptureCleaner : IScreenCapture
+{
+    public ScreenCaptureCleaner(ILogger logger, DataConfig dataConfig)
+    {
+        try
+        {
+            DateTime olderThen = DateTime.UtcNow.AddDays(-7);
+
+            DirectoryInfo di = new(dataConfig.Screenshot);
+            FileInfo[] files = di.GetFiles("*.jpg");
+            for (int i = files.Length - 1; i >= 0; i--)
+            {
+                FileInfo file = files[i];
+                if (file.CreationTimeUtc < olderThen)
+                {
+                    file.Delete();
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, ex.Message);
+        }
+    }
+
+    public abstract void Request();
+}

--- a/Core/StartupConfig/StartupConfigDiagnostics.cs
+++ b/Core/StartupConfig/StartupConfigDiagnostics.cs
@@ -1,0 +1,10 @@
+﻿namespace Core;
+
+public sealed class StartupConfigDiagnostics
+{
+    public const string Position = "Diagnostics";
+
+    public bool Enabled { get; }
+
+    public StartupConfigDiagnostics() { }
+}

--- a/DataConfig/DataConfig.cs
+++ b/DataConfig/DataConfig.cs
@@ -7,7 +7,7 @@ using static Newtonsoft.Json.JsonConvert;
 
 public static class DataConfigMeta
 {
-    public const int Version = 12;
+    public const int Version = 13;
     public const string DefaultFileName = "data_config.json";
 }
 
@@ -30,6 +30,8 @@ public sealed class DataConfig
     public string ExpArea => Join(Root, "area", Exp);
     [JsonIgnore]
     public string PPather => Join(Root, "PPather");
+    [JsonIgnore]
+    public string Screenshot => Join(Root, "cap");
     [JsonIgnore]
     public string ExpHistory => Join(Root, "History", Exp);
     [JsonIgnore]

--- a/Game/WoWScreen/WowScreen.cs
+++ b/Game/WoWScreen/WowScreen.cs
@@ -117,6 +117,12 @@ public sealed class WowScreen : IWowScreen, IBitmapProvider, IDisposable
         return bitmap;
     }
 
+    public void DrawBitmapTo(Graphics graphics)
+    {
+        Update();
+        graphics.DrawImage(Bitmap, 0, 0, rect, GraphicsUnit.Pixel);
+    }
+
     public Color GetColorAt(Point point)
     {
         return Bitmap.GetPixel(point.X, point.Y);

--- a/HeadlessServer/Program.cs
+++ b/HeadlessServer/Program.cs
@@ -103,6 +103,17 @@ internal sealed class Program
 
         services.AddSingleton<MinimapNodeFinder>();
 
+        if (options.Value.Diagnostics)
+        {
+            services.AddSingleton<IScreenCapture, ScreenCapture>();
+            Log.Information($"[{nameof(Program)}] {nameof(ScreenCapture)}");
+        }
+        else
+        {
+            services.AddSingleton<IScreenCapture, NoScreenCapture>();
+            Log.Information($"[{nameof(Program)}] {nameof(NoScreenCapture)}");
+        }
+
         services.AddSingleton<IGrindSessionDAO, LocalGrindSessionDAO>();
         services.AddSingleton<WorldMapAreaDB>();
         services.AddSingleton<IPPather>(x =>

--- a/HeadlessServer/RunOptions.cs
+++ b/HeadlessServer/RunOptions.cs
@@ -55,4 +55,10 @@ public sealed class RunOptions
         Default = 47111,
         HelpText = $"Navigation Remote V3 port")]
     public int Portv3 { get; set; }
+
+    [Option('d', "diag",
+        Required = false,
+        Default = false,
+        HelpText = $"Capture Screenshot for Diagnostics")]
+    public bool Diagnostics { get; set; }
 }

--- a/PPather/Search/PPatherService.cs
+++ b/PPather/Search/PPatherService.cs
@@ -46,7 +46,7 @@ public sealed class PPatherService
     {
         System.IO.DirectoryInfo di = new(dataConfig.PPather);
         System.IO.FileInfo[] files = di.GetFiles("*.tmp");
-        for (int i = 0; i < files.Length; i++)
+        for (int i = files.Length - 1; i >= 0; i--)
         {
             files[i].Delete();
         }

--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ In order to run `HeadlessServer` please look at the `HeadlessServer\run.bat`.
 | `portv1` | Navigation Remote V1 port | `5001` | - |
 | `hostv3` | Navigation Remote V3 host | `127.0.0.1` | - |
 | `portv3` | Navigation Remote V3 port | `47111` | - |
+| `-d` or `-diag` | Diagnostics, when set, takes screen captures under `Json\cap\*.json` | - | - |
 
 e.g. run from Powershell without any optional parameter
 ```ps


### PR DESCRIPTION
Useful while running in Diagnostics mode. Spotting issues. By default its off, have to opt-in. Saving the image to disk has been delegated to a worker thread, so the main both thread wont notice any slowdown nor cause extra allocations. The images going to be saved by default, under `Json\cap\*.jpg`.

**Note: the saved images expires after 7 days! Before sharing the images for investigation purposes, be sure to censor or blur your personal data!**

To match the log event with the captured image find the file name in the logs.

To enable Diagnostics:
* In `BlazorServer`: `appsettings.config` set `Diagnostics.Enabled` to `true`
* In `HeadlessServer`: use the designated cli command `-d` or `-diag`

The screen capture enabled during:
* `LootGoal` / `SkinningGoal`: When failed loot detected.
* Unable to clear target!

Other changes:
* Core: Replace `ManualReserEvent` to Slim
