### PR TITLE
Addon: [1.7.44] - Feature: `AssistFocusGoal` and fixes

### DIFF
--- a/Addons/DataToColor/Collections.lua
+++ b/Addons/DataToColor/Collections.lua
@@ -118,3 +118,7 @@ end
 function struct:remove(key)
     self[key] = nil
 end
+
+function struct:iterator()
+    return pairs(self)
+end

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -3,7 +3,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors
-## Version: 1.7.43
+## Version: 1.7.44
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/Storage.lua
+++ b/Addons/DataToColor/Storage.lua
@@ -36,14 +36,19 @@ function CreateSpellInRangeTarget()
             5176, -- "Wrath"
             5211, -- "Bash"
             1079, -- "Rip"
-            6807 -- "Maul"
+            6807, -- "Maul"
+            5185, -- "Healing Touch"
+            1126, -- "Mark of the Wild"
+            8936, -- "Regrowth"
+            774, -- "Rejuvenation",
+            467, -- "Thorns"
         }
     elseif DataToColor.C.CHARACTER_CLASS == "WARRIOR" then
         DataToColor.S.spellInRangeTarget = {
             100, -- "Charge"
             772, -- "Rend"
             3018, -- "Shoot" for classic -> 7918, -- "Shoot Gun"
-            2764 -- "Throw"
+            2764, -- "Throw"
         }
     elseif DataToColor.C.CHARACTER_CLASS == "PRIEST" then
         DataToColor.S.spellInRangeTarget = {
@@ -51,11 +56,23 @@ function CreateSpellInRangeTarget()
             5019, -- "Shoot"
             15407, -- "Mind Flay"
             8092, -- "Mind Blast"
-            585 -- "Smite"
+            585, -- "Smite"
+            14752, -- "Divine Spirit"
+            1243, -- "Power World: Fortitude"
+            17, -- Power Word: Shield
+            2050, -- "Lesser Heal"
+            33076, -- "Prayer of Mending"
+            139, -- "Renew"
+            976, -- "Shadow Protection"
         }
     elseif DataToColor.C.CHARACTER_CLASS == "PALADIN" then
         DataToColor.S.spellInRangeTarget = {
-            20271 -- "Judgement" / "Judgement of Light"
+            20271, -- "Judgement" / "Judgement of Light"
+            879, -- "Exorcism"
+            19750, -- "Flash Heal"
+            635, -- "Holy Light"
+            19740, -- "Blessing of Might"
+            25782, -- "Greater Blessing of Might"
         }
     elseif DataToColor.C.CHARACTER_CLASS == "MAGE" then
         DataToColor.S.spellInRangeTarget = {
@@ -63,23 +80,28 @@ function CreateSpellInRangeTarget()
             5019, -- "Shoot"
             11366, -- "Pyroblast"
             116, -- "Frostbolt"
-            2136 -- "Fire Blast"
+            2136, -- "Fire Blast"
         }
     elseif DataToColor.C.CHARACTER_CLASS == "HUNTER" then
         DataToColor.S.spellInRangeTarget = {
             2973, -- "Raptor Strike"
             75, -- "Auto Shot"
-            1978 -- "Serpent Sting"
+            1978, -- "Serpent Sting"
         }
     elseif DataToColor.C.CHARACTER_CLASS == "WARLOCK" then
         DataToColor.S.spellInRangeTarget = {
             686, -- "Shadow Bolt",
-            5019 -- "Shoot"
+            5019, -- "Shoot"
         }
     elseif DataToColor.C.CHARACTER_CLASS == "SHAMAN" then
         DataToColor.S.spellInRangeTarget = {
             403, -- "Lightning Bolt",
-            8042 -- "Earth Shock"
+            8042, -- "Earth Shock"
+            331, -- "Healing Wave"
+            8004, -- "Lesser Healing Wave"
+            131, -- "Water Breathing"
+            1064, -- "Chain Heal"
+            974, -- "Earth Shield"
         }
     elseif DataToColor.C.CHARACTER_CLASS == "DEATHKNIGHT" then
         DataToColor.S.spellInRangeTarget = {
@@ -99,7 +121,7 @@ function CreateSpellInRangeUnit()
         }
     elseif DataToColor.C.CHARACTER_CLASS == "WARLOCK" then
         DataToColor.S.spellInRangeUnit = {
-            { 27259, DataToColor.C.unitPet }, -- "Health Funnel"
+            { 755, DataToColor.C.unitPet }, -- "Health Funnel"
         }
     end
 end

--- a/Core/Actionbar/ActionBarPopulator.cs
+++ b/Core/Actionbar/ActionBarPopulator.cs
@@ -43,6 +43,11 @@ public sealed class ActionBarPopulator
             AddUnique(items, config.Adhoc.Sequence[i]);
         }
 
+        for (int i = 0; i < config.AssistFocus.Sequence.Length; i++)
+        {
+            AddUnique(items, config.AssistFocus.Sequence[i]);
+        }
+
         for (int i = 0; i < config.Parallel.Sequence.Length; i++)
         {
             AddUnique(items, config.Parallel.Sequence[i]);

--- a/Core/Addon/AuraTimeReader.cs
+++ b/Core/Addon/AuraTimeReader.cs
@@ -16,6 +16,8 @@ public interface ITargetDebuffTimeReader : IAuraTimeReader { }
 
 public interface ITargetBuffTimeReader : IAuraTimeReader { }
 
+public interface IFocusBuffTimeReader : IAuraTimeReader { }
+
 public sealed class AuraTimeReader<T> : IAuraTimeReader, IReader
 {
     public readonly struct Data

--- a/Core/Addon/PlayerReader.cs
+++ b/Core/Addon/PlayerReader.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Specialized;
+using System.Collections.Specialized;
 using System.Numerics;
 
 using Core.Database;
@@ -69,7 +69,7 @@ public sealed partial class PlayerReader : IMouseOverReader, IReader
 
     public int ManaMax() => reader.GetInt(14);
     public int ManaCurrent() => reader.GetInt(15);
-    public int ManaPercentage() => (1 + ManaCurrent()) * 100 / (1 + ManaMax());
+    public int ManaPercent() => (1 + ManaCurrent()) * 100 / (1 + ManaMax());
 
     public int MaxRune() => reader.GetInt(14);
 
@@ -79,11 +79,11 @@ public sealed partial class PlayerReader : IMouseOverReader, IReader
 
     public int TargetMaxHealth() => reader.GetInt(18);
     public int TargetHealth() => reader.GetInt(19);
-    public int TargetHealthPercentage() => (1 + TargetHealth()) * 100 / (1 + TargetMaxHealth());
+    public int TargetHealthPercent() => (1 + TargetHealth()) * 100 / (1 + TargetMaxHealth());
 
     public int PetMaxHealth() => reader.GetInt(38);
     public int PetHealth() => reader.GetInt(39);
-    public int PetHealthPercentage() => (1 + PetHealth()) * 100 / (1 + PetMaxHealth());
+    public int PetHealthPercent() => (1 + PetHealth()) * 100 / (1 + PetMaxHealth());
 
 
     public SpellInRange SpellInRange { get; }
@@ -118,7 +118,7 @@ public sealed partial class PlayerReader : IMouseOverReader, IReader
     public RecordInt PlayerXp { get; } = new(50);
 
     public int PlayerMaxXp => reader.GetInt(51);
-    public int PlayerXpPercentage => (1 + PlayerXp.Value) * 100 / (1 + PlayerMaxXp);
+    public int PlayerXpPercent => (1 + PlayerXp.Value) * 100 / (1 + PlayerMaxXp);
 
     private UI_ERROR UIError => (UI_ERROR)reader.GetInt(52);
     public UI_ERROR LastUIError { get; set; }
@@ -172,6 +172,9 @@ public sealed partial class PlayerReader : IMouseOverReader, IReader
     public int MouseOverId => reader.GetInt(86);
     public int MouseOverGuid => reader.GetInt(87);
 
+    public int FocusHealthMax() => reader.GetInt(89);
+    public int FocusHealthCurrent() => reader.GetInt(90);
+    public int FocusHealthPercent() => (1 + FocusHealthCurrent()) * 100 / (1 + FocusHealthMax());
 
     public int LastCastGCD { get; set; }
     public void ReadLastCastGCD()

--- a/Core/Addon/PlayerReader.cs
+++ b/Core/Addon/PlayerReader.cs
@@ -1,4 +1,4 @@
-using System.Collections.Specialized;
+﻿using System.Collections.Specialized;
 using System.Numerics;
 
 using Core.Database;
@@ -38,6 +38,7 @@ public sealed partial class PlayerReader : IMouseOverReader, IReader
 
     public Vector3 MapPos => new(MapX, MapY, WorldPosZ);
     public Vector3 MapPosNoZ => new(MapX, MapY, 0);
+    public Vector3 _MapPosNoZ() => MapPosNoZ;
     public Vector3 WorldPos => worldMapAreaDB.ToWorld_FlipXY(UIMapId.Value, MapPos);
 
     public float WorldPosZ { get; set; } // MapZ not exists. Alias for WorldLoc.Z

--- a/Core/AddonComponent/AddonBits.cs
+++ b/Core/AddonComponent/AddonBits.cs
@@ -68,4 +68,5 @@ public sealed class AddonBits : IReader
     public bool MouseOverTargetIsPlayerOrPet() => v2[Mask._16];
     public bool MouseOverPlayerControlled() => v2[Mask._17];
     public bool TargetIsPlayerControlled() => v2[Mask._18];
+    public bool AutoFollow() => v2[Mask._19];
 }

--- a/Core/AddonComponent/BuffStatus.cs
+++ b/Core/AddonComponent/BuffStatus.cs
@@ -2,13 +2,19 @@
 
 namespace Core;
 
-public sealed class BuffStatus : IReader
-{
-    private const int cell = 41;
+public interface IFocus { }
 
+public interface IPlayer { }
+
+public sealed class BuffStatus<T> : IReader
+{
+    private readonly int cell;
     private BitVector32 v;
 
-    public BuffStatus() { }
+    public BuffStatus(int cell)
+    {
+        this.cell = cell;
+    }
 
     public void Update(IAddonDataProvider reader)
     {
@@ -28,100 +34,114 @@ public sealed class BuffStatus : IReader
 
     // Priest
     public bool Fortitude() => v[Mask._10];
-    public bool InnerFire() => v[Mask._11];
+    public bool Inner_Fire() => v[Mask._11];
     public bool Renew() => v[Mask._12];
     public bool Shield() => v[Mask._13];
-    public bool DivineSpirit() => v[Mask._14];
+    public bool Divine_Spirit() => v[Mask._14];
 
     // Druid
-    public bool MarkOfTheWild() => v[Mask._10];
+    public bool Mark_of_the_Wild() => v[Mask._10];
     public bool Thorns() => v[Mask._11];
-    public bool TigersFury() => v[Mask._12];
+
+    [Names(new[] { "Tiger's Fury" })]
+    public bool Tigers_Fury() => v[Mask._12];
     public bool Prowl() => v[Mask._13];
     public bool Rejuvenation() => v[Mask._14];
     public bool Regrowth() => v[Mask._15];
-    public bool OmenOfClarity() => v[Mask._16];
+    public bool Omen_of_Clarity() => v[Mask._16];
 
     // Paladin
-    public bool SealofRighteousness() => v[Mask._5];
-    public bool SealoftheCrusader() => v[Mask._6];
-    public bool SealofCommand() => v[Mask._7];
-    public bool SealofWisdom() => v[Mask._8];
-    public bool SealofLight() => v[Mask._9];
-    public bool SealofBlood() => v[Mask._10];
-    public bool SealofVengeance() => v[Mask._11];
+    public bool Seal_of_Righteousness() => v[Mask._5];
+    public bool Seal_of_the_Crusader() => v[Mask._6];
+    public bool Seal_of_Command() => v[Mask._7];
+    public bool Seal_of_Wisdom() => v[Mask._8];
+    public bool Seal_of_Light() => v[Mask._9];
+    public bool Seal_of_Blood() => v[Mask._10];
+    public bool Seal_of_Vengeance() => v[Mask._11];
 
-    public bool BlessingofMight() => v[Mask._12];
-    public bool BlessingofProtection() => v[Mask._13];
-    public bool BlessingofWisdom() => v[Mask._14];
-    public bool BlessingofKings() => v[Mask._15];
-    public bool BlessingofSalvation() => v[Mask._16];
-    public bool BlessingofSanctuary() => v[Mask._17];
-    public bool BlessingofLight() => v[Mask._18];
+    public bool Blessing_of_Might() => v[Mask._12];
+    public bool Blessing_of_Protection() => v[Mask._13];
+    public bool Blessing_of_Wisdom() => v[Mask._14];
+    public bool Blessing_of_Kings() => v[Mask._15];
+    public bool Blessing_of_Salvation() => v[Mask._16];
+    public bool Blessing_of_Sanctuary() => v[Mask._17];
+    public bool Blessing_of_Light() => v[Mask._18];
 
-    public bool RighteousFury() => v[Mask._19];
-    public bool DivineProtection() => v[Mask._20];
-    public bool AvengingWrath() => v[Mask._21];
-    public bool HolyShield() => v[Mask._22];
-    public bool DivineShield() => v[Mask._23];
+    public bool Righteous_Fury() => v[Mask._19];
+    public bool Divine_Protection() => v[Mask._20];
+    public bool Avenging_Wrath() => v[Mask._21];
+    public bool Holy_Shield() => v[Mask._22];
+    public bool Divine_Shield() => v[Mask._23];
 
     // Mage
-    public bool FrostArmor() => v[Mask._10];
-    public bool ArcaneIntellect() => v[Mask._11];
-    public bool IceBarrier() => v[Mask._12];
+    [Names(new[] {
+        "Frost Armor",
+        "Ice Armor",
+        "Molten Armor",
+        "Mage Armor" })]
+    public bool Frost_Armor() => v[Mask._10];
+    public bool Arcane_Intellect() => v[Mask._11];
+    public bool Ice_Barrier() => v[Mask._12];
     public bool Ward() => v[Mask._13];
-    public bool FirePower() => v[Mask._14];
-    public bool ManaShield() => v[Mask._15];
-    public bool PresenceOfMind() => v[Mask._16];
-    public bool ArcanePower() => v[Mask._17];
+    public bool Fire_Power() => v[Mask._14];
+    public bool Mana_Shield() => v[Mask._15];
+    public bool Presence_of_Mind() => v[Mask._16];
+    public bool Arcane_Power() => v[Mask._17];
 
     // Rogue
-    public bool SliceAndDice() => v[Mask._10];
+    public bool Slice_and_Dice() => v[Mask._10];
     public bool Stealth() => v[Mask._11];
 
     // Warrior
-    public bool BattleShout() => v[Mask._10];
+    public bool Battle_Shout() => v[Mask._10];
     public bool Bloodrage() => v[Mask._11];
 
     // Warlock
-    public bool Demon() => v[Mask._10]; //Skin and Armor
-    public bool SoulLink() => v[Mask._11];
-    public bool SoulstoneResurrection() => v[Mask._12];
-    public bool ShadowTrance() => v[Mask._13];
-    public bool FelArmor() => v[Mask._14];
-    public bool FelDomination() => v[Mask._15];
-    public bool DemonicSacrifice() => v[Mask._16];
+    [Names(new[] {
+        "Demon Skin",
+        "Demon Armor" })]
+    public bool Demon_Skin() => v[Mask._10]; //Skin and Armor
+    public bool Soul_Link() => v[Mask._11];
+    public bool Soulstone_Resurrection() => v[Mask._12];
+    public bool Shadow_Trance() => v[Mask._13];
+    public bool Fel_Armor() => v[Mask._14];
+    public bool Fel_Domination() => v[Mask._15];
+    public bool Demonic_Sacrifice() => v[Mask._16];
     public bool Sacrifice() => v[Mask._17];
 
     // Shaman
-    public bool LightningShield() => v[Mask._10];
-    public bool WaterShield() => v[Mask._11];
-    public bool ShamanisticFocus() => v[Mask._12];
+    public bool Lightning_Shield() => v[Mask._10];
+    public bool Water_Shield() => v[Mask._11];
+    [Names(new[] {
+        "Shamanistic Focus",
+        "Focused" })]
+    public bool Shamanistic_Focus() => v[Mask._12];
     public bool Stoneskin() => v[Mask._13];
 
     // Hunter
-    public bool AspectoftheCheetah() => v[Mask._10];
-    public bool AspectofthePack() => v[Mask._11];
-    public bool AspectoftheHawk() => v[Mask._12];
-    public bool AspectoftheMonkey() => v[Mask._13];
-    public bool AspectoftheViper() => v[Mask._14];
-    public bool RapidFire() => v[Mask._15];
-    public bool QuickShots() => v[Mask._16];
-    public bool TrueshotAura() => v[Mask._17];
-    public bool AspectoftheDragonhawk() => v[Mask._18];
-    public bool LockandLoad() => v[Mask._19];
+    public bool Aspect_of_the_Cheetah() => v[Mask._10];
+    public bool Aspect_of_the_Pack() => v[Mask._11];
+    public bool Aspect_of_the_Hawk() => v[Mask._12];
+    public bool Aspect_of_the_Monkey() => v[Mask._13];
+    public bool Aspect_of_the_Viper() => v[Mask._14];
+    public bool Rapid_Fire() => v[Mask._15];
+    public bool Quick_Shots() => v[Mask._16];
+    public bool Trueshot_Aura() => v[Mask._17];
+    public bool Aspect_of_the_Dragonhawk() => v[Mask._18];
+    public bool Lock_and_Load() => v[Mask._19];
 
     // Death Knight
-    public bool BloodTap() => v[Mask._10];
-    public bool HornofWinter() => v[Mask._11];
-    public bool IceboundFortitude() => v[Mask._12];
-    public bool PathofFrost() => v[Mask._13];
-    public bool AntiMagicShell() => v[Mask._14];
-    public bool ArmyoftheDead() => v[Mask._15];
-    public bool VampiricBlood() => v[Mask._16];
-    public bool DancingRuneWeapon() => v[Mask._17];
-    public bool UnbreakableArmor() => v[Mask._18];
-    public bool BoneShield() => v[Mask._19];
-    public bool SummonGargoyle() => v[Mask._20];
-    public bool FreezingFog() => v[Mask._21];
+    public bool Blood_Tap() => v[Mask._10];
+    public bool Horn_of_Winter() => v[Mask._11];
+    public bool Icebound_Fortitude() => v[Mask._12];
+    public bool Path_of_Frost() => v[Mask._13];
+    [Names(new[] { "Anti-Magic Shell" })]
+    public bool Anti_Magic_Shell() => v[Mask._14];
+    public bool Army_of_the_Dead() => v[Mask._15];
+    public bool Vampiric_Blood() => v[Mask._16];
+    public bool Dancing_Rune_Weapon() => v[Mask._17];
+    public bool Unbreakable_Armor() => v[Mask._18];
+    public bool Bone_Shield() => v[Mask._19];
+    public bool Summon_Gargoyle() => v[Mask._20];
+    public bool Freezing_Fog() => v[Mask._21];
 }

--- a/Core/AddonComponent/SpellInRange.cs
+++ b/Core/AddonComponent/SpellInRange.cs
@@ -34,15 +34,32 @@ public sealed class SpellInRange : IReader
     public bool Priest_MindFlay => b[Mask._2];
     public bool Priest_MindBlast => b[Mask._3];
     public bool Priest_Smite => b[Mask._4];
+    public bool Priest_Divine_Spirit => b[Mask._5];
+    public bool Priest_Power_World_Fortitude => b[Mask._6];
+    public bool Priest_Power_Word_Shield => b[Mask._7];
+    public bool Priest_Lesser_Heal => b[Mask._8];
+    public bool Priest_Prayer_of_Mending => b[Mask._9];
+    public bool Priest_Renew => b[Mask._10];
+    public bool Priest_Shadow_Protection => b[Mask._11];
 
     // Druid
     public bool Druid_Wrath => b[Mask._0];
     public bool Druid_Bash => b[Mask._1];
     public bool Druid_Rip => b[Mask._2];
     public bool Druid_Maul => b[Mask._3];
+    public bool Druid_Healing_Touch => b[Mask._4];
+    public bool Druid_Mark_of_the_Wild => b[Mask._5];
+    public bool Druid_Regrowth => b[Mask._6];
+    public bool Druid_Rejuvenation => b[Mask._7];
+    public bool Druid_Thorns => b[Mask._8];
 
     //Paladin
     public bool Paladin_Judgement => b[Mask._0];
+    public bool Paladin_Exorcism => b[Mask._1];
+    public bool Paladin_Flash_Heal => b[Mask._2];
+    public bool Paladin_Holy_Light => b[Mask._3];
+    public bool Paladin_Blessing_of => b[Mask._4];
+    public bool Paladin_Greater_Blessing_of => b[Mask._5];
 
     //Mage
     public bool Mage_Fireball => b[Mask._0];
@@ -65,6 +82,11 @@ public sealed class SpellInRange : IReader
     // Shaman
     public bool Shaman_LightningBolt => b[Mask._0];
     public bool Shaman_EarthShock => b[Mask._1];
+    public bool Shaman_Healing_Wave => b[Mask._2];
+    public bool Shaman_Lesser_Healing_Wave => b[Mask._3];
+    public bool Shaman_Water_Breathing => b[Mask._4];
+    public bool Shaman_Chain_Heal => b[Mask._5];
+    public bool Shaman_Earth_Shield => b[Mask._6];
 
     // Death Knight
     public bool DeathKnight_IcyTouch => b[Mask._0];

--- a/Core/AddonComponent/TargetDebuffStatus.cs
+++ b/Core/AddonComponent/TargetDebuffStatus.cs
@@ -21,23 +21,24 @@ public sealed class TargetDebuffStatus : IReader
     }
 
     // Priest
-    public bool ShadowWordPain() => v[Mask._0];
+    [Names(new[] { "Shadow Word: Pain" })]
+    public bool Shadow_Word_Pain() => v[Mask._0];
 
     // Druid
-    public bool Roar() => v[Mask._0];
-    public bool FaerieFire() => v[Mask._1];
+    public bool Demoralizing_Roar() => v[Mask._0];
+    public bool Faerie_Fire() => v[Mask._1];
     public bool Rip() => v[Mask._2];
     public bool Moonfire() => v[Mask._3];
-    public bool EntanglingRoots() => v[Mask._4];
+    public bool Entangling_Roots() => v[Mask._4];
     public bool Rake() => v[Mask._5];
 
     // Paladin
-    public bool JudgementoftheCrusader() => v[Mask._0];
-    public bool HammerOfJustice() => v[Mask._1];
-    public bool JudgementAny() => JudgementofWisdom() || JudgementofLight() || JudgementofJustice();
-    public bool JudgementofWisdom() => v[Mask._2];
-    public bool JudgementofLight() => v[Mask._3];
-    public bool JudgementofJustice() => v[Mask._4];
+    public bool Judgement_of_the_Crusader() => v[Mask._0];
+    public bool Hammer_of_Justice() => v[Mask._1];
+    public bool Judgement_of_Any() => Judgement_of_Wisdom() || Judgement_of_Light() || Judgement_of_Justice();
+    public bool Judgement_of_Wisdom() => v[Mask._2];
+    public bool Judgement_of_Light() => v[Mask._3];
+    public bool Judgement_of_Justice() => v[Mask._4];
 
     // Mage
     public bool Frostbite() => v[Mask._0];
@@ -47,26 +48,34 @@ public sealed class TargetDebuffStatus : IReader
 
     // Warrior
     public bool Rend() => v[Mask._0];
-    public bool ThunderClap() => v[Mask._1];
+    public bool Thunder_Clap() => v[Mask._1];
     public bool Hamstring() => v[Mask._2];
-    public bool ChargeStun() => v[Mask._3];
+    public bool Charge_Stun() => v[Mask._3];
 
     // Warlock
-    public bool Curseof() => v[Mask._0];
+    [Names(new[] {
+        "Curse of Weakness",
+        "Curse of Elements",
+        "Curse of Recklessness",
+        "Curse of Shadow",
+        "Curse of Agony",
+        "Curse of" })]
+    public bool Curse_of() => v[Mask._0];
     public bool Corruption() => v[Mask._1];
     public bool Immolate() => v[Mask._2];
-    public bool SiphonLife() => v[Mask._3];
+    public bool Siphon_Life() => v[Mask._3];
 
     // Hunter
-    public bool SerpentSting() => v[Mask._0];
-    public bool HuntersMark() => v[Mask._1];
-    public bool ViperSting() => v[Mask._2];
-    public bool ExplosiveShot() => v[Mask._3];
-    public bool BlackArrow() => v[Mask._4];
+    public bool Serpent_Sting() => v[Mask._0];
+    [Names(new[] { "Hunter's Mark" })]
+    public bool Hunters_Mark() => v[Mask._1];
+    public bool Viper_Sting() => v[Mask._2];
+    public bool Explosive_Shot() => v[Mask._3];
+    public bool Black_Arrow() => v[Mask._4];
 
     // Death Knight
-    public bool BloodPlague() => v[Mask._0];
-    public bool FrostFever() => v[Mask._1];
+    public bool Blood_Plague() => v[Mask._0];
+    public bool Frost_Fever() => v[Mask._1];
     public bool Strangulate() => v[Mask._2];
-    public bool ChainsofIce() => v[Mask._3];
+    public bool Chains_of_Ice() => v[Mask._3];
 }

--- a/Core/Attribute/NamesAttribute.cs
+++ b/Core/Attribute/NamesAttribute.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Core;
+
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class NamesAttribute : Attribute
+{
+    public string[] Values { get; set; }
+
+    public NamesAttribute(params string[] values)
+    {
+        Values = values;
+    }
+}

--- a/Core/BotController.cs
+++ b/Core/BotController.cs
@@ -35,6 +35,7 @@ public sealed partial class BotController : IBotController, IDisposable
     private readonly AuraTimeReader<IPlayerBuffTimeReader> playerBuff;
     private readonly AuraTimeReader<ITargetDebuffTimeReader> targetDebuff;
     private readonly AuraTimeReader<ITargetBuffTimeReader> targetBuff;
+    private readonly AuraTimeReader<IFocusBuffTimeReader> focusBuff;
 
     public bool IsBotActive => GoapAgent != null && GoapAgent.Active;
 
@@ -74,7 +75,8 @@ public sealed partial class BotController : IBotController, IDisposable
         IServiceProvider serviceProvider,
         AuraTimeReader<IPlayerBuffTimeReader> playerBuff,
         AuraTimeReader<ITargetDebuffTimeReader> targetDebuff,
-        AuraTimeReader<ITargetBuffTimeReader> targetBuff)
+        AuraTimeReader<ITargetBuffTimeReader> targetBuff,
+        AuraTimeReader<IFocusBuffTimeReader> focusBuff)
     {
         this.serviceProvider = serviceProvider;
 
@@ -88,6 +90,7 @@ public sealed partial class BotController : IBotController, IDisposable
         this.playerBuff = playerBuff;
         this.targetDebuff = targetDebuff;
         this.targetBuff = targetBuff;
+        this.focusBuff = focusBuff;
 
         this.wowScreen = wowScreen;
 
@@ -274,7 +277,7 @@ public sealed partial class BotController : IBotController, IDisposable
             ClassConfig.Initialise(dataConfig, addonReader, playerReader,
                 addonReader.GlobalTime, costReader,
                 requirementFactory, globalLogger,
-                playerBuff, targetDebuff, targetBuff,
+                playerBuff, targetDebuff, targetBuff, focusBuff,
                 pathFile);
 
             LogProfileLoaded(logger, classFile, ClassConfig.PathFilename);

--- a/Core/ClassConfig/ClassConfiguration.cs
+++ b/Core/ClassConfig/ClassConfiguration.cs
@@ -64,6 +64,7 @@ public sealed class ClassConfiguration : IDisposable
     public KeyActions Adhoc { get; } = new();
     public KeyActions Parallel { get; } = new();
     public KeyActions NPC { get; } = new();
+    public KeyActions AssistFocus { get; } = new();
     public WaitKeyActions Wait { get; } = new();
 
     public KeyAction[] Form { get; init; } = Array.Empty<KeyAction>();
@@ -129,12 +130,14 @@ public sealed class ClassConfiguration : IDisposable
         AuraTimeReader<IPlayerBuffTimeReader> playerBuff,
         AuraTimeReader<ITargetDebuffTimeReader> targetDebuff,
         AuraTimeReader<ITargetBuffTimeReader> targetBuff,
+        AuraTimeReader<IFocusBuffTimeReader> focusBuff,
         string? overridePathProfileFile)
     {
         requirementFactory.InitUserDefinedIntVariables(IntVariables,
             playerBuff,
             targetDebuff,
-            targetBuff);
+            targetBuff,
+            focusBuff);
 
         Jump.Key = JumpKey;
         Jump.Name = nameof(Jump);
@@ -251,6 +254,7 @@ public sealed class ClassConfiguration : IDisposable
         Combat.PreInitialise(nameof(Combat), requirementFactory, logger);
         Adhoc.PreInitialise(nameof(Adhoc), requirementFactory, logger);
         NPC.PreInitialise(nameof(NPC), requirementFactory, logger);
+        AssistFocus.PreInitialise(nameof(AssistFocus), requirementFactory, logger);
         Parallel.PreInitialise(nameof(Parallel), requirementFactory, logger);
         Wait.PreInitialise(nameof(Wait), requirementFactory, logger);
 
@@ -258,6 +262,7 @@ public sealed class ClassConfiguration : IDisposable
         Combat.Initialise(nameof(Combat), this, addonReader, playerReader, globalTime, costReader, requirementFactory, logger, Log);
         Adhoc.Initialise(nameof(Adhoc), this, addonReader, playerReader, globalTime, costReader, requirementFactory, logger, Log);
         NPC.Initialise(nameof(NPC), this, addonReader, playerReader, globalTime, costReader, requirementFactory, logger, Log);
+        AssistFocus.Initialise(nameof(NPC), this, addonReader, playerReader, globalTime, costReader, requirementFactory, logger, Log);
         Parallel.Initialise(nameof(Parallel), this, addonReader, playerReader, globalTime, costReader, requirementFactory, logger, Log);
         Wait.Initialise(nameof(Wait), this, addonReader, playerReader, globalTime, costReader, requirementFactory, logger, Log);
 
@@ -298,6 +303,7 @@ public sealed class ClassConfiguration : IDisposable
         Parallel.Dispose();
         Adhoc.Dispose();
         NPC.Dispose();
+        AssistFocus.Dispose();
         Wait.Dispose();
     }
 

--- a/Core/DependencyInjection.cs
+++ b/Core/DependencyInjection.cs
@@ -34,8 +34,9 @@ public static class DependencyInjection
 
         s.ForwardSingleton<AddonBits, IReader>();
         s.ForwardSingleton<SpellInRange, IReader>();
-        s.ForwardSingleton<BuffStatus, IReader>();
+        s.ForwardSingleton<BuffStatus<IPlayer>, IReader>(x => new(41));
         s.ForwardSingleton<TargetDebuffStatus, IReader>();
+        s.ForwardSingleton<BuffStatus<IFocus>, IReader>(x => new(91));
         s.ForwardSingleton<Stance, IReader>();
 
         s.ForwardSingleton<CombatLog, IReader>();
@@ -59,6 +60,8 @@ public static class DependencyInjection
             x => new(81, 82));
         s.ForwardSingleton<AuraTimeReader<ITargetBuffTimeReader>, IReader>(
             x => new(83, 84));
+        s.ForwardSingleton<AuraTimeReader<IFocusBuffTimeReader>, IReader>(
+            x => new(92, 93));
 
         return s;
     }
@@ -100,8 +103,9 @@ public static class DependencyInjection
 
         s.ForwardSingleton<AddonBits>(sp);
         s.ForwardSingleton<SpellInRange>(sp);
-        s.ForwardSingleton<BuffStatus>(sp);
+        s.ForwardSingleton<BuffStatus<IPlayer>>(sp);
         s.ForwardSingleton<TargetDebuffStatus>(sp);
+        s.ForwardSingleton<BuffStatus<IFocus>>(sp);
         s.ForwardSingleton<Stance>(sp);
 
         s.ForwardSingleton<IScreenCapture>(sp);
@@ -125,6 +129,7 @@ public static class DependencyInjection
         s.ForwardSingleton<AuraTimeReader<IPlayerBuffTimeReader>>(sp);
         s.ForwardSingleton<AuraTimeReader<ITargetDebuffTimeReader>>(sp);
         s.ForwardSingleton<AuraTimeReader<ITargetBuffTimeReader>>(sp);
+        s.ForwardSingleton<AuraTimeReader<IFocusBuffTimeReader>>(sp);
 
         return s;
     }

--- a/Core/GOAP/GoapAgent.cs
+++ b/Core/GOAP/GoapAgent.cs
@@ -257,7 +257,7 @@ public sealed partial class GoapAgent : IDisposable
             (B(hasTarget && !b.TargetIsDead()) << (int)GoapKey.targetisalive) |
 
             (B((hasTarget &&
-            playerReader.TargetHealthPercentage() < 30) ||
+            playerReader.TargetHealthPercent() < 30) ||
             playerReader.TargetTarget is UnitsTarget.Me or
                 UnitsTarget.Pet or UnitsTarget.PartyOrPet) << (int)GoapKey.targettargetsus) |
 

--- a/Core/Goals/AssistFocusGoal.cs
+++ b/Core/Goals/AssistFocusGoal.cs
@@ -1,0 +1,106 @@
+﻿using Core.GOAP;
+
+using Microsoft.Extensions.Logging;
+
+namespace Core.Goals;
+
+public sealed class AssistFocusGoal : GoapGoal
+{
+    private readonly ILogger<AssistFocusGoal> logger;
+    private readonly ConfigurableInput input;
+    private readonly ClassConfiguration classConfig;
+    private readonly Wait wait;
+    private readonly PlayerReader playerReader;
+    private readonly AddonBits bits;
+    private readonly StopMoving stopMoving;
+    private readonly CastingHandler castingHandler;
+    private readonly IMountHandler mountHandler;
+    private readonly CombatLog combatLog;
+
+    public AssistFocusGoal(ILogger<AssistFocusGoal> logger,
+        ConfigurableInput input,
+        ClassConfiguration classConfig,
+        Wait wait,
+        PlayerReader playerReader,
+        AddonBits bits,
+        StopMoving stopMoving,
+        CastingHandler castingHandler,
+        IMountHandler mountHandler,
+        CombatLog combatLog
+        )
+        : base(nameof(AssistFocusGoal))
+    {
+        this.logger = logger;
+        this.input = input;
+        this.classConfig = classConfig;
+        this.wait = wait;
+        this.playerReader = playerReader;
+        this.bits = bits;
+        this.stopMoving = stopMoving;
+        this.castingHandler = castingHandler;
+        this.mountHandler = mountHandler;
+        this.combatLog = combatLog;
+
+        this.Keys = classConfig.AssistFocus.Sequence;
+
+        AddPrecondition(GoapKey.hasfocus, true);
+    }
+
+    public override float Cost => 3.9f;
+
+    public override bool CanRun()
+    {
+        for (int i = 0; i < Keys.Length; i++)
+        {
+            KeyAction key = Keys[i];
+            if (key.CanRun())
+                return true;
+        }
+
+        return false;
+    }
+
+    public override void OnEnter()
+    {
+        wait.Update();
+        input.PressTargetFocus();
+        wait.Update();
+    }
+
+    public override void OnExit()
+    {
+        wait.Update();
+        input.PressClearTarget();
+        wait.Update();
+    }
+
+    public override void Update()
+    {
+        wait.Update();
+
+        for (int i = 0; bits.TargetAlive() && i < Keys.Length; i++)
+        {
+            KeyAction keyAction = Keys[i];
+
+            if (castingHandler.SpellInQueue() && !keyAction.BaseAction)
+            {
+                continue;
+            }
+
+            if (keyAction.BeforeCastDismount && mountHandler.IsMounted())
+            {
+                mountHandler.Dismount();
+                wait.Update();
+            }
+
+            if (castingHandler.CastIfReady(keyAction,
+                keyAction.Interrupts.Count > 0
+                ? keyAction.CanBeInterrupted
+                : bits.TargetAlive))
+            {
+                break;
+            }
+        }
+    }
+
+}

--- a/Core/Goals/LootGoal.cs
+++ b/Core/Goals/LootGoal.cs
@@ -179,8 +179,12 @@ public sealed partial class LootGoal : GoapGoal, IGoapEventListener
 
         if (!MinRangeZero())
         {
-            elapsedMs = wait.Until(MAX_TIME_TO_REACH_MELEE, MinRangeZero, input.PressApproachOnCooldown);
+            elapsedMs =
+                wait.AfterEquals(MAX_TIME_TO_REACH_MELEE, 2, playerReader._MapPosNoZ,
+                input.PressApproachOnCooldown);
             LogReachedCorpse(logger, elapsedMs);
+
+            return MinRangeZero();
         }
 
         return true;
@@ -285,8 +289,12 @@ public sealed partial class LootGoal : GoapGoal, IGoapEventListener
 
                 if (!MinRangeZero())
                 {
-                    float elapsedMs = wait.Until(MAX_TIME_TO_REACH_MELEE, MinRangeZero, input.PressApproachOnCooldown);
+                    float elapsedMs =
+                        wait.AfterEquals(MAX_TIME_TO_REACH_MELEE, 2, playerReader._MapPosNoZ,
+                        input.PressApproachOnCooldown);
                     LogReachedCorpse(logger, elapsedMs);
+
+                    return MinRangeZero();
                 }
             }
             else

--- a/Core/Goals/SkinningGoal.cs
+++ b/Core/Goals/SkinningGoal.cs
@@ -155,9 +155,11 @@ public sealed partial class SkinningGoal : GoapGoal, IGoapEventListener, IDispos
 
             if (!MinRangeZero())
             {
-                e = wait.Until(MAX_TIME_TO_REACH_MELEE, MinRangeZero, input.PressApproachOnCooldown);
+                e = wait.AfterEquals(MAX_TIME_TO_REACH_MELEE, 2, playerReader._MapPosNoZ,
+                    input.PressApproachOnCooldown);
+
                 LogReachedCorpse(logger, e);
-                interact = true;
+                interact = !MinRangeZero();
             }
 
             playerReader.LastUIError = 0;

--- a/Core/Goals/TargetFocusTargetGoal.cs
+++ b/Core/Goals/TargetFocusTargetGoal.cs
@@ -29,6 +29,16 @@ public sealed class TargetFocusTargetGoal : GoapGoal
         AddPrecondition(GoapKey.focushastarget, true);
     }
 
+    public override bool CanRun()
+    {
+        if (bits.TargetOfTargetIsPlayerOrPet())
+            return false;
+
+        return
+            (bits.FocusTargetCanBeHostile() && bits.FocusTargetInCombat()) ||
+            !bits.FocusTargetCanBeHostile();
+    }
+
     public override void OnEnter()
     {
         input.PressTargetFocus();
@@ -43,7 +53,6 @@ public sealed class TargetFocusTargetGoal : GoapGoal
             {
                 input.PressTargetFocus();
                 input.PressTargetOfTarget();
-                wait.Update();
             }
         }
         else if (playerReader.SpellInRange.FocusTarget_Trade)
@@ -51,7 +60,6 @@ public sealed class TargetFocusTargetGoal : GoapGoal
             input.PressTargetFocus();
             input.PressTargetOfTarget();
             input.PressInteract();
-            wait.Update();
         }
 
         wait.Update();

--- a/Core/GoalsComponent/DruidMountHandler.cs
+++ b/Core/GoalsComponent/DruidMountHandler.cs
@@ -24,6 +24,9 @@ public sealed class DruidMountHandler : IMountHandler
     }
 
     public bool CanMount() =>
+        playerReader.Form is not
+        Form.Druid_Flight or
+        Form.Druid_Travel &&
         mountHandler.CanMount();
 
 

--- a/Core/GoalsComponent/Wait.cs
+++ b/Core/GoalsComponent/Wait.cs
@@ -96,7 +96,7 @@ public sealed class Wait
     }
 
     [SkipLocalsInit]
-    public float AfterEquals<T>(int timeoutMs, int updateCount, Func<T> func)
+    public float AfterEquals<T>(int timeoutMs, int updateCount, Func<T> func, Action? repeat = null)
     {
         DateTime start = DateTime.UtcNow;
         float elapsedMs;
@@ -104,10 +104,12 @@ public sealed class Wait
         {
             T initial = func();
 
+            repeat?.Invoke();
+
             for (int i = 0; i < updateCount; i++)
                 Update();
 
-            if (Comparer<T>.Default.Compare(initial, func()) == 0)
+            if (EqualityComparer<T>.Default.Equals(initial, func()))
                 return elapsedMs;
         }
 

--- a/Core/GoalsFactory/GoalFactory.cs
+++ b/Core/GoalsFactory/GoalFactory.cs
@@ -65,8 +65,8 @@ public static class GoalFactory
 
         if (playerReader.Class is UnitClass.Druid)
         {
-            services.AddScoped<MountHandler>();
             services.AddScoped<IMountHandler, DruidMountHandler>();
+            services.AddScoped<MountHandler>();
         }
         else
         {

--- a/Core/GoalsFactory/GoalFactory.cs
+++ b/Core/GoalsFactory/GoalFactory.cs
@@ -110,6 +110,7 @@ public static class GoalFactory
         {
             services.AddScoped<GoapGoal, PullTargetGoal>();
             services.AddScoped<GoapGoal, ApproachTargetGoal>();
+            services.AddScoped<GoapGoal, AssistFocusGoal>();
             services.AddScoped<GoapGoal, CombatGoal>();
 
             ResolveLootAndSkin(services, classConfig);

--- a/Frontend/Pages/BotHeader.razor
+++ b/Frontend/Pages/BotHeader.razor
@@ -26,7 +26,7 @@
     <div class="card-body p-0">
         <table class="table">
             <tr>
-                <th>Level @playerReader.Level.Value<br>(XP: @((int)playerReader.PlayerXpPercentage)%)</th>
+                <th>Level @playerReader.Level.Value<br>(XP: @((int)playerReader.PlayerXpPercent)%)</th>
                 <th>Health / Resource:</th>
                 <th>Bag Items:</th>
                 <th>Actionbar / Spell / Talent:</th>
@@ -47,7 +47,7 @@
                         <a href="@($"{api.NpcId}{playerReader.TargetId}")" target="_blank">
                             <div>
                                 @addonReader.TargetName<br />
-                                (@playerReader.TargetLevel) @((int)playerReader.TargetHealthPercentage()) %<br />
+                                (@playerReader.TargetLevel) @((int)playerReader.TargetHealthPercent()) %<br />
                                 GUID: @playerReader.TargetGuid
 
                                 @if (playerReader.ComboPoints() > 0)

--- a/Frontend/Pages/RawPlayerReaderComponent.razor
+++ b/Frontend/Pages/RawPlayerReaderComponent.razor
@@ -1,39 +1,76 @@
 ﻿@using System.Reflection
 
 @inject IAddonReader addonReader
-
 @inject PlayerReader PlayerReader
+@inject AddonBits bits
+@inject SpellInRange spellInRange
+@inject BuffStatus<IPlayer> playerbuffs
+@inject BuffStatus<IFocus> focusbuffs
+@inject CombatLog combatLog
 
 @implements IDisposable
 
 <div class="container">
     <div class="card">
         <div class="card-header">
-            Raw PlayerReader
+            AddonReader
         </div>
         <div class="card-body" style="padding-bottom: 0">
-            <table class="table table-bordered">
-                @foreach (var property in GetPropertyValues(PlayerReader))
-                {
-                    <tr>
-                        <td>@(property.Name)</td>
-                        <td>
-                            <input value="@property.Value" class="form-control" Disabled="true" />
-                        </td>
-                    </tr>
-                }
-            </table>
-            <table class="table table-bordered">
-                @foreach (var property in GetPropertyValues(addonReader))
-                {
-                    <tr>
-                        <td>@(property.Name)</td>
-                        <td>
-                            <input value="@property.Value" class="form-control" Disabled="true" />
-                        </td>
-                    </tr>
-                }
-            </table>
+            <TableOfComponent Obj="@addonReader" />
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-header">
+            PlayerReader
+        </div>
+        <div class="card-body" style="padding-bottom: 0">
+            <TableOfComponent Obj="@PlayerReader" />
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-header">
+            AddonBits
+        </div>
+        <div class="card-body" style="padding-bottom: 0">
+            <TableOfComponent Obj="@bits" />
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-header">
+            SpellInRange
+        </div>
+        <div class="card-body" style="padding-bottom: 0">
+            <TableOfComponent Obj="@spellInRange" />
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-header">
+            CombatLog
+        </div>
+        <div class="card-body" style="padding-bottom: 0">
+            <TableOfComponent Obj="@combatLog" />
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-header">
+            Player Buffs
+        </div>
+        <div class="card-body" style="padding-bottom: 0">
+            <TableOfComponent Obj="@playerbuffs" />
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-header">
+            Focus Buffs
+        </div>
+        <div class="card-body" style="padding-bottom: 0">
+            <TableOfComponent Obj="@focusbuffs" />
         </div>
     </div>
 </div>
@@ -53,135 +90,6 @@
     private void OnAddonDataChanged()
     {
         base.InvokeAsync(StateHasChanged);
-    }
-
-
-    public class ObjectField
-    {
-        public string Name { get; init; } = string.Empty;
-        public string Value { get; init; } = string.Empty;
-    }
-
-    static List<ObjectField> GetPropertyValues(object obj)
-    {
-        List<ObjectField> propList = new List<ObjectField>();
-        string objName = obj.ToString() ?? "";
-        if (objName.Length > 0) objName += ".";
-
-        foreach (var pinfo in obj.GetType().GetProperties())
-        {
-            if (pinfo.GetIndexParameters().Length != 0) return propList;
-
-            var value = pinfo.GetValue(obj, null);
-            if (value == null) continue;
-
-            if (pinfo.PropertyType.IsArray)
-            {
-                var arr = value as object[];
-                if (arr == null) continue;
-                for (var i = 0; i < arr.Length; i++)
-                {
-                    if (arr[i] != null && arr[i].GetType().IsPrimitive)
-                    {
-                        propList.Add(new ObjectField() { Name = objName + pinfo.Name + i.ToString(), Value = arr[i].ToString() ?? "" });
-                    }
-                    else
-                    {
-                        var lst = GetPropertyValues(arr[i]);
-                        if (lst != null && lst.Count > 0)
-                            propList.AddRange(lst);
-                    }
-                }
-            }
-            else if (pinfo.PropertyType.IsGenericType)
-            {
-                if (value.GetType() == typeof(HashSet<int>))
-                {
-                    var collection = value as HashSet<int>;
-                    if (collection == null) continue;
-
-                    int i = 0;
-                    foreach (var item in collection)
-                    {
-                        propList.Add(new ObjectField() { Name = "    " + objName + pinfo.Name + $"[{i}]", Value = item.ToString() ?? "" });
-                        i++;
-                    }
-                }
-            }
-            else
-            {
-                if (pinfo.PropertyType.IsPrimitive || pinfo.PropertyType.IsEnum || value.GetType() == typeof(string))
-                {
-                    propList.Add(new ObjectField() { Name = objName + pinfo.Name, Value = value.ToString() ?? "" });
-                }
-                else if (value is RecordInt recordInt)
-                {
-                    propList.Add(new ObjectField() { Name = objName + pinfo.Name, Value = recordInt.Value.ToString() });
-                }
-                else if (value is AuraCount auraCount)
-                {
-                    propList.Add(new ObjectField() { Name = objName + pinfo.Name, Value = auraCount.ToString() });
-                }
-                else if (value is PlayerReader playerReader)
-                {
-                    var lst = GetFunctionValues(playerReader, typeof(int));
-                    if (lst != null && lst.Count > 0)
-                        propList.AddRange(lst);
-                }
-                else if (value is AddonBits addonBits)
-                {
-                    var lst = GetFunctionValues(addonBits, typeof(bool));
-                    if (lst != null && lst.Count > 0)
-                        propList.AddRange(lst);
-                }
-                else if (value is SpellInRange spellInRange)
-                {
-                    var lst = GetFunctionValues(spellInRange, typeof(bool));
-                    if (lst != null && lst.Count > 0)
-                        propList.AddRange(lst);
-                }
-                else if (value is BuffStatus buffStatus)
-                {
-                    var lst = GetFunctionValues(buffStatus, typeof(bool));
-                    if (lst != null && lst.Count > 0)
-                        propList.AddRange(lst);
-                }
-                else if (value is TargetDebuffStatus targetDebuffStatus)
-                {
-                    var lst = GetFunctionValues(targetDebuffStatus, typeof(bool));
-                    if (lst != null && lst.Count > 0)
-                        propList.AddRange(lst);
-                }
-                else if (value is CombatLog creatureHistory)
-                {
-                    var lst = GetPropertyValues(creatureHistory);
-                    if (lst != null && lst.Count > 0)
-                        propList.AddRange(lst);
-                }
-            }
-        }
-        return propList;
-    }
-
-    static List<ObjectField> GetFunctionValues(object obj, Type t)
-    {
-        List<ObjectField> propList = new List<ObjectField>();
-        string objName = obj.ToString() ?? "";
-        if (objName.Length > 0) objName += ".";
-
-        foreach (var minfo in obj.GetType().GetMethods(BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance))
-        {
-            if (minfo.ReturnType != t)
-                continue;
-
-            ParameterInfo[] parameters = minfo.GetParameters();
-            if (parameters.Length == 0)
-            {
-                propList.Add(new ObjectField() { Name = objName + minfo.Name, Value = minfo.Invoke(obj, null)!.ToString() ?? "" });
-            }
-        }
-
-        return propList;
     }
 
 }

--- a/Frontend/Pages/TableOfComponent.razor
+++ b/Frontend/Pages/TableOfComponent.razor
@@ -1,0 +1,134 @@
+﻿@using System.Reflection
+
+@if (Obj != null)
+{
+    <table class="table table-bordered">
+        @foreach (var property in GetPropertyValues(Obj))
+        {
+            <tr>
+                <td>@(property.Name)</td>
+                <td>
+                    <input value="@property.Value" class="form-control" Disabled="true" />
+                </td>
+            </tr>
+        }
+        @foreach (var property in GetFunctionValues(Obj, typeof(bool)))
+        {
+            <tr>
+                <td>@(property.Name)</td>
+                <td>
+                    <input value="@property.Value" class="form-control" Disabled="true" />
+                </td>
+            </tr>
+        }
+        @foreach (var property in GetFunctionValues(Obj, typeof(int)))
+        {
+            <tr>
+                <td>@(property.Name)</td>
+                <td>
+                    <input value="@property.Value" class="form-control" Disabled="true" />
+                </td>
+            </tr>
+        }
+    </table>
+}
+
+@code {
+
+    [Parameter]
+    public object? Obj { get; set; }
+
+    public class ObjectField
+    {
+        public string Name { get; init; } = string.Empty;
+        public string Value { get; init; } = string.Empty;
+    }
+
+    static List<ObjectField> GetPropertyValues(object obj)
+    {
+        List<ObjectField> propList = new List<ObjectField>();
+        string objName = obj.ToString() ?? "";
+        if (objName.Length > 0) objName += ".";
+
+        foreach (var pinfo in obj.GetType().GetProperties())
+        {
+            if (pinfo.GetIndexParameters().Length != 0) return propList;
+
+            var value = pinfo.GetValue(obj, null);
+            if (value == null) continue;
+
+            if (pinfo.PropertyType.IsArray)
+            {
+                var arr = value as object[];
+                if (arr == null) continue;
+                for (var i = 0; i < arr.Length; i++)
+                {
+                    if (arr[i] != null && arr[i].GetType().IsPrimitive)
+                    {
+                        propList.Add(new ObjectField() { Name = objName + pinfo.Name + i.ToString(), Value = arr[i].ToString() ?? "" });
+                    }
+                    else
+                    {
+                        var lst = GetPropertyValues(arr[i]);
+                        if (lst != null && lst.Count > 0)
+                            propList.AddRange(lst);
+                    }
+                }
+            }
+            else if (pinfo.PropertyType.IsGenericType)
+            {
+                if (value.GetType() == typeof(HashSet<int>))
+                {
+                    var collection = value as HashSet<int>;
+                    if (collection == null) continue;
+
+                    int i = 0;
+                    foreach (var item in collection)
+                    {
+                        propList.Add(new ObjectField() { Name = "    " + objName + pinfo.Name + $"[{i}]", Value = item.ToString() ?? "" });
+                        i++;
+                    }
+                }
+            }
+            else
+            {
+                if (pinfo.PropertyType.IsPrimitive || pinfo.PropertyType.IsEnum || value.GetType() == typeof(string))
+                {
+                    propList.Add(new ObjectField() { Name = objName + pinfo.Name, Value = value.ToString() ?? "" });
+                }
+                else if (value is RecordInt recordInt)
+                {
+                    propList.Add(new ObjectField() { Name = objName + pinfo.Name, Value = recordInt.Value.ToString() });
+                }
+                else if (value is AuraCount auraCount)
+                {
+                    propList.Add(new ObjectField() { Name = objName + pinfo.Name, Value = auraCount.ToString() });
+                }
+            }
+        }
+
+        return propList;
+    }
+
+    static List<ObjectField> GetFunctionValues(object obj, Type t)
+    {
+        List<ObjectField> propList = new List<ObjectField>();
+        string objName = obj.ToString() ?? "";
+        if (objName.Length > 0) objName += ".";
+
+        foreach (var minfo in obj.GetType().GetMethods(BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (minfo.ReturnType != t)
+                continue;
+
+            ParameterInfo[] parameters = minfo.GetParameters();
+            if (parameters.Length == 0)
+            {
+                propList.Add(new ObjectField() { Name = objName + minfo.Name, Value = minfo.Invoke(obj, null)!.ToString() ?? "" });
+            }
+        }
+
+        return propList;
+    }
+
+}

--- a/Json/class/Druid_80_moonkin_assist.json
+++ b/Json/class/Druid_80_moonkin_assist.json
@@ -1,0 +1,258 @@
+{
+  "ClassName": "Druid",
+  //"Mode": "AttendedGrind", //Grind
+  "Mode": "AssistFocus",
+  "Loot": true,
+  "Skin": true,
+  "MountKey": "N0",
+  "PathFilename": "_pack\\60-70\\Terokkar Forest\\62-64.json",
+  "PathThereAndBack": false,
+  "PathReduceSteps": true,
+  "NPCMaxLevels_Above": 3,
+  "NPCMaxLevels_Below": 20,
+  "IntVariables": {
+    "MIN_TARGET_HP_DOT%": 20,
+    "MIN_TARGET_HP_CD%": 75,
+    "Debuff_Faerie Fire": 136033,
+    "Debuff_Mangle": 132135,
+    "FBuff_Mount": 132239
+  },
+  "Form": [
+    {
+      "Name": "Flight Form",
+      "Key": "N0",
+      "Form": "Druid_Flight"
+    },
+    {
+      //macro: /cancelform
+      "Name": "cancelform",
+      "Key": "F1",
+      "Form": "None"
+    },
+    {
+      "Name": "Bear Form",
+      "Key": "F2",
+      "Form": "Druid_Bear"
+    },
+    {
+      "Name": "Cat Form",
+      "Key": "F3",
+      "Form": "Druid_Cat"
+    },
+    {
+      "Name": "Travel Form",
+      "Key": "F4",
+      "Form": "Druid_Travel"
+    },
+    {
+      "Name": "Moonkin Form",
+      "Key": "F5",
+      "Form": "Druid_Moonkin"
+    }
+  ],
+  "Pull": {
+    "Sequence": [
+      {
+        "Name": "Regrowth",
+        "Key": "0",
+        "Form": "None",
+        "HasCastBar": true,
+        "WhenUsable": true,
+        "AfterCastWaitBuff": true,
+        "Requirements": [
+          "Health% < 65",
+          "!Regrowth"
+        ]
+      },
+      {
+        "Name": "Rejuvenation",
+        "Key": "6",
+        "Form": "None",
+        "BeforeCastStop": true,
+        "AfterCastWaitBuff": true,
+        "Requirements": [
+          "Health% < 75",
+          "!Rejuvenation"
+        ]
+      },
+      {
+        "Name": "Moonkin Form",
+        "Key": "F5",
+        "BeforeCastStop": true,
+        "Requirements": [
+          "SpellInRange:0",
+          "!Form:Druid_Moonkin"
+        ]
+      },
+      {
+        "Name": "Faerie Fire (Feral)",
+        "Key": "F6",
+        "AfterCastAuraExpected": true,
+        "AfterCastWaitCombat": true,
+        "Requirements": [
+          "!Moonfire",
+          "Form:Druid_Moonkin",
+          "Debuff_Faerie Fire < 2",
+          "Spell:Faerie Fire"
+        ]
+      },
+      {
+        "Name": "Approach",
+        "Requirements": [
+          "MinRange > 36"
+        ]
+      }
+    ]
+  },
+  "AssistFocus": {
+    "Sequence": [
+      {
+        "Name": "Mark of the Wild",
+        "Key": "4",
+        "Form": "None",
+        "Requirements": [
+          "!Mounted",
+          "!F_Mark of the Wild",
+          "SpellInRange:5"
+        ]
+      },
+      {
+        "Name": "Thorns",
+        "Key": "7",
+        "Form": "None",
+        "Requirements": [
+          "!Mounted",
+          "!F_Thorns",
+          "SpellInRange:8"
+        ]
+      },
+      {
+        "Name": "Regrowth",
+        "Key": "0",
+        "Form": "None",
+        "HasCastBar": true,
+        "WhenUsable": true,
+        "AfterCastAuraExpected": true,
+        "Requirements": [
+          "!Mounted",
+          "!F_Regrowth",
+          "FocusHealth% < 65",
+          "SpellInRange:6"
+        ]
+      },
+      {
+        "Name": "Rejuvenation",
+        "Key": "6",
+        "Form": "None",
+        "BeforeCastStop": true,
+        "AfterCastWaitBuff": true,
+        "Requirements": [
+          "!Mounted",
+          "!F_Rejuvenation",
+          "FocusHealth% < 75",
+          "SpellInRange:7"
+        ]
+      }
+    ]
+  },
+  "Combat": {
+    "Sequence": [
+      {
+        "Name": "Regrowth",
+        "Key": "0",
+        "HasCastBar": true,
+        "WhenUsable": true,
+        "AfterCastAuraExpected": true,
+        "AfterCastWaitCastbar": true,
+        "Requirements": [
+          "Health% < 30"
+        ],
+        "Form": "None"
+      },
+      {
+        "Name": "Trinket 1",
+        "Key": "F11",
+        "Item": true,
+        "WhenUsable": true,
+        "Requirements": [
+          "InMeleeRange",
+          "TargetHealth% > MIN_TARGET_HP_CD%"
+        ]
+      },
+      {
+        "Name": "Moonfire",
+        "Key": "5",
+        "Requirements": [
+          "!Moonfire",
+          "TargetHealth% > 25"
+        ]
+      },
+      {
+        "Name": "Wrath",
+        "Key": "2",
+        "HasCastBar": true
+      },
+      {
+        "Name": "Approach",
+        "Requirements": [
+          "MinRange > 36",
+          "!Casting"
+        ]
+      }
+    ]
+  },
+  "Adhoc": {
+    "Sequence": [
+      {
+        "Name": "Mark of the Wild",
+        "Key": "4",
+        "Form": "None",
+        "Requirement": "!Mark of the Wild"
+      },
+      {
+        "Name": "Thorns",
+        "Key": "7",
+        "Form": "None",
+        "Requirement": "!Thorns"
+      },
+      {
+        "Name": "Innervate",
+        "Cost": 3,
+        "InCombat": "idc",
+        "Key": "N1",
+        "Form": "None",
+        "WhenUsable": true,
+        "Requirement": "Mana% < 15"
+      },
+      {
+        "Name": "MountUp",
+        "Key": "N0",
+        "InCombat": false,
+        "WhenUsable": true,
+        "HasCastbar": true,
+        "AfterCastWaitCastbar": true,
+        "AfterCastWaitGCD": true,
+        "Requirements": [
+          "!Mounted",
+          "FBuff_Mount > 0"
+        ]
+      }
+    ]
+  },
+  "Parallel": {
+    "Sequence": [
+      {
+        "Name": "Food",
+        "Key": "=",
+        "Form": "None",
+        "Requirement": "Health% < 40"
+      },
+      {
+        "Name": "Drink",
+        "Key": "-",
+        "Form": "None",
+        "Requirement": "Mana% < 40 && DrinkCount > 0"
+      }
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ Take a look at the class files in `/Json/class` for examples of what you can do.
 | --- | --- | --- | --- |
 | `"Pull"` | Sequence of `KeyAction(s)` to execute upon [Pull Goal](#Pull-Goal) | true | `[]` |
 | `"Combat"` | Sequence of `KeyAction(s)` to execute upon [Combat Goal](#Combat-Goal) | **false** | `[]` |
+| `"AssistFocus"` | Sequence of `KeyAction(s)` to execute upon [Assist Focus Goal](#Assist-Focus-Goal) | **false** | `[]` |
 | `"Adhoc"` | Sequence of `KeyAction(s)` to execute upon [Adhoc Goals](#Adhoc-Goals) | true | `[]` |
 | `"Parallel"` | Sequence of `KeyAction(s)` to execute upon [Parallel Goal](#Parallel-Goals) | true | `[]` |
 | `"NPC"` | Sequence of `KeyAction(s)` to execute upon [NPC Goal](#NPC-Goals) | true | `[]` |
@@ -545,7 +546,7 @@ e.g. for Rogue ability
 
 Theres are few specially named [KeyAction](#KeyAction) such as `Food` and `Drink` which is reserved for eating and drinking.
 
-They already have some pre baked `Requirement` conditions in order to avoid mistype the definition. 
+They already have some pre baked [Requirement(s)](#Requirement) conditions in order to avoid mistype the definition. 
 
 The bare minimum for `Food` and `Drink` is looks something like this.
 ```json
@@ -620,6 +621,77 @@ e.g.
 }
 ```
 
+### Assist Focus Goal
+
+The `Sequence` of [KeyAction(s)](#KeyAction) that are used while the `AssistFocus` Mode is active. 
+
+Upon any [KeyAction](#KeyAction) [Requirement(s)](#Requirement) are met, the **Assist Focus Goal** is become active.
+
+Upon entering **Assist Focus Goal**, the bot attempts to target the `focus`/`party1` as Target.
+
+Then as defined, in-order, executes those [KeyAction(s)](#KeyAction) which fulfills its given [Requirement(s)](#Requirement).
+
+Upon exiting **Assist Focus Goal**, going to Clear the current target.
+
+Note: You can use every `Buff` and `Debuff` names on the `focus` without being targeted.
+
+Just have to prefix it with `F_` example: `F_Mark of the Wild` which means `focus` has `Mark of the Wild` buff active.
+
+e.g. of a Balance Druid
+```json
+"AssistFocus": {
+    "Sequence": [
+        {
+            "Name": "Mark of the Wild",
+            "Key": "4",
+            "Form": "None",
+            "Requirements": [
+                "!Mounted",
+                "!F_Mark of the Wild",
+                "SpellInRange:5"
+            ]
+        },
+        {
+            "Name": "Thorns",
+            "Key": "7",
+            "Form": "None",
+            "Requirements": [
+                "!Mounted",
+                "!F_Thorns",
+                "SpellInRange:8"
+            ]
+        },
+        {
+            "Name": "Regrowth",
+            "Key": "0",
+            "HasCastBar": true,
+            "WhenUsable": true,
+            "AfterCastAuraExpected": true,
+            "Requirements": [
+                "!Mounted",
+                "!F_Regrowth",
+                "FocusHealth% < 65",
+                "SpellInRange:6"
+            ],
+            "Form": "None"
+        },
+        {
+            "Name": "Rejuvenation",
+            "Key": "6",
+            "BeforeCastStop": true,
+            "AfterCastWaitBuff": true,
+            "Requirements": [
+                "!Mounted",
+                "!F_Rejuvenation",
+                "FocusHealth% < 75",
+                "SpellInRange:7"
+            ],
+            "Form": "None"
+        }
+    ]
+},
+```
+
 ### Combat Goal
 
 The `Sequence` of [KeyAction(s)](#KeyAction) that are used when in combat and trying to kill a mob. 
@@ -681,7 +753,7 @@ e.g.
 
 These `Sequence` of [KeyAction(s)](#KeyAction) are done when not in combat and are not on cooldown. 
 
-The key presses happens simultaneously on all [KeyAction(s)](#KeyAction) which meets the `Requirement`.
+The key presses happens simultaneously on all [KeyAction(s)](#KeyAction) which meets the [Requirement(s)](#Requirement).
 
 Suitable for `Food` and `Drink`.
 
@@ -704,7 +776,7 @@ e.g.
 ```
 ### Wait Goals
 
-These actions cause to wait while the Requirements are met, during this time the player going to be idle, until lowered cost action can be executed.
+These actions cause to wait while the [Requirement(s)](#Requirement) are met, during this time the player going to be idle, until lowered cost action can be executed.
 
 e.g.
 ```json
@@ -784,7 +856,7 @@ Short Path Example:
 
 ### Repeatable Quests Handin
 
-In theory if there is a repeatable quest to collect items, you could set up a NPC task as follows. See 'Bag requirements' for Requirements format.
+In theory if there is a repeatable quest to collect items, you could set up a NPC task as follows. See 'Bag requirements' for [Requirement(s)](#Requirement) format.
 ```json
 {
     "Name": "Handin",
@@ -886,6 +958,7 @@ Formula: `[Keyword] [Operator] [Numeric integer value]`
 | --- | --- |
 | `Health%` | Player health in percentage |
 | `TargetHealth%` | Target health in percentage |
+| `FocusHealth%` | Focus health in percentage |
 | `PetHealth%` | Pet health in percentage |
 | `Mana%` | Player mana in percentage |
 | `Mana` | Player current mana |
@@ -1206,6 +1279,20 @@ e.g.
 },
 ```
 ---
+### **Focus Buff remaining time requirements**
+
+First in the `IntVariables` have to mention the buff icon id such as `FBuff_{your fancy name}: {icon_id}`
+
+It is important, the addon keeps track of the **icon_id**! Not **spell_id**
+
+e.g.
+```json
+"IntVariables": {
+    "FBuff_Battle Shout": 132333,
+    "FBuff_Mount": 132239
+},
+```
+---
 ### **Trigger requirements**
 
 If you feel the current Requirement toolset is not enough for you, you can use other addons such as **WeakAura's** Trigger to control a given bit.
@@ -1307,7 +1394,7 @@ Allow requirements about what buffs/debuffs you have or the target has or in gen
 | All | `"Clearcasting"` |
 | Druid | `"Mark of the Wild"` |
 | Druid | `"Thorns"` |
-| Druid | `"TigersFury"` |
+| Druid | `"Tiger's Fury"` |
 | Druid | `"Prowl"` |
 | Druid | `"Rejuvenation"` |
 | Druid | `"Regrowth"` |
@@ -1343,7 +1430,7 @@ Allow requirements about what buffs/debuffs you have or the target has or in gen
 | Paladin | `"Holy Shield"` |
 | Paladin | `"Divine Shield"` |
 | Priest | `"Fortitude"` |
-| Priest | `"InnerFire"` |
+| Priest | `"Inner Fire"` |
 | Priest | `"Divine Spirit"` |
 | Priest | `"Renew"` |
 | Priest | `"Shield"` |
@@ -1443,6 +1530,8 @@ e.g.
 "Requirement": "BagFull"           // Inventory is full.
 "Requirement": "HasRangedWeapon"   // Has an item equipped at the ranged slot.
 "Requirement": "InMeleeRange"      // Determines if the target is in melee range (0-5 yard)
+"Requirement": "!F_Thorns"         // Focus don't have the thorns buff.
+"Requirement": "F_Rejuvenation"    // Focus Has Rejuvenation buff active.
 ```
 
 ---
@@ -1465,6 +1554,11 @@ Formula: `SpellInRange:[Numeric integer value]`
 | Druid | Bash | 1 |
 | Druid | Rip | 2 |
 | Druid | Maul | 3 |
+| Druid | Healing Touch | 4 |
+| Druid | Mark of the Wild | 5 |
+| Druid | Regrowth | 6 |
+| Druid | Rejuvenation | 7 |
+| Druid | Thorns | 8 |
 | Warrior | Charge | 0 |
 | Warrior | Rend | 1 |
 | Warrior | Shoot Gun | 2 |
@@ -1474,7 +1568,19 @@ Formula: `SpellInRange:[Numeric integer value]`
 | Priest | Mind Flay | 2 |
 | Priest | Mind Blast | 3 |
 | Priest | Smite | 4 |
+| Priest | Divine Spirit | 5 |
+| Priest | Power World: Fortitude | 6 |
+| Priest | Power Word: Shield | 7 |
+| Priest | Lesser Heal | 8 |
+| Priest | Prayer of Mending | 9 |
+| Priest | Renew | 10 |
+| Priest | Shadow Protection | 11 |
 | Paladin | Judgement | 0 |
+| Paladin | Exorcism | 1 |
+| Paladin | Flash Heal | 2 |
+| Paladin | Holy Light | 3 |
+| Paladin | Blessing of * | 4 |
+| Paladin | Greater Blessing of * | 5 |
 | Mage | Fireball | 0 |
 | Mage | Shoot| 1 |
 | Mage | Pyroblast | 2 |
@@ -1489,6 +1595,11 @@ Formula: `SpellInRange:[Numeric integer value]`
 | Warlock | Health Funnel | 2 |
 | Shaman | Lightning Bolt | 0 |
 | Shaman | Earth Shock | 1 |
+| Shaman | Healing Wave | 2 |
+| Shaman | Lesser Healing Wave | 3 |
+| Shaman | Water Breathing | 4 |
+| Shaman | Chain Heal | 5 |
+| Shaman | Earth Shield | 6 |
 | Death Knight | Icy Touch | 0 |
 | Death Knight | Death Coil | 1 |
 | Death Knight | Death Grip | 2 |
@@ -1556,6 +1667,7 @@ As of now every [Goal groups](#Goal-groups) has a default Interrupt.
 * [Combat Goal](#Combat-Goal) based [KeyAction(s)](#KeyAction) interrupted once the target dies and the player loses the target.
 * [Parallel Goal](#Parallel-Goals) based [KeyAction(s)](#KeyAction) has **No** interrupt conditions.
 * [Adhoc Goals](#Adhoc-Goals) based [KeyAction(s)](#KeyAction) depends on `KeyAction.InCombat` flag.
+* [Assist Focus Goal](#Assist-Focus-Goal) based [KeyAction(s)](#KeyAction) interrupted once the target dies and the player loses the target.
 
 Here's and example for low level Hunters, while playing without a pet companion take advantage of interrupt.
 
@@ -1607,7 +1719,7 @@ The available modes are:
 | `"AttendedGrind"` | Similair to `"Grind"`.<br>Navigation disabled.<br>The only difference is that **you** control the route, and select what target to kill. |
 | `"CorpseRun"` | Runs back to the corpse after dies.<br>Can be useful if you are farming an instance and die, the bot will run you back some or all of the way to the instance entrance. |
 | `"AttendedGather"` | Have to `Start Bot` under `Gather` tab and stay at `Gather` tab.<br>Follows the route and scan the minimap for the yellow nodes which indicate a herb or mining node.<br>Once one or more present, the navigation stops and alerts you by playing beeping sound!<br>**You** have to click at the herb/mine. In the `LogComponent` the necessary prompt going be shown to proceed.<br>**Important note**: `Falling` and `Jumping` means the same thing, if you lose the ground the bot going to take over the control! Be patient.<br>(*if exists*) Executes `"Adhoc"`, `"NPC"`, `"Parallel"`, `"Pull"`, `"Combat"`, `"Wait"` Sequences |
-| `"AssistFocus"` | Navigation disabled.<br>Requires a friendly `focus` to exists. Follows the `focus` target.<br>Once a friendly `focustarget` in 11 yard range attempts to Interact with it.<br>Once a hostile `focustarget` in-combat exists, attempts to assist it (kill it).<br>After leaving combat, (*if enabled*) attempts to Loot and GatherCorpse nearby corpses.<br>Works inside Instances.<br>(*if exists*) Executes `"Adhoc"`, `"Parallel"`, `"Pull"`, `"Combat"`, `"Wait"` Sequences.<br>**Note**: In Vanilla `focus` dosen't exists, so instead using `party1`. Party is **required**. |
+| `"AssistFocus"` | Navigation disabled.<br>Requires a friendly `focus` to exists. Follows the `focus` target.<br>Once a friendly `focustarget` in 11 yard range attempts to Interact with it.<br>Once a hostile `focustarget` in-combat exists, attempts to assist it (kill it).<br>After leaving combat, (*if enabled*) attempts to Loot and GatherCorpse nearby corpses.<br>Works inside Instances.<br>(*if exists*) Executes `"Adhoc"`, `"Parallel"`, `"Pull"`, `"AssistFocus"`, `"Combat"`, `"Wait"` Sequences.<br>**Note**: In Vanilla `focus` dosen't exists, so instead using `party1`. Party is **required**. |
 
 # User Interface
 
@@ -1665,7 +1777,7 @@ This displays the finite state machine. The state is goal which can run and has 
 
 Some goals (combat,pull target) contain a list of spells which can be cast. The combat task evaluates its spells in order with the first available being cast. The goal then gives up control so that a higher priority task can take over (e.g. Healing potion).
 
-The visualisation of the pre-conditions and spell requirements makes it easier to understand what the bot is doing and determine if the class file needs to be tweaked.
+The visualisation of the pre-conditions and spell [requirement(s)](#Requirement) makes it easier to understand what the bot is doing and determine if the class file needs to be tweaked.
 
 ![Goals](images/actionsComponent.png)
 


### PR DESCRIPTION
Changes:
* **Core**: `ClassConfiguration` extended with `AssistFocus` section
* **Core**: Added `AssistFocusGoal`
* **Core**: Refactor `RequirementFactory` - for now - uses reflection to create delegates to access `BuffStatus` and `TargetDebuffStatus` functions
* **Core**: `RequirementFactory` `boolVariables` is no longer case sensitive
* **Core**: `RequirementFactory` for `focus` based aura timers can use the following prefix `FBuff_`
* **Core**: `LootGoal`,`SkinningGoal`: New way to determine if the player has reached the target in melee range. Exits much earlier in case after pressing the interact key, nothing happens.
* **Core**: `SpellInRange` extended with a few Friendly target spells for those classes where it might matter.
* **Core**: `FollowFocusGoal` no longer spams `KeyAction`(s)

Fixes:
* **Core**: possible issue about Druid mounting, `Flight Form` were not considered correctly
* **Addon**: Fixed many low level spells which were used for range checks.
* **Addon**: Incase the `focus` is not in group with the player then the target always be `UnitIsTapDenied`
* **Frontend**: Raw page shows up more information

Added:
* **Json**: Example profile [Druid_80_moonkin_assist.json](https://github.com/Xian55/WowClassicGrindBot/blob/378e4a90d8291d9118a4b0894335278938227e13/Json/class/Druid_80_moonkin_assist.json)

**Breaking Changes**:

In the Requirement section there were a few renames:
* `InnerFire` -> `Inner Fire`
* `TigersFury` -> `Tiger's Fury`

Tested:
* Classic Wrath PTR - Warlock Druid classes
* Classic Era PTR - logged in with all classes level 60 preset

