### PR TITLE
Refactor: Abstraction layer for `IWoWScreen`

### DIFF
--- a/BlazorServer/BlazorServer.csproj
+++ b/BlazorServer/BlazorServer.csproj
@@ -33,11 +33,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
-    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Process" Version="2.0.2" />
     <PackageReference Include="Serilog.Expressions" Version="3.4.1" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">

--- a/Core/AddonDataProvider/AddonDataProviderBitBlt.cs
+++ b/Core/AddonDataProvider/AddonDataProviderBitBlt.cs
@@ -23,7 +23,7 @@ public sealed class AddonDataProviderBitBlt : IAddonDataProvider
     private readonly Bitmap bitmap;
     private readonly Graphics graphics;
 
-    private readonly WowScreen wowScreen;
+    private readonly IWowScreen wowScreen;
 
     private IntPtr hWnd = IntPtr.Zero;
     private IntPtr windowDC = IntPtr.Zero;
@@ -31,7 +31,7 @@ public sealed class AddonDataProviderBitBlt : IAddonDataProvider
     private readonly bool windowedMode;
     private Point p;
 
-    public AddonDataProviderBitBlt(WowScreen wowScreen, DataFrame[] frames)
+    public AddonDataProviderBitBlt(IWowScreen wowScreen, DataFrame[] frames)
     {
         this.wowScreen = wowScreen;
         this.frames = frames;

--- a/Core/AddonDataProvider/AddonDataProviderGDI.cs
+++ b/Core/AddonDataProvider/AddonDataProviderGDI.cs
@@ -20,12 +20,12 @@ public sealed class AddonDataProviderGDI : IAddonDataProvider
     private readonly Bitmap bitmap;
     private readonly Graphics graphics;
 
-    private readonly WowScreen wowScreen;
+    private readonly IWowScreen wowScreen;
 
     private readonly bool windowedMode;
     private Point p;
 
-    public AddonDataProviderGDI(WowScreen wowScreen, DataFrame[] frames)
+    public AddonDataProviderGDI(IWowScreen wowScreen, DataFrame[] frames)
     {
         this.wowScreen = wowScreen;
         this.frames = frames;

--- a/Core/AddonDataProvider/AddonDataProviderGDIConfig.cs
+++ b/Core/AddonDataProvider/AddonDataProviderGDIConfig.cs
@@ -15,7 +15,7 @@ public sealed class AddonDataProviderGDIConfig : IAddonDataProvider
 
     private readonly CancellationToken ct;
     private readonly ManualResetEventSlim manualReset = new(true);
-    private readonly WowScreen wowScreen;
+    private readonly IWowScreen wowScreen;
 
     private DataFrame[] frames = Array.Empty<DataFrame>();
 
@@ -25,7 +25,7 @@ public sealed class AddonDataProviderGDIConfig : IAddonDataProvider
 
     private bool disposing;
 
-    public AddonDataProviderGDIConfig(CancellationTokenSource cts, WowScreen wowScreen, DataFrame[] frames)
+    public AddonDataProviderGDIConfig(CancellationTokenSource cts, IWowScreen wowScreen, DataFrame[] frames)
     {
         ct = cts.Token;
         this.wowScreen = wowScreen;

--- a/Core/BotController.cs
+++ b/Core/BotController.cs
@@ -31,7 +31,7 @@ public sealed partial class BotController : IBotController, IDisposable
     private readonly AddonReader addonReader;
     private readonly AddonBits bits;
     private readonly PlayerReader playerReader;
-    private readonly WowScreen wowScreen;
+    private readonly IWowScreen wowScreen;
 
     public bool IsBotActive => GoapAgent != null && GoapAgent.Active;
 
@@ -61,7 +61,7 @@ public sealed partial class BotController : IBotController, IDisposable
         ILogger<BotController> logger,
         CancellationTokenSource cts,
         IPPather pather, DataConfig dataConfig,
-        WowScreen wowScreen,
+        IWowScreen wowScreen,
         NpcNameFinder npcNameFinder,
         INpcResetEvent npcResetEvent,
         PlayerReader playerReader, AddonReader addonReader,

--- a/Core/Configurator/FrameConfigurator.cs
+++ b/Core/Configurator/FrameConfigurator.cs
@@ -35,7 +35,7 @@ public sealed class FrameConfigurator : IDisposable
 
     private readonly ILogger<FrameConfigurator> logger;
     private readonly WowProcess wowProcess;
-    private readonly WowScreen wowScreen;
+    private readonly IWowScreen wowScreen;
     private readonly WowProcessInput wowProcessInput;
     private readonly ExecGameCommand execGameCommand;
     private readonly AddonConfigurator addonConfigurator;
@@ -61,7 +61,7 @@ public sealed class FrameConfigurator : IDisposable
 
     public FrameConfigurator(ILogger<FrameConfigurator> logger, Wait wait,
         WowProcess wowProcess, IAddonDataProvider reader,
-        WowScreen wowScreen, WowProcessInput wowProcessInput,
+        IWowScreen wowScreen, WowProcessInput wowProcessInput,
         ExecGameCommand execGameCommand, AddonConfigurator addonConfigurator)
     {
         this.logger = logger;

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -14,9 +14,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
-    <PackageReference Include="Vortice.Direct3D11" Version="2.1.41" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Core/Minimap/MinimapNodeFinder.cs
+++ b/Core/Minimap/MinimapNodeFinder.cs
@@ -31,14 +31,14 @@ public sealed class MinimapNodeFinder
     private const bool DEBUG_MASK = false;
 
     private readonly ILogger logger;
-    private readonly WowScreen wowScreen;
+    private readonly IWowScreen wowScreen;
     public event EventHandler<MinimapNodeEventArgs>? NodeEvent;
 
     private const int minScore = 2;
     private const byte maxBlue = 34;
     private const byte minRedGreen = 176;
 
-    public MinimapNodeFinder(ILogger logger, WowScreen wowScreen)
+    public MinimapNodeFinder(ILogger logger, IWowScreen wowScreen)
     {
         this.logger = logger;
         this.wowScreen = wowScreen;

--- a/Core/ScreenCapture/ScreenCapture.cs
+++ b/Core/ScreenCapture/ScreenCapture.cs
@@ -14,7 +14,7 @@ public sealed partial class ScreenCapture : ScreenCaptureCleaner, IDisposable
 {
     private readonly ILogger<ScreenCapture> logger;
     private readonly DataConfig dataConfig;
-    private readonly WowScreen wowScreen;
+    private readonly IWowScreen wowScreen;
     private readonly CancellationToken token;
 
     private readonly ManualResetEventSlim manualReset;
@@ -24,7 +24,7 @@ public sealed partial class ScreenCapture : ScreenCaptureCleaner, IDisposable
     private readonly Graphics graphics;
 
     public ScreenCapture(ILogger<ScreenCapture> logger, DataConfig dataConfig,
-        CancellationTokenSource cts, WowScreen wowScreen)
+        CancellationTokenSource cts, IWowScreen wowScreen)
         : base(logger, dataConfig)
     {
         this.logger = logger;

--- a/CoreTests/Input/Test_Input.cs
+++ b/CoreTests/Input/Test_Input.cs
@@ -14,7 +14,7 @@ public class Test_Input : IDisposable
 
     private readonly ILogger logger;
     private readonly WowProcess wowProcess;
-    private readonly WowScreen wowScreen;
+    private readonly IWowScreen wowScreen;
     private readonly WowProcessInput wowProcessInput;
 
     public Test_Input(ILogger logger, ILoggerFactory loggerFactory)
@@ -23,7 +23,7 @@ public class Test_Input : IDisposable
         this.cts = new();
 
         wowProcess = new WowProcess();
-        wowScreen = new(loggerFactory.CreateLogger<WowScreen>(), wowProcess);
+        wowScreen = new WowScreenGDI(loggerFactory.CreateLogger<WowScreenGDI>(), wowProcess);
         wowProcessInput = new(loggerFactory.CreateLogger<WowProcessInput>(), cts, wowProcess);
     }
 

--- a/CoreTests/MinimapNodeFinder/Test_MinimapNodeFinder.cs
+++ b/CoreTests/MinimapNodeFinder/Test_MinimapNodeFinder.cs
@@ -22,7 +22,7 @@ internal sealed class Test_MinimapNodeFinder : IDisposable
     private readonly ILogger logger;
 
     private readonly WowProcess wowProcess;
-    private readonly WowScreen wowScreen;
+    private readonly IWowScreen wowScreen;
 
     private readonly MinimapNodeFinder minimapNodeFinder;
 
@@ -33,7 +33,7 @@ internal sealed class Test_MinimapNodeFinder : IDisposable
         this.logger = logger;
 
         wowProcess = new();
-        wowScreen = new(loggerFactory.CreateLogger<WowScreen>(), wowProcess);
+        wowScreen = new WowScreenGDI(loggerFactory.CreateLogger<WowScreenGDI>(), wowProcess);
 
         minimapNodeFinder = new(logger, wowScreen);
     }

--- a/CoreTests/NpcNameFinder/MockMouseOverReader.cs
+++ b/CoreTests/NpcNameFinder/MockMouseOverReader.cs
@@ -2,7 +2,7 @@
 
 namespace CoreTests;
 
-public class MockMouseOverReader : IMouseOverReader
+internal sealed class MockMouseOverReader : IMouseOverReader
 {
     public int MouseOverLevel => throw new System.NotImplementedException();
 

--- a/CoreTests/NpcNameFinder/MockWoWProcess.cs
+++ b/CoreTests/NpcNameFinder/MockWoWProcess.cs
@@ -5,7 +5,7 @@ using Game;
 
 namespace CoreTests;
 
-public class MockWoWProcess : IMouseInput
+internal sealed class MockWoWProcess : IMouseInput
 {
     public void RightClick(Point p)
     {

--- a/CoreTests/NpcNameFinder/MockWoWScreen.cs
+++ b/CoreTests/NpcNameFinder/MockWoWScreen.cs
@@ -4,13 +4,27 @@ using System.Drawing;
 
 namespace CoreTests;
 
-public class MockWoWScreen : IWowScreen
+internal sealed class MockWoWScreen : IWowScreen
 {
     public bool Enabled { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
     public Bitmap Bitmap => throw new NotImplementedException();
 
     public Rectangle Rect => throw new NotImplementedException();
+
+    public nint ProcessHwnd => throw new NotImplementedException();
+
+    public Bitmap MiniMapBitmap => throw new NotImplementedException();
+
+    public Rectangle MiniMapRect => throw new NotImplementedException();
+
+    public bool EnablePostProcess { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+#pragma warning disable CS0414 // The field 'MockWoWScreen.OnScreenChanged' is assigned but its value is never used
+#pragma warning disable CS8632 // The field 'MockWoWScreen.OnScreenChanged' is assigned but its value is never used
+    public event Action OnScreenChanged;
+#pragma warning restore CS8632 // The field 'MockWoWScreen.OnScreenChanged' is assigned but its value is never used
+#pragma warning restore CS0414 // The field 'MockWoWScreen.OnScreenChanged' is assigned but its value is never used
 
     public void AddDrawAction(Action<Graphics> g)
     {
@@ -33,6 +47,24 @@ public class MockWoWScreen : IWowScreen
     }
 
     public void GetRectangle(out Rectangle rect)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Update() { }
+
+    public void UpdateMinimapBitmap() { }
+
+    public void Dispose()
+    {
+    }
+
+    public void DrawBitmapTo(Graphics g)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void PostProcess()
     {
         throw new NotImplementedException();
     }

--- a/CoreTests/NpcNameFinder/MockWowProcessInput.cs
+++ b/CoreTests/NpcNameFinder/MockWowProcessInput.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Drawing;
+using System.Threading;
+
+using Game;
+
+namespace CoreTests;
+
+internal sealed class MockWowProcessInput : IMouseInput
+{
+    public void InteractMouseOver(CancellationToken ct)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void LeftClick(Point p)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void RightClick(Point p)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void SetCursorPos(Point p)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/CoreTests/NpcNameFinder/NpcNameOverlay.cs
+++ b/CoreTests/NpcNameFinder/NpcNameOverlay.cs
@@ -9,49 +9,52 @@ using SharedLib.Extensions;
 using SharedLib.NpcFinder;
 
 using DPoint = System.Drawing.Point;
+using DRectangle = System.Drawing.Rectangle;
 
 namespace CoreTests;
 
-public class NpcNameOverlay : IDisposable
+internal sealed class NpcNameOverlay : IDisposable
 {
     private readonly GraphicsWindow window;
     private readonly Graphics graphics;
 
     private Font font;
-    private SolidBrush brush;
-    private SolidBrush brushBackground;
+    private SolidBrush brushWhite;
+    private SolidBrush brushGrey;
 
     private readonly NpcNameFinder npcNameFinder;
     private readonly NpcNameTargeting npcNameTargeting;
 
     private readonly bool debugTargeting;
     private readonly bool debugSkinning;
+    private readonly bool debugTargetVsAdd;
 
     private const int padding = 6;
     private const float NumberLeftPadding = 20f;
     private const int FontSize = 10;
 
     public NpcNameOverlay(IntPtr handle, NpcNameFinder npcNameFinder,
-        NpcNameTargeting npcNameTargeting, bool debugTargeting, bool debugSkinning)
+        NpcNameTargeting npcNameTargeting, bool debugTargeting, bool debugSkinning, bool debugTargetVsAdd)
     {
         this.npcNameFinder = npcNameFinder;
         this.npcNameTargeting = npcNameTargeting;
         this.debugTargeting = debugTargeting;
         this.debugSkinning = debugSkinning;
+        this.debugTargetVsAdd = debugTargetVsAdd;
 
         graphics = new Graphics()
         {
-            MeasureFPS = true,
-            PerPrimitiveAntiAliasing = true,
-            TextAntiAliasing = true,
+            MeasureFPS = false,
+            PerPrimitiveAntiAliasing = false,
+            TextAntiAliasing = false,
             UseMultiThreadedFactories = false,
-            VSync = false,
+            VSync = true,
             WindowHandle = IntPtr.Zero
         };
 
         window = new StickyWindow(handle, graphics)
         {
-            FPS = 60,
+            FPS = 10,
             AttachToClientArea = true,
             BypassTopmost = true,
         };
@@ -71,7 +74,7 @@ public class NpcNameOverlay : IDisposable
 
     private bool disposed;
 
-    protected virtual void Dispose(bool disposing)
+    public void Dispose(bool disposing)
     {
         if (disposed) return;
 
@@ -92,15 +95,15 @@ public class NpcNameOverlay : IDisposable
         Graphics graphics = e.Graphics;
 
         font = graphics.CreateFont("Arial", 16);
-        brushBackground = graphics.CreateSolidBrush(0, 0x27, 0x31, 0);
 
-        brush = graphics.CreateSolidBrush(255, 255, 255, 255);
+        brushWhite = graphics.CreateSolidBrush(255, 255, 255, 255);
+        brushGrey = graphics.CreateSolidBrush(128, 128, 128, 255);
     }
 
     private void DestroyGraphics(object sender, DestroyGraphicsEventArgs e)
     {
-        brush.Dispose();
-        brushBackground.Dispose();
+        brushWhite.Dispose();
+        brushGrey.Dispose();
         font.Dispose();
     }
 
@@ -108,47 +111,67 @@ public class NpcNameOverlay : IDisposable
     {
         Graphics g = e.Graphics;
 
-        g.ClearScene(brushBackground);
+        g.ClearScene();
 
         if (npcNameFinder.NpcCount <= 0)
             return;
 
-        g.DrawRectangle(brush, npcNameFinder.Area.Left, npcNameFinder.Area.Top, npcNameFinder.Area.Right, npcNameFinder.Area.Bottom, 1);
+        int c = npcNameTargeting.locFindBy.Length;
+        const int ex = 3;
+        Span<DPoint> attemptPoints = stackalloc DPoint[c + (c * ex)];
+
+        DRectangle area = npcNameFinder.Area;
+
+        g.DrawRectangle(brushWhite, area.Left, area.Top, area.Right, area.Bottom, 1);
+
+        if (debugTargetVsAdd)
+        {
+            int sm = npcNameFinder.screenMid;
+            int stb = npcNameFinder.screenTargetBuffer;
+            int sab = npcNameFinder.screenAddBuffer;
+
+            // target area
+            g.DrawLine(brushWhite, new Point(sm - stb, area.Top), new Point(sm - stb, area.Bottom), 1);
+            g.DrawLine(brushWhite, new Point(sm + stb, area.Top), new Point(sm + stb, area.Bottom), 1);
+
+            // adds area
+            g.DrawLine(brushGrey, new Point(sm - sab, area.Top), new Point(sm - sab, area.Bottom), 1);
+            g.DrawLine(brushGrey, new Point(sm + sab, area.Top), new Point(sm + sab, area.Bottom), 1);
+        }
 
         for (int i = 0; i < npcNameFinder.Npcs.Count; i++)
         {
             NpcPosition npc = npcNameFinder.Npcs[i];
+            DRectangle rect = npc.Rect;
 
-            g.DrawRectangle(brush, npc.Rect.Left - padding, npc.Rect.Top - padding, npc.Rect.Right + padding, npc.Rect.Bottom + padding, 1);
-            g.DrawText(font, FontSize, brush, npc.Rect.Left - NumberLeftPadding - padding, npc.Rect.Top - padding, i.ToString());
+            g.DrawRectangle(!debugTargetVsAdd ? brushWhite : npcNameFinder.IsAdd(npc) ? brushGrey : brushWhite,
+                rect.Left - padding, rect.Top - padding, rect.Right + padding, rect.Bottom + padding, 1);
+
+            g.DrawText(font, FontSize, brushWhite, rect.Left - NumberLeftPadding - padding, rect.Top - padding, i.ToString());
 
             if (debugTargeting)
             {
                 for (int k = 0; k < npcNameTargeting.locTargeting.Length; k++)
                 {
-                    DPoint l = npcNameTargeting.locTargeting[k];
-                    g.DrawCircle(brush, l.X + npc.ClickPoint.X, l.Y + npc.ClickPoint.Y, 5, 1);
+                    DPoint p = npcNameTargeting.locTargeting[k];
+                    g.DrawCircle(brushWhite, p.X + npc.ClickPoint.X, p.Y + npc.ClickPoint.Y, 5, 1);
                 }
             }
 
             if (debugSkinning)
             {
-                int c = npcNameTargeting.locFindBy.Length;
-                const int ex = 3;
-
-                DPoint[] attemptPoints = new DPoint[c + (c * ex)];
                 for (int j = 0; j < c; j += ex)
                 {
                     DPoint p = npcNameTargeting.locFindBy[j];
                     attemptPoints[j] = p;
-                    attemptPoints[j + c] = new DPoint(npc.Rect.Width / 2, p.Y).Scale(npcNameFinder.ScaleToRefWidth, npcNameFinder.ScaleToRefHeight);
-                    attemptPoints[j + c + 1] = new DPoint(-npc.Rect.Width / 2, p.Y).Scale(npcNameFinder.ScaleToRefWidth, npcNameFinder.ScaleToRefHeight);
+                    attemptPoints[j + c] = new DPoint(rect.Width / 2, p.Y).Scale(npcNameFinder.ScaleToRefWidth, npcNameFinder.ScaleToRefHeight);
+                    attemptPoints[j + c + 1] = new DPoint(-rect.Width / 2, p.Y).Scale(npcNameFinder.ScaleToRefWidth, npcNameFinder.ScaleToRefHeight);
                 }
 
                 for (int k = 0; k < attemptPoints.Length; k++)
                 {
-                    DPoint l = attemptPoints[k];
-                    g.DrawCircle(brush, l.X + npc.ClickPoint.X, l.Y + npc.ClickPoint.Y, 5, 1);
+                    DPoint p = attemptPoints[k];
+                    g.DrawCircle(brushWhite, p.X + npc.ClickPoint.X, p.Y + npc.ClickPoint.Y, 5, 1);
                 }
             }
         }

--- a/CoreTests/NpcNameFinder/RectProvider.cs
+++ b/CoreTests/NpcNameFinder/RectProvider.cs
@@ -3,7 +3,7 @@ using System.Drawing;
 
 namespace CoreTests;
 
-public class RectProvider : IRectProvider
+internal sealed class RectProvider : IRectProvider
 {
     public RectProvider()
     {

--- a/CoreTests/NpcNameFinder/Test_NpcNameFinder.cs
+++ b/CoreTests/NpcNameFinder/Test_NpcNameFinder.cs
@@ -51,8 +51,8 @@ public sealed class Test_NpcNameFinder : IDisposable
         this.logger = logger;
 
         wowProcess = new();
-        wowScreen = new(loggerFactory.CreateLogger<WowScreen>(), wowProcess);
-        WowProcessInput wowProcessInput = new(loggerFactory.CreateLogger<WowProcessInput>(), new(), wowProcess);
+        wowScreen = new WowScreenDXGI(loggerFactory.CreateLogger<WowScreenDXGI>(), wowProcess);
+        //wowScreen = new WowScreenGDI(loggerFactory.CreateLogger<WowScreenGDI>(), wowProcess);
 
         INpcResetEvent npcResetEvent = new NpcResetEvent();
         npcNameFinder = new(logger, wowScreen, npcResetEvent);

--- a/DataConfig/DataConfig.csproj
+++ b/DataConfig/DataConfig.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
 </Project>

--- a/Frontend/Frontend.csproj
+++ b/Frontend/Frontend.csproj
@@ -13,9 +13,9 @@
 
   <ItemGroup>
     <PackageReference Include="BlazorTable" Version="1.17.0" />
-    <PackageReference Include="MatBlazor" Version="2.8.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.6" />
-    <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
+    <PackageReference Include="MatBlazor" Version="2.10.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.12" />
+    <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Frontend/Pages/MiniMapComponent.razor
+++ b/Frontend/Pages/MiniMapComponent.razor
@@ -1,7 +1,7 @@
 ﻿@implements IDisposable
 
 @inject IBotController botController
-@inject WowScreen wowScreen
+@inject IWowScreen wowScreen
 
 @inject MinimapNodeFinder minimapNodeFinder
 
@@ -25,7 +25,7 @@
     <div class="card-body" style="padding: 0 0 0 0; width:@(Size)px; height:@(Size)px">
         @if (inited && previewEnabled)
         {
-            <img style="width:@(Size)px; height:@(Size)px" src="data:image/png;base64, @WowScreen.ToBase64(wowScreen.MiniMapBitmap, bitmap, graphics)" alt="Red dot" />
+            <img style="width:@(Size)px; height:@(Size)px" src="data:image/png;base64, @WoWScreenUtil.ToBase64(wowScreen.MiniMapBitmap, bitmap, graphics)" alt="Red dot" />
         }
     </div>
 </div>

--- a/Frontend/Pages/ScreenshotComponent.razor
+++ b/Frontend/Pages/ScreenshotComponent.razor
@@ -1,4 +1,4 @@
-﻿@inject WowScreen wowScreen
+﻿@inject IWowScreen wowScreen
 
 @using System.Drawing
 @using System.Drawing.Drawing2D;
@@ -6,7 +6,7 @@
 <div class="card" @onclick="Toggle">
     @if (inited && wowScreen.EnablePostProcess)
     {
-        <img class="@(Stretch ? "img-filled" : "img-filled-half")" src="data:image/png;base64, @WowScreen.ToBase64(wowScreen.Bitmap, bitmap, graphics)" alt="Toggle preview!" />
+        <img class="@(Stretch ? "img-filled" : "img-filled-half")" src="data:image/png;base64, @WoWScreenUtil.ToBase64(wowScreen.Bitmap, bitmap, graphics)" alt="Toggle preview!" />
     }
     else
     {

--- a/Game/Game.csproj
+++ b/Game/Game.csproj
@@ -7,7 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="GregsStack.InputSimulatorStandard" Version="1.3.5" />
-    <PackageReference Include="TextCopy" Version="6.2.0" />
+    <PackageReference Include="TextCopy" Version="6.2.1" />
+    <PackageReference Include="Vortice.Direct3D11" Version="3.3.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Game/WoWScreen/IWowScreen.cs
+++ b/Game/WoWScreen/IWowScreen.cs
@@ -5,9 +5,21 @@ using SharedLib;
 
 namespace Game;
 
-public interface IWowScreen : IColorReader, IRectProvider, IBitmapProvider
+public interface IWowScreen : IColorReader, IRectProvider, IBitmapProvider, IMinimapBitmapProvider, IDisposable
 {
     bool Enabled { get; set; }
 
+    IntPtr ProcessHwnd { get; }
+
+    bool EnablePostProcess { get; set; }
+    void PostProcess();
     void AddDrawAction(Action<Graphics> g);
+
+    event Action OnScreenChanged;
+
+    void Update();
+
+    void UpdateMinimapBitmap();
+
+    void DrawBitmapTo(Graphics g);
 }

--- a/Game/WoWScreen/WoWScreenUtil.cs
+++ b/Game/WoWScreen/WoWScreenUtil.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Drawing.Imaging;
+using System.Drawing;
+using System.IO;
+
+namespace Game;
+
+public static class WoWScreenUtil
+{
+    public static string ToBase64(Bitmap bitmap, Bitmap resized, Graphics graphics)
+    {
+        graphics.DrawImage(bitmap, 0, 0, resized.Width, resized.Height);
+
+        using MemoryStream ms = new();
+        resized.Save(ms, ImageFormat.Png);
+
+        byte[] byteImage = ms.ToArray();
+        return Convert.ToBase64String(byteImage);
+    }
+}

--- a/Game/WoWScreen/WowScreenDXGI.cs
+++ b/Game/WoWScreen/WowScreenDXGI.cs
@@ -1,0 +1,280 @@
+﻿using Microsoft.Extensions.Logging;
+
+using SharedLib;
+
+using SharpGen.Runtime;
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
+
+using Vortice.Direct3D;
+using Vortice.Direct3D11;
+using Vortice.DXGI;
+using Vortice.Mathematics;
+
+using WinAPI;
+
+using static WinAPI.NativeMethods;
+
+namespace Game;
+
+public sealed class WowScreenDXGI : IWowScreen, IBitmapProvider, IDisposable
+{
+    private readonly ILogger<WowScreenDXGI> logger;
+    private readonly WowProcess wowProcess;
+
+    public event Action OnScreenChanged;
+
+    private readonly List<Action<Graphics>> drawActions = new();
+
+    // TODO: make it work for higher resolution ex. 4k
+    public const int MinimapSize = 200;
+
+    public bool Enabled { get; set; }
+
+    public bool EnablePostProcess { get; set; }
+    public Bitmap Bitmap { get; private set; }
+
+    public Bitmap MiniMapBitmap { get; private set; }
+    public Rectangle MiniMapRect { get; private set; }
+
+    public IntPtr ProcessHwnd => wowProcess.Process.MainWindowHandle;
+
+    private static readonly FeatureLevel[] s_featureLevels =
+    {
+        FeatureLevel.Level_12_1,
+        FeatureLevel.Level_12_0,
+        FeatureLevel.Level_11_0,
+    };
+
+    private readonly IDXGIAdapter adapter;
+    private readonly IDXGIOutput output;
+    private readonly IDXGIOutput1 output1;
+
+    private readonly ID3D11Texture2D screenTexture;
+    private readonly ID3D11Device device;
+    private readonly IDXGIOutputDuplication duplication;
+
+    private Point p;
+
+    private Rectangle rect;
+    public Rectangle Rect => rect;
+
+    private readonly Graphics graphics;
+    private readonly Graphics graphicsMinimap;
+
+    private readonly SolidBrush blackPen;
+
+    private readonly bool windowedMode;
+
+    public WowScreenDXGI(ILogger<WowScreenDXGI> logger, WowProcess wowProcess)
+    {
+        this.logger = logger;
+        this.wowProcess = wowProcess;
+
+        GetRectangle(out rect);
+        p = rect.Location;
+        windowedMode = IsWindowedMode(rect.Location);
+
+        Bitmap = new Bitmap(rect.Width, rect.Height, PixelFormat.Format32bppPArgb);
+        graphics = Graphics.FromImage(Bitmap);
+
+        MiniMapBitmap = new Bitmap(MinimapSize, MinimapSize, PixelFormat.Format32bppPArgb);
+        graphicsMinimap = Graphics.FromImage(MiniMapBitmap);
+
+        blackPen = new SolidBrush(System.Drawing.Color.Black);
+
+        IntPtr hMonitor = MonitorFromWindow(wowProcess.Process.MainWindowHandle, MONITOR_DEFAULT_TO_NULL);
+
+        Result result;
+
+        IDXGIFactory1 factory = DXGI.CreateDXGIFactory1<IDXGIFactory1>();
+        result = factory.EnumAdapters(0, out adapter);
+        if (result == Result.Fail)
+            throw new Exception($"Unable to enumerate adapter! {result.Description}");
+
+        int srcIdx = 0;
+        do
+        {
+            result = adapter.EnumOutputs(srcIdx, out output);
+            if (result == Result.Ok &&
+                output.Description.Monitor == hMonitor)
+            {
+                break;
+            }
+        } while (result != Result.Fail);
+
+        output1 = output.QueryInterface<IDXGIOutput1>();
+        result = D3D11.D3D11CreateDevice(adapter, DriverType.Unknown, DeviceCreationFlags.Singlethreaded, s_featureLevels, out device!);
+
+        if (result == Result.Fail)
+            throw new Exception($"device is null {result.Description}");
+
+        duplication = output1.DuplicateOutput(device);
+
+        Texture2DDescription textureDesc = new()
+        {
+            CPUAccessFlags = CpuAccessFlags.Read,
+            BindFlags = BindFlags.None,
+            Format = Format.B8G8R8A8_UNorm,
+            Width = rect.Right,
+            Height = rect.Bottom,
+            MiscFlags = ResourceOptionFlags.None,
+            MipLevels = 1,
+            ArraySize = 1,
+            SampleDescription = { Count = 1, Quality = 0 },
+            Usage = ResourceUsage.Staging
+        };
+
+        screenTexture = device.CreateTexture2D(textureDesc);
+
+        this.logger.LogInformation($"{rect} - " +
+            $"Windowed Mode: {windowedMode} - " +
+            $"Scale: {DPI2PPI(GetDpi()):F2}");
+    }
+
+    public void Update()
+    {
+        if (windowedMode)
+            GetRectangle(out rect);
+
+        duplication.ReleaseFrame();
+
+        Result result = duplication.AcquireNextFrame(999,
+            out OutduplFrameInfo frameInfo,
+            out IDXGIResource desktopResource);
+
+        if (!result.Success ||
+            //frameInfo.AccumulatedFrames != 1 ||
+            frameInfo.LastPresentTime == 0)
+        {
+            return;
+        }
+
+        ID3D11Texture2D texture = desktopResource.QueryInterface<ID3D11Texture2D>();
+
+        Box box = new(p.X, p.Y, 0, p.X + rect.Right, p.Y + rect.Bottom, 1);
+        device.ImmediateContext.CopySubresourceRegion(screenTexture, 0, 0, 0, 0, texture, 0, box);
+
+        MappedSubresource dataBox = device.ImmediateContext.Map(screenTexture, 0, MapMode.Read, Vortice.Direct3D11.MapFlags.None);
+        int sizeInBytesToCopy = (rect.Right - rect.Left) * 4;
+
+        BitmapData bd = Bitmap.LockBits(rect, ImageLockMode.WriteOnly, Bitmap.PixelFormat);
+        if (windowedMode)
+        {
+            for (int y = 0; y < rect.Bottom; y++)
+            {
+                MemoryHelpers.CopyMemory(bd.Scan0 + y * bd.Stride, dataBox.DataPointer + y * dataBox.RowPitch, sizeInBytesToCopy);
+            }
+        }
+        else
+        {
+            MemoryHelpers.CopyMemory(bd.Scan0, dataBox.DataPointer, sizeInBytesToCopy * rect.Bottom);
+        }
+
+        device.ImmediateContext.Unmap(screenTexture, 0);
+
+        texture.Dispose();
+
+        Bitmap.UnlockBits(bd);
+    }
+
+    public void AddDrawAction(Action<Graphics> a)
+    {
+        drawActions.Add(a);
+    }
+
+    public void PostProcess()
+    {
+        using (Graphics gr = Graphics.FromImage(Bitmap))
+        {
+            gr.FillRectangle(blackPen,
+                new Rectangle(new Point(Bitmap.Width / 15, Bitmap.Height / 40),
+                new Size(Bitmap.Width / 15, Bitmap.Height / 40)));
+
+            for (int i = 0; i < drawActions.Count; i++)
+            {
+                drawActions[i](gr);
+            }
+        }
+
+        OnScreenChanged?.Invoke();
+    }
+
+    public void GetPosition(ref Point point)
+    {
+        NativeMethods.GetPosition(wowProcess.Process.MainWindowHandle, ref point);
+    }
+
+    public void GetRectangle(out Rectangle rect)
+    {
+        NativeMethods.GetWindowRect(wowProcess.Process.MainWindowHandle, out rect);
+    }
+
+
+    public Bitmap GetBitmap(int width, int height)
+    {
+        Bitmap bitmap = new(width, height);
+        Rectangle sourceRect = new(0, 0, width, height);
+
+        using Graphics graphics = Graphics.FromImage(bitmap);
+        graphics.DrawImage(Bitmap, 0, 0, sourceRect, GraphicsUnit.Pixel);
+
+        return bitmap;
+    }
+
+    public void DrawBitmapTo(Graphics graphics)
+    {
+        graphics.DrawImage(Bitmap, 0, 0, rect, GraphicsUnit.Pixel);
+
+        GetCursorPos(out Point cursorPoint);
+        GetRectangle(out Rectangle windowRect);
+
+        if (!windowRect.Contains(cursorPoint))
+            return;
+
+        CURSORINFO cursorInfo = new();
+        cursorInfo.cbSize = Marshal.SizeOf(cursorInfo);
+        if (GetCursorInfo(ref cursorInfo) &&
+            cursorInfo.flags == CURSOR_SHOWING)
+        {
+            DrawIcon(graphics.GetHdc(),
+                cursorPoint.X, cursorPoint.Y, cursorInfo.hCursor);
+
+            graphics.ReleaseHdc();
+        }
+    }
+
+    public System.Drawing.Color GetColorAt(Point point)
+    {
+        return Bitmap.GetPixel(point.X, point.Y);
+    }
+
+    public void UpdateMinimapBitmap()
+    {
+        // TODO: move this to update
+        //GetRectangle(out var rect);
+        //graphicsMinimap.CopyFromScreen(rect.Right - MinimapSize, rect.Top, 0, 0, MiniMapBitmap.Size);
+    }
+
+    public void Dispose()
+    {
+        duplication.ReleaseFrame();
+        duplication.Dispose();
+
+        screenTexture.Dispose();
+        device.Dispose();
+        adapter.Dispose();
+        output1.Dispose();
+        output.Dispose();
+
+        Bitmap.Dispose();
+        graphics.Dispose();
+        graphicsMinimap.Dispose();
+
+        blackPen.Dispose();
+    }
+}

--- a/HeadlessServer/HeadlessServer.csproj
+++ b/HeadlessServer/HeadlessServer.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
     <PackageReference Include="Serilog.Expressions" Version="3.4.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />

--- a/PathingAPI/PathingAPI.csproj
+++ b/PathingAPI/PathingAPI.csproj
@@ -8,11 +8,11 @@
 
   <ItemGroup>
     <PackageReference Include="MatBlazor" Version="2.10.0" />
-    <PackageReference Include="Serilog" Version="2.12.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Serilog" Version="3.0.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SharedLib/DirectBitmap/IMinimapBitmapProvider.cs
+++ b/SharedLib/DirectBitmap/IMinimapBitmapProvider.cs
@@ -1,0 +1,10 @@
+﻿using System.Drawing;
+
+namespace SharedLib;
+
+public interface IMinimapBitmapProvider
+{
+    Bitmap MiniMapBitmap { get; }
+
+    Rectangle MiniMapRect { get; }
+}

--- a/SharedLib/NpcFinder/NpcNameFinder.cs
+++ b/SharedLib/NpcFinder/NpcNameFinder.cs
@@ -1,4 +1,4 @@
-﻿using SharedLib.Extensions;
+using SharedLib.Extensions;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Drawing;
@@ -608,7 +608,7 @@ public sealed partial class NpcNameFinder : IDisposable
             Math.Abs(c.ClickPoint.X - screenMid) < screenTargetBuffer;
     }
 
-    private bool IsAdd(NpcPosition c)
+    public bool IsAdd(NpcPosition c)
     {
         return
             (c.ClickPoint.X < screenMid - screenTargetBuffer &&

--- a/SharedLib/SharedLib.csproj
+++ b/SharedLib/SharedLib.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
     <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
   </ItemGroup>
 

--- a/WinAPI/WinAPI.csproj
+++ b/WinAPI/WinAPI.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
-    <PackageReference Include="System.Management" Version="7.0.0" />
+    <PackageReference Include="System.Management" Version="7.0.2" />
   </ItemGroup>
 
 </Project>

--- a/WowheadDB/WowheadDB.csproj
+++ b/WowheadDB/WowheadDB.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Changes:
* Updated 3rd party libraries on every projects, to prepare for `net8`
* `Game`: Added `WoWScreenDXGI`. Should reduce the bitmap capture time depending on the hardware. On my machine from managed to get **~10**ms from **~26**ms.

However, in order to fully utilize `WoWScreenDXGI` have to make more architectural changes, currently conflicts with `AddonDataProviderDXGI`. A single process can have only one `IDXGIOutputDuplication`. Have to rethink the thread handling in `BotController`