### PR TITLE
Addon: [1.7.48] - Feature: `ChatReader`: Extract chat history. Whisper, say, yell, party and emote messages

### DIFF
--- a/Addons/DataToColor/Collections.lua
+++ b/Addons/DataToColor/Collections.lua
@@ -32,6 +32,16 @@ function Queue:push(item)
     return table.insert(self.tail, item)
 end
 
+function Queue:peek()
+    if self.index <= self.headLength then
+        return self.head[self.index]
+    elseif #self.tail > 0 then
+        return self.tail[1]
+    end
+
+    return nil
+end
+
 local MinQueue = {}
 DataToColor.MinQueue = MinQueue
 

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -3,7 +3,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors
-## Version: 1.7.47
+## Version: 1.7.48
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/EventHandlers.lua
+++ b/Addons/DataToColor/EventHandlers.lua
@@ -125,6 +125,14 @@ function DataToColor:RegisterEvents()
     DataToColor:RegisterEvent('AUTOFOLLOW_BEGIN', 'AutoFollowBegin')
     DataToColor:RegisterEvent('AUTOFOLLOW_END', 'AutoFollowEnd')
 
+    DataToColor:RegisterEvent('CHAT_MSG_WHISPER', 'OnMessageWhisper')
+    DataToColor:RegisterEvent('CHAT_MSG_SAY', 'OnMessageSay')
+    DataToColor:RegisterEvent('CHAT_MSG_YELL', 'OnMessageYell')
+    DataToColor:RegisterEvent('CHAT_MSG_EMOTE', 'OnMessageEmote')
+    DataToColor:RegisterEvent('CHAT_MSG_TEXT_EMOTE', 'OnMessageEmote')
+    DataToColor:RegisterEvent('CHAT_MSG_PARTY', 'OnMessageParty')
+    DataToColor:RegisterEvent('CHAT_MSG_PARTY_LEADER', 'OnMessageParty')
+
     -- Season of mastery / vanilla
     if WOW_PROJECT_ID == WOW_PROJECT_CLASSIC then
         DataToColor:RegisterEvent('UNIT_SPELLCAST_START', 'SoM_OnCastStart')
@@ -598,6 +606,45 @@ end
 function DataToColor:AutoFollowEnd()
     DataToColor.autoFollow = false
 end
+
+function DataToColor:OnMessageWhisper(event, msg, author)
+    AddMessageToQueue(0, msg, author)
+end
+
+function DataToColor:OnMessageSay(event, msg, author)
+    AddMessageToQueue(1, msg, author)
+end
+
+function DataToColor:OnMessageYell(event, msg, author)
+    AddMessageToQueue(2, msg, author)
+end
+
+function DataToColor:OnMessageEmote(event, msg, author)
+    AddMessageToQueue(3, msg, author)
+end
+
+function DataToColor:OnMessageParty(event, msg, author)
+    AddMessageToQueue(4, msg, author)
+end
+
+function AddMessageToQueue(type, msg, author)
+    --print(author, msg)
+    --author split '-' MyName-Realm
+    local i, length = string.find(author, '-')
+    if i ~= nil then
+        length = length - 1
+    else
+        length = string.len(author)
+    end
+    author = string.sub(author, 1, length)
+
+    msg = author .. ' ' .. msg
+
+    --print(type, string.len(msg), msg)
+
+    DataToColor.ChatQueue:push({ type = type, length = string.len(msg), msg = msg })
+end
+
 
 local CORPSE_RETRIEVAL_DISTANCE = 40
 

--- a/Core/Chat/ChatReader.cs
+++ b/Core/Chat/ChatReader.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Text;
+
+namespace Core;
+
+public enum ChatMessageType
+{
+    Whisper,
+    Say,
+    Yell,
+    Emote,
+    Party
+}
+
+public readonly record struct ChatMessageEntry(DateTime Time, ChatMessageType Type, string Author, string Message);
+
+public sealed class ChatReader : IReader
+{
+    private const int cMsg = 98;
+    private const int cMeta = 99;
+
+    public ObservableCollection<ChatMessageEntry> Messages { get; } = new();
+
+    // 12 character name
+    // 1 space
+    // 256 maximum message length
+    private readonly StringBuilder sb = new(12 + 1 + 256);
+
+    private int _head;
+
+    public void Update(IAddonDataProvider reader)
+    {
+        int meta = reader.GetInt(cMeta);
+        if (meta == 0)
+        {
+            _head = 0;
+            return;
+        }
+
+        ChatMessageType type = (ChatMessageType)(meta / 1000000);
+        int length = meta % 1000000 / 1000;
+        int head = meta % 1000;
+
+        if (_head != head)
+            _head = head;
+        else if (_head == head)
+            return;
+
+        string part = reader.GetString(cMsg).Replace('@', ' ');
+
+        sb.Append(part);
+
+        if (head + 2 < length)
+            return;
+
+        string text = sb.ToString().ToLowerInvariant();
+        sb.Clear();
+
+        int firstSpaceIdx = text.IndexOf(" ");
+        string author = text.AsSpan(0, firstSpaceIdx).ToString();
+        text = text.AsSpan(firstSpaceIdx).ToString();
+
+        Messages.Add(new(DateTime.Now, type, author, text));
+    }
+}

--- a/Core/DependencyInjection.cs
+++ b/Core/DependencyInjection.cs
@@ -47,6 +47,7 @@ public static class DependencyInjection
         s.ForwardSingleton<GossipReader, IReader>();
         s.ForwardSingleton<SpellBookReader, IReader>();
         s.ForwardSingleton<TalentReader, IReader>();
+        s.ForwardSingleton<ChatReader, IReader>();
 
         s.ForwardSingleton<ActionBarCostReader, IReader>();
         s.ForwardSingleton<ActionBarCooldownReader, IReader>();
@@ -123,6 +124,7 @@ public static class DependencyInjection
         s.ForwardSingleton<GossipReader>(sp);
         s.ForwardSingleton<SpellBookReader>(sp);
         s.ForwardSingleton<TalentReader>(sp);
+        s.ForwardSingleton<ChatReader>(sp);
 
         s.ForwardSingleton<ActionBarCostReader>(sp);
         s.ForwardSingleton<ActionBarCooldownReader>(sp);

--- a/Frontend/Pages/Chat.razor
+++ b/Frontend/Pages/Chat.razor
@@ -1,0 +1,2 @@
+﻿@page "/Chat"
+<ChatComponent MaxHeight="0" />

--- a/Frontend/Pages/ChatComponent.razor
+++ b/Frontend/Pages/ChatComponent.razor
@@ -1,0 +1,55 @@
+﻿@using System.Collections.Specialized
+
+@implements IDisposable
+
+@inject ChatReader reader
+
+<style>
+    .log {
+        font-family: Consolas, monaco, monospace;
+        font-size: small;
+        padding: 0 0 5px 0 !important;
+        padding-right: 5px !important;
+    }
+</style>
+
+<div class="col-sm" style="@(MaxHeight > 0 ? $"overflow: auto; max-height: {MaxHeight}px;" : string.Empty)">
+    <table class="table table-borderless table-dark" cellspacing="20">
+        @foreach (var cme in reader.Messages.Reverse())
+        {
+            <tr style="color: @(typeColor[(int)cme.Type])">
+                <td width="65px" class="log">@cme.Time.ToString("HH:mm:ss")</td>
+                <td width="80px" class="log">@cme.Author:</td>
+                <td class="log">@cme.Message</td>
+            </tr>
+        }
+    </table>
+</div>
+
+@code {
+    [Parameter]
+    public int MaxHeight { get; set; } = 400;
+
+    private static readonly string[] typeColor = {
+        "pink",     // ChatMessageType.Whisper
+        "white",    // ChatMessageType.Say
+        "red",      // ChatMessageType.Yell
+        "orange",   // ChatMessageType.Emote
+        "cyan",    // ChatMessageType.Party
+    };
+
+    protected override void OnInitialized()
+    {
+        reader.Messages.CollectionChanged += Changed;
+    }
+
+    public void Dispose()
+    {
+        reader.Messages.CollectionChanged -= Changed;
+    }
+
+    private void Changed(object? s, NotifyCollectionChangedEventArgs e)
+    {
+        base.InvokeAsync(StateHasChanged);
+    }
+}

--- a/Frontend/Pages/Index.razor
+++ b/Frontend/Pages/Index.razor
@@ -24,6 +24,11 @@
                             <BagChanges />
                         </td>
                     </tr>
+                    <tr>
+                        <td>
+                            <ChatComponent MaxHeight="400" />
+                        </td>
+                    </tr>
                 </table>
             </div>
 

--- a/Frontend/Shared/NavMenu.razor
+++ b/Frontend/Shared/NavMenu.razor
@@ -91,6 +91,12 @@
                     </NavLink>
                 </li>
                 <li class="nav-item px-3">
+                    <NavLink class="nav-link" href="Chat">
+                        <span class="oi oi-people" aria-hidden="true"></span>
+                        <span class="@NavMenuTextCssClass">Chat</span>
+                    </NavLink>
+                </li>
+                <li class="nav-item px-3">
                     <NavLink class="nav-link" href="Log">
                         <span class="oi oi-text" aria-hidden="true"></span>
                         <span class="@NavMenuTextCssClass">Log</span>


### PR DESCRIPTION
Limitation:
* Only works with [ASCII](https://www.asciitable.com/) characters, (<100 dec, only 2 digit allowed)
*  ![image](https://github.com/Xian55/WowClassicGrindBot/assets/367101/abe176eb-de04-4212-9418-fa42c418ee92)
* In case a non ASCII character is present, it will be replaced with ` ` character
* From the Author, the Realm name is ignored

Worst case scenario:
* While running the game at 90FPS, it takes about **5** seconds to extract the whole message, when the text length is maximum(256) characters long.

Frontend:
* ![Untitled](https://github.com/Xian55/WowClassicGrindBot/assets/367101/6e80d9cd-08ca-4597-8854-538669df2ee5)

Breaking Change:
* Addon: Increased the `NUMBER_OF_FRAMES` from `100` to `102`