### PR TITLE
Refactor: PPather and PathingAPI improved memory usage - Better building and underground path creation

### DIFF
--- a/Core/Path/RouteInfo.cs
+++ b/Core/Path/RouteInfo.cs
@@ -279,13 +279,13 @@ public sealed class RouteInfo : IDisposable
         return sb.ToString();
     }
 
-    private const string first = "<br><b>First</b>";
-    private const string last = "<br><b>Last</b>";
+    private const string FIRST = "<br><b>First</b>";
+    private const string LAST = "<br><b>Last</b>";
 
     public string RenderPathPoints(ReadOnlySpan<Vector3> path)
     {
         StringBuilder sb = new();
-        int count = path.Length;
+        int last = path.Length - 1;
         for (int i = 0; i < path.Length; i++)
         {
             Vector3 p = path[i];
@@ -293,11 +293,15 @@ public sealed class RouteInfo : IDisposable
             float y = p.Y;
             sb.AppendLine(
                 $"<circle onmousedown=\"pointClick(evt,{x},{y},{i});\" " +
-                $"onmousemove=\"showTooltip(evt,'{x},{y}{(i == 0 ? first : i == count - 1 ? last : string.Empty)}');\" " +
+                $"onmousemove=\"showTooltip(evt,'{x},{y}{(
+                    i == 0
+                    ? FIRST
+                    : i == last
+                    ? LAST
+                    : string.Empty)}');\" " +
                 $"onmouseout=\"hideTooltip();\" " +
                 $"cx='{ToCanvasPointX(x)}' " +
                 $"cy='{ToCanvasPointY(y)}' r='{dSize}' />");
-            i++;
         }
         return sb.ToString();
     }

--- a/PPather/Graph/Path.cs
+++ b/PPather/Graph/Path.cs
@@ -30,6 +30,8 @@ public sealed class Path
 
     public Path(List<Spot> steps)
     {
+        locations.Capacity = steps.Count;
+
         var span = CollectionsMarshal.AsSpan(steps);
         for (int i = 0; i < span.Length; i++)
         {

--- a/PPather/Graph/PathGraph.cs
+++ b/PPather/Graph/PathGraph.cs
@@ -242,7 +242,7 @@ public sealed class PathGraph
             return s;
         }
 
-        Span<Spot> close = FindAllSpots(s.Loc, MaxStepLength);
+        ReadOnlySpan<Spot> close = FindAllSpots(s.Loc, MaxStepLength);
         for (int i = 0; i < close.Length; i++)
         {
             Spot cs = close[i];
@@ -360,7 +360,7 @@ public sealed class PathGraph
         return closest;
     }
 
-    public Span<Spot> FindAllSpots(Vector3 l, float max_d)
+    public ReadOnlySpan<Spot> FindAllSpots(Vector3 l, float max_d)
     {
         const int SV_LENGTH = 4;
         var pooler = ArrayPool<Spot>.Shared;
@@ -406,7 +406,7 @@ public sealed class PathGraph
         pooler.Return(sv);
         pooler.Return(sl);
 
-        return sl.AsSpan(0, c);
+        return new(sl, 0, c);
     }
 
 
@@ -435,7 +435,7 @@ public sealed class PathGraph
                 isAtSpot.AddPathTo(wasAt);
             }
 
-            Span<Spot> sl = FindAllSpots(isAtSpot.Loc, MaxStepLength);
+            ReadOnlySpan<Spot> sl = FindAllSpots(isAtSpot.Loc, MaxStepLength);
             int connected = 0;
             for (int i = 0; i < sl.Length; i++)
             {
@@ -619,15 +619,15 @@ public sealed class PathGraph
             CreateSpotsAroundSpot(currentSearchSpot);
 
             //score each spot around the current search spot and add them to the queue
-            ReadOnlySpan<Spot> list = currentSearchSpot.GetPathsToSpots(this);
-            //TestPoints = list.ToArray().Select(s => new Vector3(s.Loc.X, s.Loc.Y, s.Loc.Z)).ToArray();
+            ReadOnlySpan<Spot> spots = currentSearchSpot.GetPathsToSpots(this);
+            //TestPoints = spots.ToVecArray();
 
-            for (int i = 0; i < list.Length; i++)
+            for (int i = 0; i < spots.Length; i++)
             {
-                Spot spotLinkedToCurrent = list[i];
-                if (spotLinkedToCurrent != null && !spotLinkedToCurrent.IsBlocked() && !spotLinkedToCurrent.SearchIsClosed(currentSearchID))
+                Spot linked = spots[i];
+                if (linked != null && !linked.IsBlocked() && !linked.SearchIsClosed(currentSearchID))
                 {
-                    ScoreSpot(spotLinkedToCurrent, destinationSpot, searchScoreSpot, currentSearchID, prioritySpotQueue);
+                    ScoreSpot(linked, destinationSpot, searchScoreSpot, currentSearchID, prioritySpotQueue);
                 }
             }
         }

--- a/PPather/Graph/Spot.cs
+++ b/PPather/Graph/Spot.cs
@@ -50,10 +50,7 @@ public sealed class Spot
     public float score; // Used by search
     public bool closed, scoreSet;
 
-    public Spot(float x, float y, float z)
-    {
-        Loc = new(x, y, z);
-    }
+    public Spot(float x, float y, float z) : this(new(x, y, z)) { }
 
     public Spot(Vector3 l)
     {
@@ -154,7 +151,7 @@ public sealed class Spot
         }
 
         pooler.Return(array);
-        return array.AsSpan(0, j);
+        return new(array, 0, j);
     }
 
     public bool HasPathTo(PathGraph pg, Spot s)

--- a/PPather/Graph/SpotExtensions.cs
+++ b/PPather/Graph/SpotExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Numerics;
+
+namespace PPather.Graph;
+
+public static class SpotExtensions
+{
+    public static Vector3[] ToVecArray(this ReadOnlySpan<Spot> spot)
+    {
+        Vector3[] result = new Vector3[spot.Length];
+        for (int i = 0; i < spot.Length; i++)
+        {
+            result[i] = spot[i].Loc;
+        }
+        return result;
+    }
+}

--- a/PPather/Search/PPatherService.cs
+++ b/PPather/Search/PPatherService.cs
@@ -155,15 +155,12 @@ public sealed class PPatherService
         return search.PathGraph.CurrentSearchPath();
     }
 
-    public void DrawPath(float mapId, List<float[]> coords)
+    public void DrawPath(float mapId, ReadOnlySpan<Vector3> path)
     {
-        var first = coords[0];
-        var last = coords[^1];
+        Vector4 from = new(path[0], mapId);
+        Vector4 to = new(path[^1], mapId);
 
-        var fromLoc = new Vector4(first[0], first[1], first[2], mapId);
-        var toLoc = new Vector4(last[0], last[1], last[2], mapId);
-
-        SetLocations(fromLoc, toLoc);
+        SetLocations(from, to);
 
         if (search.PathGraph == null)
         {
@@ -171,14 +168,13 @@ public sealed class PPatherService
         }
 
         List<Spot> spots = new();
-        for (int i = 0; i < coords.Count; i++)
+        for (int i = 0; i < path.Length; i++)
         {
-            Spot spot = new(new(coords[i][0], coords[i][1], coords[i][2]));
+            Spot spot = new(path[i]);
             spots.Add(spot);
             search.PathGraph.CreateSpotsAroundSpot(spot, false);
         }
 
-        var path = new Path(spots);
-        OnPathCreated?.Invoke(path);
+        OnPathCreated?.Invoke(new(spots));
     }
 }

--- a/PPather/Triangles/Data/SparseFloatMatrix2D.cs
+++ b/PPather/Triangles/Data/SparseFloatMatrix2D.cs
@@ -1,4 +1,5 @@
-﻿using System.Buffers;
+﻿using System;
+using System.Buffers;
 
 using static System.MathF;
 
@@ -30,7 +31,7 @@ public sealed class SparseFloatMatrix2D<T> : SparseMatrix2D<T>
         return (int)((f + offset) / gridSize);
     }
 
-    public (T[], int) GetAllInSquare(float min_x, float min_y,
+    public (ReadOnlyMemory<T>, int) GetAllInSquare(float min_x, float min_y,
                                   float max_x, float max_y)
     {
         int sx = LocalToGrid(min_x);
@@ -40,7 +41,9 @@ public sealed class SparseFloatMatrix2D<T> : SparseMatrix2D<T>
         int ey = LocalToGrid(max_y);
 
         var pooler = ArrayPool<T>.Shared;
-        var l = pooler.Rent((int)Ceiling(((ex - sx + 1) * gridSize) + ((ey - sy + 1) * gridSize)));
+        var l = pooler.Rent((int)Ceiling(
+            ((ex - sx + 1) * gridSize) +
+            ((ey - sy + 1) * gridSize)));
 
         int i = 0;
         for (int x = sx; x <= ex; x++)

--- a/PPather/Triangles/Data/TriangleType.cs
+++ b/PPather/Triangles/Data/TriangleType.cs
@@ -3,10 +3,11 @@
 [System.Flags]
 public enum TriangleType : byte
 {
-    Terrain = 0,
-    Water = 1,
-    Object = 2,
-    Model = 4,
+    None = 0,
+    Terrain = 1,
+    Water = 2,
+    Object = 4,
+    Model = 8
 }
 
 public static class TriangleType_Ext

--- a/PPather/Triangles/TriangleCollection.cs
+++ b/PPather/Triangles/TriangleCollection.cs
@@ -6,6 +6,7 @@
 
 using System.Collections.Generic;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 
 using Microsoft.Extensions.Logging;
 
@@ -20,8 +21,10 @@ namespace WowTriangles;
 public sealed class TriangleCollection
 {
     private readonly ILogger logger;
-    public List<Vector3> Vertecies { get; }
-    public List<Triangle<int>> Triangles { get; }
+    private readonly List<Vector3> vertecies;
+    private readonly List<Triangle<int>> triangles;
+
+    public List<Vector3> Vertecies => vertecies;
 
     private TriangleMatrix matrix;
 
@@ -37,15 +40,15 @@ public sealed class TriangleCollection
     private Vector3 limit_min = new(-1E30f, -1E30f, -1E30f);
 
     private int triangleCount;
-    public int TriangleCount => Triangles.Count;
+    public int TriangleCount => triangles.Count;
 
     public int VertexCount { get; private set; }
 
     public TriangleCollection(ILogger logger)
     {
         this.logger = logger;
-        Vertecies = new(2 ^ 16); // terrain mesh
-        Triangles = new(128);
+        vertecies = new(2 ^ 16); // terrain mesh
+        triangles = new(128);
     }
 
     public void Clear()
@@ -53,18 +56,14 @@ public sealed class TriangleCollection
         triangleCount = 0;
         VertexCount = 0;
 
-        Triangles.Clear();
-        Vertecies.Clear();
+        triangles.Clear();
+        vertecies.Clear();
         matrix.Clear();
     }
 
-    public bool HasTriangleMatrix => matrix != null;
-
     public TriangleMatrix GetTriangleMatrix()
     {
-        if (matrix == null)
-            matrix = new TriangleMatrix(this, logger);
-
+        matrix ??= new TriangleMatrix(this, logger);
         return matrix;
     }
 
@@ -150,7 +149,7 @@ public sealed class TriangleCollection
         VerticesGet(v2, out x2, out y2, out z2);
     }
 
-    [System.Runtime.CompilerServices.SkipLocalsInit]
+    [SkipLocalsInit]
     public void GetTriangleVertices(int i,
                                     out float x0, out float y0, out float z0,
                                     out float x1, out float y1, out float z1,
@@ -163,10 +162,10 @@ public sealed class TriangleCollection
         VerticesGet(v2, out x2, out y2, out z2);
     }
 
-    [System.Runtime.CompilerServices.SkipLocalsInit]
+    [SkipLocalsInit]
     private void VerticesGet(int index, out float x, out float y, out float z)
     {
-        var local = Vertecies;
+        var local = vertecies;
         Vector3 v = local[index];
         x = v.X;
         y = v.Y;
@@ -175,20 +174,20 @@ public sealed class TriangleCollection
 
     private void VerticesSet(int index, float x, float y, float z)
     {
-        Vertecies.Insert(index, new(x, y, z));
+        vertecies.Insert(index, new(x, y, z));
     }
 
 
-    [System.Runtime.CompilerServices.SkipLocalsInit]
+    [SkipLocalsInit]
     private void TrianglesGet(int index, out int v0, out int v1, out int v2, out TriangleType flags)
     {
-        var local = Triangles;
+        var local = triangles;
         Triangle<int> t = local[index];
         (v0, v1, v2, flags) = t;
     }
 
     private void TrianglesSet(int index, int v0, int v1, int v2, TriangleType flags)
     {
-        Triangles.Insert(index, new(v0, v1, v2, flags));
+        triangles.Insert(index, new(v0, v1, v2, flags));
     }
 }

--- a/PathingAPI/DisposableComponent/ComponentWithCancellationToken.cs
+++ b/PathingAPI/DisposableComponent/ComponentWithCancellationToken.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.AspNetCore.Components;
+using System.Threading;
+using System;
+
+#nullable enable
+
+namespace PathingAPI;
+
+public abstract class ComponentWithCancellationToken : ComponentBase, IDisposable
+{
+    private CancellationTokenSource? _cts;
+
+    protected CancellationToken Token => (_cts ??= new()).Token;
+
+    public virtual void Dispose()
+    {
+        if (_cts == null)
+            return;
+
+        _cts.Cancel();
+        _cts.Dispose();
+        _cts = null;
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/PathingAPI/Pages/Route.razor
+++ b/PathingAPI/Pages/Route.razor
@@ -1,19 +1,5 @@
 ﻿@page "/Route"
 
-@using PPather
-@using PPather.Data
-@using PPather.Graph
-@using System.Numerics
-@using System.Threading
-@using Newtonsoft
-
-@using MatBlazor
-@using System.IO
-@using PathingAPI.Controllers
-@using SharedLib.Data
-@using SharedLib
-@using WinAPI
-
 @inject IJSRuntime jsRuntime
 @inject PPatherService pPatherService
 @inject DataConfig dataConfig
@@ -86,7 +72,7 @@
                 @{
                     string imgFile = @context.Replace("json", "jpg");
                 }
-                @if (File.Exists(System.IO.Path.Combine(dataConfig.Path, imgFile)))
+                @if (System.IO.Path.Exists(System.IO.Path.Combine(dataConfig.Path, imgFile)))
                 {
                     <a class="thumbnail">
                         <span class="oi oi-image" aria-hidden="true"> </span>
@@ -272,45 +258,33 @@
         VisibleNum = string.IsNullOrEmpty(text) ? 10 : 20;
     }
 
-    private void OnChanged(object sender, FileSystemEventArgs e)
+    private void OnChanged(object sender, System.IO.FileSystemEventArgs e)
     {
         base.InvokeAsync(StateHasChanged);
     }
 
     private void StartDraw()
     {
-        path = GetPath(Selected);
-        List<float[]> coords = new List<float[]>();
-        bool? allzero = null;
-
-        for (int i = 0; i < path.Length; i++)
-        {
-            Vector3 p = path[i];
-            coords.Add(new float[] { p.X, p.Y, p.Z });
-
-            if (allzero == null && p.Z == 0)
-            {
-                allzero = true;
-            }
-        }
-        if (allzero == null)
-            allzero = false;
-
         worldMapAreaDb.TryGet(UIMapId, out var wma);
-
         float mapId = ContinentDB.NameToId[wma.Continent];
 
-        if (allzero.Value)
+        path = GetPath(Selected);
+
+        static bool Z_Zero(Vector3 v) => v.Z == 0;
+        if (path.All(Z_Zero))
         {
-            for (int i = 0; i < coords.Count; i++)
+            for (int i = 0; i < path.Length; i++)
             {
-                var row = coords[i];
+                var row = path[i];
 
-                Vector4 world = pPatherService.ToWorld(UIMapId, row[0], row[1], row[2]);
+                // try to guess Z component by looking at the previous path point
+                float lastZ = 0;
+                if (i > 0)
+                    lastZ = path[i - 1].Z;
 
-                path[i].X = row[0] = world.X;
-                path[i].Y = row[1] = world.Y;
-                path[i].Z = row[2] = world.Z;
+                Vector4 world = pPatherService.ToWorld(UIMapId, row.X, row.Y, lastZ);
+
+                path[i] = world.AsVector3();
             }
         }
 
@@ -319,7 +293,7 @@
         clearPath = false;
         StateHasChanged();
 
-        pPatherService.DrawPath(mapId, coords);
+        pPatherService.DrawPath(mapId, path);
     }
 
     public Vector3[] GetPath(string path)
@@ -332,19 +306,18 @@
     private string RelativeFilePath(DataConfig dataConfig, string path)
     {
         return !path.Contains(dataConfig.Path)
-            ? System.IO.Path.Join(dataConfig.Path, path)
+            ? Join(dataConfig.Path, path)
             : path;
     }
 
     public IEnumerable<string> PathFiles()
     {
-        var root = System.IO.Path.Join(
-            dataConfig.Path, System.IO.Path.DirectorySeparatorChar.ToString());
+        var root = Join(
+            dataConfig.Path, DirectorySeparatorChar.ToString());
 
-        return Directory.EnumerateFiles(root, "*.json*", SearchOption.AllDirectories)
+        return EnumerateFiles(root, "*.json*", System.IO.SearchOption.AllDirectories)
             .Select(path => path.Replace(root, string.Empty))
-            .OrderBy(x => x, new NaturalStringComparer())
-            .ToList();
+            .OrderBy(x => x, new NaturalStringComparer());
     }
 
 }

--- a/PathingAPI/Pages/Search.razor
+++ b/PathingAPI/Pages/Search.razor
@@ -1,11 +1,5 @@
 ﻿@page "/Search"
 
-@using PPather
-@using PPather.Data
-@using PPather.Graph
-@using System.Numerics
-@using System.Threading
-
 @inject IJSRuntime jsRuntime
 @inject PPatherService pPatherService
 

--- a/PathingAPI/Pages/SearchParameters.razor
+++ b/PathingAPI/Pages/SearchParameters.razor
@@ -1,7 +1,4 @@
-﻿@using PPather.Graph
-@using SharedLib.Data
-
-@inject IJSRuntime jsRuntime
+﻿@inject IJSRuntime jsRuntime
 
 <span class="form-inline px-4">
 

--- a/PathingAPI/Pages/Watch.razor
+++ b/PathingAPI/Pages/Watch.razor
@@ -1,19 +1,11 @@
 ﻿@page "/Watch"
 
-@using System.Collections.Generic
-@using PPather.Data
-@using PPather.Graph
-@using System.Threading
-@using System.Numerics
-@using SharedLib.Extensions
-@using WowTriangles
-@using System.Text.Json
-@using SharedLib.Converters
-@using Serilog.Events
+@using static System.Text.Json.JsonSerializer
 
 @inject IJSRuntime jsRuntime
 @inject PPatherService pPatherService
 @inject PathingAPILoggerSink loggerSink
+@inject JsonSerializerOptions options
 
 @implements IAsyncDisposable
 
@@ -67,9 +59,10 @@
     [Parameter]
     public bool ClearPath { get; set; } = true;
 
+    private bool firstRender = false;
+
     private Thread thread;
-    private CancellationTokenSource cts;
-    private JsonSerializerOptions options = null;
+    private CancellationTokenSource searchCts;
 
     private Queue<ChunkEventArgs> chunkEventArgs = new();
 
@@ -82,29 +75,29 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (firstRender)
-        {
-            await jsRuntime.InvokeVoidAsync("log", "Waiting for first search from the API...");
-            await jsRuntime.InvokeVoidAsync("createScene");
+        if (!firstRender)
+            return;
 
-            options = new();
-            options.Converters.Add(new Vector3Converter());
-            options.Converters.Add(new Vector4Converter());
+        this.firstRender = true;
 
-            loggerSink.OnLog += OnLog;
+        await jsRuntime.InvokeVoidAsync("log", Token,
+            "Waiting for first search from the API...");
 
-            pPatherService.OnChunkAdded += OnChunkAdded;
-            pPatherService.OnPathCreated += OnDrawFinalPath;
+        await jsRuntime.InvokeVoidAsync("createScene", Token);
 
-            pPatherService.OnLinesAdded += OnDrawlines;
-            pPatherService.OnSphereAdded += OnDrawSphere;
-            pPatherService.SearchBegin += OnSearchBegin;
-        }
+        loggerSink.OnLog += OnLog;
+
+        pPatherService.OnChunkAdded += OnChunkAdded;
+        pPatherService.OnPathCreated += OnDrawFinalPath;
+
+        pPatherService.OnLinesAdded += OnDrawlines;
+        pPatherService.OnSphereAdded += OnDrawSphere;
+        pPatherService.SearchBegin += OnSearchBegin;
     }
 
     public async ValueTask DisposeAsync()
     {
-        if (options == null) return;
+        if (!firstRender) return;
 
         loggerSink.OnLog -= OnLog;
 
@@ -115,23 +108,26 @@
         pPatherService.OnSphereAdded -= OnDrawSphere;
 
         await Reset();
+
+        base.Dispose();
     }
 
     private async void ToggleLayer(TriangleType layer)
     {
-        await jsRuntime.InvokeVoidAsync("toggleLayer", layer);
+        await jsRuntime.InvokeVoidAsync("toggleLayer", Token, layer);
     }
 
     private async void ToggleWireFrame()
     {
-        await jsRuntime.InvokeVoidAsync("toggleWireFrame");
+        await jsRuntime.InvokeVoidAsync("toggleWireFrame", Token);
     }
 
     private async ValueTask Reset()
     {
-        cts?.Cancel();
+        searchCts?.Cancel();
 
-        await jsRuntime.InvokeVoidAsync("clear");
+        await jsRuntime.InvokeVoidAsync("clear", Token);
+
         pPatherService.Reset();
         GC.Collect();
     }
@@ -143,12 +139,13 @@
 
     private async void Log(string message)
     {
-        await jsRuntime.InvokeVoidAsync("log", message);
+        await jsRuntime.InvokeVoidAsync("log", Token, message);
     }
 
     private async void SearchPath_Thread()
     {
-        while (!cts.IsCancellationRequested)
+        while (!searchCts.IsCancellationRequested &&
+            !Token.IsCancellationRequested)
         {
             var spots = pPatherService.GetCurrentSearchPath();
             if (spots != null)
@@ -156,30 +153,30 @@
                 var path = spots.Where(s => s != null).Select(s => s.Loc);
                 if (path.Count() > 0)
                 {
-                    await jsRuntime.InvokeVoidAsync("drawPath",
-                        JsonSerializer.Serialize(path, options), Color.White, "search");
+                    await jsRuntime.InvokeVoidAsync("drawPath", Token,
+                        Serialize(path, options), Color.White, "search");
                 }
             }
 
             if (lastFrom != pPatherService.SearchFrom)
             {
                 lastFrom = pPatherService.SearchFrom;
-                await jsRuntime.InvokeVoidAsync("drawLine",
-                    JsonSerializer.Serialize(lastFrom.AsVector3(), options), Color.Green, "start2");
+                await jsRuntime.InvokeVoidAsync("drawLine", Token,
+                    Serialize(lastFrom.AsVector3(), options), Color.Green, "start2");
             }
 
             if (lastTo != pPatherService.SearchTo)
             {
                 lastTo = pPatherService.SearchTo;
-                await jsRuntime.InvokeVoidAsync("drawLine",
-                    JsonSerializer.Serialize(lastTo.AsVector3(), options), Color.Blue, "endd");
+                await jsRuntime.InvokeVoidAsync("drawLine", Token,
+                    Serialize(lastTo.AsVector3(), options), Color.Blue, "endd");
             }
 
             if (lastClosest != pPatherService.ClosestLocation)
             {
                 lastClosest = pPatherService.ClosestLocation;
-                await jsRuntime.InvokeVoidAsync("drawLine",
-                    JsonSerializer.Serialize(pPatherService.ClosestLocation, options), Color.Teal, "closest");
+                await jsRuntime.InvokeVoidAsync("drawLine", Token,
+                    Serialize(pPatherService.ClosestLocation, options), Color.Teal, "closest");
             }
 
             if (testPoints != pPatherService.TestPoints)
@@ -189,8 +186,8 @@
                 for (int i = 0; i < testPoints.Length; i++)
                 {
                     Vector3 p = testPoints[i];
-                    await jsRuntime.InvokeVoidAsync("drawLineDebug",
-                        JsonSerializer.Serialize(p, options), Color.Yellow, "debug" + i, testPoints.Length);
+                    await jsRuntime.InvokeVoidAsync("drawLineDebug", Token,
+                        Serialize(p, options), Color.Yellow, "debug" + i, testPoints.Length);
                 }
             }
 
@@ -198,18 +195,18 @@
             {
                 lastPeek = pPatherService.PeekLocation;
 
-                await jsRuntime.InvokeVoidAsync("drawLine",
-                    JsonSerializer.Serialize(pPatherService.PeekLocation, options), Color.Orange, "peek");
+                await jsRuntime.InvokeVoidAsync("drawLine", Token,
+                    Serialize(pPatherService.PeekLocation, options), Color.Orange, "peek");
             }
 
-            cts.Token.WaitHandle.WaitOne(100);
+            searchCts.Token.WaitHandle.WaitOne(100);
         }
     }
 
 
     private void OnSearchBegin()
     {
-        cts = new();
+        searchCts = new();
         thread = new Thread(SearchPath_Thread);
         thread.Start();
     }
@@ -224,12 +221,12 @@
             }
 
             if (ClearPath)
-                await jsRuntime.InvokeVoidAsync("removeMeshes", Name);
+                await jsRuntime.InvokeVoidAsync("removeMeshes", Token, Name);
 
-            await jsRuntime.InvokeVoidAsync("drawPath",
-                JsonSerializer.Serialize(spotPath.locations, options), PathColour, Name);
+            await jsRuntime.InvokeVoidAsync("drawPath", Token,
+                Serialize(spotPath.locations, options), PathColour, Name);
 
-            await jsRuntime.InvokeVoidAsync("removeMeshes", "search");
+            await jsRuntime.InvokeVoidAsync("removeMeshes", Token, "search");
         }
         else
         {
@@ -240,19 +237,21 @@
             Log("No path found");
         }
 
-        cts?.Cancel();
+        searchCts?.Cancel();
     }
 
     private async void OnDrawSphere(SphereEventArgs e)
     {
-        await jsRuntime.InvokeVoidAsync("drawSphere",
-            JsonSerializer.Serialize(e.Location, options), e.Colour, e.Name);
+        await jsRuntime.InvokeVoidAsync("drawSphere", Token,
+            Serialize(e.Location, options), e.Colour, e.Name);
     }
 
     private async void OnDrawlines(LinesEventArgs e)
     {
-        await jsRuntime.InvokeVoidAsync("drawPath",
-            JsonSerializer.Serialize(e.Locations, options), e.Colour, e.Name);
+        await jsRuntime.InvokeVoidAsync("removeMeshes", Token, e.Name);
+
+        await jsRuntime.InvokeVoidAsync("drawPath", Token,
+            Serialize(e.Locations, options), e.Colour, e.Name);
     }
 
     private /*async*/ void OnChunkAdded(ChunkEventArgs e)
@@ -263,6 +262,8 @@
 
     private async ValueTask DequeueChunkEvent(ChunkEventArgs e)
     {
+        if (Token.IsCancellationRequested) return;
+
         TriangleCollection chunks = pPatherService.GetChunkAt(e.GridX, e.GridY);
 
         int i = 0;
@@ -274,8 +275,8 @@
 
         var positions = MeshFactory.CreatePoints(chunks);
 
-        await jsRuntime.InvokeVoidAsync("addModels",
-            JsonSerializer.Serialize(models, options),
-            JsonSerializer.Serialize(positions, options));
+        await jsRuntime.InvokeVoidAsync("addModels", Token,
+            Serialize(models, options),
+            Serialize(positions, options));
     }
 }

--- a/PathingAPI/Program.cs
+++ b/PathingAPI/Program.cs
@@ -1,5 +1,11 @@
+using System;
+
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+using Serilog;
 
 namespace PathingAPI;
 
@@ -17,6 +23,8 @@ public sealed class Program
             .ConfigureWebHostDefaults(webBuilder =>
             {
                 webBuilder.UseUrls(hostUrl);
+                webBuilder.ConfigureLogging(logging =>
+                    logging.ClearProviders().AddSerilog());
                 webBuilder.UseStartup<Startup>();
             });
 }

--- a/PathingAPI/Startup.cs
+++ b/PathingAPI/Startup.cs
@@ -15,6 +15,7 @@ using Microsoft.OpenApi.Models;
 using PPather;
 
 using Serilog;
+using Serilog.Events;
 
 using SharedLib;
 using SharedLib.Converters;
@@ -32,7 +33,7 @@ public sealed class Startup
             PathingAPILoggerSink sink = new();
             builder.Services.AddSingleton(sink);
 
-            const string outputTemplate = "[{Timestamp:HH:mm:ss:fff} {Level:u3}] {Message:lj}{NewLine}{Exception}";
+            const string outputTemplate = "[{Timestamp:HH:mm:ss:fff} {Level:u1}] {Message:lj}{NewLine}{Exception}";
 
             Log.Logger = new LoggerConfiguration()
                 //.MinimumLevel.Debug()

--- a/PathingAPI/_Imports.razor
+++ b/PathingAPI/_Imports.razor
@@ -1,11 +1,37 @@
 ﻿@using System.Net.Http
+@using System.Numerics
+@using System.Threading
+@using static System.IO.Path
+@using static System.IO.Directory
+
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.JSInterop
+@using Microsoft.Extensions.Logging
+
 @using PathingAPI
 @using PathingAPI.Shared
+
+@using System.Collections.Generic
+@using WowTriangles
+@using System.Text.Json
+@using SharedLib.Converters
+@using Serilog.Events
+
 @using PPather
-@using Microsoft.Extensions.Logging
+@using PPather.Data
+@using PPather.Graph
+
+@using Newtonsoft
+
+@using SharedLib.Data
+@using SharedLib
+@using SharedLib.Extensions
+@using WinAPI
+
+@using MatBlazor
+
+@inherits ComponentWithCancellationToken

--- a/PathingAPI/wwwroot/js/babylonjs.js
+++ b/PathingAPI/wwwroot/js/babylonjs.js
@@ -44,7 +44,14 @@
     }
 
     toggleLayer = function (layer) {
-        if (layer >= layers) layer = layers - 1;
+        // TriangleType 2^x => array index
+        // Where TriangleType.None is excluded
+        switch (layer) {
+            case 1: layer = 0; break;
+            case 2: layer = 1; break;
+            case 4: layer = 2; break;
+            case 8: layer = 3; break;
+        }
         rootNodes[layer].setEnabled(!rootNodes[layer].isEnabled());
     }
 
@@ -185,7 +192,7 @@
         skybox.material = skyboxMaterial;
 
         engine.runRenderLoop(function () {
-            if (!startedRendering) {
+            if (!scene.paused) {
                 scene.render();
             }
         });
@@ -281,15 +288,6 @@
             customMesh.parent = rootNodes[p];
         }
 
-        if (!startedRendering) {
-            startedRendering = true;
-            // run the render loop
-            engine.runRenderLoop(function () {
-                scene.render();
-            });
-        }
-
-        //console.log("addModels completed");
     }
 
     setCamera = function (pos, look, height) {

--- a/SharedLib/Converters/Vector3Converter.cs
+++ b/SharedLib/Converters/Vector3Converter.cs
@@ -7,6 +7,10 @@ namespace SharedLib.Converters;
 
 public sealed class Vector3Converter : JsonConverter<Vector3>
 {
+    private const string X = "x";
+    private const string Y = "y";
+    private const string Z = "z";
+
     public override bool CanConvert(Type typeToConvert)
     {
         return typeToConvert == typeof(Vector3);
@@ -15,55 +19,23 @@ public sealed class Vector3Converter : JsonConverter<Vector3>
     public override Vector3 Read(ref Utf8JsonReader reader,
         Type typeToConvert, JsonSerializerOptions options)
     {
-        if (reader.TokenType != JsonTokenType.StartObject)
-        {
-            throw new JsonException();
-        }
+        JsonDocument doc = JsonDocument.ParseValue(ref reader);
+        JsonElement root = doc.RootElement;
 
-        Vector3 result = new();
+        float x = root.GetProperty(X).GetSingle();
+        float y = root.GetProperty(Y).GetSingle();
+        float z = root.GetProperty(Z).GetSingle();
 
-        while (reader.Read())
-        {
-            if (reader.TokenType == JsonTokenType.EndObject)
-            {
-                return result;
-            }
-
-            if (reader.TokenType != JsonTokenType.PropertyName)
-            {
-                throw new JsonException();
-            }
-
-            switch (reader.GetString())
-            {
-                case "x":
-                case "X":
-                    reader.Read();
-                    result.X = reader.GetSingle();
-                    break;
-                case "y":
-                case "Y":
-                    reader.Read();
-                    result.Y = reader.GetSingle();
-                    break;
-                case "z":
-                case "Z":
-                    reader.Read();
-                    result.Z = reader.GetSingle();
-                    break;
-            }
-        }
-
-        throw new JsonException();
+        return new Vector3(x, y, z);
     }
 
     public override void Write(Utf8JsonWriter writer,
         Vector3 value, JsonSerializerOptions options)
     {
         writer.WriteStartObject();
-        writer.WriteNumber("x", value.X);
-        writer.WriteNumber("y", value.Y);
-        writer.WriteNumber("z", value.Z);
+        writer.WriteNumber(X, value.X);
+        writer.WriteNumber(Y, value.Y);
+        writer.WriteNumber(Z, value.Z);
         writer.WriteEndObject();
     }
 }

--- a/SharedLib/Converters/Vector4Converter.cs
+++ b/SharedLib/Converters/Vector4Converter.cs
@@ -7,6 +7,11 @@ namespace SharedLib.Converters;
 
 public sealed class Vector4Converter : JsonConverter<Vector4>
 {
+    private const string X = "x";
+    private const string Y = "y";
+    private const string Z = "z";
+    private const string W = "w";
+
     public override bool CanConvert(Type typeToConvert)
     {
         return typeToConvert == typeof(Vector4);
@@ -15,61 +20,25 @@ public sealed class Vector4Converter : JsonConverter<Vector4>
     public override Vector4 Read(ref Utf8JsonReader reader,
         Type typeToConvert, JsonSerializerOptions options)
     {
-        if (reader.TokenType != JsonTokenType.StartObject)
-        {
-            throw new JsonException();
-        }
+        JsonDocument doc = JsonDocument.ParseValue(ref reader);
+        JsonElement root = doc.RootElement;
 
-        Vector4 result = new();
+        float x = root.GetProperty(X).GetSingle();
+        float y = root.GetProperty(Y).GetSingle();
+        float z = root.GetProperty(Z).GetSingle();
+        float w = root.GetProperty(W).GetSingle();
 
-        while (reader.Read())
-        {
-            if (reader.TokenType == JsonTokenType.EndObject)
-            {
-                return result;
-            }
-
-            if (reader.TokenType != JsonTokenType.PropertyName)
-            {
-                throw new JsonException();
-            }
-
-            switch (reader.GetString())
-            {
-                case "x":
-                case "X":
-                    reader.Read();
-                    result.X = reader.GetSingle();
-                    break;
-                case "y":
-                case "Y":
-                    reader.Read();
-                    result.Y = reader.GetSingle();
-                    break;
-                case "z":
-                case "Z":
-                    reader.Read();
-                    result.Z = reader.GetSingle();
-                    break;
-                case "w":
-                case "W":
-                    reader.Read();
-                    result.Z = reader.GetSingle();
-                    break;
-            }
-        }
-
-        throw new JsonException();
+        return new Vector4(x, y, z, w);
     }
 
     public override void Write(Utf8JsonWriter writer,
         Vector4 value, JsonSerializerOptions options)
     {
         writer.WriteStartObject();
-        writer.WriteNumber("x", value.X);
-        writer.WriteNumber("y", value.Y);
-        writer.WriteNumber("z", value.Z);
-        writer.WriteNumber("w", value.W);
+        writer.WriteNumber(X, value.X);
+        writer.WriteNumber(Y, value.Y);
+        writer.WriteNumber(Z, value.Z);
+        writer.WriteNumber(W, value.W);
         writer.WriteEndObject();
     }
 }

--- a/SharedLib/Data/WorldMapAreaDB.cs
+++ b/SharedLib/Data/WorldMapAreaDB.cs
@@ -16,7 +16,11 @@ public sealed class WorldMapAreaDB
 
     public WorldMapAreaDB(DataConfig dataConfig)
     {
-        ReadOnlySpan<WorldMapArea> wmas = JsonConvert.DeserializeObject<WorldMapArea[]>(File.ReadAllText(Path.Join(dataConfig.ExpDbc, "WorldMapArea.json")));
+        ReadOnlySpan<WorldMapArea> wmas =
+            JsonConvert.DeserializeObject<WorldMapArea[]>(
+                File.ReadAllText(
+                    Path.Join(dataConfig.ExpDbc, "WorldMapArea.json")));
+
         for (int i = 0; i < wmas.Length; i++)
             this.wmas.Add(wmas[i].UIMapId, wmas[i]);
     }
@@ -44,7 +48,7 @@ public sealed class WorldMapAreaDB
         return new Vector3(wma.ToWorldX(map.Y), wma.ToWorldY(map.X), map.Z);
     }
 
-    public void ToWorldXY_FlipXY(int uiMap, ref Vector3[] map)
+    public void ToWorldXY_FlipXY(int uiMap, Vector3[] map)
     {
         WorldMapArea wma = wmas[uiMap];
         for (int i = 0; i < map.Length; i++)
@@ -84,12 +88,14 @@ public sealed class WorldMapAreaDB
     public WorldMapArea GetWorldMapArea(float worldX, float worldY, int mapId, int uiMap)
     {
         IEnumerable<WorldMapArea> maps =
-            wmas.Values.Where(i =>
+            wmas.Values.Where(ContainsWorldPosAndMapId);
+
+        bool ContainsWorldPosAndMapId(WorldMapArea i) =>
                 worldX <= i.LocTop &&
                 worldX >= i.LocBottom &&
                 worldY <= i.LocLeft &&
                 worldY >= i.LocRight &&
-                i.MapID == mapId);
+                i.MapID == mapId;
 
         if (!maps.Any())
         {
@@ -104,7 +110,8 @@ public sealed class WorldMapAreaDB
 
             if (uiMap > 0)
             {
-                return maps.First(m => m.UIMapId == uiMap);
+                return maps.First(ByUIMapId);
+                bool ByUIMapId(WorldMapArea m) => m.UIMapId == uiMap;
             }
             throw new ArgumentOutOfRangeException(nameof(wmas), $"Found many map areas for spot {worldX}, {worldY}, {mapId} : {string.Join(", ", maps.Select(s => s.AreaName))}");
         }

--- a/SharedLib/NpcFinder/NpcNameFinder.cs
+++ b/SharedLib/NpcFinder/NpcNameFinder.cs
@@ -636,7 +636,7 @@ public sealed partial class NpcNameFinder : IDisposable
         bitmap.UnlockBits(bitmapData);
 
         pooler.Return(segments);
-        return segments.AsSpan(0, i);
+        return new(segments, 0, i);
     }
 
     public void ShowNames(Graphics gr)


### PR DESCRIPTION
Changes:
- Improved memory usage by using `Span<T>` over `ArraySegment<T>`
- `PathingAPI.Route`: It can load paths with caves buildings and undergrounds. The only requirement is to locate correctly the very first point of the route. Based on that it can most likely assume where the path is heading. ex. [Northshire cave](https://github.com/Xian55/WowClassicGrindBot/blob/85513c3cd0f22bdc49f3c110f138becd9f824f3f/Json/path/_pack/1-20/Human/01-04_Elwynn%20Forest_Northshire%20Valley%20Cave.jpg)
- `PathingAPI` while using `Watch` and `Route` components now it is possible to clean up the memory from the previous action / query.
- `PPather`: `nearCliffCheck` is disabled as causes some issues while near `TriangleType.Terrain` and `TriangleType.Water` is near to each other. ex. [Nagrand](https://github.com/Xian55/WowClassicGrindBot/blob/85513c3cd0f22bdc49f3c110f138becd9f824f3f/Json/path/_pack/60-70/Nagrand/65-66%20talbuks.jpg)
- `TriangleType.None` introduced to create better masks

---

**Important**: Be sure to delete `\Json\PathInfo\*` folders, except the `empty` named file in order to take full advantage of the changes.