### PR TITLE
Addon: [1.7.40] - Fix: Addon sell grey items, `AdhocNPCGoal` closest point on resume, support abort, PathRecorder fixes

### DIFF
--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -3,7 +3,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors
-## Version: 1.7.39
+## Version: 1.7.40
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/SellJunk.lua
+++ b/Addons/DataToColor/SellJunk.lua
@@ -84,6 +84,11 @@ function SellJunkFunc()
                     soldCount = soldCount + 1
                     UseContainerItem(bagID, bagSlot)
 
+                    if not mSelling then
+                        mSelling = true
+                        DataToColor.gossipQueue:push(MERCHANT_SELLING)
+                    end
+
                     if mSellJunkTicker._remainingIterations == mIterationCount then
                         mTotalPrice = mTotalPrice + (itemPrice * itemCount)
                         -- Store first sold bag slot for analysis

--- a/Core/Addon/PlayerReader.cs
+++ b/Core/Addon/PlayerReader.cs
@@ -28,6 +28,7 @@ public sealed partial class PlayerReader : IMouseOverReader
     public WorldMapArea WorldMapArea { get; private set; }
 
     public Vector3 MapPos => new(MapX, MapY, WorldPosZ);
+    public Vector3 MapPosNoZ => new(MapX, MapY, 0);
     public Vector3 WorldPos => worldMapAreaDB.ToWorld_FlipXY(UIMapId.Value, MapPos);
 
     public float WorldPosZ { get; set; } // MapZ not exists. Alias for WorldLoc.Z

--- a/Core/GoalsFactory/GoalFactory.cs
+++ b/Core/GoalsFactory/GoalFactory.cs
@@ -260,6 +260,11 @@ public static class GoalFactory
         for (int i = 0; i < path.Length; i++)
         {
             path[i] = rawPath[i * step];
+
+            // TODO: there could be saved user routes where
+            //       the Z component not 0
+            if (path[i].Z != 0)
+                path[i].Z = 0;
         }
         return path;
     }

--- a/Frontend/Pages/RecordPath.razor
+++ b/Frontend/Pages/RecordPath.razor
@@ -268,9 +268,9 @@
 
     private void OnAddonDataChangedAction()
     {
-        if (!UpdateRecording() && lastPlayerPoint != addonReader.PlayerReader.MapPos)
+        if (!UpdateRecording() && lastPlayerPoint != addonReader.PlayerReader.MapPosNoZ)
         {
-            lastPlayerPoint = addonReader.PlayerReader.MapPos;
+            lastPlayerPoint = addonReader.PlayerReader.MapPosNoZ;
             UpdateRouteMarkup();
             StateHasChanged();
         }
@@ -415,7 +415,7 @@
     {
         if (!recording) { return false; }
 
-        Vector3 map = addonReader.PlayerReader.MapPos;
+        Vector3 map = addonReader.PlayerReader.MapPosNoZ;
 
         if (editPath.Count == 0 ||
             map.MapDistanceXYTo(editPath.Last()) > Distance)
@@ -472,7 +472,7 @@
 
     protected void UpdateSelectedWithPlayer()
     {
-        UpdateSourcePoint(ref selectedPoint, addonReader.PlayerReader.MapPos);
+        UpdateSourcePoint(ref selectedPoint, addonReader.PlayerReader.MapPosNoZ);
     }
 
     protected void UpdateSelectedWithPreview()
@@ -566,7 +566,9 @@
         int index = editPath.FindIndex(p => p == selectedPoint);
         if (index == -1) return;
 
-        var target = addonReader.PlayerReader.MapPos;
+        var target = addonReader.PlayerReader.MapPosNoZ;
+        target.Z = 0;
+
         editPath.Insert(index + 1, target);
 
         selectedPoint = target;


### PR DESCRIPTION
Fix: `RecordPath`: An issue where saved routes Z coordinates were not 0. 
As a result unable to edit the route waypoints in the Path Editor. Before loading any path, just forcefully set the Z component to 0.