### PR TITLE
Refactor: `IAddonDataProvider` base shared code. DXGI: Ignore mouse events

### DIFF
--- a/Core/AddonDataProvider/IAddonDataProvider.cs
+++ b/Core/AddonDataProvider/IAddonDataProvider.cs
@@ -1,4 +1,9 @@
-﻿namespace Core;
+﻿using System.Drawing.Imaging;
+using System;
+
+using static Core.AddonDataProviderConfig;
+
+namespace Core;
 
 public interface IAddonDataProvider
 {
@@ -10,4 +15,34 @@ public interface IAddonDataProvider
     string GetString(int index);
 
     void Dispose();
+
+    static unsafe void InternalUpdate(BitmapData bd,
+        ReadOnlySpan<DataFrame> frames, Span<int> output)
+    {
+        ReadOnlySpan<byte> first = new(
+            (byte*)bd.Scan0 + (frames[0].Y * bd.Stride) +
+            (frames[0].X * BYTES_PER_PIXEL),
+            BYTES_PER_PIXEL);
+
+        ReadOnlySpan<byte> last = new(
+            (byte*)bd.Scan0 + (frames[^1].Y * bd.Stride) +
+            (frames[^1].X * BYTES_PER_PIXEL),
+            BYTES_PER_PIXEL);
+
+        if (!first.SequenceEqual(fColor) ||
+            !last.SequenceEqual(lColor))
+        {
+            return;
+        }
+
+        for (int i = 0; i < frames.Length; i++)
+        {
+            DataFrame frame = frames[i];
+
+            byte* y = (byte*)bd.Scan0 + (frame.Y * bd.Stride);
+            int x = frame.X * BYTES_PER_PIXEL;
+
+            output[frame.Index] = y[x] | (y[x + 1] << 8) | (y[x + 2] << 16);
+        }
+    }
 }

--- a/Game/WoWScreen/WowScreen.cs
+++ b/Game/WoWScreen/WowScreen.cs
@@ -45,15 +45,15 @@ public sealed class WowScreen : IWowScreen, IBitmapProvider, IDisposable
 
     private readonly SolidBrush blackPen;
 
+    private readonly bool windowedMode;
+
     public WowScreen(ILogger<WowScreen> logger, WowProcess wowProcess)
     {
         this.logger = logger;
         this.wowProcess = wowProcess;
 
-        Point p = new();
-        GetPosition(ref p);
         GetRectangle(out rect);
-        rect.Location = p;
+        windowedMode = IsWindowedMode(rect.Location);
 
         Bitmap = new Bitmap(rect.Width, rect.Height, PixelFormat.Format32bppPArgb);
         graphics = Graphics.FromImage(Bitmap);
@@ -64,15 +64,14 @@ public sealed class WowScreen : IWowScreen, IBitmapProvider, IDisposable
         blackPen = new SolidBrush(Color.Black);
 
         logger.LogInformation($"{rect} - " +
-            $"Windowed Mode: {IsWindowedMode(p)} - " +
+            $"Windowed Mode: {windowedMode} - " +
             $"Scale: {DPI2PPI(GetDpi()):F2}");
     }
 
     public void Update()
     {
-        Point p = new();
-        GetPosition(ref p);
-        rect.Location = p;
+        if (windowedMode)
+            GetRectangle(out rect);
 
         graphics.CopyFromScreen(rect.Location, Point.Empty, Bitmap.Size);
     }


### PR DESCRIPTION
Changes:
* `IAddonDataProvider`: `InternalUpdate` is shared among all the implementations.
* `DXGI`: prevent processing frames which triggered by mouse event.
* `WoWScreen`: GetPosition returns a non valid location while windowed mode.
* Only request the game client Rectangle while running in `WindowedMode`