### PR TITLE
Refactor: Enrich logging with `SourceContext`

### DIFF
--- a/BlazorServer/BlazorServer.csproj
+++ b/BlazorServer/BlazorServer.csproj
@@ -36,6 +36,7 @@
     <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />
     <PackageReference Include="Serilog.Enrichers.Process" Version="2.0.2" />
+    <PackageReference Include="Serilog.Expressions" Version="3.4.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
   </ItemGroup>
 

--- a/BlazorServer/appsettings.json
+++ b/BlazorServer/appsettings.json
@@ -18,7 +18,7 @@
     "Id": -1
   },
   "Reader": {
-    "Type": "GDI" // from Win7 'GDI' - from Win8 'DXGI'
+    "Type": "GDI" // from Win7 'GDI' - from Win8 'DXGI' - from Win7 background 'GDIBlit'
   },
   "Diagnostics": {
     "Enabled": false

--- a/Core/ClassConfig/KeyAction.cs
+++ b/Core/ClassConfig/KeyAction.cs
@@ -207,7 +207,7 @@ public sealed partial class KeyAction : IDisposable
         FormAction = true;
         Initialise(config, addonReader, requirementFactory, logger, globalLog);
 
-        logger.LogInformation($"[{Name}] Added {FormEnum} to FormCost with {MinCost}");
+        logger.LogInformation($"[{Name,-15}] Added {FormEnum} to FormCost with {MinCost}");
     }
 
     public void ResetCosts()
@@ -348,7 +348,7 @@ public sealed partial class KeyAction : IDisposable
                 int formCost = FormCost();
                 if (formCost > 0)
                 {
-                    logger.LogInformation($"[{Name}] +{formCost} Mana to change into {FormEnum.ToStringF()}");
+                    logger.LogInformation($"[{Name,-15}] +{formCost} Mana to change into {FormEnum.ToStringF()}");
                 }
             }
         }
@@ -409,39 +409,39 @@ public sealed partial class KeyAction : IDisposable
     #region Logging
 
     [LoggerMessage(
-        EventId = 4,
+        EventId = 0001,
         Level = LogLevel.Information,
-        Message = "[{name}] Path: {path}")]
+        Message = "[{name,-15}] Path: {path}")]
     static partial void LogPath(ILogger logger, string name, string path);
 
     [LoggerMessage(
-        EventId = 5,
+        EventId = 0002,
         Level = LogLevel.Information,
-        Message = "[{name}] Required Form: {form}")]
+        Message = "[{name,-15}] Required Form: {form}")]
     static partial void LogFormRequired(ILogger logger, string name, string form);
 
     [LoggerMessage(
-        EventId = 6,
+        EventId = 0003,
         Level = LogLevel.Information,
-        Message = "[{name}] Actionbar Key:{key} -> Actionbar:{slot} -> Index:{slotIndex}")]
+        Message = "[{name,-15}] Actionbar Key:{key} -> Actionbar:{slot} -> Index:{slotIndex}")]
     static partial void LogInputActionbar(ILogger logger, string name, string key, int slot, int slotIndex);
 
     [LoggerMessage(
-        EventId = 7,
+        EventId = 0004,
         Level = LogLevel.Information,
-        Message = "[{name}] Non Actionbar {key} -> {consoleKey}")]
+        Message = "[{name,-15}] Non Actionbar {key} -> {consoleKey}")]
     static partial void LogInputNonActionbar(ILogger logger, string name, string key, ConsoleKey consoleKey);
 
     [LoggerMessage(
-        EventId = 8,
+        EventId = 0005,
         Level = LogLevel.Warning,
-        Message = "[{name}] has no valid Key={key} or ConsoleKey={consoleKey}")]
+        Message = "[{name,-15}] has no valid Key={key} or ConsoleKey={consoleKey}")]
     static partial void LogInputNoValidKey(ILogger logger, string name, string key, ConsoleKey consoleKey);
 
     [LoggerMessage(
-        EventId = 9,
+        EventId = 0006,
         Level = LogLevel.Information,
-        Message = "[{name}] Update {type} cost to {newCost} from {oldCost}")]
+        Message = "[{name,-15}] Update {type} cost to {newCost} from {oldCost}")]
     static partial void LogPowerCostChange(ILogger logger, string name, string type, int newCost, int oldCost);
 
     #endregion

--- a/Core/ClassConfig/KeyActions.cs
+++ b/Core/ClassConfig/KeyActions.cs
@@ -45,13 +45,13 @@ public partial class KeyActions : IDisposable
     }
 
     [LoggerMessage(
-        EventId = 10,
+        EventId = 0010,
         Level = LogLevel.Information,
         Message = "[{prefix}] CreateDynamicBindings.")]
     protected static partial void LogDynamicBinding(ILogger logger, string prefix);
 
     [LoggerMessage(
-        EventId = 11,
+        EventId = 0011,
         Level = LogLevel.Information,
         Message = "[{prefix}] Initialise KeyActions.")]
     protected static partial void LogInitKeyActions(ILogger logger, string prefix);

--- a/Core/ClassConfig/WaitKeyActions.cs
+++ b/Core/ClassConfig/WaitKeyActions.cs
@@ -100,7 +100,7 @@ public sealed partial class WaitKeyActions : KeyActions
     #region logging
 
     [LoggerMessage(
-        EventId = 12,
+        EventId = 0016,
         Level = LogLevel.Information,
         Message = "[{typeName}] Added awaiting action for {keyActionName}")]
     static partial void LogAddedWait(ILogger logger, string typeName, string keyActionName);

--- a/Core/Configurator/AddonConfigurator.cs
+++ b/Core/Configurator/AddonConfigurator.cs
@@ -10,7 +10,7 @@ namespace Core;
 
 public sealed class AddonConfigurator
 {
-    private readonly ILogger logger;
+    private readonly ILogger<AddonConfigurator> logger;
     private readonly WowProcess wowProcess;
 
     public AddonConfig Config { get; init; }
@@ -25,7 +25,7 @@ public sealed class AddonConfigurator
 
     public event Action? OnChange;
 
-    public AddonConfigurator(ILogger logger, WowProcess wowProcess)
+    public AddonConfigurator(ILogger<AddonConfigurator> logger, WowProcess wowProcess)
     {
         this.logger = logger;
         this.wowProcess = wowProcess;
@@ -99,11 +99,11 @@ public sealed class AddonConfigurator
             RenameAddon();
             MakeUnique();
 
-            logger.LogInformation($"{nameof(AddonConfigurator)}.{nameof(Install)} - Success");
+            logger.LogInformation($"{nameof(Install)} - Success");
         }
         catch (Exception e)
         {
-            logger.LogInformation($"{nameof(AddonConfigurator)}.{nameof(Install)} - Failed\n{e.Message}");
+            logger.LogInformation($"{nameof(Install)} - Failed\n{e.Message}");
         }
     }
 
@@ -111,13 +111,13 @@ public sealed class AddonConfigurator
     {
         if (Directory.Exists(DefaultAddonPath))
         {
-            logger.LogInformation($"{nameof(AddonConfigurator)}.{nameof(DeleteAddon)} -> Default Addon Exists");
+            logger.LogInformation($"{nameof(DeleteAddon)} -> Default Addon Exists");
             Directory.Delete(DefaultAddonPath, true);
         }
 
         if (!string.IsNullOrEmpty(Config.Title) && Directory.Exists(FinalAddonPath))
         {
-            logger.LogInformation($"{nameof(AddonConfigurator)}.{nameof(DeleteAddon)} -> Unique Addon Exists");
+            logger.LogInformation($"{nameof(DeleteAddon)} -> Unique Addon Exists");
             Directory.Delete(FinalAddonPath, true);
         }
     }
@@ -127,7 +127,7 @@ public sealed class AddonConfigurator
         try
         {
             CopyFolder("");
-            logger.LogInformation($"{nameof(AddonConfigurator)}.{nameof(CopyAddonFiles)} - Success");
+            logger.LogInformation($"{nameof(CopyAddonFiles)} - Success");
         }
         catch (Exception e)
         {
@@ -135,7 +135,7 @@ public sealed class AddonConfigurator
 
             // This only should be happen when running from IDE
             CopyFolder(".");
-            logger.LogInformation($"{nameof(AddonConfigurator)}.{nameof(CopyAddonFiles)} - Success");
+            logger.LogInformation($"{nameof(CopyAddonFiles)} - Success");
         }
     }
 

--- a/Core/Configurator/FrameConfigurator.cs
+++ b/Core/Configurator/FrameConfigurator.cs
@@ -31,7 +31,7 @@ public sealed class FrameConfigurator : IDisposable
     private const int MAX_HEIGHT = 25; // this one just arbitrary number for sanity check
     private const int INTERVAL = 500;
 
-    private readonly ILogger logger;
+    private readonly ILogger<FrameConfigurator> logger;
     private readonly WowProcess wowProcess;
     private readonly WowScreen wowScreen;
     private readonly WowProcessInput wowProcessInput;
@@ -57,7 +57,7 @@ public sealed class FrameConfigurator : IDisposable
 
     public event Action? OnUpdate;
 
-    public FrameConfigurator(ILogger logger, Wait wait,
+    public FrameConfigurator(ILogger<FrameConfigurator> logger, Wait wait,
         WowProcess wowProcess, IAddonDataProvider reader,
         WowScreen wowScreen, WowProcessInput wowProcessInput,
         ExecGameCommand execGameCommand, AddonConfigurator addonConfigurator)
@@ -106,7 +106,7 @@ public sealed class FrameConfigurator : IDisposable
                 {
                     if (auto)
                     {
-                        logger.LogInformation($"Found {nameof(WowProcess)}");
+                        logger.LogInformation($"Found {nameof(WowProcess)} with pid={wowProcess.Process}");
                     }
                     stage++;
                 }
@@ -150,7 +150,7 @@ public sealed class FrameConfigurator : IDisposable
                     if (version == null)
                     {
                         stage = Stage.Reset;
-                        logger.LogError($"Addon is not installed!");
+                        logger.LogError("Addon is not installed!");
                         return false;
                     }
                     logger.LogInformation($"Addon installed! Version: {version}");
@@ -170,7 +170,7 @@ public sealed class FrameConfigurator : IDisposable
 
                     if (auto)
                     {
-                        logger.LogInformation($"DataFrameMeta: {DataFrameMeta}");
+                        logger.LogInformation($"{nameof(DataFrameMeta)}: {DataFrameMeta}");
                     }
                 }
                 break;
@@ -220,7 +220,7 @@ public sealed class FrameConfigurator : IDisposable
             case Stage.ReturnNormalMode:
                 if (auto)
                 {
-                    logger.LogInformation($"Exit configuration mode.");
+                    logger.LogInformation("Exit configuration mode.");
                     wowProcessInput.SetForegroundWindow();
                     ToggleInGameConfiguration(execGameCommand);
                     wait.Fixed(INTERVAL);
@@ -312,14 +312,14 @@ public sealed class FrameConfigurator : IDisposable
             DataFrames.Length != DataFrameMeta.frames ||
             !TryResolveRaceAndClass(out _, out _, out _))
         {
-            logger.LogInformation($"Frame configuration was incomplete! Please try again, after resolving the previusly mentioned issues...");
+            logger.LogInformation("Frame configuration was incomplete! Please try again, after resolving the previusly mentioned issues...");
             ResetConfigState();
             return false;
         }
 
         wowScreen.GetRectangle(out Rectangle rect);
         FrameConfig.Save(rect, version, DataFrameMeta, DataFrames);
-        logger.LogInformation($"Frame configuration was successful! Configuration saved!");
+        logger.LogInformation("Frame configuration was successful! Configuration saved!");
         Saved = true;
 
         return true;

--- a/Core/ExecGameCommand/ExecGameCommand.cs
+++ b/Core/ExecGameCommand/ExecGameCommand.cs
@@ -7,11 +7,12 @@ namespace Core;
 
 public sealed class ExecGameCommand
 {
-    private readonly ILogger logger;
+    private readonly ILogger<ExecGameCommand> logger;
     private readonly WowProcessInput wowProcessInput;
     private readonly CancellationToken ct;
 
-    public ExecGameCommand(ILogger logger, CancellationTokenSource cts, WowProcessInput wowProcessInput)
+    public ExecGameCommand(ILogger<ExecGameCommand> logger,
+        CancellationTokenSource cts, WowProcessInput wowProcessInput)
     {
         this.logger = logger;
         ct = cts.Token;

--- a/Core/GOAP/GoapAgent.cs
+++ b/Core/GOAP/GoapAgent.cs
@@ -18,6 +18,8 @@ public sealed partial class GoapAgent : IDisposable
     private readonly IServiceScope scope;
 
     private readonly ILogger logger;
+    private readonly ILogger globalLogger;
+
     private readonly ClassConfiguration classConfig;
     private readonly AddonReader addonReader;
     private readonly PlayerReader playerReader;
@@ -97,7 +99,9 @@ public sealed partial class GoapAgent : IDisposable
     {
         this.scope = scope;
 
-        this.logger = scope.ServiceProvider.GetRequiredService<ILogger>();
+        this.logger = scope.ServiceProvider.GetRequiredService<ILogger<GoapAgent>>();
+        this.globalLogger = scope.ServiceProvider.GetRequiredService<ILogger>();
+
         this.screenCapture = screenCapture;
         this.classConfig = scope.ServiceProvider.GetRequiredService<ClassConfiguration>();
         this.cts = new();
@@ -114,7 +118,7 @@ public sealed partial class GoapAgent : IDisposable
 
         SessionStat = sessionStat;
 
-        sessionHandler = new GrindSessionHandler(logger, dataConfig, playerReader, SessionStat, sessionDAO, cts);
+        sessionHandler = new GrindSessionHandler(globalLogger, dataConfig, playerReader, SessionStat, sessionDAO, cts);
 
         WowProcessInput baseInput = scope.ServiceProvider.GetRequiredService<WowProcessInput>();
         stopMoving = new StopMoving(baseInput, playerReader, cts);
@@ -358,25 +362,25 @@ public sealed partial class GoapAgent : IDisposable
     #region Logging
 
     [LoggerMessage(
-        EventId = 50,
+        EventId = 0050,
         Level = LogLevel.Information,
         Message = "Kill credit detected! Known kills: {count} | Fighting with: {remain}")]
     static partial void LogActiveKillDetected(ILogger logger, int count, int remain);
 
     [LoggerMessage(
-        EventId = 51,
+        EventId = 0051,
         Level = LogLevel.Information,
         Message = "Inactive, kill credit detected!")]
     static partial void LogInactiveKillDetected(ILogger logger);
 
     [LoggerMessage(
-        EventId = 52,
+        EventId = 0052,
         Level = LogLevel.Information,
         Message = "New Plan= {name}")]
     static partial void LogNewGoal(ILogger logger, string name);
 
     [LoggerMessage(
-        EventId = 53,
+        EventId = 0053,
         Level = LogLevel.Warning,
         Message = "New Plan= NO PLAN")]
     static partial void LogNewEmptyGoal(ILogger logger);

--- a/Core/Goals/AdhocNPCGoal.cs
+++ b/Core/Goals/AdhocNPCGoal.cs
@@ -28,7 +28,7 @@ public sealed class AdhocNPCGoal : GoapGoal, IGoapEventListener, IRouteProvider,
 
     public override float Cost => key.Cost;
 
-    private readonly ILogger logger;
+    private readonly ILogger<AdhocNPCGoal> logger;
     private readonly ConfigurableInput input;
     private readonly KeyAction key;
     private readonly Wait wait;
@@ -66,7 +66,7 @@ public sealed class AdhocNPCGoal : GoapGoal, IGoapEventListener, IRouteProvider,
 
     #endregion
 
-    public AdhocNPCGoal(KeyAction key, ILogger logger, ConfigurableInput input,
+    public AdhocNPCGoal(KeyAction key, ILogger<AdhocNPCGoal> logger, ConfigurableInput input,
         Wait wait, AddonReader addonReader, Navigation navigation, StopMoving stopMoving,
         NpcNameTargeting npcNameTargeting, ClassConfiguration classConfig,
         IMountHandler mountHandler, ExecGameCommand exec, CancellationTokenSource cts)

--- a/Core/Goals/ApproachTargetGoal.cs
+++ b/Core/Goals/ApproachTargetGoal.cs
@@ -16,7 +16,7 @@ public sealed class ApproachTargetGoal : GoapGoal, IGoapEventListener
 
     public override float Cost => 8f;
 
-    private readonly ILogger logger;
+    private readonly ILogger<ApproachTargetGoal> logger;
     private readonly ConfigurableInput input;
     private readonly Wait wait;
     private readonly AddonReader addonReader;
@@ -33,11 +33,12 @@ public sealed class ApproachTargetGoal : GoapGoal, IGoapEventListener
     private int initialTargetGuid;
     private float initialMinRange;
 
-    private double ApproachDurationMs => (DateTime.UtcNow - approachStart).TotalMilliseconds;
+    private double ApproachDurationMs =>
+        (DateTime.UtcNow - approachStart).TotalMilliseconds;
 
-    public ApproachTargetGoal(ILogger logger, ConfigurableInput input, Wait wait,
-        AddonReader addonReader, StopMoving stopMoving, CombatUtil combatUtil,
-        IBlacklist blacklist)
+    public ApproachTargetGoal(ILogger<ApproachTargetGoal> logger, 
+        ConfigurableInput input, Wait wait, AddonReader addonReader,
+        StopMoving stopMoving, CombatUtil combatUtil, IBlacklist blacklist)
         : base(nameof(ApproachTargetGoal))
     {
         this.logger = logger;

--- a/Core/Goals/CombatGoal.cs
+++ b/Core/Goals/CombatGoal.cs
@@ -11,7 +11,7 @@ public sealed class CombatGoal : GoapGoal, IGoapEventListener
 {
     public override float Cost => 4f;
 
-    private readonly ILogger logger;
+    private readonly ILogger<CombatGoal> logger;
     private readonly ConfigurableInput input;
     private readonly ClassConfiguration classConfig;
     private readonly Wait wait;
@@ -25,8 +25,8 @@ public sealed class CombatGoal : GoapGoal, IGoapEventListener
     private float lastMinDistance;
     private float lastMaxDistance;
 
-    public CombatGoal(ILogger logger, ConfigurableInput input, Wait wait,
-        AddonReader addonReader, StopMoving stopMoving,
+    public CombatGoal(ILogger<CombatGoal> logger, ConfigurableInput input,
+        Wait wait, AddonReader addonReader, StopMoving stopMoving,
         ClassConfiguration classConfiguration, ClassConfiguration classConfig,
         CastingHandler castingHandler,
         IMountHandler mountHandler)

--- a/Core/Goals/ConsumeCorpseGoal.cs
+++ b/Core/Goals/ConsumeCorpseGoal.cs
@@ -7,11 +7,12 @@ public sealed partial class ConsumeCorpseGoal : GoapGoal
 {
     public override float Cost => 4.1f;
 
-    private readonly ILogger logger;
+    private readonly ILogger<ConsumeCorpseGoal> logger;
     private readonly ClassConfiguration classConfig;
     private readonly GoapAgentState state;
 
-    public ConsumeCorpseGoal(ILogger logger, ClassConfiguration classConfig, GoapAgentState state)
+    public ConsumeCorpseGoal(ILogger<ConsumeCorpseGoal> logger,
+        ClassConfiguration classConfig, GoapAgentState state)
         : base(nameof(ConsumeCorpseGoal))
     {
         this.logger = logger;
@@ -57,8 +58,8 @@ public sealed partial class ConsumeCorpseGoal : GoapGoal
     }
 
     [LoggerMessage(
-        EventId = 100,
+        EventId = 0100,
         Level = LogLevel.Information,
-        Message = "----- Safe to consume a corpse.")]
+        Message = "Safe to consume a corpse.")]
     static partial void LogConsume(ILogger logger);
 }

--- a/Core/Goals/CorpseConsumedGoal.cs
+++ b/Core/Goals/CorpseConsumedGoal.cs
@@ -10,13 +10,14 @@ public sealed partial class CorpseConsumedGoal : GoapGoal
 {
     public override float Cost => 4.7f;
 
-    private readonly ILogger logger;
+    private readonly ILogger<CorpseConsumedGoal> logger;
     private readonly GoapAgentState goapAgentState;
     private readonly Wait wait;
 
     private readonly bool lootEnabled;
 
-    public CorpseConsumedGoal(ILogger logger, ClassConfiguration classConfig, GoapAgentState goapAgentState, Wait wait)
+    public CorpseConsumedGoal(ILogger<CorpseConsumedGoal> logger,
+        ClassConfiguration classConfig, GoapAgentState goapAgentState, Wait wait)
         : base(nameof(CorpseConsumedGoal))
     {
         this.logger = logger;
@@ -65,8 +66,8 @@ public sealed partial class CorpseConsumedGoal : GoapGoal
     }
 
     [LoggerMessage(
-        EventId = 101,
+        EventId = 0120,
         Level = LogLevel.Information,
-        Message = "----- Corpse consumed. Total: {total} | Remaining: {remains}")]
+        Message = "Total: {total} | Remaining: {remains}")]
     static partial void LogConsumed(ILogger logger, int total, int remains);
 }

--- a/Core/Goals/FollowRouteGoal.cs
+++ b/Core/Goals/FollowRouteGoal.cs
@@ -18,7 +18,7 @@ public sealed class FollowRouteGoal : GoapGoal, IGoapEventListener, IRouteProvid
 
     private const bool debug = false;
 
-    private readonly ILogger logger;
+    private readonly ILogger<FollowRouteGoal> logger;
     private readonly ConfigurableInput input;
     private readonly Wait wait;
     private readonly AddonReader addonReader;
@@ -64,9 +64,10 @@ public sealed class FollowRouteGoal : GoapGoal, IGoapEventListener, IRouteProvid
     #endregion
 
 
-    public FollowRouteGoal(ILogger logger, ConfigurableInput input, Wait wait,
-        AddonReader addonReader, ClassConfiguration classConfig, Vector3[] route,
-        Navigation navigation, IMountHandler mountHandler, TargetFinder targetFinder,
+    public FollowRouteGoal(ILogger<FollowRouteGoal> logger, 
+        ConfigurableInput input, Wait wait, AddonReader addonReader,
+        ClassConfiguration classConfig, Vector3[] route, Navigation navigation,
+        IMountHandler mountHandler, TargetFinder targetFinder,
         IBlacklist blacklist)
         : base(nameof(FollowRouteGoal))
     {
@@ -393,16 +394,16 @@ public sealed class FollowRouteGoal : GoapGoal, IGoapEventListener, IRouteProvid
 
     private void LogDebug(string text)
     {
-        logger.LogDebug($"{nameof(FollowRouteGoal)}: {text}");
+        logger.LogDebug(text);
     }
 
     private void LogWarning(string text)
     {
-        logger.LogWarning($"{nameof(FollowRouteGoal)}: {text}");
+        logger.LogWarning(text);
     }
 
     private void Log(string text)
     {
-        logger.LogInformation($"{nameof(FollowRouteGoal)}: {text}");
+        logger.LogInformation(text);
     }
 }

--- a/Core/Goals/PullTargetGoal.cs
+++ b/Core/Goals/PullTargetGoal.cs
@@ -11,7 +11,7 @@ public sealed class PullTargetGoal : GoapGoal, IGoapEventListener
 
     private const int AcquireTargetTimeMs = 5000;
 
-    private readonly ILogger logger;
+    private readonly ILogger<PullTargetGoal> logger;
     private readonly ConfigurableInput input;
     private readonly ClassConfiguration classConfig;
     private readonly Wait wait;
@@ -34,11 +34,12 @@ public sealed class PullTargetGoal : GoapGoal, IGoapEventListener
 
     private double PullDurationMs => (DateTime.UtcNow - pullStart).TotalMilliseconds;
 
-    public PullTargetGoal(ILogger logger, ConfigurableInput input, Wait wait,
-        AddonReader addonReader, IBlacklist blacklist, StopMoving stopMoving,
-        CastingHandler castingHandler, IMountHandler mountHandler,
-        NpcNameTargeting npcNameTargeting, StuckDetector stuckDetector,
-        CombatUtil combatUtil, ClassConfiguration classConfig)
+    public PullTargetGoal(ILogger<PullTargetGoal> logger, ConfigurableInput input,
+        Wait wait, AddonReader addonReader, IBlacklist blacklist,
+        StopMoving stopMoving, CastingHandler castingHandler,
+        IMountHandler mountHandler, NpcNameTargeting npcNameTargeting,
+        StuckDetector stuckDetector, CombatUtil combatUtil,
+        ClassConfiguration classConfig)
         : base(nameof(PullTargetGoal))
     {
         this.logger = logger;

--- a/Core/Goals/WaitForGatheringGoal.cs
+++ b/Core/Goals/WaitForGatheringGoal.cs
@@ -165,25 +165,25 @@ public partial class WaitForGatheringGoal : GoapGoal
     #region Logging
 
     [LoggerMessage(
-        EventId = 101,
+        EventId = 0101,
         Level = LogLevel.Information,
         Message = "{state}")]
     static partial void LogState(ILogger logger, string state);
 
     [LoggerMessage(
-        EventId = 102,
+        EventId = 0102,
         Level = LogLevel.Warning,
         Message = "Waiting indefinitely for [Gathering cast to start] or [Press Jump to Abort]")]
     static partial void LogOnEnter(ILogger logger);
 
     [LoggerMessage(
-        EventId = 103,
+        EventId = 0103,
         Level = LogLevel.Error,
         Message = "{state} -- Waiting(max {Timeout} ms) for [Gathering cast to start] or [Press Jump to Abort]")]
     static partial void LogFailed(ILogger logger, string state, int Timeout);
 
     [LoggerMessage(
-        EventId = 104,
+        EventId = 0104,
         Level = LogLevel.Information,
         Message = "{success} -> {state} Waiting(max {Timeout} ms) for [More Mining cast] or [Press Jump to Abort]")]
     static partial void LogSuccessMining(ILogger logger, string success, string state, int Timeout);

--- a/Core/Goals/WalkToCorpseGoal.cs
+++ b/Core/Goals/WalkToCorpseGoal.cs
@@ -9,7 +9,7 @@ public sealed partial class WalkToCorpseGoal : GoapGoal, IGoapEventListener, IRo
 {
     public override float Cost => 1f;
 
-    private readonly ILogger logger;
+    private readonly ILogger<WalkToCorpseGoal> logger;
     private readonly Wait wait;
     private readonly ConfigurableInput input;
 
@@ -41,7 +41,9 @@ public sealed partial class WalkToCorpseGoal : GoapGoal, IGoapEventListener, IRo
 
     #endregion
 
-    public WalkToCorpseGoal(ILogger logger, ConfigurableInput input, Wait wait, AddonReader addonReader, Navigation navigation, StopMoving stopMoving)
+    public WalkToCorpseGoal(ILogger<WalkToCorpseGoal> logger,
+        ConfigurableInput input, Wait wait, AddonReader addonReader,
+        Navigation navigation, StopMoving stopMoving)
         : base(nameof(WalkToCorpseGoal))
     {
         this.logger = logger;
@@ -125,6 +127,6 @@ public sealed partial class WalkToCorpseGoal : GoapGoal, IGoapEventListener, IRo
 
     private void Log(string text)
     {
-        logger.LogInformation($"[{nameof(WalkToCorpseGoal)}]: {text}");
+        logger.LogInformation(text);
     }
 }

--- a/Core/GoalsComponent/Blacklist/MouseOverBlacklist.cs
+++ b/Core/GoalsComponent/Blacklist/MouseOverBlacklist.cs
@@ -160,43 +160,43 @@ public sealed partial class MouseOverBlacklist : IBlacklist
     #region logging
 
     [LoggerMessage(
-        EventId = 60,
+        EventId = 0060,
         Level = LogLevel.Warning,
         Message = "MouseOverBlacklist ({id},{guid},{name}) is player!")]
     static partial void LogPlayerOrPet(ILogger logger, int id, int guid, string name);
 
     [LoggerMessage(
-        EventId = 61,
+        EventId = 0061,
         Level = LogLevel.Warning,
         Message = "MouseOverBlacklist ({id},{guid},{name}) is tagged!")]
     static partial void LogTagged(ILogger logger, int id, int guid, string name);
 
     [LoggerMessage(
-        EventId = 62,
+        EventId = 0062,
         Level = LogLevel.Warning,
         Message = "MouseOverBlacklist ({id},{guid},{name}) too high level!")]
     static partial void LogLevelHigh(ILogger logger, int id, int guid, string name);
 
     [LoggerMessage(
-        EventId = 63,
+        EventId = 0063,
         Level = LogLevel.Warning,
         Message = "MouseOverBlacklist ({id},{guid},{name}) too low level!")]
     static partial void LogLevelLow(ILogger logger, int id, int guid, string name);
 
     [LoggerMessage(
-        EventId = 64,
+        EventId = 0064,
         Level = LogLevel.Warning,
         Message = "MouseOverBlacklist ({id},{guid},{name}) not yield experience!")]
     static partial void LogNoExperienceGain(ILogger logger, int id, int guid, string name);
 
     [LoggerMessage(
-        EventId = 65,
+        EventId = 0065,
         Level = LogLevel.Warning,
         Message = "MouseOverBlacklist ({id},{guid},{name}) name match!")]
     static partial void LogNameMatch(ILogger logger, int id, int guid, string name);
 
     [LoggerMessage(
-        EventId = 66,
+        EventId = 0066,
         Level = LogLevel.Warning,
         Message = "MouseOverBlacklist ({id},{guid},{name},{classification}) not defined in the TargetMask!")]
     static partial void LogClassification(ILogger logger, int id, int guid, string name, string classification);

--- a/Core/GoalsComponent/Blacklist/TargetBlacklist.cs
+++ b/Core/GoalsComponent/Blacklist/TargetBlacklist.cs
@@ -187,49 +187,49 @@ public sealed partial class TargetBlacklist : IBlacklist, IDisposable
     #region logging
 
     [LoggerMessage(
-        EventId = 60,
+        EventId = 0060,
         Level = LogLevel.Warning,
         Message = "Blacklist ({id},{guid},{name}) is player or pet!")]
     static partial void LogPlayerOrPet(ILogger logger, int id, int guid, string name);
 
     [LoggerMessage(
-        EventId = 61,
+        EventId = 0061,
         Level = LogLevel.Warning,
         Message = "Blacklist ({id},{guid},{name}) is tagged!")]
     static partial void LogTagged(ILogger logger, int id, int guid, string name);
 
     [LoggerMessage(
-        EventId = 62,
+        EventId = 0062,
         Level = LogLevel.Warning,
         Message = "Blacklist ({id},{guid},{name}) too high level!")]
     static partial void LogLevelHigh(ILogger logger, int id, int guid, string name);
 
     [LoggerMessage(
-        EventId = 63,
+        EventId = 0063,
         Level = LogLevel.Warning,
         Message = "Blacklist ({id},{guid},{name}) too low level!")]
     static partial void LogLevelLow(ILogger logger, int id, int guid, string name);
 
     [LoggerMessage(
-        EventId = 64,
+        EventId = 0064,
         Level = LogLevel.Warning,
         Message = "Blacklist ({id},{guid},{name}) not yield experience!")]
     static partial void LogNoExperienceGain(ILogger logger, int id, int guid, string name);
 
     [LoggerMessage(
-        EventId = 65,
+        EventId = 0065,
         Level = LogLevel.Warning,
         Message = "Blacklist ({id},{guid},{name}) name match!")]
     static partial void LogNameMatch(ILogger logger, int id, int guid, string name);
 
     [LoggerMessage(
-        EventId = 66,
+        EventId = 0066,
         Level = LogLevel.Warning,
         Message = "Blacklist ({id},{guid},{name},{classification}) not defined in the TargetMask!")]
     static partial void LogClassification(ILogger logger, int id, int guid, string name, string classification);
 
     [LoggerMessage(
-        EventId = 67,
+        EventId = 0067,
         Level = LogLevel.Warning,
         Message = "Blacklist ({id},{guid},{name},{classification}) evade on attack!")]
     static partial void LogEvade(ILogger logger, int id, int guid, string name, string classification);

--- a/Core/GoalsComponent/CastingHandler.cs
+++ b/Core/GoalsComponent/CastingHandler.cs
@@ -152,7 +152,7 @@ public sealed partial class CastingHandler
 
         if (!CastSuccessful(playerReader.CastEvent.Value))
         {
-            react.Do(item, $"{item.Name}-{nameof(CastingHandler)}: {nameof(CastInstant)}");
+            react.Do(item);
             return false;
         }
 
@@ -213,7 +213,7 @@ public sealed partial class CastingHandler
 
         if (!CastSuccessful(playerReader.CastEvent.Value))
         {
-            react.Do(item, $"{item.Name}-{nameof(CastingHandler)}: {nameof(CastCastbar)}");
+            react.Do(item);
             return false;
         }
 
@@ -553,160 +553,160 @@ public sealed partial class CastingHandler
     #region Logging
 
     [LoggerMessage(
-        EventId = 70,
+        EventId = 0070,
         Level = LogLevel.Information,
-        Message = "[{name}] ... AfterCastWaitSwing")]
+        Message = "[{name,-15}] ... AfterCastWaitSwing")]
     static partial void LogAfterCastWaitSwing(ILogger logger, string name);
 
     [LoggerMessage(
-        EventId = 71,
+        EventId = 0071,
         Level = LogLevel.Information,
-        Message = "[{name}] instant skip validation")]
+        Message = "[{name,-15}] instant skip validation")]
     static partial void LogInstantSkipValidation(ILogger logger, string name);
 
     [LoggerMessage(
-        EventId = 72,
+        EventId = 0072,
         Level = LogLevel.Information,
-        Message = "[{name}] instant input {pressTime}ms {inputElapsedMs}ms")]
+        Message = "[{name,-15}] instant input {pressTime}ms {inputElapsedMs}ms")]
     static partial void LogInstantInput(ILogger logger, string name, int pressTime, float inputElapsedMs);
 
     [LoggerMessage(
-        EventId = 73,
+        EventId = 0073,
         Level = LogLevel.Information,
-        Message = "[{name}] instant usable: {beforeUsable}->{afterUsable} | {beforeCastEvent}->{afterCastEvent}")]
+        Message = "[{name,-15}] instant usable: {beforeUsable}->{afterUsable} | {beforeCastEvent}->{afterCastEvent}")]
     static partial void LogInstantUsableChange(ILogger logger, string name, bool beforeUsable, bool afterUsable, string beforeCastEvent, string afterCastEvent);
 
     [LoggerMessage(
-        EventId = 74,
+        EventId = 0074,
         Level = LogLevel.Information,
-        Message = "[{name}] ... castbar skip validation")]
+        Message = "[{name,-15}] ... castbar skip validation")]
     static partial void LogCastbarSkipValidation(ILogger logger, string name);
 
     [LoggerMessage(
-        EventId = 75,
+        EventId = 0075,
         Level = LogLevel.Information,
-        Message = "[{name}] castbar input {pressTime}ms {inputElapsedMs}ms")]
+        Message = "[{name,-15}] castbar input {pressTime}ms {inputElapsedMs}ms")]
     static partial void LogCastbarInput(ILogger logger, string name, int pressTime, float inputElapsedMs);
 
     [LoggerMessage(
-        EventId = 76,
+        EventId = 0076,
         Level = LogLevel.Information,
-        Message = "[{name}] ... casting: {casting} | count:{castCount} | usable: {beforeUsable}->{afterUsable} | {beforeCastEvent}->{afterCastEvent}")]
+        Message = "[{name,-15}] ... casting: {casting} | count:{castCount} | usable: {beforeUsable}->{afterUsable} | {beforeCastEvent}->{afterCastEvent}")]
     static partial void LogCastbarUsableChange(ILogger logger, string name, bool casting, int castCount, bool beforeUsable, bool afterUsable, string beforeCastEvent, string afterCastEvent);
 
     [LoggerMessage(
-        EventId = 77,
+        EventId = 0077,
         Level = LogLevel.Information,
-        Message = "[{name}] ... AfterCastWaitCastbar(V) {remain}ms or interrupt...")]
+        Message = "[{name,-15}] ... AfterCastWaitCastbar(V) {remain}ms or interrupt...")]
     static partial void LogVisibleAfterCastWaitCastbar(ILogger logger, string name, int remain);
 
     [LoggerMessage(
-        EventId = 78,
+        EventId = 0078,
         Level = LogLevel.Warning,
-        Message = "[{name}] ... AfterCastWaitCastbar(v) interrupted!")]
+        Message = "[{name,-15}] ... AfterCastWaitCastbar(v) interrupted!")]
     static partial void LogVisibleAfterCastWaitCastbarInterrupted(ILogger logger, string name);
 
     [LoggerMessage(
-        EventId = 79,
+        EventId = 0079,
         Level = LogLevel.Information,
-        Message = "[{name}] ... AfterCastWaitCastbar(h) {remain}ms or interrupt...")]
+        Message = "[{name,-15}] ... AfterCastWaitCastbar(h) {remain}ms or interrupt...")]
     static partial void LogHiddenAfterCastWaitCastbar(ILogger logger, string name, int remain);
 
     [LoggerMessage(
-        EventId = 80,
+        EventId = 0080,
         Level = LogLevel.Warning,
-        Message = "[{name}] ... AfterCastWaitCastbar(h) interrupted!")]
+        Message = "[{name,-15}] ... AfterCastWaitCastbar(h) interrupted!")]
     static partial void LogHiddenAfterCastWaitCastbarInterrupted(ILogger logger, string name);
 
 
     [LoggerMessage(
-        EventId = 81,
+        EventId = 0081,
         Level = LogLevel.Warning,
-        Message = "[{name}] ... after {before}->{after} form switch still not usable!")]
+        Message = "[{name,-15}] ... after {before}->{after} form switch still not usable!")]
     static partial void LogAfterFormSwitchNotUsable(ILogger logger, string name, string before, string after);
 
     [LoggerMessage(
-        EventId = 82,
+        EventId = 0082,
         Level = LogLevel.Information,
-        Message = "[{name}] ... BeforeCastDelay {delayBeforeCast}ms")]
+        Message = "[{name,-15}] ... BeforeCastDelay {delayBeforeCast}ms")]
     static partial void LogBeforeCastDelay(ILogger logger, string name, int delayBeforeCast);
 
     [LoggerMessage(
-        EventId = 83,
+        EventId = 0083,
         Level = LogLevel.Information,
-        Message = "[{name}] ... AfterCastWaitBuff count: {auraCount} | miss: {missType} | {elapsedMs}ms")]
+        Message = "[{name,-15}] ... AfterCastWaitBuff count: {auraCount} | miss: {missType} | {elapsedMs}ms")]
     static partial void LogAfterCastWaitBuff(ILogger logger, string name, string auraCount, string missType, float elapsedMs);
 
     [LoggerMessage(
-        EventId = 84,
+        EventId = 0084,
         Level = LogLevel.Information,
-        Message = "[{name}] ... AfterCastWaitCombat {delayAfterCast}ms")]
+        Message = "[{name,-15}] ... AfterCastWaitCombat {delayAfterCast}ms")]
     static partial void LogAfterCastWaitCombat(ILogger logger, string name, float delayAfterCast);
 
     [LoggerMessage(
-        EventId = 85,
+        EventId = 0085,
         Level = LogLevel.Information,
-        Message = "[{name}] ... AfterCastDelay {delayAfterCast}ms")]
+        Message = "[{name,-15}] ... AfterCastDelay {delayAfterCast}ms")]
     static partial void LogAfterCastDelay(ILogger logger, string name, int delayAfterCast);
 
     [LoggerMessage(
-        EventId = 86,
+        EventId = 0086,
         Level = LogLevel.Information,
-        Message = "[{name}] ... AfterCastDelay interrupted {delayElaspedMs}ms")]
+        Message = "[{name,-15}] ... AfterCastDelay interrupted {delayElaspedMs}ms")]
     static partial void LogAfterCastDelayInterrupted(ILogger logger, string name, float delayElaspedMs);
 
     [LoggerMessage(
-        EventId = 88,
+        EventId = 0088,
         Level = LogLevel.Information,
-        Message = "[{name}] ... AfterCastStepBack {stepBackAfterCast}ms")]
+        Message = "[{name,-15}] ... AfterCastStepBack {stepBackAfterCast}ms")]
     static partial void LogAfterCastStepBack(ILogger logger, string name, int stepBackAfterCast);
 
     [LoggerMessage(
-        EventId = 89,
+        EventId = 0089,
         Level = LogLevel.Information,
-        Message = "[{name}] .... AfterCastStepBack {stepbackElapsedMs}ms")]
+        Message = "[{name,-15}] .... AfterCastStepBack {stepbackElapsedMs}ms")]
     static partial void LogAfterCastStepBackInterrupted(ILogger logger, string name, float stepbackElapsedMs);
 
     [LoggerMessage(
-        EventId = 90,
+        EventId = 0090,
         Level = LogLevel.Information,
-        Message = "[{name}] ... GCD usable: {usable} | remain: {remain}ms | {elapsedMs}ms")]
+        Message = "[{name,-15}] ... GCD usable: {usable} | remain: {remain}ms | {elapsedMs}ms")]
     static partial void LogGCD(ILogger logger, string name, bool usable, int remain, float elapsedMs);
 
     [LoggerMessage(
-        EventId = 91,
+        EventId = 0091,
         Level = LogLevel.Information,
-        Message = "[{name}] ... form {before}->{after} | {elapsedMs}ms")]
+        Message = "[{name,-15}] ... form {before}->{after} | {elapsedMs}ms")]
     static partial void LogFormChanged(ILogger logger, string name, string before, string after, float elapsedMs);
 
     [LoggerMessage(
-        EventId = 92,
+        EventId = 0092,
         Level = LogLevel.Information,
-        Message = "[{name}] ... AfterCastWaitBag {elapsedMs}ms")]
+        Message = "[{name,-15}] ... AfterCastWaitBag {elapsedMs}ms")]
     static partial void LogAfterCastWaitBag(ILogger logger, string name, float elapsedMs);
 
     [LoggerMessage(
-        EventId = 93,
+        EventId = 0093,
         Level = LogLevel.Information,
-        Message = "[{name}] PrevGCD: {prevGCD}ms | GCD: {gcd}ms | Cast: {remainCastMs}ms | Next spell {duration}ms")]
+        Message = "[{name,-15}] PrevGCD: {prevGCD}ms | GCD: {gcd}ms | Cast: {remainCastMs}ms | Next spell {duration}ms")]
     static partial void LogWaitForGCD(ILogger logger, string name, int prevGCD, int gcd, int remainCastMs, float duration);
 
     [LoggerMessage(
-        EventId = 94,
+        EventId = 0094,
         Level = LogLevel.Information,
-        Message = "[{name}] ... AfterCastAuraExpected {delay}ms")]
+        Message = "[{name,-15}] ... AfterCastAuraExpected {delay}ms")]
     static partial void LogAfterCastAuraExpected(ILogger logger, string name, int delay);
 
     [LoggerMessage(
-        EventId = 95,
+        EventId = 0095,
         Level = LogLevel.Information,
-        Message = "[{name}] ... AfterCastWaitGCD {gcd}ms")]
+        Message = "[{name,-15}] ... AfterCastWaitGCD {gcd}ms")]
     static partial void LogAfterCastWaitGCD(ILogger logger, string name, int gcd);
 
     [LoggerMessage(
-        EventId = 96,
+        EventId = 0096,
         Level = LogLevel.Information,
-        Message = "[{name}] ... AfterCastWaitMeleeRange")]
+        Message = "[{name,-15}] ... AfterCastWaitMeleeRange")]
     static partial void LogAfterCastWaitMeleeRange(ILogger logger, string name);
 
     #endregion

--- a/Core/GoalsComponent/CastingHandlerInterruptWatchdog.cs
+++ b/Core/GoalsComponent/CastingHandlerInterruptWatchdog.cs
@@ -11,7 +11,7 @@ public sealed class CastingHandlerInterruptWatchdog : IDisposable
 {
     private const bool Log = false;
 
-    private readonly ILogger logger;
+    private readonly ILogger<CastingHandlerInterruptWatchdog> logger;
     private readonly Wait wait;
 
     private readonly Thread thread;
@@ -22,7 +22,8 @@ public sealed class CastingHandlerInterruptWatchdog : IDisposable
     private Func<bool>? interrupt;
     private CancellationTokenSource? cts;
 
-    public CastingHandlerInterruptWatchdog(ILogger logger, Wait wait)
+    public CastingHandlerInterruptWatchdog(
+        ILogger<CastingHandlerInterruptWatchdog> logger, Wait wait)
     {
         this.logger = logger;
         this.wait = wait;
@@ -52,7 +53,7 @@ public sealed class CastingHandlerInterruptWatchdog : IDisposable
                 if (initial != interrupt?.Invoke())
                 {
                     if (Log)
-                        logger.LogWarning($"[{nameof(CastingHandlerInterruptWatchdog)}] Interrupted!");
+                        logger.LogWarning("Interrupted!");
 
                     initial = null;
                     interrupt = null;
@@ -67,20 +68,20 @@ public sealed class CastingHandlerInterruptWatchdog : IDisposable
             }
 
             if (Log)
-                logger.LogWarning($"[{nameof(CastingHandlerInterruptWatchdog)}] waiting...");
+                logger.LogWarning("Waiting...");
 
             resetEvent.Reset();
             resetEvent.Wait();
         }
 
         if (logger.IsEnabled(LogLevel.Debug))
-            logger.LogDebug($"{nameof(CastingHandlerInterruptWatchdog)} thread stopped!");
+            logger.LogDebug("Thread stopped!");
     }
 
     public void Set(Func<bool> interrupt, CancellationTokenSource cts)
     {
         if (Log)
-            logger.LogWarning($"[{nameof(CastingHandlerInterruptWatchdog)}] Set interrupt");
+            logger.LogWarning("Set interrupt");
 
         this.initial = interrupt();
         this.interrupt = interrupt;

--- a/Core/GoalsComponent/CombatUtil.cs
+++ b/Core/GoalsComponent/CombatUtil.cs
@@ -8,7 +8,7 @@ public sealed class CombatUtil
 {
     private const float MIN_DISTANCE = 0.01f;
 
-    private readonly ILogger logger;
+    private readonly ILogger<CombatUtil> logger;
     private readonly AddonReader addonReader;
     private readonly PlayerReader playerReader;
     private readonly ConfigurableInput input;
@@ -18,7 +18,8 @@ public sealed class CombatUtil
 
     private bool outOfCombat;
 
-    public CombatUtil(ILogger logger, ConfigurableInput input, Wait wait, AddonReader addonReader)
+    public CombatUtil(ILogger<CombatUtil> logger, ConfigurableInput input,
+        Wait wait, AddonReader addonReader)
     {
         this.logger = logger;
         this.input = input;
@@ -112,7 +113,7 @@ public sealed class CombatUtil
     {
         if (debug)
         {
-            logger.LogDebug($"{nameof(CombatUtil)}: {text}");
+            logger.LogDebug($"{text}");
         }
     }
 }

--- a/Core/GoalsComponent/MountHandler.cs
+++ b/Core/GoalsComponent/MountHandler.cs
@@ -14,7 +14,7 @@ public sealed partial class MountHandler : IMountHandler
 
     private const int MIN_DISTANCE_TO_INTERRUPT_CAST = 60;
 
-    private readonly ILogger logger;
+    private readonly ILogger<MountHandler> logger;
     private readonly ConfigurableInput input;
     private readonly ClassConfiguration classConfig;
     private readonly Wait wait;
@@ -25,7 +25,7 @@ public sealed partial class MountHandler : IMountHandler
     private readonly StopMoving stopMoving;
     private readonly IBlacklist targetBlacklist;
 
-    public MountHandler(ILogger logger, ConfigurableInput input,
+    public MountHandler(ILogger<MountHandler> logger, ConfigurableInput input,
         ClassConfiguration classConfig, Wait wait, AddonReader addonReader,
         StopMoving stopMoving, IBlacklist blacklist)
     {
@@ -64,7 +64,7 @@ public sealed partial class MountHandler : IMountHandler
 
         float e =
             wait.Until(CastingHandler.SPELL_QUEUE + playerReader.NetworkLatency.Value, CastDetected);
-        LogCastStarted(logger, nameof(MountHandler), e);
+        LogCastStarted(logger, e);
 
         if (bits.IsMounted())
             return;
@@ -73,7 +73,7 @@ public sealed partial class MountHandler : IMountHandler
 
         e =
             wait.Until(playerReader.RemainCastMs + playerReader.NetworkLatency.Value, MountedOrNotCastingOrValidTargetOrEnteredCombat);
-        LogCastEnded(logger, nameof(MountHandler), bits.IsMounted(), e);
+        LogCastEnded(logger, bits.IsMounted(), e);
 
         if (bits.IsMounted())
             return;
@@ -87,7 +87,7 @@ public sealed partial class MountHandler : IMountHandler
             else if (!bits.IsMounted())
             {
                 e = wait.Until(CastingHandler.SPELL_QUEUE + playerReader.NetworkLatency.Value, bits.IsMounted);
-                LogIsMounted(logger, nameof(MountHandler), bits.IsMounted(), e);
+                LogIsMounted(logger, bits.IsMounted(), e);
                 wait.Update();
             }
         }
@@ -129,20 +129,20 @@ public sealed partial class MountHandler : IMountHandler
         playerReader.MinRange() < MIN_DISTANCE_TO_INTERRUPT_CAST;
 
     [LoggerMessage(
-        EventId = 110,
+        EventId = 0110,
         Level = LogLevel.Information,
-        Message = "{className}: Cast started {elapsed}ms")]
-    static partial void LogCastStarted(ILogger logger, string className, float elapsed);
+        Message = "Cast started {elapsed}ms")]
+    static partial void LogCastStarted(ILogger logger, float elapsed);
 
     [LoggerMessage(
-        EventId = 111,
+        EventId = 0111,
         Level = LogLevel.Information,
-        Message = "{className}: Cast ended | mounted? {mounted} {elapsed}ms")]
-    static partial void LogCastEnded(ILogger logger, string className, bool mounted, float elapsed);
+        Message = "Cast ended | mounted? {mounted} {elapsed}ms")]
+    static partial void LogCastEnded(ILogger logger, bool mounted, float elapsed);
 
     [LoggerMessage(
-        EventId = 112,
+        EventId = 0112,
         Level = LogLevel.Information,
-        Message = "{className}: Mounted? {mounted} {elapsed}ms")]
-    static partial void LogIsMounted(ILogger logger, string className, bool mounted, float elapsed);
+        Message = "Mounted? {mounted} {elapsed}ms")]
+    static partial void LogIsMounted(ILogger logger, bool mounted, float elapsed);
 }

--- a/Core/GoalsComponent/Navigation.cs
+++ b/Core/GoalsComponent/Navigation.cs
@@ -22,7 +22,7 @@ public sealed partial class Navigation : IDisposable
 
     private readonly string patherName;
 
-    private readonly ILogger logger;
+    private readonly ILogger<Navigation> logger;
     private readonly PlayerDirection playerDirection;
     private readonly ConfigurableInput input;
     private readonly AddonReader addonReader;
@@ -69,7 +69,7 @@ public sealed partial class Navigation : IDisposable
     private int failedAttempt;
     private Vector3 lastFailedDestination;
 
-    public Navigation(ILogger logger, PlayerDirection playerDirection,
+    public Navigation(ILogger<Navigation> logger, PlayerDirection playerDirection,
         ConfigurableInput input, AddonReader addonReader, StopMoving stopMoving,
         StuckDetector stuckDetector, IPPather pather, IMountHandler mountHandler,
         ClassConfiguration classConfiguration)
@@ -530,43 +530,43 @@ public sealed partial class Navigation : IDisposable
 
     private void LogDebug(string text)
     {
-        logger.LogDebug($"{nameof(Navigation)}: {text}");
+        logger.LogDebug($"D: {text}");
     }
 
     #region Logging
 
     [LoggerMessage(
-        EventId = 40,
+        EventId = 0040,
         Level = LogLevel.Warning,
         Message = "Unable to find path {start} -> {end}. Character may stuck! {elapsedMs}ms")]
     static partial void LogPathfinderFailed(ILogger logger, Vector3 start, Vector3 end, double elapsedMs);
 
     [LoggerMessage(
-        EventId = 41,
+        EventId = 0041,
         Level = LogLevel.Information,
         Message = "Pathfinder - {distance} - {start} -> {end} {elapsedMs}ms")]
     static partial void LogPathfinderSuccess(ILogger logger, float distance, Vector3 start, Vector3 end, double elapsedMs);
 
     [LoggerMessage(
-        EventId = 42,
+        EventId = 0042,
         Level = LogLevel.Information,
         Message = "Clear route to waypoint! Stucked for {elapsedMs}ms")]
     static partial void LogClearRouteToWaypointStuck(ILogger logger, double elapsedMs);
 
     [LoggerMessage(
-        EventId = 43,
+        EventId = 0043,
         Level = LogLevel.Information,
         Message = "[{name}] distance from nearlest point is {distance}. Have to clear RouteToWaypoint.")]
     static partial void LogV1ClearRouteToWaypoint(ILogger logger, string name, float distance);
 
     [LoggerMessage(
-        EventId = 44,
+        EventId = 0044,
         Level = LogLevel.Information,
         Message = "[{name}] distance is close {distance}. Keep RouteToWaypoint.")]
     static partial void LogV1KeepRouteToWaypoint(ILogger logger, string name, float distance);
 
     [LoggerMessage(
-        EventId = 45,
+        EventId = 0045,
         Level = LogLevel.Information,
         Message = "[{name}] total distance {totalDistance} > {maxDistancehalf}. Have to clear RouteToWaypoint.")]
     static partial void LogV1ClearRouteToWaypointTooFar(ILogger logger, string name, float totalDistance, float maxDistancehalf);

--- a/Core/GoalsComponent/PlayerDirection.cs
+++ b/Core/GoalsComponent/PlayerDirection.cs
@@ -16,12 +16,13 @@ public sealed partial class PlayerDirection : IDisposable
     private const float RADIAN = PI * 2;
     private const int DefaultIgnoreDistance = 10;
 
-    private readonly ILogger logger;
+    private readonly ILogger<PlayerDirection> logger;
     private readonly ConfigurableInput input;
     private readonly PlayerReader playerReader;
     private readonly CancellationTokenSource _cts;
 
-    public PlayerDirection(ILogger logger, ConfigurableInput input, PlayerReader playerReader)
+    public PlayerDirection(ILogger<PlayerDirection> logger,
+        ConfigurableInput input, PlayerReader playerReader)
     {
         this.logger = logger;
         this.input = input;
@@ -82,13 +83,13 @@ public sealed partial class PlayerDirection : IDisposable
     #region Logging
 
     [LoggerMessage(
-        EventId = 30,
+        EventId = 0030,
         Level = LogLevel.Debug,
         Message = "SetDirection: Too close, ignored direction change. {distance} < {ignoreDistance}")]
     static partial void LogDebugClose(ILogger logger, float distance, float ignoreDistance);
 
     [LoggerMessage(
-        EventId = 31,
+        EventId = 0031,
         Level = LogLevel.Debug,
         Message = "SetDirection: {direction:0.000} -> {desiredDirection:0.000} - {distance:0.000}")]
     static partial void LogDebugSetDirection(ILogger logger, float direction, float desiredDirection, float distance);

--- a/Core/GoalsComponent/StuckDetector.cs
+++ b/Core/GoalsComponent/StuckDetector.cs
@@ -22,7 +22,7 @@ public sealed class StuckDetector
     private const double UNSTUCK_AFTER_MS = 2000;
     private const double ACTION_STUCK_TIME = 3000;
 
-    private readonly ILogger logger;
+    private readonly ILogger<StuckDetector> logger;
     private readonly ConfigurableInput input;
 
     private readonly PlayerReader playerReader;
@@ -38,7 +38,9 @@ public sealed class StuckDetector
     public double ActionDurationMs => (DateTime.UtcNow - startTime).TotalMilliseconds;
     private double UnstuckMs => (DateTime.UtcNow - attemptTime).TotalMilliseconds;
 
-    public StuckDetector(ILogger logger, ConfigurableInput input, PlayerReader playerReader, PlayerDirection playerDirection, StopMoving stopMoving)
+    public StuckDetector(ILogger<StuckDetector> logger, ConfigurableInput input, 
+        PlayerReader playerReader, PlayerDirection playerDirection,
+        StopMoving stopMoving)
     {
         this.logger = logger;
         this.input = input;

--- a/Core/Requirement/RequirementFactory.cs
+++ b/Core/Requirement/RequirementFactory.cs
@@ -1215,19 +1215,19 @@ public sealed partial class RequirementFactory
     #region Logging
 
     [LoggerMessage(
-        EventId = 11,
+        EventId = 0017,
         Level = LogLevel.Information,
         Message = "[{typeName}] Defined int variable [{key} -> {value}]")]
     static partial void LogUserDefinedValue(ILogger logger, string typeName, string key, int value);
 
     [LoggerMessage(
-        EventId = 12,
+        EventId = 0018,
         Level = LogLevel.Information,
-        Message = "[{name}] Requirement: \"{requirement}\"")]
+        Message = "[{name,-15}] Requirement: \"{requirement}\"")]
     static partial void LogProcessingRequirement(ILogger logger, string name, string requirement);
 
     [LoggerMessage(
-        EventId = 13,
+        EventId = 0019,
         Level = LogLevel.Error,
         Message = "UNKNOWN REQUIREMENT! {requirement}: try one of: {available}")]
     static partial void LogUnknownRequirement(ILogger logger, string requirement, string available);

--- a/Core/ScreenCapture/ScreenCapture.cs
+++ b/Core/ScreenCapture/ScreenCapture.cs
@@ -12,7 +12,7 @@ namespace Core;
 
 public sealed partial class ScreenCapture : ScreenCaptureCleaner, IDisposable
 {
-    private readonly ILogger logger;
+    private readonly ILogger<ScreenCapture> logger;
     private readonly DataConfig dataConfig;
     private readonly WowScreen wowScreen;
     private readonly CancellationToken token;
@@ -23,7 +23,7 @@ public sealed partial class ScreenCapture : ScreenCaptureCleaner, IDisposable
     private readonly Bitmap bitmap;
     private readonly Graphics graphics;
 
-    public ScreenCapture(ILogger logger, DataConfig dataConfig,
+    public ScreenCapture(ILogger<ScreenCapture> logger, DataConfig dataConfig,
         CancellationTokenSource cts, WowScreen wowScreen)
         : base(logger, dataConfig)
     {
@@ -71,7 +71,7 @@ public sealed partial class ScreenCapture : ScreenCaptureCleaner, IDisposable
         }
 
         if (logger.IsEnabled(LogLevel.Debug))
-            logger.LogDebug($"{nameof(ScreenCapture)} thread stopped!");
+            logger.LogDebug($"Thread stopped!");
     }
 
     public override void Request()
@@ -83,9 +83,9 @@ public sealed partial class ScreenCapture : ScreenCaptureCleaner, IDisposable
     #region Logging 
 
     [LoggerMessage(
-        EventId = 111,
+        EventId = 0111,
         Level = LogLevel.Information,
-        Message = "[ScreenCapture] {fileName}")]
+        Message = "{fileName}")]
     static partial void LogScreenCapture(ILogger logger, string fileName);
 
     #endregion

--- a/Game/Input/WowProcessInput.cs
+++ b/Game/Input/WowProcessInput.cs
@@ -203,25 +203,25 @@ public sealed partial class WowProcessInput : IMouseInput
     }
 
     [LoggerMessage(
-        EventId = 25,
+        EventId = 3000,
         Level = LogLevel.Debug,
         Message = @"Input: KeyDown {key}")]
     static partial void LogKeyDown(ILogger logger, ConsoleKey key);
 
     [LoggerMessage(
-        EventId = 26,
+        EventId = 3001,
         Level = LogLevel.Debug,
         Message = @"Input: KeyUp {key}")]
     static partial void LogKeyUp(ILogger logger, ConsoleKey key);
 
     [LoggerMessage(
-        EventId = 27,
+        EventId = 3002,
         Level = LogLevel.Debug,
         Message = @"Input: [{key}] pressed for {milliseconds}ms")]
     static partial void LogKeyPress(ILogger logger, ConsoleKey key, int milliseconds);
 
     [LoggerMessage(
-        EventId = 28,
+        EventId = 3003,
         Level = LogLevel.Debug,
         Message = @"Input: [{key}] pressing for {milliseconds}ms")]
     static partial void LogKeyPressNoDelay(ILogger logger, ConsoleKey key, int milliseconds);

--- a/HeadlessServer/HeadlessServer.cs
+++ b/HeadlessServer/HeadlessServer.cs
@@ -6,15 +6,17 @@ namespace HeadlessServer;
 
 public sealed class HeadlessServer
 {
-    private readonly ILogger logger;
+    private readonly ILogger<HeadlessServer> logger;
     private readonly IBotController botController;
     private readonly IAddonReader addonReader;
     private readonly ExecGameCommand exec;
     private readonly AddonConfigurator addonConfigurator;
     private readonly Wait wait;
 
-    public HeadlessServer(ILogger logger, IBotController botController,
-        IAddonReader addonReader, ExecGameCommand exec, AddonConfigurator addonConfigurator, Wait wait)
+    public HeadlessServer(ILogger<HeadlessServer> logger,
+        IBotController botController,
+        IAddonReader addonReader, ExecGameCommand exec,
+        AddonConfigurator addonConfigurator, Wait wait)
     {
         this.logger = logger;
         this.botController = botController;
@@ -26,7 +28,7 @@ public sealed class HeadlessServer
 
     public void Run(ParserResult<RunOptions> options)
     {
-        logger.LogInformation($"Running {nameof(HeadlessServer)}!");
+        logger.LogInformation($"Running!");
 
         if (options.Value.Pid != -1)
         {

--- a/HeadlessServer/HeadlessServer.csproj
+++ b/HeadlessServer/HeadlessServer.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
+    <PackageReference Include="Serilog.Expressions" Version="3.4.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
   </ItemGroup>

--- a/HeadlessServer/Program.cs
+++ b/HeadlessServer/Program.cs
@@ -1,4 +1,4 @@
-using Core;
+﻿using Core;
 using Core.Database;
 using Core.Session;
 using Game;
@@ -46,11 +46,13 @@ internal sealed class Program
             builder.AddSerilog();
         });
 
-        Log.Information($"[{nameof(Program)}] {Thread.CurrentThread.CurrentCulture.TwoLetterISOLanguageName} {DateTimeOffset.Now}");
+        var log = Log.Logger.ForContext<Program>();
+
+        log.Information($"{Thread.CurrentThread.CurrentCulture.TwoLetterISOLanguageName} {DateTimeOffset.Now}");
 
         ParserResult<RunOptions> options = Parser.Default.ParseArguments<RunOptions>(args).WithNotParsed(a =>
         {
-            Log.Error("Missing Required command line argument!");
+            log.Error("Missing Required command line argument!");
         });
 
         if (options.Tag == ParserResultType.NotParsed)
@@ -61,23 +63,23 @@ internal sealed class Program
 
         if (!FrameConfig.Exists() || !AddonConfig.Exists())
         {
-            Log.Error("Unable to run headless server as crucial configuration files missing!");
-            Log.Warning($"Please be sure, the following validated configuration files present next to the executable:");
-            Log.Warning($"{System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)}");
-            Log.Warning($"* {DataConfigMeta.DefaultFileName}");
-            Log.Warning($"* {FrameConfigMeta.DefaultFilename}");
-            Log.Warning($"* {AddonConfigMeta.DefaultFileName}");
+            log.Error("Unable to run headless server as crucial configuration files missing!");
+            log.Warning($"Please be sure, the following validated configuration files present next to the executable:");
+            log.Warning($"{System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)}");
+            log.Warning($"* {DataConfigMeta.DefaultFileName}");
+            log.Warning($"* {FrameConfigMeta.DefaultFilename}");
+            log.Warning($"* {AddonConfigMeta.DefaultFileName}");
             Console.ReadLine();
             return;
         }
 
         while (WowProcess.Get(options.Value.Pid) == null)
         {
-            Log.Warning($"[{nameof(Program)}] Unable to find any Wow process, is it running ?");
+            log.Warning($"Unable to find any Wow process, is it running ?");
             Thread.Sleep(1000);
         }
 
-        if (ConfigureServices(services, options))
+        if (ConfigureServices(log, services, options))
         {
             ServiceProvider provider = services
                 .AddSingleton<HeadlessServer>()
@@ -100,9 +102,9 @@ internal sealed class Program
         Console.ReadLine();
     }
 
-    private static bool ConfigureServices(IServiceCollection services, ParserResult<RunOptions> options)
+    private static bool ConfigureServices(Serilog.ILogger log, IServiceCollection services, ParserResult<RunOptions> options)
     {
-        if (!Validate(options.Value.Pid))
+        if (!Validate(log, options.Value.Pid))
             return false;
 
         services.AddSingleton<CancellationTokenSource>();
@@ -120,19 +122,19 @@ internal sealed class Program
         if (options.Value.Diagnostics)
         {
             services.AddSingleton<IScreenCapture, ScreenCapture>();
-            Log.Information($"[{nameof(Program)}] {nameof(ScreenCapture)}");
+            log.Information(nameof(ScreenCapture));
         }
         else
         {
             services.AddSingleton<IScreenCapture, NoScreenCapture>();
-            Log.Information($"[{nameof(Program)}] {nameof(NoScreenCapture)}");
+            log.Information(nameof(NoScreenCapture));
         }
 
         services.AddSingleton<SessionStat>();
         services.AddSingleton<IGrindSessionDAO, LocalGrindSessionDAO>();
         services.AddSingleton<WorldMapAreaDB>();
         services.AddSingleton<IPPather>(x =>
-            GetPather(x.GetRequiredService<Microsoft.Extensions.Logging.ILogger>(),
+            GetPather(log, x.GetRequiredService<Microsoft.Extensions.Logging.ILogger>(),
                 x.GetRequiredService<DataConfig>(), x.GetRequiredService<WorldMapAreaDB>(), options));
 
         services.AddSingleton<AutoResetEvent>(x => new(false));
@@ -144,15 +146,15 @@ internal sealed class Program
         {
             case AddonDataProviderType.GDI:
                 services.AddSingleton<IAddonDataProvider, AddonDataProviderGDI>();
-                Log.Information($"[{nameof(Program)}] {nameof(AddonDataProviderGDI)}");
+                log.Information(nameof(AddonDataProviderGDI));
                 break;
             case AddonDataProviderType.GDIBlit:
                 services.AddSingleton<IAddonDataProvider, AddonDataProviderBitBlt>();
-                Log.Information($"[{nameof(Program)}] {nameof(AddonDataProviderBitBlt)}");
+                log.Information(nameof(AddonDataProviderBitBlt));
                 break;
             case AddonDataProviderType.DXGI:
                 services.AddSingleton<IAddonDataProvider, AddonDataProviderDXGI>();
-                Log.Information($"[{nameof(Program)}] {nameof(AddonDataProviderDXGI)}");
+                log.Information(nameof(AddonDataProviderDXGI));
                 break;
         }
 
@@ -170,7 +172,7 @@ internal sealed class Program
         return true;
     }
 
-    private static IPPather GetPather(Microsoft.Extensions.Logging.ILogger logger, DataConfig dataConfig, WorldMapAreaDB worldMapAreaDB, ParserResult<RunOptions> options)
+    private static IPPather GetPather(Serilog.ILogger log, Microsoft.Extensions.Logging.ILogger logger, DataConfig dataConfig, WorldMapAreaDB worldMapAreaDB, ParserResult<RunOptions> options)
     {
         StartupConfigPathing scp = new(options.Value.Mode.ToString()!,
             options.Value.Hostv1!, options.Value.Portv1,
@@ -183,7 +185,7 @@ internal sealed class Program
             RemotePathingAPIV3 api = new(logger, scp.hostv3, scp.portv3, worldMapAreaDB);
             if (api.PingServer())
             {
-                Log.Information($"[{nameof(Program)}] Using {StartupConfigPathing.Types.RemoteV3}({api.GetType().Name}) {scp.hostv3}:{scp.portv3}");
+                log.Information($"Using {StartupConfigPathing.Types.RemoteV3}({api.GetType().Name}) {scp.hostv3}:{scp.portv3}");
                 return api;
             }
             api.Dispose();
@@ -199,10 +201,10 @@ internal sealed class Program
             {
                 if (scp.Type == StartupConfigPathing.Types.RemoteV3)
                 {
-                    Log.Warning($"[{nameof(Program)}] Unavailable {StartupConfigPathing.Types.RemoteV3} {scp.hostv3}:{scp.portv3} - Fallback to {StartupConfigPathing.Types.RemoteV1}");
+                    log.Warning($"Unavailable {StartupConfigPathing.Types.RemoteV3} {scp.hostv3}:{scp.portv3} - Fallback to {StartupConfigPathing.Types.RemoteV1}");
                 }
 
-                Log.Information($"[{nameof(Program)}] Using {StartupConfigPathing.Types.RemoteV1}({api.GetType().Name}) {scp.hostv1}:{scp.portv1}");
+                log.Information($"Using {StartupConfigPathing.Types.RemoteV1}({api.GetType().Name}) {scp.hostv1}:{scp.portv1}");
                 return api;
             }
 
@@ -211,25 +213,27 @@ internal sealed class Program
 
         if (scp.Type != StartupConfigPathing.Types.Local)
         {
-            Log.Warning($"[{nameof(Program)}] {scp.Type} not available!");
+            log.Warning($"{scp.Type} not available!");
         }
 
         LocalPathingApi localApi = new(logger, new PPatherService(logger, dataConfig, worldMapAreaDB), dataConfig);
-        Log.Information($"[{nameof(Program)}] Using {StartupConfigPathing.Types.Local}({localApi.GetType().Name})");
+        log.Information($"Using {StartupConfigPathing.Types.Local}({localApi.GetType().Name})");
         return localApi;
     }
 
-    private static bool Validate(int pid)
+    private static bool Validate(Serilog.ILogger log, int pid)
     {
         WowProcess wowProcess = new(pid);
-        Log.Information($"[{nameof(Program)}] Pid: {wowProcess.ProcessId}");
-        Log.Information($"[{nameof(Program)}] Version: {wowProcess.FileVersion}");
+        log.Information($"Pid: {wowProcess.ProcessId}");
+        log.Information($"Version: {wowProcess.FileVersion}");
         NativeMethods.GetWindowRect(wowProcess.Process.MainWindowHandle, out Rectangle rect);
 
-        var logger = new SerilogLoggerProvider(Log.Logger, true).CreateLogger(nameof(AddonConfigurator));
+        ILoggerFactory factory = new LoggerFactory().AddSerilog(Log.Logger);
+        var logger = factory.CreateLogger<AddonConfigurator>();
+
         AddonConfigurator addonConfigurator = new(logger, wowProcess);
         Version? installVersion = addonConfigurator.GetInstallVersion();
-        Log.Information($"[{nameof(Program)}] Addon version: {installVersion}");
+        log.Information($"Addon version: {installVersion}");
 
         bool valid = true;
 
@@ -240,7 +244,7 @@ internal sealed class Program
             FrameConfig.Delete();
             valid = false;
 
-            Log.Error($"[{nameof(Program)}] {nameof(AddonConfig)} doesn't exists or addon not installed yet!");
+            log.Error($"{nameof(AddonConfig)} doesn't exists or addon not installed yet!");
         }
 
         if (FrameConfig.Exists() && !FrameConfig.IsValid(rect, installVersion!))
@@ -249,7 +253,7 @@ internal sealed class Program
             FrameConfig.Delete();
             valid = false;
 
-            Log.Error($"[{nameof(Program)}] {nameof(FrameConfig)} doesn't exists or window rect is different then config!");
+            log.Error($"{nameof(FrameConfig)} doesn't exists or window rect is different then config!");
         }
 
         wowProcess.Dispose();

--- a/SharedLib/NpcFinder/NpcNameFinder.cs
+++ b/SharedLib/NpcFinder/NpcNameFinder.cs
@@ -665,7 +665,7 @@ public sealed partial class NpcNameFinder : IDisposable
     #region Logging
 
     [LoggerMessage(
-        EventId = 1,
+        EventId = 2000,
         Level = LogLevel.Information,
         Message = "[NpcNameFinder] type = {type} | mode = {mode}")]
     static partial void LogTypeChanged(ILogger logger, string type, string mode);


### PR DESCRIPTION
Using `Serilog.Expressions` to obtain `SourceContext`.

Before:
![image](https://github.com/Xian55/WowClassicGrindBot/assets/367101/ee43f34e-684e-4793-8d98-16764991aadd)


After:
![image](https://github.com/Xian55/WowClassicGrindBot/assets/367101/65235103-bdb7-44b5-a0df-5c33befff6fc)
