### PR TITLE
Fix: PPather: Improve staircase path creation

### DIFF
--- a/PPather/Triangles/ChunkedTriangleCollection.cs
+++ b/PPather/Triangles/ChunkedTriangleCollection.cs
@@ -203,20 +203,33 @@ public sealed class ChunkedTriangleCollection
         to_up.Z = z1 + toonHeight - toonSize;
 
         //diagonal
-        if (CheckForCollision(tc, ts, from, to_up)) { return true; }
+        if (CheckForCollision(tc, ts, from, to_up))
+        {
+            return true;
+        }
 
         //diagonal
-        if (CheckForCollision(tc, ts, from_up, to)) { return true; }
+        if (CheckForCollision(tc, ts, from_up, to))
+        {
+            return true;
+        }
 
         //head height
         // if (CheckForCollision(tc, ts, ref from_up, ref to_up)) { return true; }
 
         //close to the ground
+        const float stepDistance = 0.3f;
+
         from_low = new Vector3(from.X, from.Y, from.Z);
-        from_low.Z = z0 + 0.2f;
+        from_low.Z = z0 + stepDistance;
+
         to_low = new Vector3(to.X, to.Y, to.Z);
-        to_low.Z = z1 + 0.2f;
-        if (CheckForCollision(tc, ts, from_low, to_low)) { return true; }
+        to_low.Z = z1 + stepDistance;
+
+        if (CheckForCollision(tc, ts, from_low, to_low))
+        {
+            return true;
+        }
 
         GetNormal(x0, y0, x1, y1, out float ddx, out float ddy, 0.2f);
 
@@ -224,7 +237,11 @@ public sealed class ChunkedTriangleCollection
         from_low.Y += ddx;
         to_low.X += ddy;
         to_low.Y += ddx;
-        if (CheckForCollision(tc, ts, from_low, to_low)) { return true; }
+
+        if (CheckForCollision(tc, ts, from_low, to_low))
+        {
+            return true;
+        }
 
         from_low.X -= 2 * ddy;
         from_low.Y -= 2 * ddx;


### PR DESCRIPTION
There was a spot in [Zul'Drak](api/PPather/MapRoute?uimap1=121&x1=40.4058&y1=63.024403&uimap2=121&x2=40.3816&y2=64.259705) where the `PPather` navigation failed to calculate path.

**Important**: In order to this fix take effect on your machine please delete the following folders `\WowClassicGrindBot\Json\PathInfo\*` content beside the `empty` file!

![image](https://github.com/Xian55/WowClassicGrindBot/assets/367101/e069df83-7db3-4261-b7ec-417e0ce1597c)
