### PR TITLE
Big Refactor: Dependency Injection with small fixes

### DIFF
--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -100,24 +100,26 @@ DataToColor.DATA_CONFIG = {
     AUTO_SELL_GREY_ITEMS = true
 }
 
+local FRAME_CHANGE_RATE = 5
+
 -- How often item frames change
-local ITEM_ITERATION_FRAME_CHANGE_RATE = 5
+local ITEM_ITERATION_FRAME_CHANGE_RATE = FRAME_CHANGE_RATE
 -- How often the actionbar frames change
-local ACTION_BAR_ITERATION_FRAME_CHANGE_RATE = 5
+local ACTION_BAR_ITERATION_FRAME_CHANGE_RATE = FRAME_CHANGE_RATE
 -- How often the gossip frames change
-local GOSSIP_ITERATION_FRAME_CHANGE_RATE = 5
+local GOSSIP_ITERATION_FRAME_CHANGE_RATE = FRAME_CHANGE_RATE
 -- How often the spellbook frames change
-local SPELLBOOK_ITERATION_FRAME_CHANGE_RATE = 5
+local SPELLBOOK_ITERATION_FRAME_CHANGE_RATE = FRAME_CHANGE_RATE
 -- How often the spellbook frames change
-local TALENT_ITERATION_FRAME_CHANGE_RATE = 5
+local TALENT_ITERATION_FRAME_CHANGE_RATE = FRAME_CHANGE_RATE
 -- How often the spellbook frames change
-local COMBAT_LOG_ITERATION_FRAME_CHANGE_RATE = 5
+local COMBAT_LOG_ITERATION_FRAME_CHANGE_RATE = FRAME_CHANGE_RATE
 -- How often the check network latency
 local LATENCY_ITERATION_FRAME_CHANGE_RATE = 500 -- 500ms * refresh rate in ms
 -- How often the lastLoot return from Closed to Corpse
-local LOOT_RESET_RATE = 5
+local LOOT_RESET_RATE = FRAME_CHANGE_RATE
 -- How often the Player Buff / target Debuff frames change
-local AURA_DURATION_ITERATION_FRAME_CHANGE_RATE = 5
+local AURA_DURATION_ITERATION_FRAME_CHANGE_RATE = FRAME_CHANGE_RATE
 
 -- Timers
 DataToColor.globalTime = 0

--- a/BlazorServer/DependencyInjection.cs
+++ b/BlazorServer/DependencyInjection.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+using SharedLib;
+
+namespace BlazorServer;
+
+public static class DependencyInjection
+{
+    public static void AddStartupConfigurations(this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.Configure<StartupConfigPid>
+            (configuration.GetSection(StartupConfigPid.Position));
+
+        services.Configure<StartupConfigDiagnostics>
+            (configuration.GetSection(StartupConfigDiagnostics.Position));
+
+        services.Configure<StartupConfigPathing>
+            (configuration.GetSection(StartupConfigPathing.Position));
+
+        services.Configure<StartupConfigReader>
+            (configuration.GetSection(StartupConfigReader.Position));
+    }
+}

--- a/BlazorServer/Program.cs
+++ b/BlazorServer/Program.cs
@@ -17,7 +17,7 @@ public static class Program
     {
         while (true)
         {
-            Log.Information("Program.Main(): Starting blazor server");
+            Log.Information($"[{nameof(Program),-15}] Starting blazor server");
             try
             {
                 IHost host = CreateHostBuilder(args).Build();
@@ -33,7 +33,7 @@ public static class Program
             }
             catch (Exception ex)
             {
-                Log.Information($"Program.Main(): {ex.Message}");
+                Log.Information($"[{nameof(Program),-15}] {ex.Message}");
                 Log.Information("");
                 System.Threading.Thread.Sleep(3000);
             }

--- a/BlazorServer/Startup.cs
+++ b/BlazorServer/Startup.cs
@@ -1,19 +1,10 @@
 using System;
-using System.Drawing;
 using System.IO;
 using System.Threading;
-using System.Threading.Tasks;
-
-using BlazorTable;
 
 using Core;
-using Core.Addon;
-using Core.Database;
-using Core.Session;
 
-using Game;
-
-using MatBlazor;
+using Frontend;
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -23,27 +14,21 @@ using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
-using PPather;
-
 using Serilog;
 using Serilog.Events;
-using Serilog.Templates.Themes;
 using Serilog.Templates;
-
-using SharedLib;
-
-using WinAPI;
+using Serilog.Templates.Themes;
 
 namespace BlazorServer;
 
 public sealed class Startup
 {
+    private readonly IConfiguration configuration;
+
     public Startup(IConfiguration configuration)
     {
-        Configuration = configuration;
+        this.configuration = configuration;
     }
-
-    public IConfiguration Configuration { get; }
 
     // This method gets called by the runtime. Use this method to add services to the container.
     // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
@@ -62,7 +47,7 @@ public sealed class Startup
             const string outputTemplate = "[{@t:HH:mm:ss:fff} {@l:u1}] {#if Length(SourceContext) > 0}[{Substring(SourceContext, LastIndexOf(SourceContext, '.') + 1),-15}] {#end}{@m}\n{@x}";
 
             Log.Logger = new LoggerConfiguration()
-                //.MinimumLevel.Debug()
+                .MinimumLevel.Debug()
                 .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
                 .MinimumLevel.Override("Microsoft.Hosting.Lifetime", LogEventLevel.Information)
                 .Enrich.FromLogContext()
@@ -77,191 +62,33 @@ public sealed class Startup
             builder.Services.AddSingleton<Microsoft.Extensions.Logging.ILogger>(logFactory.CreateLogger(string.Empty));
         });
 
-        var log = Log.Logger.ForContext<Startup>();
+        ILogger<Startup> log = logFactory.CreateLogger<Startup>();
 
-        log.Information($"{Thread.CurrentThread.CurrentCulture.TwoLetterISOLanguageName} {DateTimeOffset.Now}");
+        log.LogInformation(
+            $"{Thread.CurrentThread.CurrentCulture.TwoLetterISOLanguageName} " +
+            $"{DateTimeOffset.Now}");
 
-        StartupConfigPid StartupConfigPid = new();
-        Configuration.GetSection(StartupConfigPid.Position).Bind(StartupConfigPid);
-        while (WowProcess.Get(StartupConfigPid.Id) == null)
-        {
-            log.Warning($"Unable to find any Wow process, is it running ?");
-            Thread.Sleep(1000);
-        }
+        services.AddStartupConfigurations(configuration);
 
-        WowProcess wowProcess = new(StartupConfigPid.Id);
-        log.Information($"Pid: {wowProcess.ProcessId}");
-        log.Information($"Version: {wowProcess.FileVersion}");
+        services.AddWoWProcess(log);
 
-        NativeMethods.GetWindowRect(wowProcess.Process.MainWindowHandle, out Rectangle rect);
-
-        var logger = logFactory.CreateLogger<AddonConfigurator>();
-
-        AddonConfigurator addonConfigurator = new(logger, wowProcess);
-        Version? installVersion = addonConfigurator.GetInstallVersion();
-        log.Information($"Addon version: {installVersion}");
-
-        if (addonConfigurator.IsDefault() || installVersion == null)
-        {
-            // At this point the webpage never loads so fallback to configuration page
-            addonConfigurator.Delete();
-            FrameConfig.Delete();
-
-            log.Error($"{nameof(AddonConfig)} doesn't exists or addon not installed yet!");
-        }
-
-        if (FrameConfig.Exists() && !FrameConfig.IsValid(rect, installVersion!))
-        {
-            // At this point the webpage never loads so fallback to configuration page
-            FrameConfig.Delete();
-            log.Error($"{nameof(FrameConfig)} doesn't exists or window rect is different then config!");
-        }
-
-        wowProcess.Dispose();
-
-        services.AddSingleton<CancellationTokenSource>();
-        services.AddSingleton<AutoResetEvent>(x => new(false));
-        services.AddSingleton<Wait>();
-
-        services.AddSingleton<WowProcess>(x => new(StartupConfigPid.Id));
-        services.AddSingleton<StartupClientVersion>();
-        services.AddSingleton<DataConfig>(x => DataConfig.Load(x.GetRequiredService<StartupClientVersion>().Path));
-        services.AddSingleton<WowScreen>();
-        services.AddSingleton<WowProcessInput>();
-        services.AddSingleton<ExecGameCommand>();
-        services.AddSingleton<AddonConfigurator>();
-
-        services.AddSingleton<DataFrame[]>(x => FrameConfig.LoadFrames());
-        services.AddSingleton<FrameConfigurator>();
+        services.AddCoreBase();
 
         if (AddonConfig.Exists() && FrameConfig.Exists())
         {
-            services.AddSingleton<MinimapNodeFinder>();
-
-            StartupConfigDiagnostics StartupDiagnostics = new();
-            Configuration.GetSection(StartupConfigDiagnostics.Position).Bind(StartupDiagnostics);
-
-            if (StartupDiagnostics.Enabled)
-            {
-                services.AddSingleton<IScreenCapture, ScreenCapture>();
-                log.Information(nameof(ScreenCapture));
-            }
-            else
-            {
-                services.AddSingleton<IScreenCapture, NoScreenCapture>();
-                log.Information(nameof(NoScreenCapture));
-            }
-
-            services.AddSingleton<SessionStat>();
-            services.AddSingleton<IGrindSessionDAO, LocalGrindSessionDAO>();
-            services.AddSingleton<WorldMapAreaDB>();
-            services.AddSingleton<IPPather>(x =>
-                GetPather(logFactory, x.GetRequiredService<Microsoft.Extensions.Logging.ILogger>(),
-                x.GetRequiredService<DataConfig>(), x.GetRequiredService<WorldMapAreaDB>()));
-
-            StartupConfigReader scr = new();
-            Configuration.GetSection(StartupConfigReader.Position).Bind(scr);
-
-            switch (scr.ReaderType)
-            {
-                case AddonDataProviderType.GDI:
-                    services.AddSingleton<IAddonDataProvider, AddonDataProviderGDI>();
-                    log.Information(nameof(AddonDataProviderGDI));
-                    break;
-                case AddonDataProviderType.GDIBlit:
-                    services.AddSingleton<IAddonDataProvider, AddonDataProviderBitBlt>();
-                    log.Information(nameof(AddonDataProviderBitBlt));
-                    break;
-                case AddonDataProviderType.DXGI:
-                    services.AddSingleton<IAddonDataProvider, AddonDataProviderDXGI>();
-                    log.Information(nameof(AddonDataProviderDXGI));
-                    break;
-            }
-
-            services.AddSingleton<AreaDB>();
-            services.AddSingleton<WorldMapAreaDB>();
-            services.AddSingleton<ItemDB>();
-            services.AddSingleton<CreatureDB>();
-            services.AddSingleton<SpellDB>();
-            services.AddSingleton<TalentDB>();
-
-            services.AddSingleton<PlayerReader>();
-            services.AddSingleton<IAddonReader, AddonReader>();
-
-            services.AddSingleton<LevelTracker>();
-
-            services.AddSingleton<IBotController, BotController>();
+            services.AddCoreNormal(log);
         }
         else
         {
-            services.AddSingleton<IAddonDataProvider, AddonDataProviderGDIConfig>();
-            services.AddSingleton<IBotController, ConfigBotController>();
-            services.AddSingleton<IAddonReader, ConfigAddonReader>();
+            services.AddCoreConfiguration();
         }
 
-        services.AddSingleton<WApi>();
-        services.AddSingleton<FrontendUpdate>();
+        services.AddFrontend();
 
-        services.AddMatBlazor();
-        services.AddRazorPages();
-        services.AddServerSideBlazor();
-        services.AddBlazorTable();
+        services.AddCoreFrontend();
 
-        services.BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true });
-    }
-
-    private IPPather GetPather(ILoggerFactory loggerFactory, Microsoft.Extensions.Logging.ILogger logger,
-        DataConfig dataConfig, WorldMapAreaDB worldMapAreaDB)
-    {
-        StartupConfigPathing scp = new();
-        Configuration.GetSection(StartupConfigPathing.Position).Bind(scp);
-
-        bool failed = false;
-
-        if (scp.Type == StartupConfigPathing.Types.RemoteV3)
-        {
-            var remoteLogger = loggerFactory.CreateLogger<RemotePathingAPIV3>();
-            RemotePathingAPIV3 api = new(remoteLogger, scp.hostv3, scp.portv3, worldMapAreaDB);
-            if (api.PingServer())
-            {
-                logger.LogInformation($"Using {StartupConfigPathing.Types.RemoteV3}({api.GetType().Name}) {scp.hostv3}:{scp.portv3}");
-                return api;
-            }
-            api.Dispose();
-            failed = true;
-        }
-
-        if (scp.Type == StartupConfigPathing.Types.RemoteV1 || failed)
-        {
-            var remoteLogger = loggerFactory.CreateLogger<RemotePathingAPI>();
-            RemotePathingAPI api = new(remoteLogger, scp.hostv1, scp.portv1);
-            Task<bool> pingTask = Task.Run(api.PingServer);
-            pingTask.Wait();
-            if (pingTask.Result)
-            {
-                if (scp.Type == StartupConfigPathing.Types.RemoteV3)
-                {
-                    logger.LogWarning($"Unavailable {StartupConfigPathing.Types.RemoteV3} {scp.hostv3}:{scp.portv3} - Fallback to {StartupConfigPathing.Types.RemoteV1}");
-                }
-
-                logger.LogInformation($"Using {StartupConfigPathing.Types.RemoteV1}({api.GetType().Name}) {scp.hostv1}:{scp.portv1}");
-                return api;
-            }
-
-            failed = true;
-        }
-
-        if (scp.Type != StartupConfigPathing.Types.Local)
-        {
-            logger.LogWarning($"{scp.Type} not available!");
-        }
-
-        var pathingLogger = loggerFactory.CreateLogger<LocalPathingApi>();
-        var serviceLogger = loggerFactory.CreateLogger<PPatherService>();
-        LocalPathingApi localApi = new(pathingLogger, new(serviceLogger, dataConfig, worldMapAreaDB), dataConfig);
-        logger.LogInformation($"Using {StartupConfigPathing.Types.Local}({localApi.GetType().Name})");
-
-        return localApi;
+        services.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateOnBuild = true });
     }
 
     // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -278,7 +105,7 @@ public sealed class Startup
 
         app.UseStaticFiles();
 
-        var dataConfig = DataConfig.Load();
+        DataConfig dataConfig = app.ApplicationServices.GetRequiredService<DataConfig>();
         app.UseStaticFiles(new StaticFileOptions
         {
             FileProvider = new PhysicalFileProvider(Path.Combine(env.ContentRootPath, dataConfig.Path)),

--- a/Core/Actionbar/ActionBarBits.cs
+++ b/Core/Actionbar/ActionBarBits.cs
@@ -2,7 +2,17 @@
 
 namespace Core;
 
-public sealed class ActionBarBits
+public interface IActionBarBits
+{
+    void Update(IAddonDataProvider reader);
+    bool Is(KeyAction keyAction);
+}
+
+public interface ICurrentAction : IActionBarBits { }
+
+public interface IUsableAction : IActionBarBits { }
+
+public sealed class ActionBarBits<T> : IActionBarBits
 {
     private readonly int[] cells;
 

--- a/Core/Actionbar/ActionBarCooldownReader.cs
+++ b/Core/Actionbar/ActionBarCooldownReader.cs
@@ -18,14 +18,12 @@ public sealed class ActionBarCooldownReader
 
     private const float FRACTION_PART = 10f;
 
-    private readonly int cActionbarNum;
+    private const int cActionbarNum = 37;
 
     private readonly Data[] data;
 
-    public ActionBarCooldownReader(int cActionbarNum)
+    public ActionBarCooldownReader()
     {
-        this.cActionbarNum = cActionbarNum;
-
         data = new Data[ActionBar.CELL_COUNT * ActionBar.BIT_PER_CELL];
         Reset();
     }

--- a/Core/Actionbar/ActionBarCostReader.cs
+++ b/Core/Actionbar/ActionBarCostReader.cs
@@ -31,8 +31,8 @@ public class ActionBarCostReader
     private const int COST_ORDER = 10000;
     private const int POWER_TYPE_MOD = 100;
 
-    private readonly int cActionbarMeta;
-    private readonly int cActionbarNum;
+    private const int cActionbarMeta = 35;
+    private const int cActionbarNum = 36;
 
     private static readonly ActionBarCost defaultCost = new(PowerType.Mana, 0);
     private readonly ActionBarCost[][] data;
@@ -42,11 +42,8 @@ public class ActionBarCostReader
     public event EventHandler<ActionBarCostEventArgs>? OnActionCostChanged;
     public event Action? OnActionCostReset;
 
-    public ActionBarCostReader(int cActionbarMeta, int cActionbarNum)
+    public ActionBarCostReader()
     {
-        this.cActionbarMeta = cActionbarMeta;
-        this.cActionbarNum = cActionbarNum;
-
         data = new ActionBarCost[ActionBar.CELL_COUNT * ActionBar.BIT_PER_CELL][];
         for (int s = 0; s < data.Length; s++)
         {

--- a/Core/Addon/AuraTimeReader.cs
+++ b/Core/Addon/AuraTimeReader.cs
@@ -3,7 +3,20 @@ using System.Collections.Generic;
 
 namespace Core;
 
-public sealed class AuraTimeReader
+public interface IAuraTimeReader
+{
+    void Read(IAddonDataProvider reader);
+    void Reset();
+    int GetRemainingTimeMs(int textureId);
+}
+
+public interface IPlayerBuffTimeReader : IAuraTimeReader { }
+
+public interface ITargetDebuffTimeReader : IAuraTimeReader { }
+
+public interface ITargetBuffTimeReader : IAuraTimeReader { }
+
+public sealed class AuraTimeReader<T> : IAuraTimeReader
 {
     public readonly struct Data
     {

--- a/Core/Addon/ConfigAddonReader.cs
+++ b/Core/Addon/ConfigAddonReader.cs
@@ -5,30 +5,13 @@ namespace Core.Addon;
 
 public sealed class ConfigAddonReader : IAddonReader
 {
-    public PlayerReader PlayerReader => throw new NotImplementedException();
-    public BagReader BagReader => throw new NotImplementedException();
-    public EquipmentReader EquipmentReader => throw new NotImplementedException();
-    public ActionBarCostReader ActionBarCostReader => throw new NotImplementedException();
-    public ActionBarCooldownReader ActionBarCooldownReader => throw new NotImplementedException();
-
-    public AuraTimeReader PlayerBuffTimeReader => throw new NotImplementedException();
-    public AuraTimeReader TargetDebuffTimeReader => throw new NotImplementedException();
-
-    public SpellBookReader SpellBookReader => throw new NotImplementedException();
-    public TalentReader TalentReader => throw new NotImplementedException();
-
-    public CombatLog CombatLog => throw new NotImplementedException();
+    private readonly IAddonDataProvider reader;
+    private readonly AutoResetEvent autoResetEvent;
 
     public double AvgUpdateLatency => throw new NotImplementedException();
-
-    public int DamageTakenCount() => throw new NotImplementedException();
-
     public string TargetName => throw new NotImplementedException();
 
     public event Action? AddonDataChanged;
-
-    private readonly IAddonDataProvider reader;
-    private readonly AutoResetEvent autoResetEvent;
 
     public ConfigAddonReader(IAddonDataProvider reader, AutoResetEvent autoResetEvent)
     {

--- a/Core/Addon/IAddonReader.cs
+++ b/Core/Addon/IAddonReader.cs
@@ -4,29 +4,7 @@ namespace Core;
 
 public interface IAddonReader
 {
-    PlayerReader PlayerReader { get; }
-
-    BagReader BagReader { get; }
-
-    EquipmentReader EquipmentReader { get; }
-
-    ActionBarCostReader ActionBarCostReader { get; }
-
-    ActionBarCooldownReader ActionBarCooldownReader { get; }
-
-    AuraTimeReader PlayerBuffTimeReader { get; }
-
-    AuraTimeReader TargetDebuffTimeReader { get; }
-
-    SpellBookReader SpellBookReader { get; }
-
-    TalentReader TalentReader { get; }
-
-    CombatLog CombatLog { get; }
-
     double AvgUpdateLatency { get; }
-
-    int DamageTakenCount();
 
     string TargetName { get; }
 

--- a/Core/Addon/PlayerReader.cs
+++ b/Core/Addon/PlayerReader.cs
@@ -12,16 +12,26 @@ public sealed partial class PlayerReader : IMouseOverReader
 
     public int SpellQueueTimeMs { get; set; } = 400;
 
-    public PlayerReader(IAddonDataProvider reader, WorldMapAreaDB mapAreaDB)
+    public PlayerReader(
+        IAddonDataProvider reader,
+        WorldMapAreaDB mapAreaDB,
+        AddonBits addonBits,
+        SpellInRange spellInRange,
+        BuffStatus buffStatus,
+        TargetDebuffStatus targetDebuffStatus,
+        Stance stance)
     {
         this.worldMapAreaDB = mapAreaDB;
 
         this.reader = reader;
-        Bits = new(8, 9);
-        SpellInRange = new(40);
-        Buffs = new(41);
-        TargetDebuffs = new(42);
-        Stance = new(48);
+
+        Bits = addonBits;
+        SpellInRange = spellInRange;
+        Buffs = buffStatus;
+        TargetDebuffs = targetDebuffStatus;
+        Stance = stance;
+
+        // TODO: inject! value type tho
         CustomTrigger1 = new(reader.GetInt(74));
     }
 
@@ -186,13 +196,11 @@ public sealed partial class PlayerReader : IMouseOverReader
 
     public void Update(IAddonDataProvider reader)
     {
-        if (UIMapId.Updated(reader) && UIMapId.Value != 0)
+        if (UIMapId.Updated(reader) && UIMapId.Value != 0 &&
+            worldMapAreaDB.TryGet(UIMapId.Value, out var wma))
         {
-            if (worldMapAreaDB.TryGet(UIMapId.Value, out var wma))
-            {
-                WorldMapArea = wma;
-                MapId = wma.MapID;
-            }
+            WorldMapArea = wma;
+            MapId = wma.MapID;
         }
 
         Bits.Update(reader);

--- a/Core/Addon/SpellBookReader.cs
+++ b/Core/Addon/SpellBookReader.cs
@@ -7,16 +7,15 @@ namespace Core;
 
 public sealed class SpellBookReader
 {
-    private readonly int cSpellId;
+    private const int cSpellId = 71;
 
     private readonly HashSet<int> spells = new();
 
     public SpellDB SpellDB { get; }
     public int Count => spells.Count;
 
-    public SpellBookReader(int cSpellId, SpellDB spellDB)
+    public SpellBookReader(SpellDB spellDB)
     {
-        this.cSpellId = cSpellId;
         this.SpellDB = spellDB;
     }
 

--- a/Core/AddonComponent/CombatLog.cs
+++ b/Core/AddonComponent/CombatLog.cs
@@ -16,6 +16,9 @@ public sealed class CombatLog
     public HashSet<int> DamageDone { get; } = new();
     public HashSet<int> DamageTaken { get; } = new();
 
+    public int DamageTakenCount() => DamageTaken.Count;
+    public int DamageDoneCount() => DamageDone.Count;
+
     public RecordInt DamageDoneGuid { get; }
     public RecordInt DamageTakenGuid { get; }
     public RecordInt DeadGuid { get; }
@@ -23,14 +26,14 @@ public sealed class CombatLog
     public RecordInt TargetMissType { get; }
     public RecordInt TargetDodge { get; }
 
-    public CombatLog(int cDamageDone, int cDamageTaken, int cDead, int cTargetMiss)
+    public CombatLog()
     {
-        DamageDoneGuid = new RecordInt(cDamageDone);
-        DamageTakenGuid = new RecordInt(cDamageTaken);
-        DeadGuid = new RecordInt(cDead);
+        DamageDoneGuid = new RecordInt(64);
+        DamageTakenGuid = new RecordInt(65);
+        DeadGuid = new RecordInt(66);
 
-        TargetMissType = new(cTargetMiss);
-        TargetDodge = new(cTargetMiss);
+        TargetMissType = new(67);
+        TargetDodge = new(67);
     }
 
     public void Reset()

--- a/Core/AddonComponent/Stance.cs
+++ b/Core/AddonComponent/Stance.cs
@@ -1,4 +1,6 @@
-﻿namespace Core;
+﻿using SharedLib;
+
+namespace Core;
 
 public sealed class Stance
 {

--- a/Core/AddonDataProvider/AddonDataProviderBitBlt.cs
+++ b/Core/AddonDataProvider/AddonDataProviderBitBlt.cs
@@ -73,7 +73,7 @@ public sealed class AddonDataProviderBitBlt : IAddonDataProvider, IDisposable
         IntPtr memoryDC = graphics.GetHdc();
 
         BitBlt(memoryDC,
-            0, 0, 
+            0, 0,
             rect.Width, rect.Height,
             windowDC, 0, 0,
             TernaryRasterOperations.SRCCOPY);
@@ -83,6 +83,12 @@ public sealed class AddonDataProviderBitBlt : IAddonDataProvider, IDisposable
         unsafe
         {
             BitmapData bd = bitmap.LockBits(rect, ImageLockMode.ReadOnly, AddonDataProviderConfig.PIXEL_FORMAT);
+
+            // TODO: problem the  
+            // int nXSrc, int nYSrc
+            // 0 0 coordinates dosent point to the top left corner in the window
+            // instead there are (68,28) area offset ?!
+            //bitmap.Save("helpme.bmp");
 
             ReadOnlySpan<DataFrame> frames = this.frames;
 

--- a/Core/Bag/BagChangeTracker.cs
+++ b/Core/Bag/BagChangeTracker.cs
@@ -4,7 +4,11 @@ using Microsoft.Extensions.Logging;
 
 namespace Core;
 
-public sealed partial class BagChangeTracker : IDisposable
+public interface IBagChangeTracker { }
+
+public class NoBagChangeTracker : IBagChangeTracker { }
+
+public sealed partial class BagChangeTracker : IDisposable, IBagChangeTracker
 {
     private readonly ILogger<BagChangeTracker> logger;
     private readonly BagReader reader;
@@ -27,13 +31,16 @@ public sealed partial class BagChangeTracker : IDisposable
         switch (change)
         {
             case BagItemChange.New:
-                LogItemNew(logger, bagItem.Count, bagItem.Item.Name);
+                LogItemNew(logger,
+                    bagItem.Count, bagItem.Item.Name);
                 break;
             case BagItemChange.Remove:
-                LogItemRemove(logger, bagItem.Count, bagItem.Item.Name);
+                LogItemRemove(logger,
+                    bagItem.Count, bagItem.Item.Name);
                 break;
             case BagItemChange.Update:
-                LogItemUpdate(logger, bagItem.LastCount, bagItem.Count, bagItem.Item.Name);
+                LogItemUpdate(logger,
+                    bagItem.LastCount, bagItem.Count, bagItem.Item.Name);
                 break;
         }
     }
@@ -44,19 +51,20 @@ public sealed partial class BagChangeTracker : IDisposable
     [LoggerMessage(
         EventId = 1997,
         Level = LogLevel.Information,
-        Message = "{oldCount} -> {newCount} {name}")]
-    static partial void LogItemUpdate(ILogger logger, int oldCount, int newCount, string name);
+        Message = "{oldCount,2} -> {newCount,2} {name}")]
+    static partial void LogItemUpdate(ILogger logger,
+        int oldCount, int newCount, string name);
 
     [LoggerMessage(
         EventId = 1998,
         Level = LogLevel.Information,
-        Message = "-{count} {name}")]
+        Message = "-{count,2} {name}")]
     static partial void LogItemRemove(ILogger logger, int count, string name);
 
     [LoggerMessage(
         EventId = 1999,
         Level = LogLevel.Information,
-        Message = "+{count} {name}")]
+        Message = "+{count,2} {name}")]
     static partial void LogItemNew(ILogger logger, int count, string name);
 
     #endregion

--- a/Core/Bag/BagReader.cs
+++ b/Core/Bag/BagReader.cs
@@ -18,9 +18,9 @@ public enum BagItemChange
 
 public sealed class BagReader : IDisposable
 {
-    private readonly int cBagMeta;
-    private readonly int cItemNumCount;
-    private readonly int cItemId;
+    private const int cBagMeta = 20;
+    private const int cItemNumCount = 21;
+    private const int cItemId = 22;
 
     private readonly EquipmentReader equipmentReader;
 
@@ -36,17 +36,13 @@ public sealed class BagReader : IDisposable
     public int Hash { private set; get; }
     public int HashNewOrStackGain { private set; get; }
 
-    public BagReader(ItemDB itemDb, EquipmentReader equipmentReader, int cbagMeta, int citemNumCount, int cItemId)
+    public BagReader(ItemDB itemDb, EquipmentReader equipmentReader)
     {
         this.ItemDB = itemDb;
         this.equipmentReader = equipmentReader;
 
         this.equipmentReader.OnEquipmentChanged -= OnEquipmentChanged;
         this.equipmentReader.OnEquipmentChanged += OnEquipmentChanged;
-
-        this.cBagMeta = cbagMeta;
-        this.cItemNumCount = citemNumCount;
-        this.cItemId = cItemId;
 
         for (int i = 0; i < Bags.Length; i++)
         {

--- a/Core/ClassConfig/ClassConfiguration.cs
+++ b/Core/ClassConfig/ClassConfiguration.cs
@@ -25,6 +25,7 @@ public enum Mode
 public sealed class ClassConfiguration : IDisposable
 {
     public bool Log { get; set; } = true;
+    public bool LogBagChanges { get; set; } = true;
     public bool Loot { get; set; } = true;
     public bool Skin { get; set; }
     public bool Herb { get; set; }
@@ -123,114 +124,120 @@ public sealed class ClassConfiguration : IDisposable
     public ConsoleKey TurnLeftKey { get; init; } = ConsoleKey.LeftArrow; // 37
     public ConsoleKey TurnRightKey { get; init; } = ConsoleKey.RightArrow; // 39
 
-    public void Initialise(DataConfig dataConfig, AddonReader addonReader, RequirementFactory requirementFactory, ILogger logger, string? overridePathProfileFile)
+    public void Initialise(DataConfig dataConfig,
+        AddonReader addonReader, PlayerReader playerReader, RecordInt globalTime,
+        ActionBarCostReader costReader, RequirementFactory requirementFactory,
+        ILogger logger, string? overridePathProfileFile)
     {
         if (!SpellQueue)
             logger.LogWarning($"[{nameof(ClassConfiguration)}] {nameof(SpellQueue)} is disabled!");
 
-        requirementFactory.InitUserDefinedIntVariables(IntVariables, addonReader.PlayerBuffTimeReader, addonReader.TargetDebuffTimeReader, addonReader.TargetBuffTimeReader);
+        requirementFactory.InitUserDefinedIntVariables(IntVariables,
+            addonReader.PlayerBuffTimeReader,
+            addonReader.TargetDebuffTimeReader,
+            addonReader.TargetBuffTimeReader);
 
         Jump.Key = JumpKey;
         Jump.Name = nameof(Jump);
         Jump.BaseAction = true;
-        Jump.Initialise(this, addonReader, requirementFactory, logger, Log);
+        Jump.Initialise(this, addonReader, playerReader, globalTime, costReader, requirementFactory, logger, Log);
 
         TargetLastTarget.Key = TargetLastTargetKey;
         TargetLastTarget.Name = nameof(TargetLastTarget);
         TargetLastTarget.Cooldown = 0;
         TargetLastTarget.BaseAction = true;
-        TargetLastTarget.Initialise(this, addonReader, requirementFactory, logger, Log);
+        TargetLastTarget.Initialise(this, addonReader, playerReader, globalTime, costReader, requirementFactory, logger, Log);
 
         StandUp.Key = StandUpKey;
         StandUp.Name = nameof(StandUp);
         StandUp.Cooldown = 0;
         StandUp.BaseAction = true;
-        StandUp.Initialise(this, addonReader, requirementFactory, logger, Log);
+        StandUp.Initialise(this, addonReader, playerReader, globalTime, costReader, requirementFactory, logger, Log);
 
         ClearTarget.Key = ClearTargetKey;
         ClearTarget.Name = nameof(ClearTarget);
         ClearTarget.Cooldown = 0;
         ClearTarget.BaseAction = true;
-        ClearTarget.Initialise(this, addonReader, requirementFactory, logger, Log);
+        ClearTarget.Initialise(this, addonReader, playerReader, globalTime, costReader, requirementFactory, logger, Log);
 
         StopAttack.Key = StopAttackKey;
         StopAttack.Name = nameof(StopAttack);
         StopAttack.PressDuration = 20;
         StopAttack.BaseAction = true;
-        StopAttack.Initialise(this, addonReader, requirementFactory, logger, Log);
+        StopAttack.Initialise(this, addonReader, playerReader, globalTime, costReader, requirementFactory, logger, Log);
 
         TargetNearestTarget.Key = TargetNearestTargetKey;
         TargetNearestTarget.Name = nameof(TargetNearestTarget);
         TargetNearestTarget.BaseAction = true;
-        TargetNearestTarget.Initialise(this, addonReader, requirementFactory, logger, Log);
+        TargetNearestTarget.Initialise(this, addonReader, playerReader, globalTime, costReader, requirementFactory, logger, Log);
 
         TargetPet.Key = TargetPetKey;
         TargetPet.Name = nameof(TargetPet);
         TargetPet.Cooldown = 0;
         TargetPet.BaseAction = true;
-        TargetPet.Initialise(this, addonReader, requirementFactory, logger, Log);
+        TargetPet.Initialise(this, addonReader, playerReader, globalTime, costReader, requirementFactory, logger, Log);
 
         TargetTargetOfTarget.Key = TargetTargetOfTargetKey;
         TargetTargetOfTarget.Name = nameof(TargetTargetOfTarget);
         TargetTargetOfTarget.Cooldown = 0;
         TargetTargetOfTarget.BaseAction = true;
-        TargetTargetOfTarget.Initialise(this, addonReader, requirementFactory, logger, Log);
+        TargetTargetOfTarget.Initialise(this, addonReader, playerReader, globalTime, costReader, requirementFactory, logger, Log);
 
         TargetFocus.Key = TargetFocusKey;
         TargetFocus.Name = nameof(TargetFocus);
         TargetFocus.Cooldown = 0;
         TargetFocus.BaseAction = true;
-        TargetFocus.Initialise(this, addonReader, requirementFactory, logger, Log);
+        TargetFocus.Initialise(this, addonReader, playerReader, globalTime, costReader, requirementFactory, logger, Log);
 
         FollowTarget.Key = FollowTargetKey;
         FollowTarget.Name = nameof(FollowTarget);
         FollowTarget.Cooldown = 0;
         FollowTarget.BaseAction = true;
-        FollowTarget.Initialise(this, addonReader, requirementFactory, logger, Log);
+        FollowTarget.Initialise(this, addonReader, playerReader, globalTime, costReader, requirementFactory, logger, Log);
 
         PetAttack.Key = PetAttackKey;
         PetAttack.Name = nameof(PetAttack);
         PetAttack.PressDuration = 10;
         PetAttack.BaseAction = true;
-        PetAttack.Initialise(this, addonReader, requirementFactory, logger, Log);
+        PetAttack.Initialise(this, addonReader, playerReader, globalTime, costReader, requirementFactory, logger, Log);
 
         Mount.Key = MountKey;
         Mount.Name = nameof(Mount);
         Mount.BaseAction = true;
         Mount.Cooldown = 6000;
-        Mount.Initialise(this, addonReader, requirementFactory, logger, Log);
+        Mount.Initialise(this, addonReader, playerReader, globalTime, costReader, requirementFactory, logger, Log);
 
         Hearthstone.Key = HearthstoneKey;
         Hearthstone.Name = nameof(Hearthstone);
         Hearthstone.HasCastBar = true;
         Hearthstone.AfterCastWaitCastbar = true;
-        Hearthstone.Initialise(this, addonReader, requirementFactory, logger, Log);
+        Hearthstone.Initialise(this, addonReader, playerReader, globalTime, costReader, requirementFactory, logger, Log);
 
         Interact.Key = InteractKey;
         Interact.Name = nameof(Interact);
         Interact.Cooldown = 0;
         Interact.PressDuration = 30;
         Interact.BaseAction = true;
-        Interact.Initialise(this, addonReader, requirementFactory, logger, Log);
+        Interact.Initialise(this, addonReader, playerReader, globalTime, costReader, requirementFactory, logger, Log);
 
         InteractMouseOver.Key = InteractMouseOverKey;
         InteractMouseOver.Name = nameof(InteractMouseOver);
         InteractMouseOver.Cooldown = 0;
-        InteractMouseOver.PressDuration = 15;
+        InteractMouseOver.PressDuration = 10;
         InteractMouseOver.BaseAction = true;
-        InteractMouseOver.Initialise(this, addonReader, requirementFactory, logger, Log);
+        InteractMouseOver.Initialise(this, addonReader, playerReader, globalTime, costReader, requirementFactory, logger, Log);
 
         Approach.Key = InteractKey;
         Approach.Name = nameof(Approach);
         Approach.PressDuration = 10;
         Approach.BaseAction = true;
-        Approach.Initialise(this, addonReader, requirementFactory, logger, Log);
+        Approach.Initialise(this, addonReader, playerReader, globalTime, costReader, requirementFactory, logger, Log);
 
         AutoAttack.Key = InteractKey;
         AutoAttack.Name = nameof(AutoAttack);
         AutoAttack.BaseAction = true;
         AutoAttack.Item = true;
-        AutoAttack.Initialise(this, addonReader, requirementFactory, logger, Log);
+        AutoAttack.Initialise(this, addonReader, playerReader, globalTime, costReader, requirementFactory, logger, Log);
 
         InitializeKeyActions(Pull, Interact, Approach, AutoAttack, StopAttack, PetAttack);
         InitializeKeyActions(Combat, Interact, Approach, AutoAttack, StopAttack, PetAttack);
@@ -238,7 +245,7 @@ public sealed class ClassConfiguration : IDisposable
         logger.LogInformation($"[{nameof(Form)}] Initialise KeyActions.");
         for (int i = 0; i < Form.Length; i++)
         {
-            Form[i].InitialiseForm(this, addonReader, requirementFactory, logger, Log);
+            Form[i].InitialiseForm(this, addonReader, playerReader, globalTime, costReader, requirementFactory, logger, Log);
         }
 
         Pull.PreInitialise(nameof(Pull), requirementFactory, logger);
@@ -248,12 +255,12 @@ public sealed class ClassConfiguration : IDisposable
         Parallel.PreInitialise(nameof(Parallel), requirementFactory, logger);
         Wait.PreInitialise(nameof(Wait), requirementFactory, logger);
 
-        Pull.Initialise(nameof(Pull), this, addonReader, requirementFactory, logger, Log);
-        Combat.Initialise(nameof(Combat), this, addonReader, requirementFactory, logger, Log);
-        Adhoc.Initialise(nameof(Adhoc), this, addonReader, requirementFactory, logger, Log);
-        NPC.Initialise(nameof(NPC), this, addonReader, requirementFactory, logger, Log);
-        Parallel.Initialise(nameof(Parallel), this, addonReader, requirementFactory, logger, Log);
-        Wait.Initialise(nameof(Wait), this, addonReader, requirementFactory, logger, Log);
+        Pull.Initialise(nameof(Pull), this, addonReader, playerReader, globalTime, costReader, requirementFactory, logger, Log);
+        Combat.Initialise(nameof(Combat), this, addonReader, playerReader, globalTime, costReader, requirementFactory, logger, Log);
+        Adhoc.Initialise(nameof(Adhoc), this, addonReader, playerReader, globalTime, costReader, requirementFactory, logger, Log);
+        NPC.Initialise(nameof(NPC), this, addonReader, playerReader, globalTime, costReader, requirementFactory, logger, Log);
+        Parallel.Initialise(nameof(Parallel), this, addonReader, playerReader, globalTime, costReader, requirementFactory, logger, Log);
+        Wait.Initialise(nameof(Wait), this, addonReader, playerReader, globalTime, costReader, requirementFactory, logger, Log);
 
         int index = 0;
         GatherFindKeyConfig = new KeyAction[GatherFindKeys.Length];
@@ -264,7 +271,7 @@ public sealed class ClassConfiguration : IDisposable
                 Key = GatherFindKeys[index],
                 Name = $"Profession {index}"
             };
-            GatherFindKeyConfig[index].Initialise(this, addonReader, requirementFactory, logger, Log);
+            GatherFindKeyConfig[index].Initialise(this, addonReader, playerReader, globalTime, costReader, requirementFactory, logger, Log);
             index++;
         }
 

--- a/Core/ClassConfig/KeyAction.cs
+++ b/Core/ClassConfig/KeyAction.cs
@@ -120,13 +120,17 @@ public sealed partial class KeyAction : IDisposable
         requirementFactory.InitDynamicBindings(this);
     }
 
-    public void Initialise(ClassConfiguration config, AddonReader addonReader,
+    public void Initialise(ClassConfiguration config,
+        AddonReader addonReader,
+        PlayerReader playerReader,
+        RecordInt globalTime,
+        ActionBarCostReader costReader,
         RequirementFactory requirementFactory, ILogger logger, bool globalLog)
     {
-        this.costReader = addonReader.ActionBarCostReader;
+        this.costReader = costReader;
         this.logger = logger;
 
-        globalTime = addonReader.GlobalTime;
+        this.globalTime = addonReader.GlobalTime;
         this.canRunMemoTime = globalTime.Value;
 
         FormCost = GetMinCost;
@@ -176,7 +180,7 @@ public sealed partial class KeyAction : IDisposable
 
         if (Slot > 0)
         {
-            this.SlotIndex = Stance.ToSlot(this, addonReader.PlayerReader) - 1;
+            this.SlotIndex = Stance.ToSlot(this, playerReader) - 1;
             LogInputActionbar(logger, Name, Key, Slot, SlotIndex);
         }
 
@@ -184,7 +188,7 @@ public sealed partial class KeyAction : IDisposable
         ResetCooldown();
 
         if (Slot > 0)
-            InitMinPowerType(addonReader.ActionBarCostReader);
+            InitMinPowerType(costReader);
 
         requirementFactory.InitialiseRequirements(this);
 
@@ -196,16 +200,21 @@ public sealed partial class KeyAction : IDisposable
 
     public void Dispose()
     {
-        if (costReader == null) return;
+        if (costReader == null)
+            return;
 
         costReader.OnActionCostChanged -= ActionBarCostReader_OnActionCostChanged;
         costReader.OnActionCostReset -= ResetCosts;
     }
 
-    public void InitialiseForm(ClassConfiguration config, AddonReader addonReader, RequirementFactory requirementFactory, ILogger logger, bool globalLog)
+    public void InitialiseForm(ClassConfiguration config,
+        AddonReader addonReader, PlayerReader playerReader,
+        RecordInt globalTime,
+        ActionBarCostReader actionBarCostReader,
+        RequirementFactory requirementFactory, ILogger logger, bool globalLog)
     {
         FormAction = true;
-        Initialise(config, addonReader, requirementFactory, logger, globalLog);
+        Initialise(config, addonReader, playerReader, globalTime, actionBarCostReader, requirementFactory, logger, globalLog);
 
         logger.LogInformation($"[{Name,-15}] Added {FormEnum} to FormCost with {MinCost}");
     }

--- a/Core/ClassConfig/KeyActions.cs
+++ b/Core/ClassConfig/KeyActions.cs
@@ -5,9 +5,11 @@ namespace Core;
 
 public partial class KeyActions : IDisposable
 {
-    public KeyAction[] Sequence { get; set; } = Array.Empty<KeyAction>();
+    public KeyAction[] Sequence { get; set; } =
+        Array.Empty<KeyAction>();
 
-    public virtual void PreInitialise(string prefix, RequirementFactory requirementFactory, ILogger logger)
+    public virtual void PreInitialise(string prefix,
+        RequirementFactory requirementFactory, ILogger logger)
     {
         if (Sequence.Length > 0)
         {
@@ -23,7 +25,12 @@ public partial class KeyActions : IDisposable
         }
     }
 
-    public virtual void Initialise(string prefix, ClassConfiguration config, AddonReader addonReader, RequirementFactory requirementFactory, ILogger logger, bool globalLog)
+    public virtual void Initialise(string prefix,
+        ClassConfiguration config, AddonReader addonReader,
+        PlayerReader playerReader, RecordInt globalTime,
+        ActionBarCostReader costReader,
+        RequirementFactory requirementFactory, ILogger logger,
+        bool globalLog)
     {
         if (Sequence.Length > 0)
         {
@@ -32,7 +39,9 @@ public partial class KeyActions : IDisposable
 
         for (int i = 0; i < Sequence.Length; i++)
         {
-            Sequence[i].Initialise(config, addonReader, requirementFactory, logger, globalLog);
+            Sequence[i].Initialise(config, addonReader, playerReader,
+                globalTime, costReader, requirementFactory,
+                logger, globalLog);
         }
     }
 

--- a/Core/ClassConfig/WaitKeyActions.cs
+++ b/Core/ClassConfig/WaitKeyActions.cs
@@ -15,12 +15,15 @@ public sealed partial class WaitKeyActions : KeyActions
         base.PreInitialise(prefix, requirementFactory, logger);
     }
 
-    public override void Initialise(string prefix, ClassConfiguration config, AddonReader addonReader, RequirementFactory requirementFactory, ILogger logger, bool globalLog)
+    public override void Initialise(string prefix,
+        ClassConfiguration config, AddonReader addonReader, PlayerReader playerReader,
+        RecordInt globalTime, ActionBarCostReader actionBarCostReader,
+        RequirementFactory requirementFactory, ILogger logger, bool globalLog)
     {
         if (AutoGenerateWaitForFoodAndDrink)
             AddWaitKeyActionsForFoodOrDrink(logger, config);
 
-        base.Initialise(prefix, config, addonReader, requirementFactory, logger, globalLog);
+        base.Initialise(prefix, config, addonReader, playerReader, globalTime, actionBarCostReader, requirementFactory, logger, globalLog);
     }
 
     private void AddWaitKeyActionsForFoodOrDrink(ILogger logger, ClassConfiguration classConfig)

--- a/Core/ConfigBotController.cs
+++ b/Core/ConfigBotController.cs
@@ -1,8 +1,6 @@
 ﻿using Core.GOAP;
 using System;
 using System.Collections.Generic;
-using Core.Session;
-using Game;
 using System.Threading;
 using Microsoft.Extensions.Logging;
 
@@ -10,11 +8,14 @@ namespace Core;
 
 public sealed class ConfigBotController : IBotController, IDisposable
 {
-    public IAddonReader AddonReader { get; }
+    private readonly ILogger logger;
+    private readonly CancellationTokenSource cts;
+
+    private readonly Thread addonThread;
+    private readonly IAddonReader addonReader;
+
     public GoapAgent? GoapAgent => throw new NotImplementedException();
     public RouteInfo? RouteInfo => throw new NotImplementedException();
-    public WowScreen WowScreen => throw new NotImplementedException();
-    public IGrindSessionDAO GrindSessionDAO => throw new NotImplementedException();
     public string SelectedClassFilename => throw new NotImplementedException();
     public string? SelectedPathFilename => throw new NotImplementedException();
 
@@ -25,21 +26,14 @@ public sealed class ConfigBotController : IBotController, IDisposable
     public double AvgScreenLatency => throw new NotImplementedException();
     public double AvgNPCLatency => throw new NotImplementedException();
 
-    AddonReader IBotController.AddonReader => throw new NotImplementedException();
-
     public event Action? ProfileLoaded;
     public event Action? StatusChanged;
-
-    private readonly ILogger logger;
-    private readonly CancellationTokenSource cts;
-
-    private readonly Thread addonThread;
 
     public ConfigBotController(ILogger logger, IAddonReader addonReader, CancellationTokenSource cts)
     {
         this.logger = logger;
         this.cts = cts;
-        this.AddonReader = addonReader;
+        this.addonReader = addonReader;
 
         addonThread = new(AddonThread);
         addonThread.Start();
@@ -54,9 +48,9 @@ public sealed class ConfigBotController : IBotController, IDisposable
     {
         while (!cts.IsCancellationRequested)
         {
-            AddonReader.Update();
+            addonReader.Update();
         }
-        logger.LogWarning("Addon thread stoppped!");
+        logger.LogWarning("Thread stopped!");
     }
 
 

--- a/Core/Configurator/FrameConfigurator.cs
+++ b/Core/Configurator/FrameConfigurator.cs
@@ -2,6 +2,8 @@
 
 using Microsoft.Extensions.Logging;
 
+using SharedLib;
+
 using System;
 using System.Drawing;
 using System.Drawing.Imaging;
@@ -106,7 +108,9 @@ public sealed class FrameConfigurator : IDisposable
                 {
                     if (auto)
                     {
-                        logger.LogInformation($"Found {nameof(WowProcess)} with pid={wowProcess.Process}");
+                        logger.LogInformation(
+                            $"Found {nameof(WowProcess)} with pid={wowProcess.Process.Id} " +
+                            $"{wowProcess.Process.ProcessName}");
                     }
                     stage++;
                 }

--- a/Core/Cursor/CursorClassifier.cs
+++ b/Core/Cursor/CursorClassifier.cs
@@ -25,7 +25,7 @@ public sealed class CursorClassifier : IDisposable
         new ulong[] { 13901748381153107456, 16207591392111181312, 9798142283158525952 },
         new ulong[] { 4669700909741929478, 4669700909674820614 },
         new ulong[] { 4683320813727784960, 4669700909741929478, 4683461550142398464 },
-        new ulong[] { 17940331276560775168, 17940331276594329600, 17940331276594460672 },
+        new ulong[] { 17940331276560775168, 17940331276594329600, 17940331276594460672, 18012595827828094976 },
         new ulong[] { 16207573517913036808, 4669140166357294088, 14185844589096599552, 16491828335798648832 },
         new ulong[] { 4667452417086599168, 4676529985085517824 },
         new ulong[] { 4682718988357606424, 4682718988358655000 }
@@ -98,6 +98,6 @@ public sealed class CursorClassifier : IDisposable
         }
 
         classification = (CursorType)index;
-        Debug.WriteLine($"[CursorClassifier.Classify] {classification.ToStringF()} - {similarity}");
+        Debug.WriteLine($"[CursorClassifier.Classify] {cursorHash} - {classification.ToStringF()} - {similarity}");
     }
 }

--- a/Core/DependencyInjection.cs
+++ b/Core/DependencyInjection.cs
@@ -1,0 +1,348 @@
+﻿using System;
+using System.Drawing;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Core.Addon;
+using Core.Database;
+using Core.Session;
+
+using Game;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using PPather;
+
+using SharedLib;
+using SharedLib.NpcFinder;
+
+using WinAPI;
+
+namespace Core;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddAddonComponents(
+        this IServiceCollection s)
+    {
+        s.AddSingleton<CombatLog>();
+        s.AddSingleton<EquipmentReader>();
+        s.AddSingleton<BagReader>();
+        s.AddSingleton<GossipReader>();
+        s.AddSingleton<SpellBookReader>();
+        s.AddSingleton<TalentReader>();
+
+        s.AddSingleton<ActionBarCostReader>();
+        s.AddSingleton<ActionBarCooldownReader>();
+
+        s.AddSingleton<ActionBarBits<ICurrentAction>>(x => new(25, 26, 27, 28, 29));
+        s.AddSingleton<ActionBarBits<IUsableAction>>(x => new(30, 31, 32, 33, 34));
+
+        s.AddSingleton<AuraTimeReader<IPlayerBuffTimeReader>>(x => new(79, 80));
+        s.AddSingleton<AuraTimeReader<ITargetDebuffTimeReader>>(x => new(81, 82));
+        s.AddSingleton<AuraTimeReader<ITargetBuffTimeReader>>(x => new(83, 84));
+
+        // Player Reader components
+        s.AddSingleton<AddonBits>(x => new(8, 9));
+        s.AddSingleton<SpellInRange>(x => new(40));
+        s.AddSingleton<BuffStatus>(x => new(41));
+        s.AddSingleton<TargetDebuffStatus>(x => new(42));
+        s.AddSingleton<Stance>(x => new(48));
+
+        return s;
+    }
+
+    public static IServiceCollection AddStartupIoC(
+        this IServiceCollection s, IServiceProvider sp)
+    {
+        // StartUp Container
+        s.AddSingleton(sp.GetRequiredService<CancellationTokenSource>());
+
+        s.AddSingleton(sp.GetRequiredService<WowProcessInput>());
+        s.AddSingleton(sp.GetRequiredService<IMouseInput>());
+        s.AddSingleton(sp.GetRequiredService<IMouseOverReader>());
+
+        s.AddSingleton(sp.GetRequiredService<NpcNameFinder>());
+        s.AddSingleton(sp.GetRequiredService<IWowScreen>());
+        s.AddSingleton(sp.GetRequiredService<WowScreen>());
+
+        s.AddSingleton(sp.GetRequiredService<IPPather>());
+        s.AddSingleton(sp.GetRequiredService<ExecGameCommand>());
+
+        s.AddSingleton(sp.GetRequiredService<Wait>());
+
+        s.AddSingleton(sp.GetRequiredService<DataConfig>());
+
+        s.AddSingleton(sp.GetRequiredService<AreaDB>());
+        s.AddSingleton(sp.GetRequiredService<WorldMapAreaDB>());
+        s.AddSingleton(sp.GetRequiredService<ItemDB>());
+        s.AddSingleton(sp.GetRequiredService<CreatureDB>());
+        s.AddSingleton(sp.GetRequiredService<SpellDB>());
+        s.AddSingleton(sp.GetRequiredService<TalentDB>());
+
+        s.AddSingleton(sp.GetRequiredService<AddonReader>());
+        s.AddSingleton(sp.GetRequiredService<PlayerReader>());
+
+        s.AddSingleton<ConfigurableInput>();
+
+        s.AddSingleton<IScreenCapture>(sp.GetRequiredService<IScreenCapture>());
+        s.AddSingleton<SessionStat>(sp.GetRequiredService<SessionStat>());
+        s.AddSingleton<IGrindSessionDAO>(sp.GetRequiredService<IGrindSessionDAO>());
+
+        // Addon Components
+        s.AddSingleton(sp.GetRequiredService<CombatLog>());
+        s.AddSingleton(sp.GetRequiredService<EquipmentReader>());
+        s.AddSingleton(sp.GetRequiredService<BagReader>());
+        s.AddSingleton(sp.GetRequiredService<GossipReader>());
+        s.AddSingleton(sp.GetRequiredService<SpellBookReader>());
+        s.AddSingleton(sp.GetRequiredService<TalentReader>());
+
+        s.AddSingleton(sp.GetRequiredService<ActionBarCostReader>());
+        s.AddSingleton(sp.GetRequiredService<ActionBarCooldownReader>());
+
+        s.AddSingleton(sp.GetRequiredService<ActionBarBits<ICurrentAction>>());
+        s.AddSingleton(sp.GetRequiredService<ActionBarBits<IUsableAction>>());
+
+        s.AddSingleton(sp.GetRequiredService<AuraTimeReader<IPlayerBuffTimeReader>>());
+        s.AddSingleton(sp.GetRequiredService<AuraTimeReader<ITargetDebuffTimeReader>>());
+        s.AddSingleton(sp.GetRequiredService<AuraTimeReader<ITargetBuffTimeReader>>());
+
+        // Player Reader components
+        s.AddSingleton(sp.GetRequiredService<AddonBits>());
+        s.AddSingleton(sp.GetRequiredService<SpellInRange>());
+        s.AddSingleton(sp.GetRequiredService<BuffStatus>());
+        s.AddSingleton(sp.GetRequiredService<TargetDebuffStatus>());
+        s.AddSingleton(sp.GetRequiredService<Stance>());
+
+        return s;
+    }
+
+    public static IServiceCollection AddCoreFrontend(this IServiceCollection services)
+    {
+        services.AddSingleton<WApi>();
+        services.AddSingleton<FrontendUpdate>();
+        return services;
+    }
+
+    public static IServiceCollection AddCoreConfiguration(this IServiceCollection services)
+    {
+        services.AddSingleton<IAddonDataProvider, AddonDataProviderGDIConfig>();
+        services.AddSingleton<IBotController, ConfigBotController>();
+        services.AddSingleton<IAddonReader, ConfigAddonReader>();
+
+        return services;
+    }
+
+    public static IServiceCollection AddCoreNormal(this IServiceCollection services, ILogger logger)
+    {
+        services.AddSingleton<IScreenCapture>(x =>
+            GetScreenCapture(x.GetRequiredService<IServiceProvider>(), logger));
+
+        services.AddSingleton<IPPather>(x =>
+            GetPather(x.GetRequiredService<IServiceProvider>(), logger));
+
+        services.AddSingleton<IAddonDataProvider>(x =>
+            GetAddonDataProvider(x.GetRequiredService<IServiceProvider>(), logger));
+
+        services.AddSingleton<MinimapNodeFinder>();
+
+        services.AddSingleton<SessionStat>();
+        services.AddSingleton<IGrindSessionDAO, LocalGrindSessionDAO>();
+
+        services.AddSingleton<AreaDB>();
+        services.AddSingleton<WorldMapAreaDB>();
+        services.AddSingleton<ItemDB>();
+        services.AddSingleton<CreatureDB>();
+        services.AddSingleton<SpellDB>();
+        services.AddSingleton<TalentDB>();
+
+        services.AddAddonComponents();
+
+        services.AddSingleton<PlayerReader>();
+        services.AddSingleton<IMouseOverReader>(
+            x => x.GetRequiredService<PlayerReader>());
+
+        services.AddSingleton<AddonReader>();
+        services.AddSingleton<IAddonReader>(
+            x => x.GetRequiredService<AddonReader>());
+
+        services.AddSingleton<LevelTracker>();
+
+        services.AddSingleton<IBotController, BotController>();
+
+        return services;
+    }
+
+    public static IServiceCollection AddCoreBase(this IServiceCollection services)
+    {
+        services.AddSingleton<CancellationTokenSource>();
+        services.AddSingleton<AutoResetEvent>(x => new(false));
+        services.AddSingleton<Wait>();
+
+        services.AddSingleton<StartupClientVersion>();
+        services.AddSingleton<DataConfig>(x => DataConfig.Load(
+            x.GetRequiredService<StartupClientVersion>().Path));
+
+        services.AddSingleton<WowScreen>();
+        services.AddSingleton<IBitmapProvider>(x => x.GetRequiredService<WowScreen>());
+        services.AddSingleton<IWowScreen>(x => x.GetRequiredService<WowScreen>());
+
+        services.AddSingleton<WowProcessInput>();
+        services.AddSingleton<IMouseInput>(x => x.GetRequiredService<WowProcessInput>());
+
+        services.AddSingleton<ExecGameCommand>();
+
+        services.AddSingleton<DataFrame[]>(x => FrameConfig.LoadFrames());
+        services.AddSingleton<FrameConfigurator>();
+
+        services.AddSingleton<INpcResetEvent, NpcResetEvent>();
+        services.AddSingleton<NpcNameFinder>();
+
+        return services;
+    }
+
+
+    public static bool AddWoWProcess(this IServiceCollection services, ILogger log)
+    {
+        services.AddSingleton<WowProcess>();
+        services.AddSingleton<AddonConfigurator>();
+
+        var sp = services.BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true });
+
+        WowProcess wowProcess = sp.GetRequiredService<WowProcess>();
+        log.LogInformation($"Pid: {wowProcess.ProcessId}");
+        log.LogInformation($"Version: {wowProcess.FileVersion}");
+
+        // TODO: this might need some massage
+        services.AddSingleton<Version>(x => wowProcess.FileVersion);
+
+        AddonConfigurator configurator = sp.GetRequiredService<AddonConfigurator>();
+        Version? installVersion = configurator.GetInstallVersion();
+        log.LogInformation($"Addon version: {installVersion}");
+
+        if (configurator.IsDefault() || installVersion == null)
+        {
+            // At this point the webpage never loads so fallback to configuration page
+            configurator.Delete();
+            FrameConfig.Delete();
+
+            log.LogError($"{nameof(AddonConfig)} doesn't exists or addon not installed yet!");
+            return false;
+        }
+
+        NativeMethods.GetWindowRect(wowProcess.Process.MainWindowHandle, out Rectangle rect);
+        if (FrameConfig.Exists() && !FrameConfig.IsValid(rect, installVersion))
+        {
+            // At this point the webpage never loads so fallback to configuration page
+            FrameConfig.Delete();
+            log.LogError($"{nameof(FrameConfig)} doesn't exists or window rect is different then config!");
+
+            return false;
+        }
+
+        return true;
+    }
+
+
+    private static IScreenCapture GetScreenCapture(IServiceProvider sp, ILogger log)
+    {
+        //var log = sp.GetRequiredService<ILogger<Startup>>();
+        var spd = sp.GetRequiredService<IOptions<StartupConfigDiagnostics>>();
+        var globalLogger = sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger>();
+        var logger = sp.GetRequiredService<ILogger<ScreenCapture>>();
+        var dataConfig = sp.GetRequiredService<DataConfig>();
+        var cts = sp.GetRequiredService<CancellationTokenSource>();
+        var wowScreen = sp.GetRequiredService<WowScreen>();
+
+        IScreenCapture value = spd.Value.Enabled
+            ? new ScreenCapture(logger, dataConfig, cts, wowScreen)
+            : new NoScreenCapture(globalLogger, dataConfig);
+
+        log.LogInformation(value.GetType().Name);
+
+        return value;
+    }
+
+    private static IAddonDataProvider GetAddonDataProvider(IServiceProvider sp, ILogger log)
+    {
+        //var log = sp.GetRequiredService<ILogger<Startup>>();
+        var scr = sp.GetRequiredService<IOptions<StartupConfigReader>>();
+        var wowScreen = sp.GetRequiredService<WowScreen>();
+        var frames = sp.GetRequiredService<DataFrame[]>();
+
+        IAddonDataProvider value = scr.Value.ReaderType switch
+        {
+            AddonDataProviderType.GDIConfig or
+            AddonDataProviderType.GDI =>
+                new AddonDataProviderGDI(wowScreen, frames),
+            AddonDataProviderType.GDIBlit =>
+                new AddonDataProviderBitBlt(wowScreen, frames),
+            AddonDataProviderType.DXGI =>
+                new AddonDataProviderDXGI(wowScreen, frames),
+            _ => throw new NotImplementedException(),
+        };
+
+        log.LogInformation(value.GetType().Name);
+        return value;
+    }
+
+    private static IPPather GetPather(IServiceProvider sp, ILogger logger)
+    {
+        var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
+        //var logger = sp.GetRequiredService<ILogger<Startup>>();
+        var oscp = sp.GetRequiredService<IOptions<StartupConfigPathing>>();
+        var dataConfig = sp.GetRequiredService<DataConfig>();
+        var worldMapAreaDB = sp.GetRequiredService<WorldMapAreaDB>();
+
+        StartupConfigPathing scp = oscp.Value;
+
+        bool failed = false;
+        if (scp.Type == StartupConfigPathing.Types.RemoteV3)
+        {
+            var remoteLogger = loggerFactory.CreateLogger<RemotePathingAPIV3>();
+            RemotePathingAPIV3 api = new(remoteLogger, scp.hostv3, scp.portv3, worldMapAreaDB);
+            if (api.PingServer())
+            {
+                logger.LogInformation($"Using {StartupConfigPathing.Types.RemoteV3}({api.GetType().Name}) {scp.hostv3}:{scp.portv3}");
+                return api;
+            }
+            api.Dispose();
+            failed = true;
+        }
+
+        if (scp.Type == StartupConfigPathing.Types.RemoteV1 || failed)
+        {
+            var remoteLogger = loggerFactory.CreateLogger<RemotePathingAPI>();
+            RemotePathingAPI api = new(remoteLogger, scp.hostv1, scp.portv1);
+            Task<bool> pingTask = Task.Run(api.PingServer);
+            pingTask.Wait();
+            if (pingTask.Result)
+            {
+                if (scp.Type == StartupConfigPathing.Types.RemoteV3)
+                {
+                    logger.LogWarning($"Unavailable {StartupConfigPathing.Types.RemoteV3} {scp.hostv3}:{scp.portv3} - Fallback to {StartupConfigPathing.Types.RemoteV1}");
+                }
+
+                logger.LogInformation($"Using {StartupConfigPathing.Types.RemoteV1}({api.GetType().Name}) {scp.hostv1}:{scp.portv1}");
+                return api;
+            }
+
+            failed = true;
+        }
+
+        if (scp.Type != StartupConfigPathing.Types.Local)
+        {
+            logger.LogWarning($"{scp.Type} not available!");
+        }
+
+        var pathingLogger = loggerFactory.CreateLogger<LocalPathingApi>();
+        var serviceLogger = loggerFactory.CreateLogger<PPatherService>();
+        LocalPathingApi localApi = new(pathingLogger, new(serviceLogger, dataConfig, worldMapAreaDB), dataConfig);
+        logger.LogInformation($"Using {StartupConfigPathing.Types.Local}({localApi.GetType().Name})");
+
+        return localApi;
+    }
+
+}

--- a/Core/Environment/FrontendUpdate.cs
+++ b/Core/Environment/FrontendUpdate.cs
@@ -6,14 +6,15 @@ namespace Core;
 
 public sealed class FrontendUpdate
 {
-    private readonly ILogger logger;
+    private readonly ILogger<FrontendUpdate> logger;
     private readonly IAddonReader addonReader;
     private readonly CancellationToken ct;
 
     private readonly Thread thread;
     private const int tickMs = 250;
 
-    public FrontendUpdate(ILogger logger, IAddonReader addonReader, CancellationTokenSource cts)
+    public FrontendUpdate(ILogger<FrontendUpdate> logger,
+        IAddonReader addonReader, CancellationTokenSource cts)
     {
         this.logger = logger;
         this.addonReader = addonReader;
@@ -32,6 +33,6 @@ public sealed class FrontendUpdate
         }
 
         if (logger.IsEnabled(LogLevel.Debug))
-            logger.LogDebug("Frontend thread stopped!");
+            logger.LogDebug("Thread stopped!");
     }
 }

--- a/Core/Equipments/EquipmentReader.cs
+++ b/Core/Equipments/EquipmentReader.cs
@@ -11,19 +11,17 @@ public sealed class EquipmentReader
     private const int MAX_EQUIPMENT_COUNT = 24;
 
     private readonly ItemDB itemDB;
-    private readonly int cItemId;
-    private readonly int cSlotNum;
+    private readonly int cSlotNum = 23;
+    private readonly int cItemId = 24;
 
     private readonly int[] equipmentIds = new int[MAX_EQUIPMENT_COUNT];
     public Item[] Items { get; private set; } = new Item[MAX_EQUIPMENT_COUNT];
 
     public event EventHandler<(int, int)>? OnEquipmentChanged;
 
-    public EquipmentReader(ItemDB itemDB, int cSlotNum, int cItemId)
+    public EquipmentReader(ItemDB itemDB)
     {
         this.itemDB = itemDB;
-        this.cSlotNum = cSlotNum;
-        this.cItemId = cItemId;
 
         for (int i = 0; i < MAX_EQUIPMENT_COUNT; i++)
         {

--- a/Core/Goals/AdhocGoal.cs
+++ b/Core/Goals/AdhocGoal.cs
@@ -1,6 +1,5 @@
 ﻿using Core.GOAP;
 using Microsoft.Extensions.Logging;
-using System;
 
 namespace Core.Goals;
 
@@ -13,27 +12,33 @@ public sealed class AdhocGoal : GoapGoal
 
     private readonly Wait wait;
     private readonly StopMoving stopMoving;
-    private readonly AddonReader addonReader;
     private readonly PlayerReader playerReader;
 
     private readonly KeyAction key;
     private readonly CastingHandler castingHandler;
     private readonly IMountHandler mountHandler;
+    private readonly AddonBits bits;
+    private readonly CombatLog combatLog;
 
     private readonly bool? combatMatters;
 
-    public AdhocGoal(KeyAction key, ILogger logger, ConfigurableInput input, Wait wait, AddonReader addonReader, StopMoving stopMoving, CastingHandler castingHandler, IMountHandler mountHandler)
+    public AdhocGoal(KeyAction key, ILogger logger,
+        ConfigurableInput input, Wait wait,
+        PlayerReader playerReader, StopMoving stopMoving,
+        CastingHandler castingHandler, IMountHandler mountHandler,
+        AddonBits bits, CombatLog combatLog)
         : base(nameof(AdhocGoal))
     {
         this.logger = logger;
         this.input = input;
         this.wait = wait;
         this.stopMoving = stopMoving;
-        this.addonReader = addonReader;
-        this.playerReader = addonReader.PlayerReader;
+        this.playerReader = playerReader;
         this.key = key;
         this.castingHandler = castingHandler;
         this.mountHandler = mountHandler;
+        this.bits = bits;
+        this.combatLog = combatLog;
 
         if (bool.TryParse(key.InCombat, out bool result))
         {
@@ -75,7 +80,7 @@ public sealed class AdhocGoal : GoapGoal
     private bool Interrupt()
     {
         return combatMatters.HasValue
-            ? combatMatters.Value == addonReader.PlayerReader.Bits.PlayerInCombat() && addonReader.DamageTakenCount() > 0
-            : addonReader.DamageTakenCount() > 0;
+            ? combatMatters.Value == bits.PlayerInCombat() && combatLog.DamageTakenCount() > 0
+            : combatLog.DamageTakenCount() > 0;
     }
 }

--- a/Core/Goals/ApproachTargetGoal.cs
+++ b/Core/Goals/ApproachTargetGoal.cs
@@ -19,8 +19,8 @@ public sealed class ApproachTargetGoal : GoapGoal, IGoapEventListener
     private readonly ILogger<ApproachTargetGoal> logger;
     private readonly ConfigurableInput input;
     private readonly Wait wait;
-    private readonly AddonReader addonReader;
     private readonly PlayerReader playerReader;
+    private readonly AddonBits bits;
     private readonly StopMoving stopMoving;
     private readonly CombatUtil combatUtil;
     private readonly IBlacklist targetBlacklist;
@@ -36,8 +36,9 @@ public sealed class ApproachTargetGoal : GoapGoal, IGoapEventListener
     private double ApproachDurationMs =>
         (DateTime.UtcNow - approachStart).TotalMilliseconds;
 
-    public ApproachTargetGoal(ILogger<ApproachTargetGoal> logger, 
-        ConfigurableInput input, Wait wait, AddonReader addonReader,
+    public ApproachTargetGoal(ILogger<ApproachTargetGoal> logger,
+        ConfigurableInput input, Wait wait,
+        PlayerReader playerReader, AddonBits addonBits,
         StopMoving stopMoving, CombatUtil combatUtil, IBlacklist blacklist)
         : base(nameof(ApproachTargetGoal))
     {
@@ -45,8 +46,9 @@ public sealed class ApproachTargetGoal : GoapGoal, IGoapEventListener
         this.input = input;
 
         this.wait = wait;
-        this.addonReader = addonReader;
-        this.playerReader = addonReader.PlayerReader;
+        this.playerReader = playerReader;
+        this.bits = addonBits;
+
         this.stopMoving = stopMoving;
         this.combatUtil = combatUtil;
         this.targetBlacklist = blacklist;
@@ -88,7 +90,7 @@ public sealed class ApproachTargetGoal : GoapGoal, IGoapEventListener
     {
         wait.Update();
 
-        if (combatUtil.EnteredCombat() && !playerReader.Bits.TargetInCombat())
+        if (combatUtil.EnteredCombat() && !bits.TargetInCombat())
         {
             stopMoving.Stop();
 
@@ -104,7 +106,7 @@ public sealed class ApproachTargetGoal : GoapGoal, IGoapEventListener
             input.PressApproach();
         }
 
-        if (!playerReader.Bits.PlayerInCombat())
+        if (!bits.PlayerInCombat())
         {
             NonCombatApproach();
             RandomJump();
@@ -166,7 +168,7 @@ public sealed class ApproachTargetGoal : GoapGoal, IGoapEventListener
 
             if (playerReader.TargetGuid != initialTargetGuid)
             {
-                if (playerReader.Bits.HasTarget() && !targetBlacklist.Is()) // blacklist
+                if (bits.HasTarget() && !targetBlacklist.Is())
                 {
                     if (playerReader.MinRange() < initialTargetMinRange)
                     {

--- a/Core/Goals/BlacklistTargetGoal.cs
+++ b/Core/Goals/BlacklistTargetGoal.cs
@@ -5,28 +5,33 @@ public sealed class BlacklistTargetGoal : GoapGoal
     public override float Cost => 2;
 
     private readonly PlayerReader playerReader;
+    private readonly AddonBits bits;
     private readonly ConfigurableInput input;
     private readonly IBlacklist targetBlacklist;
 
-    public BlacklistTargetGoal(PlayerReader playerReader, ConfigurableInput input, IBlacklist blacklist)
+    public BlacklistTargetGoal(PlayerReader playerReader,
+        AddonBits bits,
+        ConfigurableInput input, IBlacklist blacklist)
         : base(nameof(BlacklistTargetGoal))
     {
         this.playerReader = playerReader;
+        this.bits = bits;
         this.input = input;
         this.targetBlacklist = blacklist;
+        this.bits = bits;
     }
 
     public override bool CanRun()
     {
-        return playerReader.Bits.HasTarget() && targetBlacklist.Is();
+        return bits.HasTarget() && targetBlacklist.Is();
     }
 
     public override void OnEnter()
     {
         if (playerReader.PetHasTarget() ||
             playerReader.IsCasting() ||
-            playerReader.Bits.SpellOn_AutoAttack() || playerReader.Bits.SpellOn_AutoShot() ||
-            playerReader.Bits.SpellOn_Shoot())
+            bits.SpellOn_AutoAttack() || bits.SpellOn_AutoShot() ||
+            bits.SpellOn_Shoot())
             input.PressStopAttack();
 
         input.PressClearTarget();

--- a/Core/Goals/TargetFocusTargetGoal.cs
+++ b/Core/Goals/TargetFocusTargetGoal.cs
@@ -8,14 +8,16 @@ public sealed class TargetFocusTargetGoal : GoapGoal
 
     private readonly ConfigurableInput input;
     private readonly PlayerReader playerReader;
+    private readonly AddonBits bits;
     private readonly Wait wait;
 
     public TargetFocusTargetGoal(ConfigurableInput input, PlayerReader playerReader,
-        ClassConfiguration classConfig, Wait wait)
+        AddonBits bits, ClassConfiguration classConfig, Wait wait)
         : base(nameof(TargetFocusTargetGoal))
     {
         this.input = input;
         this.playerReader = playerReader;
+        this.bits = bits;
         this.wait = wait;
 
         if (classConfig.Loot)
@@ -35,9 +37,9 @@ public sealed class TargetFocusTargetGoal : GoapGoal
 
     public override void Update()
     {
-        if (playerReader.Bits.FocusTargetCanBeHostile())
+        if (bits.FocusTargetCanBeHostile())
         {
-            if (playerReader.Bits.FocusTargetInCombat())
+            if (bits.FocusTargetInCombat())
             {
                 input.PressTargetFocus();
                 input.PressTargetOfTarget();
@@ -57,7 +59,7 @@ public sealed class TargetFocusTargetGoal : GoapGoal
 
     public override void OnExit()
     {
-        if (!playerReader.Bits.FocusHasTarget())
+        if (!bits.FocusHasTarget())
         {
             input.PressClearTarget();
             wait.Update();

--- a/Core/Goals/TargetPetTargetGoal.cs
+++ b/Core/Goals/TargetPetTargetGoal.cs
@@ -8,14 +8,17 @@ public sealed class TargetPetTargetGoal : GoapGoal
 
     private readonly ConfigurableInput input;
     private readonly PlayerReader playerReader;
+    private readonly AddonBits bits;
     private readonly Wait wait;
 
     public TargetPetTargetGoal(ConfigurableInput input,
-        PlayerReader playerReader, Wait wait)
+        PlayerReader playerReader, AddonBits bits,
+        Wait wait)
         : base(nameof(TargetPetTargetGoal))
     {
         this.input = input;
         this.playerReader = playerReader;
+        this.bits = bits;
         this.wait = wait;
 
         AddPrecondition(GoapKey.targetisalive, false);
@@ -40,7 +43,8 @@ public sealed class TargetPetTargetGoal : GoapGoal
         input.PressTargetOfTarget();
         wait.Update();
 
-        if (playerReader.Bits.HasTarget() && (playerReader.Bits.TargetIsDead() || playerReader.TargetGuid == playerReader.PetGuid))
+        if (bits.HasTarget() &&
+            (bits.TargetIsDead() || playerReader.TargetGuid == playerReader.PetGuid))
         {
             input.PressClearTarget();
             wait.Update();

--- a/Core/Goals/WaitForGatheringGoal.cs
+++ b/Core/Goals/WaitForGatheringGoal.cs
@@ -7,16 +7,23 @@ namespace Core.Goals;
 
 public static class CastState_Extension
 {
-    public static string ToStringF(this WaitForGatheringGoal.CastState value) => value switch
-    {
-        WaitForGatheringGoal.CastState.None => nameof(WaitForGatheringGoal.CastState.None),
-        WaitForGatheringGoal.CastState.Casting => nameof(WaitForGatheringGoal.CastState.Casting),
-        WaitForGatheringGoal.CastState.Failed => nameof(WaitForGatheringGoal.CastState.Failed),
-        WaitForGatheringGoal.CastState.Abort => nameof(WaitForGatheringGoal.CastState.Abort),
-        WaitForGatheringGoal.CastState.Success => nameof(WaitForGatheringGoal.CastState.Success),
-        WaitForGatheringGoal.CastState.WaitUserInput => nameof(WaitForGatheringGoal.CastState.WaitUserInput),
-        _ => throw new System.NotImplementedException(),
-    };
+    public static string ToStringF(this WaitForGatheringGoal.CastState value)
+        => value switch
+        {
+            WaitForGatheringGoal.CastState.None =>
+                nameof(WaitForGatheringGoal.CastState.None),
+            WaitForGatheringGoal.CastState.Casting =>
+                nameof(WaitForGatheringGoal.CastState.Casting),
+            WaitForGatheringGoal.CastState.Failed =>
+                nameof(WaitForGatheringGoal.CastState.Failed),
+            WaitForGatheringGoal.CastState.Abort =>
+                nameof(WaitForGatheringGoal.CastState.Abort),
+            WaitForGatheringGoal.CastState.Success =>
+                nameof(WaitForGatheringGoal.CastState.Success),
+            WaitForGatheringGoal.CastState.WaitUserInput =>
+                nameof(WaitForGatheringGoal.CastState.WaitUserInput),
+            _ => throw new System.NotImplementedException(),
+        };
 }
 
 public partial class WaitForGatheringGoal : GoapGoal
@@ -28,6 +35,7 @@ public partial class WaitForGatheringGoal : GoapGoal
     private readonly ILogger logger;
     private readonly Wait wait;
     private readonly PlayerReader playerReader;
+    private readonly AddonBits bits;
     private readonly StopMoving stopMoving;
     private readonly Stopwatch stopWatch;
 
@@ -44,12 +52,15 @@ public partial class WaitForGatheringGoal : GoapGoal
     private CastState state;
     private int lastKnownCast;
 
-    public WaitForGatheringGoal(ILogger logger, Wait wait, PlayerReader playerReader, StopMoving stopMoving)
+    public WaitForGatheringGoal(ILogger logger, Wait wait,
+        PlayerReader playerReader, AddonBits bits,
+        StopMoving stopMoving)
         : base(nameof(WaitForGatheringGoal))
     {
         this.logger = logger;
         this.wait = wait;
         this.playerReader = playerReader;
+        this.bits = bits;
         this.stopMoving = stopMoving;
         this.stopWatch = new();
 
@@ -61,10 +72,7 @@ public partial class WaitForGatheringGoal : GoapGoal
         stopMoving.Stop();
         wait.Update();
 
-        while (playerReader.Bits.IsFalling())
-        {
-            wait.Update();
-        }
+        wait.While(bits.IsFalling);
 
         LogOnEnter(logger);
     }
@@ -154,7 +162,7 @@ public partial class WaitForGatheringGoal : GoapGoal
             }
         }
 
-        if (playerReader.Bits.IsFalling())
+        if (bits.IsFalling())
         {
             state = CastState.Abort;
             LogState(logger, state.ToStringF());

--- a/Core/Goals/WaitGoal.cs
+++ b/Core/Goals/WaitGoal.cs
@@ -6,10 +6,10 @@ public sealed class WaitGoal : GoapGoal
 {
     public override float Cost => 21;
 
-    private readonly ILogger logger;
+    private readonly ILogger<WaitGoal> logger;
     private readonly Wait wait;
 
-    public WaitGoal(ILogger logger, Wait wait)
+    public WaitGoal(ILogger<WaitGoal> logger, Wait wait)
         : base(nameof(WaitGoal))
     {
         this.logger = logger;
@@ -18,7 +18,7 @@ public sealed class WaitGoal : GoapGoal
 
     public override void OnEnter()
     {
-        logger.LogInformation("Waiting");
+        logger.LogInformation("...");
     }
 
     public override void Update()

--- a/Core/Goals/WalkToCorpseGoal.cs
+++ b/Core/Goals/WalkToCorpseGoal.cs
@@ -13,8 +13,8 @@ public sealed partial class WalkToCorpseGoal : GoapGoal, IGoapEventListener, IRo
     private readonly Wait wait;
     private readonly ConfigurableInput input;
 
-    private readonly AddonReader addonReader;
     private readonly PlayerReader playerReader;
+    private readonly AddonBits bits;
     private readonly Navigation navigation;
     private readonly StopMoving stopMoving;
 
@@ -42,7 +42,8 @@ public sealed partial class WalkToCorpseGoal : GoapGoal, IGoapEventListener, IRo
     #endregion
 
     public WalkToCorpseGoal(ILogger<WalkToCorpseGoal> logger,
-        ConfigurableInput input, Wait wait, AddonReader addonReader,
+        ConfigurableInput input, Wait wait,
+        PlayerReader playerReader, AddonBits bits,
         Navigation navigation, StopMoving stopMoving)
         : base(nameof(WalkToCorpseGoal))
     {
@@ -50,8 +51,9 @@ public sealed partial class WalkToCorpseGoal : GoapGoal, IGoapEventListener, IRo
         this.wait = wait;
         this.input = input;
 
-        this.addonReader = addonReader;
-        this.playerReader = addonReader.PlayerReader;
+        this.playerReader = playerReader;
+        this.bits = bits;
+
         this.stopMoving = stopMoving;
 
         this.navigation = navigation;
@@ -95,7 +97,7 @@ public sealed partial class WalkToCorpseGoal : GoapGoal, IGoapEventListener, IRo
 
     public override void Update()
     {
-        if (!playerReader.Bits.CorpseInRange())
+        if (!bits.CorpseInRange())
         {
             navigation.Update();
         }

--- a/Core/Goals/WrongZoneGoal.cs
+++ b/Core/Goals/WrongZoneGoal.cs
@@ -15,20 +15,23 @@ public sealed class WrongZoneGoal : GoapGoal
 {
     public override float Cost => 19f;
 
-    private const float RADIAN = MathF.PI * 2;
+    private const float RADIAN = PI * 2;
 
-    private readonly ILogger logger;
+    private readonly ILogger<WrongZoneGoal> logger;
     private readonly ConfigurableInput input;
     private readonly PlayerReader playerReader;
     private readonly PlayerDirection playerDirection;
     private readonly StuckDetector stuckDetector;
-    private readonly ClassConfiguration classConfiguration;
+    private readonly ClassConfiguration classConfig;
 
     private float lastDistance = 999;
 
     public DateTime LastActive { get; private set; }
 
-    public WrongZoneGoal(PlayerReader playerReader, ConfigurableInput input, PlayerDirection playerDirection, ILogger logger, StuckDetector stuckDetector, ClassConfiguration classConfiguration)
+    public WrongZoneGoal(ILogger<WrongZoneGoal> logger,
+        PlayerReader playerReader, ConfigurableInput input,
+        PlayerDirection playerDirection,
+        StuckDetector stuckDetector, ClassConfiguration classConfig)
         : base(nameof(WrongZoneGoal))
     {
         this.playerReader = playerReader;
@@ -36,19 +39,19 @@ public sealed class WrongZoneGoal : GoapGoal
         this.playerDirection = playerDirection;
         this.logger = logger;
         this.stuckDetector = stuckDetector;
-        this.classConfiguration = classConfiguration;
+        this.classConfig = classConfig;
 
         AddPrecondition(GoapKey.incombat, false);
     }
 
     public override bool CanRun()
     {
-        return playerReader.UIMapId.Value == classConfiguration.WrongZone.ZoneId;
+        return playerReader.UIMapId.Value == classConfig.WrongZone.ZoneId;
     }
 
     public override void Update()
     {
-        Vector3 exitMap = classConfiguration.WrongZone.ExitZoneLocation;
+        Vector3 exitMap = classConfig.WrongZone.ExitZoneLocation;
 
         input.StartForward(true);
 

--- a/Core/GoalsComponent/Navigation.cs
+++ b/Core/GoalsComponent/Navigation.cs
@@ -25,7 +25,6 @@ public sealed partial class Navigation : IDisposable
     private readonly ILogger<Navigation> logger;
     private readonly PlayerDirection playerDirection;
     private readonly ConfigurableInput input;
-    private readonly AddonReader addonReader;
     private readonly PlayerReader playerReader;
     private readonly StopMoving stopMoving;
     private readonly StuckDetector stuckDetector;
@@ -70,15 +69,14 @@ public sealed partial class Navigation : IDisposable
     private Vector3 lastFailedDestination;
 
     public Navigation(ILogger<Navigation> logger, PlayerDirection playerDirection,
-        ConfigurableInput input, AddonReader addonReader, StopMoving stopMoving,
+        ConfigurableInput input, PlayerReader playerReader, StopMoving stopMoving,
         StuckDetector stuckDetector, IPPather pather, IMountHandler mountHandler,
         ClassConfiguration classConfiguration)
     {
         this.logger = logger;
         this.playerDirection = playerDirection;
         this.input = input;
-        this.addonReader = addonReader;
-        playerReader = addonReader.PlayerReader;
+        this.playerReader = playerReader;
         this.stopMoving = stopMoving;
         this.stuckDetector = stuckDetector;
         this.pather = pather;
@@ -410,7 +408,7 @@ public sealed partial class Navigation : IDisposable
         }
 
         if (logger.IsEnabled(LogLevel.Debug))
-            logger.LogDebug("PathFinder thread stopped!");
+            logger.LogDebug("Thread stopped!");
     }
 
     private float ReachedDistance(float minDistance)

--- a/Core/GoalsComponent/StopMoving.cs
+++ b/Core/GoalsComponent/StopMoving.cs
@@ -3,6 +3,8 @@ using System.Threading;
 using System.Numerics;
 using SharedLib.Extensions;
 using Game;
+using Core.GOAP;
+using SharedLib;
 
 namespace Core.Goals;
 
@@ -17,7 +19,9 @@ public sealed class StopMoving
     private Vector3 mapPos;
     private float direction;
 
-    public StopMoving(WowProcessInput input, PlayerReader playerReader, CancellationTokenSource cts)
+    public StopMoving(WowProcessInput input,
+        PlayerReader playerReader,
+        CancellationTokenSource<GoapAgent> cts)
     {
         this.input = input;
         this.playerReader = playerReader;

--- a/Core/GoalsComponent/StuckDetector.cs
+++ b/Core/GoalsComponent/StuckDetector.cs
@@ -26,6 +26,7 @@ public sealed class StuckDetector
     private readonly ConfigurableInput input;
 
     private readonly PlayerReader playerReader;
+    private readonly AddonBits bits;
     private readonly PlayerDirection playerDirection;
     private readonly StopMoving stopMoving;
 
@@ -38,13 +39,14 @@ public sealed class StuckDetector
     public double ActionDurationMs => (DateTime.UtcNow - startTime).TotalMilliseconds;
     private double UnstuckMs => (DateTime.UtcNow - attemptTime).TotalMilliseconds;
 
-    public StuckDetector(ILogger<StuckDetector> logger, ConfigurableInput input, 
-        PlayerReader playerReader, PlayerDirection playerDirection,
+    public StuckDetector(ILogger<StuckDetector> logger, ConfigurableInput input,
+        AddonBits bits, PlayerReader playerReader, PlayerDirection playerDirection,
         StopMoving stopMoving)
     {
         this.logger = logger;
         this.input = input;
 
+        this.bits = bits;
         this.playerReader = playerReader;
         this.playerDirection = playerDirection;
         this.stopMoving = stopMoving;
@@ -71,7 +73,7 @@ public sealed class StuckDetector
 
     public void Update()
     {
-        if (playerReader.Bits.IsFalling())
+        if (bits.IsFalling())
             return;
 
         if (debug)

--- a/Core/GoalsComponent/TargetFinder.cs
+++ b/Core/GoalsComponent/TargetFinder.cs
@@ -10,7 +10,7 @@ public sealed class TargetFinder
 
     private readonly ConfigurableInput input;
     private readonly ClassConfiguration classConfig;
-    private readonly PlayerReader playerReader;
+    private readonly AddonBits bits;
     private readonly NpcNameTargeting npcNameTargeting;
     private readonly Wait wait;
 
@@ -19,11 +19,11 @@ public sealed class TargetFinder
     public int ElapsedMs => (int)(DateTime.UtcNow - lastActive).TotalMilliseconds;
 
     public TargetFinder(ConfigurableInput input, ClassConfiguration classConfig,
-        PlayerReader playerReader, NpcNameTargeting npcNameTargeting, Wait wait)
+        AddonBits bits, NpcNameTargeting npcNameTargeting, Wait wait)
     {
         this.classConfig = classConfig;
         this.input = input;
-        this.playerReader = playerReader;
+        this.bits = bits;
         this.npcNameTargeting = npcNameTargeting;
         this.wait = wait;
 
@@ -44,7 +44,7 @@ public sealed class TargetFinder
     private bool LookForTarget(NpcNames target, CancellationToken ct)
     {
         if (ElapsedMs < Random.Shared.Next(minMs, maxMs))
-            return playerReader.Bits.HasTarget();
+            return bits.HasTarget();
 
         if (!ct.IsCancellationRequested &&
             classConfig.TargetNearestTarget.GetRemainingCooldown() == 0)
@@ -53,7 +53,7 @@ public sealed class TargetFinder
             wait.Update();
         }
 
-        if (!ct.IsCancellationRequested && !input.KeyboardOnly && !playerReader.Bits.HasTarget())
+        if (!ct.IsCancellationRequested && !input.KeyboardOnly && !bits.HasTarget())
         {
             npcNameTargeting.ChangeNpcType(target);
             npcNameTargeting.WaitForUpdate();
@@ -69,7 +69,7 @@ public sealed class TargetFinder
 
         lastActive = DateTime.UtcNow;
 
-        return playerReader.Bits.HasTarget();
+        return bits.HasTarget();
     }
 
 }

--- a/Core/GoalsComponent/Wait.cs
+++ b/Core/GoalsComponent/Wait.cs
@@ -20,6 +20,11 @@ public sealed class Wait
         globalTime.WaitOne();
     }
 
+    public bool Update(int timeout)
+    {
+        return globalTime.WaitOne(timeout);
+    }
+
     public void Fixed(int durationMs)
     {
         ct.WaitHandle.WaitOne(durationMs);

--- a/Core/Gossip/GossipReader.cs
+++ b/Core/Gossip/GossipReader.cs
@@ -4,7 +4,7 @@ namespace Core;
 
 public sealed class GossipReader
 {
-    private readonly int cGossip;
+    private const int cGossip = 73;
 
     public int Count { private set; get; }
     public Dictionary<Gossip, int> Gossips { get; } = new();
@@ -26,9 +26,8 @@ public sealed class GossipReader
 
     public bool GossipStartOrMerchantWindowOpened() => GossipStart() || MerchantWindowOpened();
 
-    public GossipReader(int cGossip)
+    public GossipReader()
     {
-        this.cGossip = cGossip;
     }
 
     public void Read(IAddonDataProvider reader)

--- a/Core/IBotController.cs
+++ b/Core/IBotController.cs
@@ -1,22 +1,17 @@
 ﻿using Core.GOAP;
 using System;
 using System.Collections.Generic;
-using Core.Session;
-using Game;
 
 namespace Core;
 
 public interface IBotController
 {
     bool IsBotActive { get; }
-    AddonReader AddonReader { get; }
-    WowScreen WowScreen { get; }
     string SelectedClassFilename { get; }
     string? SelectedPathFilename { get; }
     ClassConfiguration? ClassConfig { get; }
     GoapAgent? GoapAgent { get; }
     RouteInfo? RouteInfo { get; }
-    IGrindSessionDAO GrindSessionDAO { get; }
     double AvgScreenLatency { get; }
     double AvgNPCLatency { get; }
 

--- a/Core/Logging/LoggerSink.cs
+++ b/Core/Logging/LoggerSink.cs
@@ -1,7 +1,7 @@
-﻿using Serilog.Core;
-using Serilog.Events;
+﻿using System;
 
-using System;
+using Serilog.Core;
+using Serilog.Events;
 
 namespace Core;
 
@@ -10,13 +10,15 @@ public sealed class LoggerSink : ILogEventSink
     public event Action? OnLogChanged;
 
     public const int SIZE = 256;
+    private const int MOD = 8;
+
     private int callCount;
     public LogEvent[] Log { get; private set; } = new LogEvent[SIZE];
     public int Head => callCount % SIZE;
 
     public void Emit(LogEvent logEvent)
     {
-        Log[callCount++ % SIZE] = logEvent;
+        Log[callCount++ & MOD] = logEvent;
         OnLogChanged?.Invoke();
     }
 }

--- a/Core/Session/GrindSessionHandler.cs
+++ b/Core/Session/GrindSessionHandler.cs
@@ -1,4 +1,8 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using Core.GOAP;
+
+using Microsoft.Extensions.Logging;
+
+using SharedLib;
 
 using System;
 using System.Threading;
@@ -7,7 +11,7 @@ namespace Core.Session;
 
 public sealed class GrindSessionHandler : IGrindSessionHandler
 {
-    private readonly ILogger logger;
+    private readonly ILogger<GrindSessionHandler> logger;
     private readonly PlayerReader playerReader;
     private readonly SessionStat stats;
     private readonly IGrindSessionDAO grindSessionDAO;
@@ -18,9 +22,9 @@ public sealed class GrindSessionHandler : IGrindSessionHandler
 
     private bool active;
 
-    public GrindSessionHandler(ILogger logger, DataConfig dataConfig,
-        PlayerReader playerReader, SessionStat stats, IGrindSessionDAO grindSessionDAO,
-        CancellationTokenSource cts)
+    public GrindSessionHandler(ILogger<GrindSessionHandler> logger,
+        DataConfig dataConfig, PlayerReader playerReader, SessionStat stats,
+        IGrindSessionDAO grindSessionDAO, CancellationTokenSource<GoapAgent> cts)
     {
         this.logger = logger;
         this.playerReader = playerReader;
@@ -81,6 +85,6 @@ public sealed class GrindSessionHandler : IGrindSessionHandler
         }
 
         if (logger.IsEnabled(LogLevel.Debug))
-            logger.LogDebug("SessionHandler thread stopped!");
+            logger.LogDebug("Thread stopped!");
     }
 }

--- a/Core/Talents/TalentReader.cs
+++ b/Core/Talents/TalentReader.cs
@@ -6,7 +6,7 @@ namespace Core;
 
 public sealed class TalentReader
 {
-    private readonly int cTalent;
+    private const int cTalent = 72;
 
     private readonly PlayerReader playerReader;
     private readonly TalentDB talentDB;
@@ -15,10 +15,8 @@ public sealed class TalentReader
     public Dictionary<int, Talent> Talents { get; } = new();
     public Dictionary<int, int> Spells { get; } = new();
 
-    public TalentReader(int cTalent, PlayerReader playerReader, TalentDB talentDB)
+    public TalentReader(PlayerReader playerReader, TalentDB talentDB)
     {
-        this.cTalent = cTalent;
-
         this.playerReader = playerReader;
         this.talentDB = talentDB;
     }

--- a/Core/WowheadAPI/WApi.cs
+++ b/Core/WowheadAPI/WApi.cs
@@ -1,6 +1,8 @@
 ﻿using System.Threading.Tasks;
 using System.Xml;
 
+using SharedLib;
+
 namespace Core;
 
 public sealed class WApi

--- a/CoreTests/CoreTests.csproj
+++ b/CoreTests/CoreTests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="GameOverlay.Net" Version="4.3.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />

--- a/CoreTests/Input/Test_Input.cs
+++ b/CoreTests/Input/Test_Input.cs
@@ -17,13 +17,13 @@ public class Test_Input : IDisposable
     private readonly WowScreen wowScreen;
     private readonly WowProcessInput wowProcessInput;
 
-    public Test_Input(ILogger logger)
+    public Test_Input(ILogger logger, ILoggerFactory loggerFactory)
     {
         this.logger = logger;
         this.cts = new();
 
         wowProcess = new WowProcess();
-        wowScreen = new WowScreen(logger, wowProcess);
+        wowScreen = new WowScreen(loggerFactory.CreateLogger<WowScreen>(), wowProcess);
         wowProcessInput = new WowProcessInput(logger, cts, wowProcess);
     }
 

--- a/CoreTests/MinimapNodeFinder/Test_MinimapNodeFinder.cs
+++ b/CoreTests/MinimapNodeFinder/Test_MinimapNodeFinder.cs
@@ -28,12 +28,12 @@ internal sealed class Test_MinimapNodeFinder : IDisposable
 
     private readonly Stopwatch stopwatch = new();
 
-    public Test_MinimapNodeFinder(ILogger logger)
+    public Test_MinimapNodeFinder(ILogger logger, ILoggerFactory loggerFactory)
     {
         this.logger = logger;
 
         wowProcess = new();
-        wowScreen = new(logger, wowProcess);
+        wowScreen = new(loggerFactory.CreateLogger<WowScreen>(), wowProcess);
 
         minimapNodeFinder = new(logger, wowScreen);
     }

--- a/CoreTests/NpcNameFinder/MockWoWScreen.cs
+++ b/CoreTests/NpcNameFinder/MockWoWScreen.cs
@@ -8,6 +8,15 @@ public class MockWoWScreen : IWowScreen
 {
     public bool Enabled { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
+    public Bitmap Bitmap => throw new NotImplementedException();
+
+    public Rectangle Rect => throw new NotImplementedException();
+
+    public void AddDrawAction(Action<Graphics> g)
+    {
+        throw new NotImplementedException();
+    }
+
     public Bitmap GetBitmap(int width, int height)
     {
         throw new NotImplementedException();

--- a/CoreTests/NpcNameFinder/Test_NpcNameFinder.cs
+++ b/CoreTests/NpcNameFinder/Test_NpcNameFinder.cs
@@ -10,6 +10,7 @@ using System;
 using SharedLib.Extensions;
 using Core;
 using Game;
+using SharedLib;
 
 #pragma warning disable 0162
 #nullable enable
@@ -45,18 +46,21 @@ public sealed class Test_NpcNameFinder : IDisposable
 
     private readonly NpcNameOverlay? npcNameOverlay;
 
-    public Test_NpcNameFinder(ILogger logger, NpcNames types)
+    public Test_NpcNameFinder(ILogger logger, ILoggerFactory loggerFactory, NpcNames types)
     {
         this.logger = logger;
 
         wowProcess = new();
-        wowScreen = new(logger, wowProcess);
+        wowScreen = new(loggerFactory.CreateLogger<WowScreen>(), wowProcess);
         WowProcessInput wowProcessInput = new(logger, new(), wowProcess);
 
-        npcNameFinder = new(logger, wowScreen, new ManualResetEventSlim(false));
+        INpcResetEvent npcResetEvent = new NpcResetEvent();
+        npcNameFinder = new(logger, wowScreen, npcResetEvent);
 
         MockMouseOverReader mouseOverReader = new();
-        npcNameTargeting = new(logger, new(), wowScreen, npcNameFinder, wowProcessInput, mouseOverReader, new NoBlacklist(), null!);
+        npcNameTargeting = new(loggerFactory.CreateLogger<NpcNameTargeting>(),
+            new(), wowScreen, npcNameFinder, wowProcessInput,
+            mouseOverReader, new NoBlacklist(), null!);
 
         npcNameFinder.ChangeNpcType(types);
 

--- a/CoreTests/Program.cs
+++ b/CoreTests/Program.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Linq;
 using Core;
 using System;
+using Microsoft.Extensions.Logging;
 
 #pragma warning disable 0162
 
@@ -14,6 +15,7 @@ namespace CoreTests;
 sealed class Program
 {
     private static Microsoft.Extensions.Logging.ILogger logger;
+    private static ILoggerFactory loggerFactory;
 
     private const bool LogOverall = false;
     private const int delay = 150;
@@ -27,6 +29,11 @@ sealed class Program
 
         Log.Logger = logConfig;
         logger = new SerilogLoggerProvider(Log.Logger).CreateLogger(nameof(Program));
+
+        loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.ClearProviders().AddSerilog();
+        });
 
         Test_NPCNameFinder();
         //Test_Input();
@@ -43,7 +50,7 @@ sealed class Program
         NpcNames types = NpcNames.Enemy | NpcNames.Neutral;
         //NpcNames types = NpcNames.Friendly | NpcNames.Neutral;
 
-        using Test_NpcNameFinder test = new(logger, types);
+        using Test_NpcNameFinder test = new(logger, loggerFactory, types);
         int count = 100;
         int i = 0;
 
@@ -72,7 +79,7 @@ sealed class Program
 
     private static void Test_Input()
     {
-        Test_Input test = new(logger);
+        Test_Input test = new(logger, loggerFactory);
         test.Mouse_Movement();
         test.Mouse_Clicks();
         test.Clipboard();
@@ -131,7 +138,7 @@ sealed class Program
 
     private static void Test_MinimapNodeFinder()
     {
-        using Test_MinimapNodeFinder test = new(logger);
+        using Test_MinimapNodeFinder test = new(logger, loggerFactory);
 
         int count = 100;
         int i = 0;
@@ -169,7 +176,7 @@ sealed class Program
         //NpcNames types = NpcNames.Enemy | NpcNames.Neutral;
         NpcNames types = NpcNames.Friendly | NpcNames.Neutral;
 
-        using Test_NpcNameFinder test = new(logger, types);
+        using Test_NpcNameFinder test = new(logger, loggerFactory, types);
 
         int count = 2;
         int i = 0;

--- a/Frontend/DependencyInjection.cs
+++ b/Frontend/DependencyInjection.cs
@@ -1,0 +1,19 @@
+﻿using BlazorTable;
+using MatBlazor;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Frontend;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddFrontend(this IServiceCollection services)
+    {
+        services.AddMatBlazor();
+        services.AddRazorPages();
+        services.AddServerSideBlazor();
+        services.AddBlazorTable();
+
+        return services;
+    }
+}

--- a/Frontend/Pages/BagChanges.razor
+++ b/Frontend/Pages/BagChanges.razor
@@ -1,5 +1,6 @@
 ﻿@inject IJSRuntime JSRuntime
-@inject IAddonReader addonReader
+
+@inject BagReader bagReader
 
 @implements IDisposable
 
@@ -25,7 +26,7 @@
 }
 @code {
 
-    private const int MaxItemToShow = 14;
+    private const int MaxItemToShow = 12;
     private const int MaxLifeTimeSec = 15;
 
     private Timer timer = null!;
@@ -36,16 +37,16 @@
 
     protected override void OnInitialized()
     {
-        NewItems = addonReader.BagReader.BagItems.Where(WasRecentlyUpdated);
+        NewItems = bagReader.BagItems.Where(WasRecentlyUpdated);
 
-        addonReader.BagReader.DataChanged += OnBagReaderDataChanged;
+        bagReader.DataChanged += OnBagReaderDataChanged;
 
         timer = new Timer(TimerTick);
     }
 
     public void Dispose()
     {
-        addonReader.BagReader.DataChanged -= OnBagReaderDataChanged;
+        bagReader.DataChanged -= OnBagReaderDataChanged;
         timer.Dispose();
     }
 
@@ -71,7 +72,7 @@
 
     public void OnBagReaderDataChanged()
     {
-        NewItems = addonReader.BagReader.BagItems.Where(WasRecentlyUpdated);
+        NewItems = bagReader.BagItems.Where(WasRecentlyUpdated);
 
         if (NewItems.Count() > MaxItemToShow)
         {

--- a/Frontend/Pages/BotHeader.razor
+++ b/Frontend/Pages/BotHeader.razor
@@ -1,6 +1,16 @@
 ﻿@using Core.GOAP
 
 @inject IAddonReader addonReader
+@inject PlayerReader playerReader
+@inject CombatLog combatLog
+
+@inject BagReader BagReader
+@inject SpellBookReader SpellBookReader
+@inject TalentReader TalentReader
+@inject ActionBarCostReader ActionBarCostReader
+
+@inject AddonBits Bits
+
 @inject IBotController botController
 @inject LevelTracker levelTracker
 @inject WApi api
@@ -29,10 +39,10 @@
                 </td>
                 <td>@playerReader.HealthCurrent() (@playerReader.HealthPercent() %)<br />@playerReader.PTCurrent() (@playerReader.PTPercentage() %)</td>
 
-                <td>@addonReader.BagReader.BagItems.Count / @addonReader.BagReader.SlotCount</td>
-                <td>@addonReader.ActionBarCostReader.Count / @addonReader.SpellBookReader.Count / @addonReader.TalentReader.Count</td>
+                <td>@BagReader.BagItems.Count / @BagReader.SlotCount</td>
+                <td>@ActionBarCostReader.Count / @SpellBookReader.Count / @TalentReader.Count</td>
                 <td>
-                    @if (addonReader.PlayerReader.Bits.HasTarget())
+                    @if (Bits.HasTarget())
                     {
                         <a href="@($"{api.NpcId}{playerReader.TargetId}")" target="_blank">
                             <div>
@@ -44,9 +54,9 @@
                                 {
                                     <div>Combo Points: @playerReader.ComboPoints()</div>
                                 }
-                                @if (addonReader.DamageTakenCount() > 1)
+                                @if (combatLog.DamageTakenCount() > 1)
                                 {
-                                    <div>Fighting @addonReader.DamageTakenCount() Mobs</div>
+                                    <div>Fighting @combatLog.DamageTakenCount() Mobs</div>
                                 }
 
                             </div>
@@ -80,9 +90,7 @@
     [Parameter]
     public bool ShowActiveGoal { get; set; } = true;
 
-    private PlayerReader playerReader => addonReader.PlayerReader;
-
-    private bool PlayerInCombat => this.playerReader.Bits.PlayerInCombat();
+    private bool PlayerInCombat => Bits.PlayerInCombat();
 
     private string CombatBadge()
     {

--- a/Frontend/Pages/ClassConfigurationComponent.razor
+++ b/Frontend/Pages/ClassConfigurationComponent.razor
@@ -19,7 +19,7 @@
                                 <td>@(property.Name)</td>
                                 <td>
                                     <input value="@property.GetValue(classConfig)" class="form-control" disabled="@(!editables.Contains(property.Name))"
-                               @onchange="c => { property.SetValue(classConfig, c.Value); Update(); }" />
+                                    @onchange="c => { property.SetValue(classConfig, c.Value); Update(); }" />
                                 </td>
                                 break;
 
@@ -27,15 +27,15 @@
                                 <td>@(property.Name)</td>
                                 <td>
                                     <input value="@property.GetValue(classConfig)" class="form-control" disabled="@(!editables.Contains(property.Name))"
-                               @onchange="c => { if(int.TryParse(c.Value?.ToString(), out int n)) { property.SetValue(classConfig, n); Update(); } }" />
+                                    @onchange="c => { if(int.TryParse(c.Value?.ToString(), out int n)) { property.SetValue(classConfig, n); Update(); } }" />
                                 </td>
                                 break;
                             case TypeCode.Boolean:
                                 <td>@(property.Name)</td>
                                 <td>
                                     <input type="checkbox" class="form-control" disabled="@(!editables.Contains(property.Name))"
-                               checked="@(CBool(property.GetValue(classConfig)))"
-                               @onchange="c => { property.SetValue(classConfig, c.Value); Update(); }" />
+                                           checked="@(CBool(property.GetValue(classConfig)))"
+                                    @onchange="c => { property.SetValue(classConfig, c.Value); Update(); }" />
                                 </td>
                                 break;
                             default:
@@ -53,31 +53,30 @@
 
     private ClassConfiguration classConfig = null!;
 
-    private HashSet<string> editables = null!;
+    private HashSet<string> editables = new()
+    {
+        // Int
+        nameof(ClassConfiguration.NPCMaxLevels_Above),
+        nameof(ClassConfiguration.NPCMaxLevels_Below),
+        // booleans
+        nameof(ClassConfiguration.Skin),
+        nameof(ClassConfiguration.Mine),
+        nameof(ClassConfiguration.Herb),
+        nameof(ClassConfiguration.Salvage),
+        nameof(ClassConfiguration.Loot),
+        nameof(ClassConfiguration.LogBagChanges),
+        nameof(ClassConfiguration.UseMount),
+        nameof(ClassConfiguration.KeyboardOnly),
+        nameof(ClassConfiguration.AllowPvP),
+        nameof(ClassConfiguration.AutoPetAttack),
+        nameof(ClassConfiguration.PathThereAndBack),
+        nameof(ClassConfiguration.PathReduceSteps),
+        nameof(ClassConfiguration.CheckTargetGivesExp),
+    };
 
     protected override void OnInitialized()
     {
         RefreshData();
-
-        editables = new()
-        {
-            // Int
-            nameof(classConfig.NPCMaxLevels_Above),
-            nameof(classConfig.NPCMaxLevels_Below),
-            // booleans
-            nameof(classConfig.Skin),
-            nameof(classConfig.Mine),
-            nameof(classConfig.Herb),
-            nameof(classConfig.Salvage),
-            nameof(classConfig.Loot),
-            nameof(classConfig.UseMount),
-            nameof(classConfig.KeyboardOnly),
-            nameof(classConfig.AllowPvP),
-            nameof(classConfig.AutoPetAttack),
-            nameof(classConfig.PathThereAndBack),
-            nameof(classConfig.PathReduceSteps),
-            nameof(classConfig.CheckTargetGivesExp),
-        };
 
         botController.ProfileLoaded += OnProfileLoaded;
         addonReader.AddonDataChanged += OnAddonDataChanged;

--- a/Frontend/Pages/GoalsComponent.razor
+++ b/Frontend/Pages/GoalsComponent.razor
@@ -1,15 +1,17 @@
 ﻿@inject IBotController botController
 @inject IAddonReader addonReader
 
+@inject PlayerReader PlayerReader
+
 @implements IDisposable
 
 <div class="card" style="margin-top: 10px">
     <div class="card-header">
-        Goals -> @addonReader.PlayerReader.MinRange() - @addonReader.PlayerReader.MaxRange()
+        Goals -> @PlayerReader.MinRange() - @PlayerReader.MaxRange()
         | Expand <input type="checkbox" @bind="@Expand" />
         <ToggleButton Disable="@(botController.ClassConfig?.Mode == Mode.AttendedGather)" />
         <span class="float-right">
-            Net: @addonReader.PlayerReader.NetworkLatency.Value.ToString()ms |
+            Net: @PlayerReader.NetworkLatency.Value.ToString()ms |
             Npc: @NpcLatency.ToString("0.0")ms |
             Bot: @addonReader.AvgUpdateLatency.ToString("0.0")ms
         </span>

--- a/Frontend/Pages/GoapGoalView.razor
+++ b/Frontend/Pages/GoapGoalView.razor
@@ -4,8 +4,9 @@
 @using Core.Goals
 @using System.Text.RegularExpressions
 
-@inject IAddonReader addonReader
 @inject IBotController botController
+
+@inject ActionBarCooldownReader ActionBarCooldownReader
 
 <tr class="@ActionClass(IsSelected, 0)">
     <td>
@@ -44,7 +45,7 @@
 
                     int cooldown = 0;
                     if (key.Slot > 0)
-                        cooldown = addonReader.ActionBarCooldownReader.Get(key);
+                        cooldown = ActionBarCooldownReader.Get(key);
 
                     <tr class="@ActionClass(lastKey == key.ConsoleKeyFormHash, cooldown)">
                         <td>

--- a/Frontend/Pages/Index.razor
+++ b/Frontend/Pages/Index.razor
@@ -1,7 +1,7 @@
 ﻿@page "/"
 
 @inject ILogger logger
-@inject IAddonReader addonReader
+
 @inject IBotController botController
 @inject IJSRuntime JSRuntime
 @inject AddonConfigurator addonConfigurator

--- a/Frontend/Pages/MiniMapComponent.razor
+++ b/Frontend/Pages/MiniMapComponent.razor
@@ -1,7 +1,8 @@
 ﻿@implements IDisposable
+
 @inject IBotController botController
 @inject WowScreen wowScreen
-@inject IAddonReader addonReader
+
 @inject MinimapNodeFinder minimapNodeFinder
 
 @using System.Drawing

--- a/Frontend/Pages/PathSelectorComponent.razor
+++ b/Frontend/Pages/PathSelectorComponent.razor
@@ -2,7 +2,6 @@
 @using System.IO
 
 @inject IBotController botController
-@inject IAddonReader addonReader
 @inject DataConfig dataConfig
 
 @implements IDisposable

--- a/Frontend/Pages/ProfileSelectorComponent.razor
+++ b/Frontend/Pages/ProfileSelectorComponent.razor
@@ -2,7 +2,9 @@
 
 @inject ILogger logger
 @inject IBotController botController
-@inject IAddonReader addonReader
+
+@inject BagReader bagReader
+
 @inject DataConfig dataConfig
 @inject ExecGameCommand exec
 
@@ -121,6 +123,6 @@
     private void CreateNewActionBarPopulator()
     {
         if (botController.ClassConfig != null)
-            ActionBarPopulator = new(botController.ClassConfig!, ((addonReader as AddonReader)!).BagReader, exec);
+            ActionBarPopulator = new(botController.ClassConfig!, bagReader, exec);
     }
 }

--- a/Frontend/Pages/RawPlayerReaderComponent.razor
+++ b/Frontend/Pages/RawPlayerReaderComponent.razor
@@ -1,7 +1,8 @@
 ﻿@using System.Reflection
 
-@inject IBotController botController
 @inject IAddonReader addonReader
+
+@inject PlayerReader PlayerReader
 
 @implements IDisposable
 
@@ -12,7 +13,7 @@
         </div>
         <div class="card-body" style="padding-bottom: 0">
             <table class="table table-bordered">
-                @foreach (var property in GetPropertyValues(addonReader.PlayerReader))
+                @foreach (var property in GetPropertyValues(PlayerReader))
                 {
                     <tr>
                         <td>@(property.Name)</td>

--- a/Frontend/Pages/RecordPath.razor
+++ b/Frontend/Pages/RecordPath.razor
@@ -7,6 +7,7 @@
 @using Core.Database
 
 @inject IAddonReader addonReader
+@inject PlayerReader PlayerReader
 @inject IBotController botController
 @inject IJSRuntime JSRuntime
 @inject DataConfig dataConfig
@@ -43,8 +44,8 @@
     </div>
     <div class="col-sm">
         <h3><span style="color:orange">&#9650;</span> Player</h3>
-        <input type="text" class="col-sm-2 form-control" disabled="disabled" value="@addonReader.PlayerReader.MapX" />
-        <input type="text" class="col-sm-2 form-control" disabled="disabled" value="@addonReader.PlayerReader.MapY" />
+        <input type="text" class="col-sm-2 form-control" disabled="disabled" value="@PlayerReader.MapX" />
+        <input type="text" class="col-sm-2 form-control" disabled="disabled" value="@PlayerReader.MapY" />
         <hr>
     </div>
 </div>
@@ -55,7 +56,7 @@
             <svg width="@(Size)px" height="@(Size)px">
                 <g class="background"></g>
 
-                <g id="playerloc" transform='translate(@(routeInfo.ToCanvasPointX(addonReader.PlayerReader.MapX)-5), @(routeInfo.ToCanvasPointY(addonReader.PlayerReader.MapY)-5)) rotate(@PlayerDir 5 5)'>
+                <g id="playerloc" transform='translate(@(routeInfo.ToCanvasPointX(PlayerReader.MapX)-5), @(routeInfo.ToCanvasPointY(PlayerReader.MapY)-5)) rotate(@PlayerDir 5 5)'>
                     <svg width="10" height="10">
                         <polygon points="5,0 8.5,8.5 1.5,8.5 5,0" fill="orange" />
                     </svg>
@@ -194,7 +195,7 @@
     protected MarkupString SelectedPoints = new MarkupString();
     protected MarkupString PreviewPoints = new MarkupString();
 
-    protected float PlayerDir => -addonReader.PlayerReader.Direction * (180f / MathF.PI);
+    protected float PlayerDir => -PlayerReader.Direction * (180f / MathF.PI);
 
     protected int MIN_DISTANCE = 1;
     protected int MAX_DISTANCE = 100;
@@ -268,16 +269,16 @@
 
     private void OnAddonDataChangedAction()
     {
-        if (!UpdateRecording() && lastPlayerPoint != addonReader.PlayerReader.MapPosNoZ)
+        if (!UpdateRecording() && lastPlayerPoint != PlayerReader.MapPosNoZ)
         {
-            lastPlayerPoint = addonReader.PlayerReader.MapPosNoZ;
+            lastPlayerPoint = PlayerReader.MapPosNoZ;
             UpdateRouteMarkup();
             StateHasChanged();
         }
 
         /*
         // requires async
-        var p = addonReader.PlayerReader.PlayerLocation;
+        var p = PlayerReader.PlayerLocation;
             var pp = new Vector3(
             route.ToCanvasPointX(p.X),
             route.ToCanvasPointY(p.Y),
@@ -289,7 +290,7 @@
 
     private void UpdateZoneName()
     {
-        areaName = addonReader.PlayerReader.WorldMapArea.AreaName;
+        areaName = PlayerReader.WorldMapArea.AreaName;
     }
 
     private void ActionZoneChangedAction()
@@ -415,7 +416,7 @@
     {
         if (!recording) { return false; }
 
-        Vector3 map = addonReader.PlayerReader.MapPosNoZ;
+        Vector3 map = PlayerReader.MapPosNoZ;
 
         if (editPath.Count == 0 ||
             map.MapDistanceXYTo(editPath.Last()) > Distance)
@@ -472,7 +473,7 @@
 
     protected void UpdateSelectedWithPlayer()
     {
-        UpdateSourcePoint(ref selectedPoint, addonReader.PlayerReader.MapPosNoZ);
+        UpdateSourcePoint(ref selectedPoint, PlayerReader.MapPosNoZ);
     }
 
     protected void UpdateSelectedWithPreview()
@@ -566,7 +567,7 @@
         int index = editPath.FindIndex(p => p == selectedPoint);
         if (index == -1) return;
 
-        var target = addonReader.PlayerReader.MapPosNoZ;
+        var target = PlayerReader.MapPosNoZ;
         target.Z = 0;
 
         editPath.Insert(index + 1, target);

--- a/Frontend/Pages/RouteComponent.razor
+++ b/Frontend/Pages/RouteComponent.razor
@@ -6,6 +6,10 @@
 
 @inject IAddonReader addonReader
 @inject IBotController botController
+
+@inject CombatLog combatLog
+@inject PlayerReader PlayerReader
+@inject AddonBits Bits
 @inject IJSRuntime JSRuntime
 @inject WorldMapAreaDB worldmapAreaDB
 @inject AreaDB areaDB
@@ -19,7 +23,7 @@
                 <td>Route @routeSymbol</td>
                 <td>
                     <div class="float-right">
-                        [@addonReader.PlayerReader.MapX.ToString("00.0000"),@addonReader.PlayerReader.MapY.ToString("00.0000")] @(AreaName) (@addonReader.PlayerReader.UIMapId.Value)
+                        [@PlayerReader.MapX.ToString("00.0000"),@PlayerReader.MapY.ToString("00.0000")] @(AreaName) (@PlayerReader.UIMapId.Value)
                     </div>
                 </td>
             </tr>
@@ -32,7 +36,7 @@
                 </g>
                 <g class="group2">
                     @{
-                        var colour = addonReader.PlayerReader.Bits.PlayerInCombat() ? "red" : "orange";
+                        var colour = Bits.PlayerInCombat() ? "red" : "orange";
                         if (botController.GoapAgent?.CurrentGoal is FollowRouteGoal)
                         {
                             colour = "blue";
@@ -40,7 +44,7 @@
 
                         @if (botController.RouteInfo != null)
                         {
-                            <g id="playerloc" transform='translate(@(botController.RouteInfo.ToCanvasPointX(addonReader.PlayerReader.MapX)-5), @(botController.RouteInfo.ToCanvasPointY(addonReader.PlayerReader.MapY)-5)) rotate(@PlayerDir 5 5)'>
+                            <g id="playerloc" transform='translate(@(botController.RouteInfo.ToCanvasPointX(PlayerReader.MapX)-5), @(botController.RouteInfo.ToCanvasPointY(PlayerReader.MapY)-5)) rotate(@PlayerDir 5 5)'>
                                 <svg width="10" height="10">
                                     <polygon points="5,0 8.5,8.5 1.5,8.5 5,0" fill="@colour" />
                                 </svg>
@@ -105,7 +109,7 @@
 
     private Timer refreshTimer = new Timer();
 
-    private float PlayerDir => -addonReader.PlayerReader.Direction * (180f / MathF.PI);
+    private float PlayerDir => -PlayerReader.Direction * (180f / MathF.PI);
 
     private List<Vector3> deaths = new();
 
@@ -116,7 +120,7 @@
         botController.ProfileLoaded += OnProfileLoaded;
         addonReader.AddonDataChanged += OnAddonDataChanged;
         areaDB.Changed += OnZoneChanged;
-        addonReader.CombatLog.PlayerDeath += OnPlayerDeath;
+        combatLog.PlayerDeath += OnPlayerDeath;
 
         UpdateZoneName();
         UpdateDeaths();
@@ -130,7 +134,7 @@
         botController.ProfileLoaded -= OnProfileLoaded;
         addonReader.AddonDataChanged -= OnAddonDataChanged;
         areaDB.Changed -= OnZoneChanged;
-        addonReader.CombatLog.PlayerDeath -= OnPlayerDeath;
+        combatLog.PlayerDeath -= OnPlayerDeath;
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -185,7 +189,7 @@
     private async Task OnPlayerDeathAction()
     {
         // have to wait for pressing Release Spirit
-        while (addonReader.PlayerReader.CorpseMapPos == Vector3.Zero)
+        while (PlayerReader.CorpseMapPos == Vector3.Zero)
         {
             await Task.Delay(200);
         }
@@ -213,7 +217,7 @@
         if (routeinfo.RouteToWaypoint.Length > 0)
         {
             var waylist = routeinfo.RouteToWaypoint.ToArray();
-            worldmapAreaDB.ToMap_FlipXY(addonReader.PlayerReader.UIMapId.Value, ref waylist);
+            worldmapAreaDB.ToMap_FlipXY(PlayerReader.UIMapId.Value, ref waylist);
 
             this.RouteToWaypointLines = new MarkupString(routeinfo.RenderPathLines(waylist));
             this.RouteToWaypointPoints = new MarkupString(routeinfo.RenderPathPoints(waylist));
@@ -252,13 +256,13 @@
 
     private void UpdateZoneName()
     {
-        AreaName = addonReader.PlayerReader.WorldMapArea.AreaName;
+        AreaName = PlayerReader.WorldMapArea.AreaName;
     }
 
     private void UpdateDeaths()
     {
         if (botController.GoapAgent == null) return;
 
-        deaths.Add(botController.AddonReader.PlayerReader.CorpseMapPos);
+        deaths.Add(PlayerReader.CorpseMapPos);
     }
 }

--- a/Frontend/Pages/Swag.razor
+++ b/Frontend/Pages/Swag.razor
@@ -1,9 +1,11 @@
 ﻿@page "/Swag"
 
-@inject IAddonReader addonReader
 @inject IBotController botController
 @inject IJSRuntime JSRuntime
 @inject WApi api
+
+@inject BagReader bagReader
+@inject EquipmentReader equipmentReader
 
 @implements IDisposable
 
@@ -72,15 +74,9 @@
 @code {
     private Currency TotalVendorMoney { get; set; } = Currency.Empty;
 
-    private BagReader bagReader = null!;
-    private EquipmentReader equipmentReader = null!;
-
     protected override void OnInitialized()
     {
-        bagReader = addonReader.BagReader;
         bagReader.DataChanged += OnBagReaderDataChanged;
-
-        equipmentReader = addonReader.EquipmentReader;
         equipmentReader.OnEquipmentChanged += OnEquipmentChanged;
     }
 

--- a/Frontend/Pages/TalentTreeComponent.razor
+++ b/Frontend/Pages/TalentTreeComponent.razor
@@ -2,6 +2,7 @@
 
 @inject IAddonReader addonReader
 @inject WApi api
+@inject TalentReader talentReader
 
 <div class="card mt-1">
     <div class="card-header">
@@ -62,14 +63,6 @@
 </div>
 
 @code {
-
-    private TalentReader talentReader = null!;
-
-    protected override void OnInitialized()
-    {
-        talentReader = addonReader.TalentReader;
-    }
-
     private string DisplayName(Talent t)
     {
         if (t.CurrentRank > 1)

--- a/Frontend/Pages/ToggleButton.razor
+++ b/Frontend/Pages/ToggleButton.razor
@@ -1,5 +1,4 @@
 ﻿@inject IBotController botController
-@inject IAddonReader addonReader
 
 @implements IDisposable
 

--- a/Game/WoWProcess/WowProcess.cs
+++ b/Game/WoWProcess/WowProcess.cs
@@ -2,6 +2,8 @@ using System;
 using System.Diagnostics;
 using System.Threading;
 
+using SharedLib;
+
 #nullable enable
 
 namespace Game;
@@ -42,7 +44,8 @@ public sealed class WowProcess : IDisposable
     {
         Process? p = Get(pid);
         if (p == null)
-            throw new NullReferenceException("Unable to find running World of Warcraft process!");
+            throw new NullReferenceException(
+                $"Unable to find {(pid == -1 ? "any" : $"pid={pid}")} running World of Warcraft process!");
 
         Process = p;
         processId = Process.Id;
@@ -53,6 +56,8 @@ public sealed class WowProcess : IDisposable
         thread = new(PollProcessExited);
         thread.Start();
     }
+
+    public WowProcess(StartupConfigPid pid) : this(pid.Id) { }
 
     public void Dispose()
     {

--- a/Game/WoWScreen/IWowScreen.cs
+++ b/Game/WoWScreen/IWowScreen.cs
@@ -1,8 +1,13 @@
-﻿using SharedLib;
+﻿using System;
+using System.Drawing;
+
+using SharedLib;
 
 namespace Game;
 
-public interface IWowScreen : IColorReader, IRectProvider
+public interface IWowScreen : IColorReader, IRectProvider, IBitmapProvider
 {
     bool Enabled { get; set; }
+
+    void AddDrawAction(Action<Graphics> g);
 }

--- a/Game/WoWScreen/WowScreen.cs
+++ b/Game/WoWScreen/WowScreen.cs
@@ -18,7 +18,7 @@ namespace Game;
 
 public sealed class WowScreen : IWowScreen, IBitmapProvider, IDisposable
 {
-    private readonly ILogger logger;
+    private readonly ILogger<WowScreen> logger;
     private readonly WowProcess wowProcess;
 
     public event Action OnScreenChanged;
@@ -45,7 +45,7 @@ public sealed class WowScreen : IWowScreen, IBitmapProvider, IDisposable
 
     private readonly SolidBrush blackPen;
 
-    public WowScreen(ILogger logger, WowProcess wowProcess)
+    public WowScreen(ILogger<WowScreen> logger, WowProcess wowProcess)
     {
         this.logger = logger;
         this.wowProcess = wowProcess;
@@ -63,7 +63,7 @@ public sealed class WowScreen : IWowScreen, IBitmapProvider, IDisposable
 
         blackPen = new SolidBrush(Color.Black);
 
-        logger.LogInformation($"[{nameof(WowScreen)}] {rect} - " +
+        logger.LogInformation($"{rect} - " +
             $"Windowed Mode: {IsWindowedMode(p)} - " +
             $"Scale: {DPI2PPI(GetDpi()):F2}");
     }

--- a/HeadlessServer/DependencyInjection.cs
+++ b/HeadlessServer/DependencyInjection.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+using SharedLib;
+
+namespace HeadlessServer;
+public static class DependencyInjection
+{
+    public static void AddStartupConfigFactories(this IServiceCollection services)
+    {
+        services.AddSingleton<IOptions<StartupConfigPathing>>(x =>
+            StartupConfigPathingFactory(x.GetRequiredService<RunOptions>()));
+
+        services.AddSingleton<IOptions<StartupConfigReader>>(x =>
+            StartupConfigReaderFactory(x.GetRequiredService<RunOptions>()));
+
+        services.AddSingleton<IOptions<StartupConfigPid>>(x =>
+            StartupConfigPidFactory(x.GetRequiredService<RunOptions>()));
+
+        services.AddSingleton<IOptions<StartupConfigDiagnostics>>(x =>
+            StartupConfigDiagnosticsFactory(x.GetRequiredService<RunOptions>()));
+    }
+
+    private static IOptions<StartupConfigPathing> StartupConfigPathingFactory(RunOptions options)
+    => Options.Create<StartupConfigPathing>(
+    new(options.Mode.ToString()!,
+        options.Hostv1!, options.Portv1,
+        options.Hostv3!, options.Portv3));
+
+    private static IOptions<StartupConfigReader> StartupConfigReaderFactory(RunOptions options)
+    => Options.Create<StartupConfigReader>(
+        new() { Type = options.Reader.ToString() });
+
+    private static IOptions<StartupConfigPid> StartupConfigPidFactory(RunOptions options)
+    => Options.Create<StartupConfigPid>(
+        new() { Id = options.Pid });
+
+    private static IOptions<StartupConfigDiagnostics> StartupConfigDiagnosticsFactory(RunOptions options)
+        => Options.Create<StartupConfigDiagnostics>(
+            new() { Enabled = options.Diagnostics });
+}

--- a/HeadlessServer/HeadlessServer.cs
+++ b/HeadlessServer/HeadlessServer.cs
@@ -9,18 +9,28 @@ public sealed partial class HeadlessServer
     private readonly ILogger<HeadlessServer> logger;
     private readonly IBotController botController;
     private readonly IAddonReader addonReader;
+    private readonly ActionBarCostReader actionBarCostReader;
+    private readonly SpellBookReader spellBookReader;
+    private readonly BagReader bagReader;
     private readonly ExecGameCommand exec;
     private readonly AddonConfigurator addonConfigurator;
     private readonly Wait wait;
 
     public HeadlessServer(ILogger<HeadlessServer> logger,
         IBotController botController,
-        IAddonReader addonReader, ExecGameCommand exec,
+        IAddonReader addonReader,
+        ActionBarCostReader actionBarCostReader,
+        SpellBookReader spellBookReader,
+        BagReader bagReader,
+        ExecGameCommand exec,
         AddonConfigurator addonConfigurator, Wait wait)
     {
         this.logger = logger;
         this.botController = botController;
         this.addonReader = addonReader;
+        this.actionBarCostReader = actionBarCostReader;
+        this.spellBookReader = spellBookReader;
+        this.bagReader = bagReader;
         this.exec = exec;
         this.addonConfigurator = addonConfigurator;
         this.wait = wait;
@@ -53,17 +63,17 @@ public sealed partial class HeadlessServer
 
         do
         {
-            actionbarCost = addonReader.ActionBarCostReader.Count;
-            spellBook = addonReader.SpellBookReader.Count;
-            bag = addonReader.BagReader.BagItems.Count;
+            actionbarCost = actionBarCostReader.Count;
+            spellBook = spellBookReader.Count;
+            bag = bagReader.BagItems.Count;
 
             wait.Fixed(1000);
 
             LogInitStateStatus(logger, actionbarCost, spellBook, bag);
         } while (
-            actionbarCost != addonReader.ActionBarCostReader.Count ||
-            spellBook != addonReader.SpellBookReader.Count ||
-            bag != addonReader.BagReader.BagItems.Count);
+            actionbarCost != actionBarCostReader.Count ||
+            spellBook != spellBookReader.Count ||
+            bag != bagReader.BagItems.Count);
     }
 
     #region Logging

--- a/HeadlessServer/Program.cs
+++ b/HeadlessServer/Program.cs
@@ -1,18 +1,14 @@
-﻿using Core;
-using Core.Database;
-using Core.Session;
-using Game;
+﻿using CommandLine;
+
+using Core;
+
 using Microsoft.Extensions.DependencyInjection;
-using PPather;
+using Microsoft.Extensions.Logging;
+
 using Serilog;
 using Serilog.Events;
 using Serilog.Templates;
 using Serilog.Templates.Themes;
-using CommandLine;
-using WinAPI;
-using System.Drawing;
-using SharedLib;
-using Microsoft.Extensions.Logging;
 
 namespace HeadlessServer;
 
@@ -46,11 +42,14 @@ internal sealed class Program
             builder.AddSerilog();
         });
 
-        var log = logFactory.CreateLogger<Program>();
+        ILogger<Program> log = logFactory.CreateLogger<Program>();
 
-        log.LogInformation($"{Thread.CurrentThread.CurrentCulture.TwoLetterISOLanguageName} {DateTimeOffset.Now}");
+        log.LogInformation(
+            $"{Thread.CurrentThread.CurrentCulture.TwoLetterISOLanguageName} " +
+            $"{DateTimeOffset.Now}");
 
-        ParserResult<RunOptions> options = Parser.Default.ParseArguments<RunOptions>(args).WithNotParsed(a =>
+        ParserResult<RunOptions> options =
+            Parser.Default.ParseArguments<RunOptions>(args).WithNotParsed(a =>
         {
             log.LogError("Missing Required command line argument!");
         });
@@ -61,11 +60,15 @@ internal sealed class Program
             return;
         }
 
+        services.AddSingleton<RunOptions>(options.Value);
+
+        services.AddStartupConfigFactories();
+
         if (!FrameConfig.Exists() || !AddonConfig.Exists())
         {
             log.LogError("Unable to run headless server as crucial configuration files missing!");
             log.LogWarning($"Please be sure, the following validated configuration files present next to the executable:");
-            log.LogWarning($"{System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)}");
+            log.LogWarning($"{Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)}");
             log.LogWarning($"* {DataConfigMeta.DefaultFileName}");
             log.LogWarning($"* {FrameConfigMeta.DefaultFilename}");
             log.LogWarning($"* {AddonConfigMeta.DefaultFileName}");
@@ -73,13 +76,7 @@ internal sealed class Program
             return;
         }
 
-        while (WowProcess.Get(options.Value.Pid) == null)
-        {
-            log.LogWarning($"Unable to find any Wow process, is it running ?");
-            Thread.Sleep(1000);
-        }
-
-        if (ConfigureServices(logFactory, log, services, options))
+        if (ConfigureServices(log, services))
         {
             ServiceProvider provider = services
                 .AddSingleton<HeadlessServer>()
@@ -102,167 +99,16 @@ internal sealed class Program
         Console.ReadLine();
     }
 
-    private static bool ConfigureServices(ILoggerFactory loggerFactory, Microsoft.Extensions.Logging.ILogger log, IServiceCollection services, ParserResult<RunOptions> options)
+    private static bool ConfigureServices(
+        Microsoft.Extensions.Logging.ILogger log,
+        IServiceCollection services)
     {
-        if (!Validate(loggerFactory, log, options.Value.Pid))
+        if (!services.AddWoWProcess(log))
             return false;
 
-        services.AddSingleton<CancellationTokenSource>();
-
-        services.AddSingleton<WowProcess>(x => new(options.Value.Pid));
-        services.AddSingleton<StartupClientVersion>();
-        services.AddSingleton<DataConfig>(x => DataConfig.Load(x.GetRequiredService<StartupClientVersion>().Path));
-        services.AddSingleton<WowScreen>();
-        services.AddSingleton<WowProcessInput>();
-        services.AddSingleton<ExecGameCommand>();
-        services.AddSingleton<AddonConfigurator>();
-
-        services.AddSingleton<MinimapNodeFinder>();
-
-        if (options.Value.Diagnostics)
-        {
-            services.AddSingleton<IScreenCapture, ScreenCapture>();
-            log.LogInformation(nameof(ScreenCapture));
-        }
-        else
-        {
-            services.AddSingleton<IScreenCapture, NoScreenCapture>();
-            log.LogInformation(nameof(NoScreenCapture));
-        }
-
-        services.AddSingleton<SessionStat>();
-        services.AddSingleton<IGrindSessionDAO, LocalGrindSessionDAO>();
-        services.AddSingleton<WorldMapAreaDB>();
-        services.AddSingleton<IPPather>(x =>
-            GetPather(loggerFactory, x.GetRequiredService<Microsoft.Extensions.Logging.ILogger>(),
-                x.GetRequiredService<DataConfig>(), x.GetRequiredService<WorldMapAreaDB>(), options));
-
-        services.AddSingleton<AutoResetEvent>(x => new(false));
-        services.AddSingleton<DataFrame[]>(x => FrameConfig.LoadFrames());
-        services.AddSingleton<Wait>();
-
-
-        switch (options.Value.Reader)
-        {
-            case AddonDataProviderType.GDI:
-                services.AddSingleton<IAddonDataProvider, AddonDataProviderGDI>();
-                log.LogInformation(nameof(AddonDataProviderGDI));
-                break;
-            case AddonDataProviderType.GDIBlit:
-                services.AddSingleton<IAddonDataProvider, AddonDataProviderBitBlt>();
-                log.LogInformation(nameof(AddonDataProviderBitBlt));
-                break;
-            case AddonDataProviderType.DXGI:
-                services.AddSingleton<IAddonDataProvider, AddonDataProviderDXGI>();
-                log.LogInformation(nameof(AddonDataProviderDXGI));
-                break;
-        }
-
-        services.AddSingleton<AreaDB>();
-        services.AddSingleton<ItemDB>();
-        services.AddSingleton<CreatureDB>();
-        services.AddSingleton<SpellDB>();
-        services.AddSingleton<TalentDB>();
-
-        services.AddSingleton<PlayerReader>();
-        services.AddSingleton<IAddonReader, AddonReader>();
-
-        services.AddSingleton<IBotController, BotController>();
+        services.AddCoreBase();
+        services.AddCoreNormal(log);
 
         return true;
-    }
-
-    private static IPPather GetPather(ILoggerFactory logFactory,
-        Microsoft.Extensions.Logging.ILogger logger, DataConfig dataConfig,
-        WorldMapAreaDB worldMapAreaDB, ParserResult<RunOptions> options)
-    {
-        StartupConfigPathing scp = new(options.Value.Mode.ToString()!,
-            options.Value.Hostv1!, options.Value.Portv1,
-            options.Value.Hostv3!, options.Value.Portv3);
-
-        bool failed = false;
-
-        if (scp.Type == StartupConfigPathing.Types.RemoteV3)
-        {
-            var remoteLogger = logFactory.CreateLogger<RemotePathingAPIV3>();
-            RemotePathingAPIV3 api = new(remoteLogger, scp.hostv3, scp.portv3, worldMapAreaDB);
-            if (api.PingServer())
-            {
-                logger.LogInformation($"Using {StartupConfigPathing.Types.RemoteV3}({api.GetType().Name}) {scp.hostv3}:{scp.portv3}");
-                return api;
-            }
-            api.Dispose();
-            failed = true;
-        }
-
-        if (scp.Type == StartupConfigPathing.Types.RemoteV1 || failed)
-        {
-            var remoteLogger = logFactory.CreateLogger<RemotePathingAPI>();
-            RemotePathingAPI api = new(remoteLogger, scp.hostv1, scp.portv1);
-            Task<bool> pingTask = Task.Run(api.PingServer);
-            pingTask.Wait();
-            if (pingTask.Result)
-            {
-                if (scp.Type == StartupConfigPathing.Types.RemoteV3)
-                {
-                    logger.LogWarning($"Unavailable {StartupConfigPathing.Types.RemoteV3} {scp.hostv3}:{scp.portv3} - Fallback to {StartupConfigPathing.Types.RemoteV1}");
-                }
-
-                logger.LogInformation($"Using {StartupConfigPathing.Types.RemoteV1}({api.GetType().Name}) {scp.hostv1}:{scp.portv1}");
-                return api;
-            }
-
-            failed = true;
-        }
-
-        if (scp.Type != StartupConfigPathing.Types.Local)
-        {
-            logger.LogWarning($"{scp.Type} not available!");
-        }
-
-        var pathingLogger = logFactory.CreateLogger<LocalPathingApi>();
-        var serviceLogger = logFactory.CreateLogger<PPatherService>();
-        LocalPathingApi localApi = new(pathingLogger, new(serviceLogger, dataConfig, worldMapAreaDB), dataConfig);
-        logger.LogInformation($"Using {StartupConfigPathing.Types.Local}({localApi.GetType().Name})");
-        return localApi;
-    }
-
-    private static bool Validate(ILoggerFactory logFactory, Microsoft.Extensions.Logging.ILogger log, int pid)
-    {
-        WowProcess wowProcess = new(pid);
-        log.LogInformation($"Pid: {wowProcess.ProcessId}");
-        log.LogInformation($"Version: {wowProcess.FileVersion}");
-        NativeMethods.GetWindowRect(wowProcess.Process.MainWindowHandle, out Rectangle rect);
-
-        var logger = logFactory.CreateLogger<AddonConfigurator>();
-
-        AddonConfigurator addonConfigurator = new(logger, wowProcess);
-        Version? installVersion = addonConfigurator.GetInstallVersion();
-        log.LogInformation($"Addon version: {installVersion}");
-
-        bool valid = true;
-
-        if (addonConfigurator.IsDefault() || installVersion == null)
-        {
-            // At this point the webpage never loads so fallback to configuration page
-            addonConfigurator.Delete();
-            FrameConfig.Delete();
-            valid = false;
-
-            log.LogError($"{nameof(AddonConfig)} doesn't exists or addon not installed yet!");
-        }
-
-        if (FrameConfig.Exists() && !FrameConfig.IsValid(rect, installVersion!))
-        {
-            // At this point the webpage never loads so fallback to configuration page
-            FrameConfig.Delete();
-            valid = false;
-
-            log.LogError($"{nameof(FrameConfig)} doesn't exists or window rect is different then config!");
-        }
-
-        wowProcess.Dispose();
-
-        return valid;
     }
 }

--- a/HeadlessServer/RunOptions.cs
+++ b/HeadlessServer/RunOptions.cs
@@ -1,5 +1,6 @@
 ﻿using CommandLine;
-using Core;
+
+using SharedLib;
 
 namespace HeadlessServer;
 

--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ Take a look at the class files in `/Json/class` for examples of what you can do.
 | Property Name | Description | Optional | Default value |
 | --- | --- | --- | --- |
 | `"Log"` | Should logging enabled for `KeyAction(s)`. Requires restart. | true | `true` |
+| `"LogBagChanges"` | Should bag changes logs enabled for. | true | `true` |
 | `"Loot"` | Should loot the mob | true | `true` |
 | `"Skin"` | Should skin the mob | true | `false` |
 | `"Herb"` | Should herb the mob | true | `false` |

--- a/SharedLib/AddonDataProviderType/AddonDataProviderType.cs
+++ b/SharedLib/AddonDataProviderType/AddonDataProviderType.cs
@@ -1,4 +1,4 @@
-﻿namespace Core;
+﻿namespace SharedLib;
 
 public enum AddonDataProviderType
 {

--- a/SharedLib/AddonDataProviderType/ClientVersion.cs
+++ b/SharedLib/AddonDataProviderType/ClientVersion.cs
@@ -1,4 +1,4 @@
-﻿namespace Core;
+﻿namespace SharedLib;
 
 public enum ClientVersion
 {

--- a/SharedLib/CancellationTokenSource/ICancellationTokenSource.cs
+++ b/SharedLib/CancellationTokenSource/ICancellationTokenSource.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Threading;
+
+namespace SharedLib;
+
+public interface ICancellationTokenSource<T>
+{
+    CancellationToken Token { get; }
+
+    bool IsCancellationRequested { get; }
+
+    void Cancel();
+}
+
+public sealed class CancellationTokenSource<T> :
+    CancellationTokenSource, ICancellationTokenSource<T>, IDisposable
+{
+
+}

--- a/SharedLib/NpcFinder/INpcResetEvent.cs
+++ b/SharedLib/NpcFinder/INpcResetEvent.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Threading;
+
+namespace SharedLib;
+
+public sealed class NpcResetEvent : ManualResetEventSlim, INpcResetEvent
+{
+    public NpcResetEvent() : base() { }
+}
+
+public interface INpcResetEvent : IDisposable
+{
+    void Reset();
+    void Wait();
+    void Set();
+}

--- a/SharedLib/NpcFinder/NpcNameFinder.cs
+++ b/SharedLib/NpcFinder/NpcNameFinder.cs
@@ -1,4 +1,4 @@
-using SharedLib.Extensions;
+﻿using SharedLib.Extensions;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Drawing;
@@ -63,7 +63,7 @@ public sealed partial class NpcNameFinder : IDisposable
     private readonly ILogger logger;
     private readonly IBitmapProvider bitmapProvider;
     private readonly PixelFormat pixelFormat;
-    private readonly ManualResetEventSlim resetEvent;
+    private readonly INpcResetEvent resetEvent;
 
     private readonly int bytesPerPixel;
 
@@ -156,7 +156,8 @@ public sealed partial class NpcNameFinder : IDisposable
 
     #endregion
 
-    public NpcNameFinder(ILogger logger, IBitmapProvider bitmapProvider, ManualResetEventSlim resetEvent)
+    public NpcNameFinder(ILogger logger, IBitmapProvider bitmapProvider,
+        INpcResetEvent resetEvent)
     {
         this.logger = logger;
         this.bitmapProvider = bitmapProvider;
@@ -174,7 +175,9 @@ public sealed partial class NpcNameFinder : IDisposable
         CalculateHeightMultipiler();
 
         Area = new Rectangle(new Point(0, (int)ScaleHeight(topOffset)),
-            new Size((int)(bitmapProvider.Bitmap.Width * 0.87f), (int)(bitmapProvider.Bitmap.Height * 0.6f)));
+            new Size(
+                (int)(bitmapProvider.Bitmap.Width * 0.87f),
+                (int)(bitmapProvider.Bitmap.Height * 0.6f)));
 
         int screenWidth = bitmapProvider.Rect.Width;
         screenMid = screenWidth / 2;
@@ -364,7 +367,7 @@ public sealed partial class NpcNameFinder : IDisposable
     {
         unchecked
         {
-            int sqrDistance = 
+            int sqrDistance =
                 ((rr - r) * (rr - r)) +
                 ((gg - g) * (gg - g)) +
                 ((bb - b) * (bb - b));
@@ -373,10 +376,12 @@ public sealed partial class NpcNameFinder : IDisposable
     }
 
     private static bool FuzzyEnemyOrNeutral(byte r, byte g, byte b)
-        => FuzzyColor(fE_R, fE_G, fE_B, r, g, b, colorFuzz) || FuzzyColor(fN_R, fN_G, fN_B, r, g, b, colorFuzz);
+        => FuzzyColor(fE_R, fE_G, fE_B, r, g, b, colorFuzz) ||
+            FuzzyColor(fN_R, fN_G, fN_B, r, g, b, colorFuzz);
 
     private static bool FuzzyFriendlyOrNeutral(byte r, byte g, byte b)
-        => FuzzyColor(fF_R, fF_G, fF_B, r, g, b, colorFuzz) || FuzzyColor(fN_R, fN_G, fN_B, r, g, b, colorFuzz);
+        => FuzzyColor(fF_R, fF_G, fF_B, r, g, b, colorFuzz) ||
+            FuzzyColor(fN_R, fN_G, fN_B, r, g, b, colorFuzz);
 
     private static bool FuzzyEnemy(byte r, byte g, byte b)
         => FuzzyColor(fE_R, fE_G, fE_B, r, g, b, colorFuzz);
@@ -649,6 +654,12 @@ public sealed partial class NpcNameFinder : IDisposable
         }
         */
 
+        // TODO: Overflow error. ''\_(o.o)_/''
+        /*
+        System.OverflowException: Overflow error.
+        at System.Drawing.Graphics.CheckErrorStatus(Int32 status)
+        at System.Drawing.Graphics.DrawRectangle(Pen pen, Int32 x, Int32 y, Int32 width, Int32 height)
+        */
         for (int i = 0; i < Npcs.Count; i++)
         {
             NpcPosition n = Npcs[i];

--- a/SharedLib/StartupConfig/StartupClientVersion.cs
+++ b/SharedLib/StartupConfig/StartupClientVersion.cs
@@ -1,6 +1,6 @@
-﻿using Game;
+﻿using System;
 
-namespace Core;
+namespace SharedLib;
 
 public sealed class StartupClientVersion
 {
@@ -8,9 +8,9 @@ public sealed class StartupClientVersion
 
     public string Path { get; }
 
-    public StartupClientVersion(WowProcess process)
+    public StartupClientVersion(Version version)
     {
-        switch (process.FileVersion.Major)
+        switch (version.Major)
         {
             case 1:
                 Version = ClientVersion.SoM;

--- a/SharedLib/StartupConfig/StartupConfigDiagnostics.cs
+++ b/SharedLib/StartupConfig/StartupConfigDiagnostics.cs
@@ -1,10 +1,10 @@
-﻿namespace Core;
+﻿namespace SharedLib;
 
 public sealed class StartupConfigDiagnostics
 {
     public const string Position = "Diagnostics";
 
-    public bool Enabled { get; }
+    public bool Enabled { get; set; }
 
     public StartupConfigDiagnostics() { }
 }

--- a/SharedLib/StartupConfig/StartupConfigPathing.cs
+++ b/SharedLib/StartupConfig/StartupConfigPathing.cs
@@ -1,4 +1,4 @@
-﻿namespace Core;
+﻿namespace SharedLib;
 
 public sealed class StartupConfigPathing
 {
@@ -13,7 +13,9 @@ public sealed class StartupConfigPathing
 
     public StartupConfigPathing() { }
 
-    public StartupConfigPathing(string Mode, string hostv1, int portv1, string hostv3, int portv3)
+    public StartupConfigPathing(string Mode,
+        string hostv1, int portv1,
+        string hostv3, int portv3)
     {
         this.Mode = Mode;
 
@@ -24,7 +26,8 @@ public sealed class StartupConfigPathing
         this.portv3 = portv3;
     }
 
-    public Types Type => System.Enum.TryParse(Mode, out Types m) ? m : Types.Local;
+    public Types Type =>
+        System.Enum.TryParse(Mode, out Types m) ? m : Types.Local;
 
     public string Mode { get; set; } = string.Empty;
 

--- a/SharedLib/StartupConfig/StartupConfigPid.cs
+++ b/SharedLib/StartupConfig/StartupConfigPid.cs
@@ -1,4 +1,4 @@
-﻿namespace Core;
+﻿namespace SharedLib;
 
 public sealed class StartupConfigPid
 {

--- a/SharedLib/StartupConfig/StartupConfigReader.cs
+++ b/SharedLib/StartupConfig/StartupConfigReader.cs
@@ -1,4 +1,4 @@
-﻿namespace Core;
+﻿namespace SharedLib;
 
 public sealed class StartupConfigReader
 {
@@ -9,5 +9,7 @@ public sealed class StartupConfigReader
     public string Type { get; set; } = string.Empty;
 
     public AddonDataProviderType ReaderType =>
-        System.Enum.TryParse(Type, out AddonDataProviderType m) ? m : AddonDataProviderType.GDI;
+        System.Enum.TryParse(Type, out AddonDataProviderType m)
+        ? m
+        : AddonDataProviderType.GDI;
 }


### PR DESCRIPTION
Refactor:
* Better use of Dependency Injection across the whole solution. `GoalFactory` can now access the whole application `ServiceProvider`.
* `BlazorServer` and `HeadlessServer` now uses almost the same `Startup` during orchestration even using the same `StartupConfig*`.
* `AddonReader` and `PlayerReader` no longer construct it's dependencies(`*Readers`).
* Improved Logging with `SourceContext` and consistent display
* Addon cells has been inlined and replaced with constants. There's one downside to this, the cell constants are not scattered everywhere :(
* `IAddonReader` and `IBotController` code has been cleaned up!
* `AddonReader` and `PlayerReader` are less of a god classes
* `Startup` code has been cleaned up
* `Frontend` reduced usage of the `AddonReader` and `PlayerReader` classes. `*Readers` now can be injected individually which opens up the possibility to only update the given UI component when the corresponding `*Reader` has been updated. Avoiding unnecessary redraw requests!

Fixes:
* **Core**: `MountHandler` simplified MountUp code and less likely instant dismount right after mounted.
* **Core**: `CursorType` Added `Kill` type cursor `18012595827828094976`  hash
* **Startup**: incase unable to validate the players `UnitClass` and `UnitRace` there was no indication(**no output** to the logs/console)

Remark:
* It should be more easier to clean up after the `ClassConfig`. Same goes to the `GoapAgent` as well.