### PR TITLE
Addon: [1.7.51] - Fix: Respect macro based custom item selling

### DIFF
--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -1019,43 +1019,46 @@ function DataToColor:delete(items)
 end
 
 function DataToColor:sell(items)
-    if UnitExists(DataToColor.C.unitTarget) then
-        local item = GetMerchantItemLink(1)
-        if item ~= nil then
-            DataToColor:Print("Selling items...")
-            DataToColor:OnMerchantShow()
-            local TotalPrice = 0
-            for b = 0, 4 do
-                for s = 1, GetContainerNumSlots(b) do
-                    local CurrentItemLink = GetContainerItemLink(b, s)
-                    if CurrentItemLink then
-                        for i = 1, #items, 1 do
-                            if strfind(CurrentItemLink, items[i]) then
-                                local _, _, itemRarity, _, _, _, _, _, _, _, itemSellPrice = GetItemInfo(CurrentItemLink)
-                                if (itemRarity < 2) then
-                                    local _, itemCount = GetContainerItemInfo(b, s)
-                                    TotalPrice = TotalPrice + (itemSellPrice * itemCount)
-                                    DataToColor:Print("Selling: ", itemCount, " ", CurrentItemLink,
-                                        " for ", GetCoinTextureString(itemSellPrice * itemCount))
-                                    UseContainerItem(b, s)
-                                else
-                                    DataToColor:Print("Item is not gray or common, not selling it: ", items[i])
-                                end
-                            end
+    if not UnitExists(DataToColor.C.unitTarget) then
+        DataToColor:Print("Merchant is not targetted.")
+        return
+    end
+
+    local item = GetMerchantItemLink(1)
+    if item == nil then
+        DataToColor:Print("Merchant is not open to sell to, please approach and open.")
+        return
+    end
+
+    DataToColor:Print("Selling items...")
+    DataToColor:OnMerchantShow()
+    local TotalPrice = 0
+
+    for b = 0, 4 do
+        for s = 1, GetContainerNumSlots(b) do
+            local CurrentItemLink = GetContainerItemLink(b, s)
+            if CurrentItemLink then
+                for i = 1, #items, 1 do
+                    if strfind(CurrentItemLink, items[i]) then
+                        local _, _, itemRarity, _, _, _, _, _, _, _, itemSellPrice = GetItemInfo(CurrentItemLink)
+                        if (itemRarity < 2) then
+                            local _, itemCount = GetContainerItemInfo(b, s)
+                            TotalPrice = TotalPrice + (itemSellPrice * itemCount)
+                            DataToColor:Print("Selling: ", itemCount, " ", CurrentItemLink,
+                                " for ", GetCoinTextureString(itemSellPrice * itemCount))
+                            UseContainerItem(b, s)
+                        else
+                            DataToColor:Print("Item is not gray or common, not selling it: ", items[i])
                         end
                     end
                 end
             end
-
-            if TotalPrice ~= 0 then
-                DataToColor:Print("Total Price for all items: ", GetCoinTextureString(TotalPrice))
-            else
-                DataToColor:Print("No grey items were sold.")
-            end
-        else
-            DataToColor:Print("Merchant is not open to sell to, please approach and open.")
         end
+    end
+
+    if TotalPrice ~= 0 then
+        DataToColor:Print("Total Price for all items: ", GetCoinTextureString(TotalPrice))
     else
-        DataToColor:Print("Merchant is not targetted.")
+        DataToColor:Print("No grey items were sold.")
     end
 end

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -3,7 +3,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors
-## Version: 1.7.50
+## Version: 1.7.51
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Core/Goals/AdhocNPCGoal.cs
+++ b/Core/Goals/AdhocNPCGoal.cs
@@ -333,6 +333,9 @@ public sealed class AdhocNPCGoal : GoapGoal, IGoapEventListener, IRouteProvider,
 
         Log($"Merchant window opened after {e}ms");
 
+        // Sell custom items via macro
+        input.PressRandom(key);
+
         e = wait.Until(TIMEOUT, gossipReader.MerchantWindowSelling);
         if (e >= 0)
         {


### PR DESCRIPTION
Changes:
* `Addon`: Refactor **sell** function logic
* `Core`: `AdhocNPCGoal`: Be sure that pressing the Sell key action before the auto sell junk starts, in order to respect macro based item selling.

Note: 
* The **sell** function only sells common(grey) and uncommon(white) items. 
* On the other hand uses wild card search, includes everything which contains the given "keyword".
* When you want to sell `Runecloth` it going to sell `Heavy Runecloth Bandage` as well.

Example macro:
```lua
/run DataToColor:sell({"Giant Egg","Red Wolf Meat","Jet Black Feather","Vibrant Plume","Runecloth"});
```