### PR TITLE
Addon: [1.7.52] - Fix: ADDON_ACTION_BLOCKED `CheckInteractDistance` while player is in combat!

### DIFF
--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -176,7 +176,7 @@ DataToColor.eligibleKillCredit = {}
 DataToColor.CombatDamageDoneQueue = DataToColor.Queue:new()
 local lastDamageDone = 0
 DataToColor.CombatDamageTakenQueue = DataToColor.Queue:new()
-local lastDamaeTaken = 0
+local lastDamageTaken = 0
 DataToColor.CombatCreatureDiedQueue = DataToColor.Queue:new()
 local lastDied = 0
 DataToColor.CombatMissTypeQueue = DataToColor.Queue:new()
@@ -192,6 +192,8 @@ DataToColor.targetDebuffTime = DataToColor.struct:new()
 DataToColor.focusBuffTime = DataToColor.struct:new()
 
 DataToColor.customTrigger1 = {}
+
+DataToColor.sessionKillCount = 0
 
 function DataToColor:RegisterSlashCommands()
     DataToColor:RegisterChatCommand('dc', 'StartSetup')
@@ -273,10 +275,12 @@ function DataToColor:Reset()
 
     DataToColor.corpseInRange = 0
 
+    DataToColor.sessionKillCount = 0
+
     globalCounter = 0
     lastDied = 0
     lastDamageDone = 0
-    lastDamaeTaken = 0
+    lastDamageTaken = 0
 
     bagCache = {}
 
@@ -700,9 +704,9 @@ function DataToColor:CreateFrames()
             end
 
             if globalCounter % COMBAT_LOG_ITERATION_FRAME_CHANGE_RATE == 0 or
-                globalCounter - lastDamaeTaken > COMBAT_LOG_ITERATION_FRAME_CHANGE_RATE then
+                globalCounter - lastDamageTaken > COMBAT_LOG_ITERATION_FRAME_CHANGE_RATE then
                 if Pixel(int, DataToColor.CombatDamageTakenQueue:shift() or 0, 65) then
-                    lastDamaeTaken = globalCounter
+                    lastDamageTaken = globalCounter
                 end
             end
 

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -3,7 +3,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors
-## Version: 1.7.51
+## Version: 1.7.52
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/EventHandlers.lua
+++ b/Addons/DataToColor/EventHandlers.lua
@@ -290,8 +290,9 @@ function DataToColor:OnCombatEvent(...)
         --DataToColor:Print("Damage Taken ", sourceGUID)
 
         local targetGuid = UnitGUID(DataToColor.C.unitTarget)
-        if targetGuid == sourceGUID and not UnitIsTapDenied(DataToColor.C.unitTarget) then
+        if targetGuid == sourceGUID and not UnitIsTapDenied(DataToColor.C.unitTarget) and DataToColor.eligibleKillCredit[sourceGUID] == nil then
             DataToColor.eligibleKillCredit[sourceGUID] = true
+            --DataToColor:Print("Kill Credit added(take): ", sourceGUID)
         end
 
         DataToColor.CombatDamageTakenQueue:push(DataToColor:getGuidFromUUID(sourceGUID))
@@ -392,8 +393,9 @@ function DataToColor:OnCombatEvent(...)
             --DataToColor:Print(subEvent, " ", destGUID)
 
             local targetGuid = UnitGUID(DataToColor.C.unitTarget)
-            if targetGuid == destGUID and not UnitIsTapDenied(DataToColor.C.unitTarget) then
+            if targetGuid == destGUID and not UnitIsTapDenied(DataToColor.C.unitTarget) and DataToColor.eligibleKillCredit[destGUID] == nil then
                 DataToColor.eligibleKillCredit[destGUID] = true
+                --DataToColor:Print("Kill Credit added(done): ", destGUID)
             end
 
             DataToColor.CombatDamageDoneQueue:push(DataToColor:getGuidFromUUID(destGUID))
@@ -434,6 +436,7 @@ function DataToColor:OnCombatEvent(...)
         if band(destFlags, COMBATLOG_OBJECT_TYPE_NPC) > 0 and DataToColor.eligibleKillCredit[destGUID] then
             DataToColor.CombatCreatureDiedQueue:push(DataToColor:getGuidFromUUID(destGUID))
             DataToColor.lastLoot = DataToColor.C.Loot.Corpse
+            DataToColor.sessionKillCount = DataToColor.sessionKillCount + 1
             --DataToColor:Print(subEvent, " ", destGUID, " ", DataToColor:getGuidFromUUID(destGUID))
         elseif destGUID == DataToColor.playerGUID then
             DataToColor.CombatCreatureDiedQueue:push(16777215)

--- a/Addons/DataToColor/Query.lua
+++ b/Addons/DataToColor/Query.lua
@@ -407,11 +407,14 @@ function DataToColor:areSpellsInRange()
         end
     end
 
-    local c = #DataToColor.S.interactInRangeUnit
-    for i = 1, c do
-        local data = DataToColor.S.interactInRangeUnit[i]
-        if CheckInteractDistance(data[1], data[2]) then
-            inRange = inRange + (2 ^ (24 - c + i - 1))
+    -- CheckInteractDistance restricted in combat
+    if not UnitAffectingCombat(DataToColor.C.unitPlayer) then
+        local c = #DataToColor.S.interactInRangeUnit
+        for i = 1, c do
+            local data = DataToColor.S.interactInRangeUnit[i]
+            if CheckInteractDistance(data[1], data[2]) then
+                inRange = inRange + (2 ^ (24 - c + i - 1))
+            end
         end
     end
 


### PR DESCRIPTION
Fix:
* ADDON_ACTION_BLOCKED `CheckInteractDistance` in combat!
* It's been restricted since [16 Nov 2023](https://twitter.com/WeakAuras/status/1725238451421782093)

Changes:
* Addon: Added `sessionKillCount` for validation
* Addon: Fix typo
* Addon: Added more sanity checks for determining eligible kill

Note:
* `IsItemInRange` is not used directly, however LibRangeChecker2.0 uses it. I was unable to trigger it yet.