### PR TITLE
Addon: [1.7.53] - Fix: improved way to detect kills by honoring cell show time.

### DIFF
--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -3,7 +3,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors
-## Version: 1.7.52
+## Version: 1.7.53
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Core/GOAP/GoapAgent.cs
+++ b/Core/GOAP/GoapAgent.cs
@@ -329,7 +329,7 @@ public sealed partial class GoapAgent : IDisposable
 
             BroadcastGoapEvent(GoapKey.producedcorpse, true);
 
-            LogActiveKillDetected(logger, State.LastCombatKillCount, combatLog.DamageTakenCount());
+            LogActiveKillDetected(logger, SessionStat.Kills, State.LastCombatKillCount, combatLog.DamageTakenCount());
         }
         else
         {
@@ -391,8 +391,8 @@ public sealed partial class GoapAgent : IDisposable
     [LoggerMessage(
         EventId = 0050,
         Level = LogLevel.Information,
-        Message = "Kill credit detected! Known kills: {count} | Fighting with: {remain}")]
-    static partial void LogActiveKillDetected(ILogger logger, int count, int remain);
+        Message = "Kill credit detected! Session Total: {sessionTotal} | Last Combat: {lastCombatCount} | Currently fighting: {currentCombatRemain}")]
+    static partial void LogActiveKillDetected(ILogger logger, int sessionTotal, int lastCombatCount, int currentCombatRemain);
 
     [LoggerMessage(
         EventId = 0051,


### PR DESCRIPTION
The original idea:
* Create a construct which has a fixed update time to periodically update the cell value(`COMBAT_LOG_ITERATION_FRAME_CHANGE_RATE`) is currently **5** update tick. This is tied to the FPS(higher the number it happens more often)
* Make the ability to interrupt the deterministic update flow to react the change instantly meanwhile honouring the periodically update(when a kill happens, don't fully await the 5 update ticks, but rather show the value immediately, but make sure to show the value for the 5 update tick duration)
* What left out is to record the actual event time, and based on that recorded time wait for at least `COMBAT_LOG_ITERATION_FRAME_CHANGE_RATE` duration

The problem:
* Below certain amount of stable cell wait time - usually below 5 update tick - the system become unstable and the backend is unable to read with great certainty of the addon produced values. There are many factors such as unstable frame rate.
* The code where used the following construct for detecting `damageDone`, `damageTaken`, `deadGuid` values by
```lua
globalCounter % COMBAT_LOG_ITERATION_FRAME_CHANGE_RATE == 0 
or
globalCounter - lastDied > COMBAT_LOG_ITERATION_FRAME_CHANGE_RATE
```
* The given code were not respected the `COMBAT_LOG_ITERATION_FRAME_CHANGE_RATE` duration and sometimes ended up showing the cell for 0 or 1 tick time which made the backend impossible to read the values.
* its important to mention that, `globalTick` can overflow the 24bit resolution so have to account for negative subtraction. Based on the in-game FPS. With 60fps it can occurs about every 48-72 hours(if i did the math correctly)

The new code:
* Adds more complexity, but it adds more reliability as well.

