### PR TITLE
Addon: [1.7.42] - Improved SpellQueue - GCD - Interrupt tracking

### DIFF
--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -3,7 +3,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors
-## Version: 1.7.41
+## Version: 1.7.42
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/Storage.lua
+++ b/Addons/DataToColor/Storage.lua
@@ -188,6 +188,7 @@ function CreatePlayerBuffList()
         DataToColor.S.playerBuffs[14] = { "Fel Armor", [136156] = 1 }
         DataToColor.S.playerBuffs[15] = { "Fel Domination", [136082] = 1 }
         DataToColor.S.playerBuffs[16] = { "Demonic Sacrifice", [136184] = 1 }
+        DataToColor.S.playerBuffs[17] = { "Sacrifice", [136190] = 1 }
     elseif DataToColor.C.CHARACTER_CLASS == "SHAMAN" then
         DataToColor.S.playerBuffs[10] = { "Lightning Shield", [136051] = 1 }
         DataToColor.S.playerBuffs[11] = { "Water Shield", [132315] = 1 }

--- a/Core/AddonComponent/BuffStatus.cs
+++ b/Core/AddonComponent/BuffStatus.cs
@@ -91,6 +91,7 @@ public sealed class BuffStatus : IReader
     public bool FelArmor() => v[Mask._14];
     public bool FelDomination() => v[Mask._15];
     public bool DemonicSacrifice() => v[Mask._16];
+    public bool Sacrifice() => v[Mask._17];
 
     // Shaman
     public bool LightningShield() => v[Mask._10];

--- a/Core/Requirement/RequirementFactory.cs
+++ b/Core/Requirement/RequirementFactory.cs
@@ -248,6 +248,7 @@ public sealed partial class RequirementFactory
             { "Fel Armor", playerBuffs.FelArmor },
             { "Fel Domination", playerBuffs.FelDomination },
             { "Demonic Sacrifice", playerBuffs.DemonicSacrifice },
+            { "Sacrifice", playerBuffs.Sacrifice },
             
             // Shaman
             { "Lightning Shield", playerBuffs.LightningShield },

--- a/Json/class/Warlock_66_Demo_pet_pull.json
+++ b/Json/class/Warlock_66_Demo_pet_pull.json
@@ -89,7 +89,8 @@
         "WhenUsable": true,
         "Requirements": [
           "TargetsMe",
-          "InMeleeRange"
+          "InMeleeRange",
+          "Health% < 80"
         ]
       },
       {
@@ -101,7 +102,7 @@
         "Requirements": [
           "TargetHealth% > DOT_MIN_HEALTH%",
           "!Immolate",
-          "!TargetsMe"
+          "!TargetsMe || Sacrifice"
         ]
       },
       {
@@ -138,9 +139,9 @@
         "Name": "Incinerate",
         "Key": "F4",
         "HasCastBar": true,
-        "Cooldown": 6000,
+        //"Cooldown": 6000,
         "Requirements": [
-          "!TargetsMe",
+          "!TargetsMe || Sacrifice",
           "Immolate",
           "Health% > DRAIN_MIN_HP%",
           "TargetHealth% > 40"
@@ -151,8 +152,9 @@
         "Key": "2",
         "HasCastBar": true,
         "Cooldown": 6000,
+        "WhenUsable": true,
         "Requirements": [
-          "!TargetsMe",
+          "!TargetsMe || Sacrifice",
           "!Immolate",
           "Health% > DRAIN_MIN_HP%",
           "TargetHealth% > 40"
@@ -182,6 +184,8 @@
         "Name": "Shoot",
         "Key": "3",
         "Item": true,
+        "PressDuration": 51,
+        "WhenUsable": true,
         "Requirements": [
           "HasRangedWeapon",
           "!Shooting",
@@ -238,6 +242,7 @@
         "InCombat": "true",
         "Requirements": [
           "!Has Pet",
+          "!Mounted",
           "Fel Domination",
           "BagItem:Item_Soul_Shard"
         ],
@@ -249,6 +254,7 @@
         "HasCastBar": true,
         "Requirements": [
           "!Has Pet",
+          "!Mounted",
           "BagItem:Item_Soul_Shard"
         ],
         "AfterCastWaitCastbar": true,
@@ -259,6 +265,7 @@
         "Key": "9",
         "Requirements": [
           "Has Pet",
+          "!Mounted",
           "!Soul Link"
         ]
       },
@@ -278,6 +285,7 @@
         "Name": "heal",
         "Key": "7",
         "HasCastBar": true,
+        "AfterCastWaitCastbar": true,
         "AfterCastWaitBag": true,
         "Requirements": [
           "BagItem:Item_Soul_Shard",

--- a/README.md
+++ b/README.md
@@ -1356,6 +1356,7 @@ Allow requirements about what buffs/debuffs you have or the target has or in gen
 | Warlock | `"Fel Armor"` |
 | Warlock | `"Fel Domination"` |
 | Warlock | `"Demonic Sacrifice"` |
+| Warlock | `"Sacrifice"` |
 | Warrior | `"Battle Shout"` |
 | Warrior | `"Bloodrage"` |
 | Shaman | `"Lightning Shield"` |


### PR DESCRIPTION
Changes:
* Smoother casting cycle between instant cast(spells, items) / castbar based spells
* Reduced allocations while using `CastingHandler` (reusing `CancellationTokenSource` when its possible)
* Simplified `CastingHandlerInterruptWatchdog` thread logic

Fix:
* Many potential issues from use after free `CancellationTokenSource`