### PR TITLE
Fix: Core: When `Auto Shot` or `Shoot` spells activated be sure to react any `UIError`

### DIFF
--- a/Core/Addon/PlayerReader.cs
+++ b/Core/Addon/PlayerReader.cs
@@ -47,6 +47,8 @@ public sealed partial class PlayerReader : IMouseOverReader, IReader
 
     public float Direction => reader.GetFixed(3);
 
+    public float _Direction() => Direction;
+
     public RecordInt UIMapId { get; } = new(4);
 
     public int MapId { get; private set; }

--- a/Core/GoalsComponent/Wait.cs
+++ b/Core/GoalsComponent/Wait.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -89,6 +90,25 @@ public sealed class Wait
                 return elapsedMs;
 
             Update();
+        }
+
+        return -elapsedMs;
+    }
+
+    [SkipLocalsInit]
+    public float AfterEquals<T>(int timeoutMs, int updateCount, Func<T> func)
+    {
+        DateTime start = DateTime.UtcNow;
+        float elapsedMs;
+        while ((elapsedMs = (float)(DateTime.UtcNow - start).TotalMilliseconds) < timeoutMs)
+        {
+            T initial = func();
+
+            for (int i = 0; i < updateCount; i++)
+                Update();
+
+            if (Comparer<T>.Default.Compare(initial, func()) == 0)
+                return elapsedMs;
         }
 
         return -elapsedMs;

--- a/Core/Requirement/RequirementFactory.cs
+++ b/Core/Requirement/RequirementFactory.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 
+using static System.Math;
+
 using Core.Database;
 using Core.Goals;
 
@@ -383,19 +385,19 @@ public sealed partial class RequirementFactory
 
     private int LastTargetDodgeMs()
     {
-        return Math.Max(0, combatLog.TargetDodge.ElapsedMs());
+        return Max(0, combatLog.TargetDodge.ElapsedMs());
     }
 
     private int MainHandSwing()
     {
-        return Math.Clamp(
+        return Clamp(
             playerReader.MainHandSwing.ElapsedMs() - playerReader.MainHandSpeedMs(),
             -playerReader.MainHandSpeedMs(), 0);
     }
 
     private int RangedSwing()
     {
-        return Math.Clamp(
+        return Clamp(
             playerReader.AutoShot.ElapsedMs() - playerReader.RangedSpeedMs(),
             -playerReader.RangedSpeedMs(),
             0);
@@ -871,8 +873,7 @@ public sealed partial class RequirementFactory
         Dictionary<string, Func<int>> intVariables)
     {
         return intVariables[key]() <=
-            //CastingHandler.SPELL_QUEUE - playerReader.NetworkLatency;
-            playerReader.SpellQueueTimeMs - playerReader.NetworkLatency;
+            Max(0, playerReader.SpellQueueTimeMs - playerReader.NetworkLatency);
     }
 
     private Requirement CreateTargetCastingSpell(string requirement)


### PR DESCRIPTION
Changes:
* `CastingHandler`: Issue while Auto Shot or Shoot spell is active or attempt to use enable it not reacting to UIError.
* `ReactCastError`: Upon 'ERR_BADATTACKFACING' ui error, first attempt to turn by Interact if it fails fall back to manually turning 180 degree.

Fixes:
* `RequirementFactory`: In case having really high latency, which is higher then the `SpellQueueTime` the cooldown based spells seen as never getting off cooldown. Basically never usable!

---

Note, the current most basic usage of `Shoot` is the following
```json
{
  "Name": "Shoot",
  "Key": "3",
  "Requirements": [
    "HasRangedWeapon",
    "!Shooting",
    "!Casting",
    "SpellInRange:1"
  ]
}
```

Most basic usage of `Auto Shot` is the following
```json
{
  "Name": "Auto Shot",
  "Key": "3",
  "Requirements": [
    "HasRangedWeapon",
    "HasAmmo",
    "!InMeleeRange",
    "!AutoShot"
  ]
}
```

`Item` or `HasCastbar` properties no longer mandatory.

Both spells are instant cast however have a **hidden castbar** which duration is fixed **500**ms is the weapon reload/hand waving animation. After this time the `CastEvent` will be present this time have to be awaited. This duration not needed to be awaited as the `CastingHandler.InstantCast` already covered with the timeout.

---

**There's still one problem**, when all of the following conditions are met
* while the `Auto Shot` spell already active
* no other spell is going to be used 
* the target goes behind the target

The player never going to turn and face the target! Since no UIError is fired. Got an idea about it, by comparing the last Auto Shot fired time, with the Ranged weapon attack speed plus checking the ranged swing timer. However not sure yet where should i put this very specific logic. On the other hand Wotlk expansion might have some differences compare to vanilla and tbc with the swing timer.
