### PR TITLE
Refactor: `NpcNameFinder` `SearchMode.Fuzzy` default for non corpse names and small improvements

### DIFF
--- a/Core/GoalsComponent/NpcNameTargeting.cs
+++ b/Core/GoalsComponent/NpcNameTargeting.cs
@@ -170,7 +170,7 @@ public sealed class NpcNameTargeting : IDisposable
         const int e = 3;
         Span<Point> attemptPoints = stackalloc Point[c + (c * e)];
 
-        for (int ni = 0; ni < npcNameFinder.Npcs.Length; ni++)
+        for (int ni = 0; ni < npcNameFinder.Npcs.Count; ni++)
         {
             NpcPosition npc = npcNameFinder.Npcs[ni];
             for (int i = 0; i < c; i += e)
@@ -204,7 +204,7 @@ public sealed class NpcNameTargeting : IDisposable
 
     public void ShowClickPositions(Graphics gr)
     {
-        for (int i = 0; i < npcNameFinder.Npcs.Length; i++)
+        for (int i = 0; i < npcNameFinder.Npcs.Count; i++)
         {
             NpcPosition npc = npcNameFinder.Npcs[i];
             for (int j = 0; j < locFindBy.Length; j++)

--- a/CoreTests/CoreTests.csproj
+++ b/CoreTests/CoreTests.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <ApplicationManifest>app.manifest</ApplicationManifest>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CoreTests/NpcNameFinder/NpcNameOverlay.cs
+++ b/CoreTests/NpcNameFinder/NpcNameOverlay.cs
@@ -27,7 +27,7 @@ public class NpcNameOverlay : IDisposable
     private readonly bool debugTargeting;
     private readonly bool debugSkinning;
 
-    private const int padding = 4;
+    private const int padding = 6;
     private const float NumberLeftPadding = 20f;
     private const int FontSize = 10;
 
@@ -115,7 +115,7 @@ public class NpcNameOverlay : IDisposable
 
         g.DrawRectangle(brush, npcNameFinder.Area.Left, npcNameFinder.Area.Top, npcNameFinder.Area.Right, npcNameFinder.Area.Bottom, 1);
 
-        for (int i = 0; i < npcNameFinder.Npcs.Length; i++)
+        for (int i = 0; i < npcNameFinder.Npcs.Count; i++)
         {
             NpcPosition npc = npcNameFinder.Npcs[i];
 

--- a/CoreTests/NpcNameFinder/Test_NpcNameFinder.cs
+++ b/CoreTests/NpcNameFinder/Test_NpcNameFinder.cs
@@ -83,21 +83,25 @@ public sealed class Test_NpcNameFinder : IDisposable
 
     public void Execute()
     {
-        if (LogEachUpdate)
-            stopwatch.Restart();
-
+        long captureTime = Stopwatch.GetTimestamp();
         wowScreen.Update();
 
         if (LogEachUpdate)
-            logger.LogInformation($"Capture: {stopwatch.ElapsedMilliseconds}ms");
+        {
+            stringBuilder.Length = 0;
+            stringBuilder.Append($"Capture: {Stopwatch.GetElapsedTime(captureTime).TotalMilliseconds:F6}ms");
+        }
 
-        if (LogEachUpdate)
-            stopwatch.Restart();
-
+        long updateTime = Stopwatch.GetTimestamp();
         npcNameFinder.Update();
 
         if (LogEachUpdate)
-            logger.LogInformation($"Update: {stopwatch.ElapsedMilliseconds}ms");
+        {
+            stringBuilder.Append(" | ");
+            stringBuilder.Append($"Update: {Stopwatch.GetElapsedTime(updateTime).TotalMilliseconds:F6}ms");
+
+            logger.LogInformation(stringBuilder.ToString());
+        }
 
         if (saveImage)
         {

--- a/SharedLib/Extensions/PointExt.cs
+++ b/SharedLib/Extensions/PointExt.cs
@@ -1,7 +1,5 @@
 ﻿using System.Drawing;
 
-using static System.MathF;
-
 namespace SharedLib.Extensions;
 
 public static class PointExt
@@ -18,6 +16,6 @@ public static class PointExt
 
     public static float SqrDistance(in Point p1, in Point p2)
     {
-        return Sqrt(((p1.X - p2.X) * (p1.X - p2.X)) + ((p1.Y - p2.Y) * (p1.Y - p2.Y)));
+        return ((p1.X - p2.X) * (p1.X - p2.X)) + ((p1.Y - p2.Y) * (p1.Y - p2.Y));
     }
 }

--- a/SharedLib/NpcFinder/LineSegment.cs
+++ b/SharedLib/NpcFinder/LineSegment.cs
@@ -7,11 +7,11 @@ public readonly struct LineSegment
     public readonly int XEnd;
     public readonly int XCenter;
 
-    public LineSegment(int xStart, int xend, int y)
+    public LineSegment(int xStart, int xEnd, int y)
     {
         this.XStart = xStart;
         this.Y = y;
-        this.XEnd = xend;
+        this.XEnd = xEnd;
         XCenter = XStart + ((XEnd - XStart) / 2);
     }
 }

--- a/SharedLib/NpcFinder/NpcPositionComparer.cs
+++ b/SharedLib/NpcFinder/NpcPositionComparer.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using System.Drawing;
+
+using SharedLib.Extensions;
+
+namespace SharedLib.NpcFinder;
+
+internal sealed class NpcPositionComparer : IComparer<NpcPosition>
+{
+    private readonly IBitmapProvider bitmapProvider;
+
+    public NpcPositionComparer(IBitmapProvider bitmapProvider)
+    {
+        this.bitmapProvider = bitmapProvider;
+    }
+
+    public int Compare(NpcPosition x, NpcPosition y)
+    {
+        Point origin = bitmapProvider.Rect.Centre();
+        float dx = PointExt.SqrDistance(origin, x.ClickPoint);
+        float dy = PointExt.SqrDistance(origin, y.ClickPoint);
+
+        return dx.CompareTo(dy);
+    }
+}


### PR DESCRIPTION
On the Wrath classic PTR there's a new accessibility feature which allows to adjust the minimum size of the Npc names.

The recommended `Minimum Character Name Size` value is **6** or **8** for **1920x1080** resolution.

![image](https://github.com/Xian55/WowClassicGrindBot/assets/367101/ab8d3750-37e2-478e-8368-ab559489dce6)

This greatly helps a NpcNameFinder component! There's one challenge what needs to be tackled meanwhile. As soon as the `Minimum Character Name Size` is changed from 0 there are some distance based alpha blending going on. 

So `SearchMode.Simple` yields really poor results, only works in really close range. However `SearchMode.Fuzzy` mode allows to detect shades of that given color. It works really well with friendly(green), neutral(yellow) and enemies(red).

![fuzzy_npc_name](https://github.com/Xian55/WowClassicGrindBot/assets/367101/313c3f38-1af0-4d06-9d3a-17baf18bc627)

---

For Corpse(grey / RGB=128) type names however, it's a more trickier situation since that shade is way too common in the game so for now `SearchMode.Simple` mode is used for this case.

![fuzzy_npc_name_corpse](https://github.com/Xian55/WowClassicGrindBot/assets/367101/b159569a-61aa-46e6-9c74-10eb833b76af)
