### PR TITLE
Fix: `FollowRouteGoal` losing target stuck in place

### DIFF
--- a/Core/Goals/FollowRouteGoal.cs
+++ b/Core/Goals/FollowRouteGoal.cs
@@ -203,7 +203,18 @@ public sealed class FollowRouteGoal : GoapGoal, IGoapEventListener, IRouteProvid
         if (playerReader.Bits.PlayerInCombat() && classConfig.Mode != Mode.AttendedGather) { return; }
 
         if (!sideActivityCts.IsCancellationRequested)
+        {
             navigation.Update(sideActivityCts.Token);
+        }
+        else
+        {
+            if (!playerReader.Bits.HasTarget())
+            {
+                LogWarning($"{nameof(sideActivityCts)} is cancelled but needs to be restarted!");
+                sideActivityCts = new();
+                sideActivityManualReset.Set();
+            }
+        }
 
         RandomJump();
 
@@ -218,6 +229,7 @@ public sealed class FollowRouteGoal : GoapGoal, IGoapEventListener, IRouteProvid
         {
             if (targetFinder.Search(NpcNameToFind, playerReader.Bits.TargetIsNotDead, sideActivityCts.Token))
             {
+                Log("Found target!");
                 sideActivityCts.Cancel();
                 sideActivityManualReset.Reset();
             }


### PR DESCRIPTION
While the `FollowRouteGoal` is active and happen to have found a new target the side activity for looking for new target stops.

However at some point while still in `FollowRouteGoal` the target may have lost due tagging or non controlled way. During this time the player stuck in place until external event happens.

With the recent timing changes, after successfully Skinning or Herbing a mob and looting it properly it is expected to lose the target which is an automated event which were not been fully awaited.

Fixed an issue while  Skinning or Herbing and the cast is in progress, the interrupt event from a melee hit were not been properly detected. 