### PR TITLE
Feature: Interruptable cursor based NPC name targeting

### DIFF
--- a/Core/Addon/IGameMenuWindowShown.cs
+++ b/Core/Addon/IGameMenuWindowShown.cs
@@ -1,0 +1,6 @@
+﻿namespace Core;
+
+public interface IGameMenuWindowShown
+{
+    bool GameMenuWindowShown();
+}

--- a/Core/AddonComponent/AddonBits.cs
+++ b/Core/AddonComponent/AddonBits.cs
@@ -2,7 +2,7 @@
 
 namespace Core;
 
-public sealed class AddonBits : IReader
+public sealed class AddonBits : IReader, IGameMenuWindowShown
 {
     private const int cell1 = 8;
     private const int cell2 = 9;

--- a/Core/DependencyInjection.cs
+++ b/Core/DependencyInjection.cs
@@ -33,6 +33,8 @@ public static class DependencyInjection
         s.ForwardSingleton<AddonReader, IAddonReader>();
 
         s.ForwardSingleton<AddonBits, IReader>();
+        s.ForwardSingleton<AddonBits, IGameMenuWindowShown>();
+
         s.ForwardSingleton<SpellInRange, IReader>();
         s.ForwardSingleton<BuffStatus<IPlayer>, IReader>(x => new(41));
         s.ForwardSingleton<TargetDebuffStatus, IReader>();
@@ -102,6 +104,8 @@ public static class DependencyInjection
         s.ForwardSingleton<PlayerReader>(sp);
 
         s.ForwardSingleton<AddonBits>(sp);
+        s.ForwardSingleton<IGameMenuWindowShown>(sp);
+
         s.ForwardSingleton<SpellInRange>(sp);
         s.ForwardSingleton<BuffStatus<IPlayer>>(sp);
         s.ForwardSingleton<TargetDebuffStatus>(sp);

--- a/Core/Goals/AdhocNPCGoal.cs
+++ b/Core/Goals/AdhocNPCGoal.cs
@@ -38,7 +38,7 @@ public sealed class AdhocNPCGoal : GoapGoal, IGoapEventListener, IRouteProvider,
     private readonly ClassConfiguration classConfig;
     private readonly NpcNameTargeting npcNameTargeting;
     private readonly IMountHandler mountHandler;
-    private readonly CancellationToken ct;
+    private readonly CancellationToken token;
     private readonly ExecGameCommand execGameCommand;
     private readonly GossipReader gossipReader;
 
@@ -82,7 +82,7 @@ public sealed class AdhocNPCGoal : GoapGoal, IGoapEventListener, IRouteProvider,
         this.npcNameTargeting = npcNameTargeting;
         this.classConfig = classConfig;
         this.mountHandler = mountHandler;
-        ct = cts.Token;
+        token = cts.Token;
         this.execGameCommand = exec;
         this.gossipReader = gossipReader;
 
@@ -199,7 +199,7 @@ public sealed class AdhocNPCGoal : GoapGoal, IGoapEventListener, IRouteProvider,
 
     private void Navigation_OnDestinationReached()
     {
-        if (pathState != PathState.ApproachPathStart || ct.IsCancellationRequested)
+        if (pathState != PathState.ApproachPathStart || token.IsCancellationRequested)
             return;
 
         LogDebug("Reached defined path end");
@@ -221,7 +221,7 @@ public sealed class AdhocNPCGoal : GoapGoal, IGoapEventListener, IRouteProvider,
                 CursorType.Innkeeper
             };
 
-            found = npcNameTargeting.FindBy(types);
+            found = npcNameTargeting.FindBy(types, token);
             wait.Update();
 
             if (!found)
@@ -241,7 +241,7 @@ public sealed class AdhocNPCGoal : GoapGoal, IGoapEventListener, IRouteProvider,
         if (!bits.Target())
         {
             LogWarn("No target found! Turn left to find NPC");
-            input.PressFixed(input.TurnLeftKey, 250, ct);
+            input.PressFixed(input.TurnLeftKey, 250, token);
             return;
         }
 
@@ -269,7 +269,7 @@ public sealed class AdhocNPCGoal : GoapGoal, IGoapEventListener, IRouteProvider,
         // which mean it it would exit the Goal
         // instead keep it trapped to follow the route back
         while (navigation.HasWaypoint() &&
-            !ct.IsCancellationRequested &&
+            !token.IsCancellationRequested &&
             pathState == PathState.FollowPath)
         {
             navigation.Update();

--- a/CoreTests/NpcNameFinder/MockGameMenuWindowShown.cs
+++ b/CoreTests/NpcNameFinder/MockGameMenuWindowShown.cs
@@ -1,0 +1,8 @@
+﻿using Core;
+
+namespace CoreTests;
+
+internal sealed class MockGameMenuWindowShown : IGameMenuWindowShown
+{
+    public bool GameMenuWindowShown() => false;
+}

--- a/CoreTests/NpcNameFinder/Test_NpcNameFinder.cs
+++ b/CoreTests/NpcNameFinder/Test_NpcNameFinder.cs
@@ -23,7 +23,7 @@ public sealed class Test_NpcNameFinder : IDisposable
     private const bool showOverlay = false;
 
     private const bool LogEachUpdate = true;
-    private const bool LogShowResult = false;
+    private const bool LogEachDetail = false;
 
     private const bool debugTargeting = false;
     private const bool debugSkinning = false;
@@ -58,9 +58,10 @@ public sealed class Test_NpcNameFinder : IDisposable
         npcNameFinder = new(logger, wowScreen, npcResetEvent);
 
         MockMouseOverReader mouseOverReader = new();
+        MockGameMenuWindowShown gmws = new();
         npcNameTargeting = new(loggerFactory.CreateLogger<NpcNameTargeting>(),
             new(), wowScreen, npcNameFinder, wowProcessInput,
-            mouseOverReader, new NoBlacklist(), null!);
+            mouseOverReader, new NoBlacklist(), null!, gmws);
 
         npcNameFinder.ChangeNpcType(types);
 
@@ -114,7 +115,7 @@ public sealed class Test_NpcNameFinder : IDisposable
             SaveImage();
         }
 
-        if (LogEachUpdate && LogShowResult)
+        if (LogEachUpdate && LogEachDetail)
         {
             stringBuilder.Length = 0;
 
@@ -138,7 +139,7 @@ public sealed class Test_NpcNameFinder : IDisposable
 
     public bool Execute_FindTargetBy(ReadOnlySpan<CursorType> cursorType)
     {
-        return npcNameTargeting.FindBy(cursorType);
+        return npcNameTargeting.FindBy(cursorType, CancellationToken.None);
     }
 
     private void SaveImage()

--- a/CoreTests/Program.cs
+++ b/CoreTests/Program.cs
@@ -17,7 +17,7 @@ sealed class Program
     private static Microsoft.Extensions.Logging.ILogger logger;
     private static ILoggerFactory loggerFactory;
 
-    private const bool LogOverall = false;
+    private const bool LogOverallTimes = false;
     private const int delay = 150;
 
     public static void Main()
@@ -48,6 +48,7 @@ sealed class Program
         //NpcNames types = NpcNames.Enemy;
         //NpcNames types = NpcNames.Corpse;
         NpcNames types = NpcNames.Enemy | NpcNames.Neutral;
+        //NpcNames types = NpcNames.Enemy | NpcNames.Neutral | NpcNames.NamePlate;
         //NpcNames types = NpcNames.Friendly | NpcNames.Neutral;
 
         using Test_NpcNameFinder test = new(logger, loggerFactory, types);
@@ -61,19 +62,19 @@ sealed class Program
 
         while (i < count)
         {
-            if (LogOverall)
+            if (LogOverallTimes)
                 timestamp = Stopwatch.GetTimestamp();
 
             test.Execute();
 
-            if (LogOverall)
+            if (LogOverallTimes)
                 sample[i] = Stopwatch.GetElapsedTime(timestamp).TotalMilliseconds;
 
             i++;
             Thread.Sleep(delay);
         }
 
-        if (LogOverall)
+        if (LogOverallTimes)
             Log.Logger.Information($"sample: {count} | avg: {sample.Average(),0:0.00} | min: {sample.Min(),0:0.00} | max: {sample.Max(),0:0.00} | total: {sample.Sum()}");
     }
 
@@ -150,19 +151,19 @@ sealed class Program
 
         while (i < count)
         {
-            if (LogOverall)
+            if (LogOverallTimes)
                 timestamp = Stopwatch.GetTimestamp();
 
             test.Execute();
 
-            if (LogOverall)
+            if (LogOverallTimes)
                 sample[i] = Stopwatch.GetElapsedTime(timestamp).TotalMilliseconds;
 
             i++;
             Thread.Sleep(delay);
         }
 
-        if (LogOverall)
+        if (LogOverallTimes)
             Log.Logger.Information($"sample: {count} | avg: {sample.Average(),0:0.00} | min: {sample.Min(),0:0.00} | max: {sample.Max(),0:0.00} | total: {sample.Sum()}");
     }
 

--- a/SharedLib/NpcFinder/NpcNameFinder.cs
+++ b/SharedLib/NpcFinder/NpcNameFinder.cs
@@ -20,7 +20,8 @@ public enum NpcNames
     Enemy = 1,
     Friendly = 2,
     Neutral = 4,
-    Corpse = 8
+    Corpse = 8,
+    NamePlate = 16
 }
 
 public static class NpcNames_Extension
@@ -32,6 +33,7 @@ public static class NpcNames_Extension
         NpcNames.Friendly => nameof(NpcNames.Friendly),
         NpcNames.Neutral => nameof(NpcNames.Neutral),
         NpcNames.Corpse => nameof(NpcNames.Corpse),
+        NpcNames.NamePlate => nameof(NpcNames.NamePlate),
         _ => nameof(NpcNames.None),
     };
 
@@ -155,6 +157,12 @@ public sealed partial class NpcNameFinder : IDisposable
     public const byte sN_R = 250;
     public const byte sN_G = 250;
     public const byte sN_B = 0;
+
+    public const byte sNamePlate_N = 254;
+
+    public const byte sNamePlate_H_R = 254;
+    public const byte sNamePlate_H_G = 254;
+    public const byte sNamePlate_H_B = 0;
 
     #endregion
 
@@ -286,6 +294,9 @@ public sealed partial class NpcNameFinder : IDisposable
             case NpcNames.Corpse:
                 colorMatcher = SimpleColorCorpse;
                 return;
+            case NpcNames.NamePlate:
+                colorMatcher = SimpleColorNamePlate;
+                return;
             case NpcNames.None:
                 colorMatcher = NoMatch;
                 return;
@@ -316,6 +327,15 @@ public sealed partial class NpcNameFinder : IDisposable
         return r == fC_RGB && g == fC_RGB && b == fC_RGB;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool SimpleColorNamePlate(byte r, byte g, byte b)
+    {
+        return
+            r is sNamePlate_N or sNamePlate_H_R &&
+            g is sNamePlate_N or sNamePlate_H_G &&
+            b is sNamePlate_N or sNamePlate_H_B;
+    }
+
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool CombinedFriendlyNeutrual(byte r, byte g, byte b)
@@ -343,6 +363,9 @@ public sealed partial class NpcNameFinder : IDisposable
     {
         switch (nameType)
         {
+            case NpcNames.Enemy | NpcNames.Neutral | NpcNames.NamePlate:
+                colorMatcher = FuzzyEnemyOrNeutralOrNamePlate;
+                return;
             case NpcNames.Enemy | NpcNames.Neutral:
                 colorMatcher = FuzzyEnemyOrNeutral;
                 return;
@@ -360,6 +383,9 @@ public sealed partial class NpcNameFinder : IDisposable
                 return;
             case NpcNames.Corpse:
                 colorMatcher = FuzzyCorpse;
+                return;
+            case NpcNames.NamePlate:
+                colorMatcher = FuzzyNamePlate;
                 return;
         }
     }
@@ -380,25 +406,33 @@ public sealed partial class NpcNameFinder : IDisposable
         }
     }
 
-    private static bool FuzzyEnemyOrNeutral(byte r, byte g, byte b)
-        => FuzzyColor(fE_R, fE_G, fE_B, r, g, b, colorFuzz) ||
-            FuzzyColor(fN_R, fN_G, fN_B, r, g, b, colorFuzz);
+    private static bool FuzzyEnemyOrNeutral(byte r, byte g, byte b) =>
+        FuzzyColor(fE_R, fE_G, fE_B, r, g, b, colorFuzz) ||
+        FuzzyColor(fN_R, fN_G, fN_B, r, g, b, colorFuzz);
 
-    private static bool FuzzyFriendlyOrNeutral(byte r, byte g, byte b)
-        => FuzzyColor(fF_R, fF_G, fF_B, r, g, b, colorFuzz) ||
-            FuzzyColor(fN_R, fN_G, fN_B, r, g, b, colorFuzz);
+    private static bool FuzzyEnemyOrNeutralOrNamePlate(byte r, byte g, byte b) =>
+        FuzzyEnemyOrNeutral(r, g, b) ||
+        FuzzyNamePlate(r, g, b);
 
-    private static bool FuzzyEnemy(byte r, byte g, byte b)
-        => FuzzyColor(fE_R, fE_G, fE_B, r, g, b, colorFuzz);
+    private static bool FuzzyFriendlyOrNeutral(byte r, byte g, byte b) =>
+        FuzzyColor(fF_R, fF_G, fF_B, r, g, b, colorFuzz) ||
+        FuzzyColor(fN_R, fN_G, fN_B, r, g, b, colorFuzz);
 
-    private static bool FuzzyFriendly(byte r, byte g, byte b)
-        => FuzzyColor(fF_R, fF_G, fF_B, r, g, b, colorFuzz);
+    private static bool FuzzyEnemy(byte r, byte g, byte b) =>
+        FuzzyColor(fE_R, fE_G, fE_B, r, g, b, colorFuzz);
 
-    private static bool FuzzyNeutral(byte r, byte g, byte b)
-        => FuzzyColor(fN_R, fN_G, fN_B, r, g, b, colorFuzz);
+    private static bool FuzzyFriendly(byte r, byte g, byte b) =>
+        FuzzyColor(fF_R, fF_G, fF_B, r, g, b, colorFuzz);
 
-    private static bool FuzzyCorpse(byte r, byte g, byte b)
-        => FuzzyColor(fC_RGB, fC_RGB, fC_RGB, r, g, b, fuzzCorpse);
+    private static bool FuzzyNeutral(byte r, byte g, byte b) =>
+        FuzzyColor(fN_R, fN_G, fN_B, r, g, b, colorFuzz);
+
+    private static bool FuzzyCorpse(byte r, byte g, byte b) =>
+        FuzzyColor(fC_RGB, fC_RGB, fC_RGB, r, g, b, fuzzCorpse);
+
+    private static bool FuzzyNamePlate(byte r, byte g, byte b) =>
+        FuzzyColor(sNamePlate_N, sNamePlate_N, sNamePlate_N, r, g, b, fuzzCorpse) ||
+        FuzzyColor(sNamePlate_H_R, sNamePlate_H_G, sNamePlate_H_B, r, g, b, fuzzCorpse);
 
     #endregion
 


### PR DESCRIPTION
Changes:
* Added NamePlate detection

Fix:
* Annoying issue while way too many NPC name detected on the screen and the search taking too long, it can be interrupted by pressing `ESC` button. While the `GameMenu` window is shown all mouse based search going to be interrupted!

Without NamePlate detection
![npcnamefinder_nameplate](https://github.com/Xian55/WowClassicGrindBot/assets/367101/7ef2a5b2-9154-4674-9cb3-bf425b80db11)

With Nameplate detection combined with NPC name(enemy plus neutral)
![npcnamefinder_npcname_combined_with_nameplate](https://github.com/Xian55/WowClassicGrindBot/assets/367101/75787231-5407-4f20-b12c-531e490269f7)