### PR TITLE
Core: Added way to alternate paths - PathSettings

### DIFF
--- a/Core/Addon/PlayerReader.cs
+++ b/Core/Addon/PlayerReader.cs
@@ -123,6 +123,8 @@ public sealed partial class PlayerReader : IMouseOverReader, IReader
     public int PlayerMaxXp => reader.GetInt(51);
     public int PlayerXpPercent => (1 + PlayerXp.Value) * 100 / (1 + PlayerMaxXp);
 
+    public int _PlayerXpPercent() => PlayerXpPercent;
+
     public RecordInt UIErrorTime { get; } = new(47);
 
     private UI_ERROR UIError => (UI_ERROR)reader.GetInt(52);

--- a/Core/BotController.cs
+++ b/Core/BotController.cs
@@ -48,7 +48,7 @@ public sealed partial class BotController : IBotController, IDisposable
     private const int remotePathingTickMs = 500;
 
     public string SelectedClassFilename { get; private set; } = string.Empty;
-    public string? SelectedPathFilename { get; private set; }
+    public Dictionary<int, string> SelectedPathFilename { get; private set; } = [];
     public ClassConfiguration? ClassConfig { get; private set; }
     public GoapAgent? GoapAgent { get; private set; }
     public RouteInfo? RouteInfo { get; private set; }
@@ -295,13 +295,13 @@ public sealed partial class BotController : IBotController, IDisposable
         StatusChanged?.Invoke();
     }
 
-    private bool InitialiseFromFile(string classFile, string? pathFile)
+    private bool InitialiseFromFile(string classFile, Dictionary<int, string> pathFiles)
     {
         long startTime = GetTimestamp();
         try
         {
             ClassConfig = ReadClassConfiguration(classFile);
-            ClassConfig.Initialise(serviceProvider, pathFile);
+            ClassConfig.Initialise(serviceProvider, pathFiles);
 
             LogProfileLoaded(logger, classFile, ClassConfig.PathFilename);
 
@@ -417,11 +417,11 @@ public sealed partial class BotController : IBotController, IDisposable
         ProfileLoaded?.Invoke();
     }
 
-    public void LoadPathProfile(string pathFilename)
+    public void LoadPathProfile(Dictionary<int, string> pathFilenames)
     {
-        if (InitialiseFromFile(SelectedClassFilename, pathFilename))
+        if (InitialiseFromFile(SelectedClassFilename, pathFilenames))
         {
-            SelectedPathFilename = pathFilename;
+            SelectedPathFilename = pathFilenames;
         }
 
         ProfileLoaded?.Invoke();

--- a/Core/ClassConfig/PathSettings.cs
+++ b/Core/ClassConfig/PathSettings.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Numerics;
+
+namespace Core;
+
+public sealed class PathSettings
+{
+    public string PathFilename { get; set; } = string.Empty;
+    public string? OverridePathFilename { get; set; } = string.Empty;
+    public bool PathThereAndBack { get; set; } = true;
+    public bool PathReduceSteps { get; set; }
+
+    public Vector3[] Path = Array.Empty<Vector3>();
+
+    public string FileName =>
+        !string.IsNullOrEmpty(OverridePathFilename)
+        ? OverridePathFilename
+        : PathFilename;
+
+    public List<string> Requirements = [];
+    public Requirement[] RequirementsRuntime = [];
+
+    private RecordInt globalTime = null!;
+    private int canRunTime;
+    private bool canRun;
+
+    public void Init(RecordInt globalTime)
+    {
+        this.globalTime = globalTime;
+    }
+
+    public bool CanRun()
+    {
+        if (canRunTime == globalTime.Value)
+            return canRun;
+
+        canRunTime = globalTime.Value;
+
+        ReadOnlySpan<Requirement> span = RequirementsRuntime;
+        for (int i = 0; i < span.Length; i++)
+        {
+            if (!span[i].HasRequirement())
+                return canRun = false;
+        }
+
+        return canRun = true;
+    }
+}

--- a/Core/ConfigBotController.cs
+++ b/Core/ConfigBotController.cs
@@ -19,7 +19,7 @@ public sealed class ConfigBotController : IBotController, IDisposable
     public GoapAgent? GoapAgent => throw new NotImplementedException();
     public RouteInfo? RouteInfo => throw new NotImplementedException();
     public string SelectedClassFilename => throw new NotImplementedException();
-    public string? SelectedPathFilename => throw new NotImplementedException();
+    public Dictionary<int, string> SelectedPathFilename => throw new NotImplementedException();
 
     public ClassConfiguration? ClassConfig => null;
 
@@ -94,7 +94,7 @@ public sealed class ConfigBotController : IBotController, IDisposable
         throw new NotImplementedException();
     }
 
-    public void LoadPathProfile(string pathFilename)
+    public void LoadPathProfile(Dictionary<int, string> pathFilenames)
     {
         ProfileLoaded?.Invoke();
         throw new NotImplementedException();

--- a/Core/GOAP/GoapAgent.cs
+++ b/Core/GOAP/GoapAgent.cs
@@ -78,6 +78,7 @@ public sealed partial class GoapAgent : IDisposable
 
                 if (classConfig.Mode is Mode.AttendedGrind or Mode.Grind)
                 {
+                    SessionStat.Start();
                     sessionHandler.Start(classConfig.OverridePathFilename ?? classConfig.PathFilename);
                 }
             }

--- a/Core/Goals/AdhocNPCGoal.cs
+++ b/Core/Goals/AdhocNPCGoal.cs
@@ -49,6 +49,11 @@ public sealed class AdhocNPCGoal : GoapGoal, IGoapEventListener, IRouteProvider,
 
     #region IRouteProvider
 
+    public Vector3[] MapRoute()
+    {
+        return Array.Empty<Vector3>();
+    }
+
     public Vector3[] PathingRoute()
     {
         return navigation.TotalRoute;

--- a/Core/Goals/GoapGoal.cs
+++ b/Core/Goals/GoapGoal.cs
@@ -19,7 +19,7 @@ public abstract partial class GoapGoal
         {
             keys = value;
             if (keys.Length == 1)
-                DisplayName = $"{Keys[0].Name} [{Keys[0].Key}]";
+                DisplayName = $"{keys[0].Name} [{keys[0].Key}]";
         }
     }
 

--- a/Core/Goals/WalkToCorpseGoal.cs
+++ b/Core/Goals/WalkToCorpseGoal.cs
@@ -24,6 +24,12 @@ public sealed partial class WalkToCorpseGoal : GoapGoal, IGoapEventListener, IRo
 
     public DateTime LastActive => navigation.LastActive;
 
+    public Vector3[] MapRoute()
+    {
+        return Array.Empty<Vector3>();
+    }
+
+
     public Vector3[] PathingRoute()
     {
         return navigation.TotalRoute;

--- a/Core/IBotController.cs
+++ b/Core/IBotController.cs
@@ -8,7 +8,7 @@ public interface IBotController
 {
     bool IsBotActive { get; }
     string SelectedClassFilename { get; }
-    string? SelectedPathFilename { get; }
+    Dictionary<int, string> SelectedPathFilename { get; }
     ClassConfiguration? ClassConfig { get; }
     GoapAgent? GoapAgent { get; }
     RouteInfo? RouteInfo { get; }
@@ -32,7 +32,7 @@ public interface IBotController
 
     void LoadClassProfile(string classFilename);
 
-    void LoadPathProfile(string pathFilename);
+    void LoadPathProfile(Dictionary<int, string> pathFilenames);
 
     void OverrideClassConfig(ClassConfiguration classConfig);
 }

--- a/Core/Path/IRouteProvider.cs
+++ b/Core/Path/IRouteProvider.cs
@@ -5,6 +5,8 @@ namespace Core;
 
 public interface IRouteProvider
 {
+    Vector3[] MapRoute();
+
     Vector3[] PathingRoute();
 
     DateTime LastActive { get; }

--- a/Core/Path/IRouteReceiver.cs
+++ b/Core/Path/IRouteReceiver.cs
@@ -1,8 +1,9 @@
-﻿using System.Numerics;
+﻿using System;
+using System.Numerics;
 
 namespace Core;
 
 public interface IEditedRouteReceiver
 {
-    void ReceivePath(Vector3[] mapRoute);
+    void ReceivePath(Vector3[] oldMap, Vector3[] newMap);
 }

--- a/Core/Requirement/RequirementFactory.cs
+++ b/Core/Requirement/RequirementFactory.cs
@@ -235,6 +235,10 @@ public sealed partial class RequirementFactory
             // Session Stat
             { "Deaths", sessionStat._Deaths },
             { "Kills", sessionStat._Kills },
+            { "Seconds", sessionStat._Seconds },
+
+            { "Level", playerReader.Level._Value },
+            { "ExpPerc", playerReader._PlayerXpPercent }
         };
 
         InitUserDefinedIntVariables(classConfig.IntVariables,
@@ -331,6 +335,15 @@ public sealed partial class RequirementFactory
         list.Clear();
         Process(list, item.Name, item.Interrupts);
         item.InterruptsRuntime = list.ToArray();
+    }
+
+    public void Init(PathSettings item)
+    {
+        List<Requirement> list = [];
+
+        Process(list, item.FileName, item.Requirements);
+
+        item.RequirementsRuntime = list.ToArray();
     }
 
     private void Process(List<Requirement> output, string name,

--- a/Core/Session/SessionStats/SessionStat.cs
+++ b/Core/Session/SessionStats/SessionStat.cs
@@ -1,13 +1,21 @@
-﻿namespace Core;
+﻿using System;
+
+namespace Core;
 
 public sealed class SessionStat
 {
     public int Deaths { get; set; }
     public int Kills { get; set; }
 
+    public DateTime StartTime { get; set; }
+
     public int _Deaths() => Deaths;
 
     public int _Kills() => Kills;
+
+    public int Seconds => (int)(DateTime.UtcNow - StartTime).TotalSeconds;
+
+    public int _Seconds() => Seconds;
 
     public void Reset()
     {
@@ -15,4 +23,8 @@ public sealed class SessionStat
         Kills = 0;
     }
 
+    public void Start()
+    {
+        StartTime = DateTime.UtcNow;
+    }
 }

--- a/Frontend/Pages/ClassConfigurationComponent.razor
+++ b/Frontend/Pages/ClassConfigurationComponent.razor
@@ -16,26 +16,32 @@
                         @switch (Type.GetTypeCode(property.PropertyType))
                         {
                             case TypeCode.String:
+                                if (hidden.Contains(property.Name))
+                                    break;
                                 <td>@(property.Name)</td>
                                 <td>
                                     <input value="@property.GetValue(classConfig)" class="form-control" disabled="@(!editables.Contains(property.Name))"
-                                    @onchange="c => { property.SetValue(classConfig, c.Value); Update(); }" />
+                                           @onchange="c => { property.SetValue(classConfig, c.Value); Update(); }" />
                                 </td>
                                 break;
 
                             case TypeCode.Int32:
+                                if (hidden.Contains(property.Name))
+                                    break;
                                 <td>@(property.Name)</td>
                                 <td>
                                     <input value="@property.GetValue(classConfig)" class="form-control" disabled="@(!editables.Contains(property.Name))"
-                                    @onchange="c => { if(int.TryParse(c.Value?.ToString(), out int n)) { property.SetValue(classConfig, n); Update(); } }" />
+                                           @onchange="c => { if(int.TryParse(c.Value?.ToString(), out int n)) { property.SetValue(classConfig, n); Update(); } }" />
                                 </td>
                                 break;
                             case TypeCode.Boolean:
+                                if (hidden.Contains(property.Name))
+                                    break;
                                 <td>@(property.Name)</td>
                                 <td>
                                     <input type="checkbox" class="form-control" disabled="@(!editables.Contains(property.Name))"
                                            checked="@(CBool(property.GetValue(classConfig)))"
-                                    @onchange="c => { property.SetValue(classConfig, c.Value); Update(); }" />
+                                           @onchange="c => { property.SetValue(classConfig, c.Value); Update(); }" />
                                 </td>
                                 break;
                             default:
@@ -43,6 +49,59 @@
                                 break;
                         }
                     </tr>
+
+                    @if (property.PropertyType == typeof(PathSettings[]))
+                    {
+                        var value = property.GetValue(classConfig, null);
+                        var array = value as PathSettings[];
+                        if (array == null) continue;
+
+
+                        <tr style="background-color: black">
+                            <td></td>
+                            <td></td>
+                        </tr>
+
+                        @foreach (var item in array)
+                        {
+                            @foreach (var innerProp in item.GetType().GetProperties())
+                            {
+                                <tr>
+                                    @switch (Type.GetTypeCode(innerProp.PropertyType))
+                                    {
+                                        case TypeCode.String:
+                                            if (innerProp.Name == nameof(PathSettings.FileName))
+                                                break;
+                                            <td>@(innerProp.Name)</td>
+                                            <td>
+                                                <input value="@innerProp.GetValue(item)" class="form-control"
+                                                       disabled="@(!editables.Contains(innerProp.Name))"
+                                                       @onchange="c => { innerProp.SetValue(item, c.Value); Update(); }" />
+                                            </td>
+                                            break;
+                                        case TypeCode.Boolean:
+                                            <td>@(innerProp.Name)</td>
+                                            <td>
+                                                <input type="checkbox" class="form-control"
+                                                       disabled="@(!editables.Contains(innerProp.Name))"
+                                                       checked="@(CBool(innerProp.GetValue(item)))"
+                                                       @onchange="c => { innerProp.SetValue(item, c.Value); Update(); }" />
+                                            </td>
+                                            break;
+
+                                        default:
+                                            break;
+                                    }
+                                </tr>
+                            }
+
+                            <tr style="background-color: black">
+                                <td></td>
+                                <td></td>
+                            </tr>
+                        }
+                    }
+
                 }
             </table>
         </div>
@@ -69,10 +128,20 @@
         nameof(ClassConfiguration.KeyboardOnly),
         nameof(ClassConfiguration.AllowPvP),
         nameof(ClassConfiguration.AutoPetAttack),
+        //nameof(ClassConfiguration.PathThereAndBack),
+        //nameof(ClassConfiguration.PathReduceSteps),
+        nameof(ClassConfiguration.CheckTargetGivesExp),
+
+        nameof(PathSettings.PathThereAndBack),
+        nameof(PathSettings.PathReduceSteps),
+    };
+
+    private HashSet<string> hidden = [
         nameof(ClassConfiguration.PathThereAndBack),
         nameof(ClassConfiguration.PathReduceSteps),
-        nameof(ClassConfiguration.CheckTargetGivesExp),
-    };
+        nameof(ClassConfiguration.PathFilename),
+        nameof(ClassConfiguration.OverridePathFilename),
+    ];
 
     protected override void OnInitialized()
     {

--- a/Frontend/Pages/Index.razor
+++ b/Frontend/Pages/Index.razor
@@ -51,7 +51,30 @@
 
                 <BotHeader ShowActiveGoal="false" Hide="@(botController.IsBotActive)" />
                 <ProfileSelectorComponent Hide="@(botController.IsBotActive)" />
-                <PathSelectorComponent Hide="@(botController.IsBotActive)" />
+
+                @if (botController.ClassConfig == null)
+                {
+                    <PathSelectorComponent Hide="@(botController.IsBotActive)" />
+                }
+                else
+                {
+                    <MatAccordion>
+                        <MatExpansionPanel @bind-Expanded="@panelOpenState">
+                            <MatExpansionPanelSummary>
+                                <MatExpansionPanelHeader>Override Paths</MatExpansionPanelHeader>
+                            </MatExpansionPanelSummary>
+                            <MatExpansionPanelDetails>
+                                @foreach (var pathSettings in botController.ClassConfig!.Paths)
+                                {
+                                    <PathSelectorComponent Hide="@(botController.IsBotActive)"
+                                                           Target="@(pathSettings)"
+                                                           TargetIndex="@(Array.IndexOf(botController.ClassConfig!.Paths, pathSettings))" />
+                                }
+                            </MatExpansionPanelDetails>
+                        </MatExpansionPanel>
+                    </MatAccordion>
+                }
+
                 <GoalsComponent />
             </div>
         }
@@ -72,9 +95,12 @@
 @code {
     private bool updateAvailable;
 
+    bool panelOpenState;
+
     protected override void OnInitialized()
     {
         botController.StatusChanged += OnStatusChanged;
+        botController.ProfileLoaded += OnStatusChanged;
 
         updateAvailable = addonConfigurator.UpdateAvailable();
     }

--- a/Frontend/Pages/PathSelectorComponent.razor
+++ b/Frontend/Pages/PathSelectorComponent.razor
@@ -46,7 +46,7 @@
     <div class="card-header d-flex justify-content-between align-items-center">
         <label>Path Profile</label>
 
-        <MatAutocompleteList Items="@Files" TItem="string" Label="Path" ValueChanged="OnSelectedPathChanged"
+        <MatAutocompleteList @ref="matAutocompleteList" Items="@Files" TItem="string" Label="Path" ValueChanged="OnSelectedPathChanged"
                              ShowClearButton="true" NumberOfElementsInPopup="@VisibleNum" OnTextChanged="OnTextChanged">
             <ItemTemplate>
                 <div class="mat-autocomplete-list-popup-element" style="display: flex; width: 100%; font-size: 0.75vw">
@@ -74,9 +74,16 @@
 </div>
 
 @code {
+    private MatAutocompleteList<string> matAutocompleteList = null!;
 
     [Parameter]
     public bool Hide { get; set; } = false;
+
+    [Parameter]
+    public PathSettings? Target { get; set; }
+
+    [Parameter]
+    public int TargetIndex { get; set; } = 0;
 
     private IEnumerable<string> Files { get; set; } = null!;
 
@@ -114,6 +121,16 @@
         botController.ProfileLoaded += ValidateLoadButton;
     }
 
+    protected override void OnAfterRender(bool firstRender)
+    {
+        base.OnAfterRender(firstRender);
+
+        if (firstRender)
+        {
+            matAutocompleteList.ItemSelected(Selected);
+        }
+    }
+
     public void Dispose()
     {
         watcher.Dispose();
@@ -133,6 +150,8 @@
             Selected = string.Empty;
         }
 
+        botController.SelectedPathFilename[TargetIndex] = Selected;
+
         ValidateLoadButton();
         base.InvokeAsync(StateHasChanged);
     }
@@ -151,7 +170,7 @@
 
     private void OnClickButtonLoad()
     {
-        botController.LoadPathProfile(Selected);
+        botController.LoadPathProfile(botController.SelectedPathFilename);
     }
 
     private void ValidateLoadButton()
@@ -162,6 +181,10 @@
     private void GetData()
     {
         Files = botController.PathFiles();
-        Selected = botController.SelectedPathFilename ?? string.Empty;
+
+        if (botController.SelectedPathFilename.TryGetValue(TargetIndex, out string? selected))
+        {
+            Selected = selected ?? string.Empty;
+        }
     }
 }

--- a/Frontend/Pages/RawPlayerReaderComponent.razor
+++ b/Frontend/Pages/RawPlayerReaderComponent.razor
@@ -8,6 +8,7 @@
 @inject BuffStatus<IFocus> focusbuffs
 @inject CombatLog combatLog
 @inject ActionBarCostReader costReader
+@inject SessionStat sessionStat
 
 @implements IDisposable
 
@@ -29,7 +30,6 @@
             <TableOfComponent Obj="@PlayerReader" />
         </div>
     </div>
-
     <div class="card">
         <div class="card-header">
             AddonBits
@@ -81,6 +81,15 @@
         </div>
         <div class="card-body" style="padding-bottom: 0">
             <TableOfComponent Obj="@costReader" />
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-header">
+            Session Stats
+        </div>
+        <div class="card-body" style="padding-bottom: 0">
+            <TableOfComponent Obj="@sessionStat" />
         </div>
     </div>
 </div>

--- a/Frontend/Pages/RecordPath.razor
+++ b/Frontend/Pages/RecordPath.razor
@@ -247,7 +247,8 @@
 
     private List<Vector3> editPath { get; set; } = new();
 
-    private string loadedPathFile => botController.ClassConfig!.PathFilename.Replace(dataConfig.Path, "");
+    private string loadedPathFile =>
+        botController.ClassConfig!.Paths[0].PathFilename.Replace(dataConfig.Path, "");
 
     private string areaName = string.Empty;
 

--- a/Frontend/Pages/RouteComponent.razor
+++ b/Frontend/Pages/RouteComponent.razor
@@ -257,7 +257,10 @@
     {
         if (botController.ClassConfig == null) return;
 
-        routeSymbol = botController.ClassConfig.PathThereAndBack ?
+        PathSettings? first = botController.ClassConfig.Paths.First(x => x.CanRun());
+        if (first == null) return;
+
+        routeSymbol = first.PathThereAndBack ?
         new MarkupString("<span style=\"font-size: 125%;\">⥹</span>") :
         new MarkupString("<span style=\"font-size: 125%;\">⟳</span>");
     }

--- a/Frontend/_Imports.razor
+++ b/Frontend/_Imports.razor
@@ -1,4 +1,5 @@
 ﻿@using System.Net.Http
+@using MatBlazor
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.AspNetCore.Components.Forms

--- a/Frontend/wwwroot/css/site.css
+++ b/Frontend/wwwroot/css/site.css
@@ -111,9 +111,9 @@ app {
     border: none;
 }
 
-.sidebar-text-toggler:focus {
-    outline: none;
-}
+    .sidebar-text-toggler:focus {
+        outline: none;
+    }
 
 .valid.modified:not([type=checkbox]) {
     outline: 1px solid #26b050;
@@ -233,10 +233,24 @@ app {
 
 .mat-autocomplete-list-popup {
     background-color: #191d21;
+    z-index: 5000 !important;
+    position: relative;
 }
 
 .mat-autocomplete-list-popup-element {
     color: #d3d3d3;
+}
+
+.mat-expansion-panel {
+    background-color: darkslateblue !important;
+}
+
+.mat-expansion-panel__summary {
+    background-color: darkslateblue !important;
+}
+
+.mat-expansion-panel__content {
+    background-color: #191d21 !important;
 }
 
 .bg-majestic {

--- a/Json/class/Hunter_1.json
+++ b/Json/class/Hunter_1.json
@@ -1,7 +1,30 @@
 {
   "ClassName": "Hunter",
   //"Mode": "AttendedGrind",
-  "PathFilename": "1_Gnome.json",
+  //"PathFilename": "1_Gnome.json",
+  "Paths": [
+    {
+      "PathFilename": "1-5_Gnome.json",
+      "PathThereAndBack": false,
+      "PathReduceSteps": false,
+      "Requirements": [
+        "Level < 4"
+      ]
+    },
+    {
+      "PathFilename": "_pack\\1-20\\Dwarf.Gnome\\1-4_Dun Morogh.json",
+      "PathThereAndBack": true,
+      "PathReduceSteps": false,
+      "Requirements": [
+        "Level < 5"
+      ]
+    },
+    {
+      "PathFilename": "_pack\\1-20\\Dwarf.Gnome\\4-6_Dun Morogh.json",
+      "PathThereAndBack": false,
+      "PathReduceSteps": false
+    }
+  ],
   "Pull": {
     "Sequence": [
       {
@@ -66,6 +89,7 @@
       },
       {
         "Name": "Approach",
+        "Log": false,
         "Requirements": [
           "InMeleeRange"
         ]


### PR DESCRIPTION
during runtime based on the given `Requirements` list. 

Many requested this feature, #432, #459, #577

Most of the path related settings move to a new class called `PathSettings`. 

I kept the old path related settings in `ClassConfiguration` for backward compatibility. However from those old values a new `PathSettings` is created to ensure both ways are supported. 

At this stage there are not many `Requirement` to choose from. So added the followings
- Seconds
- Level
- ExpPerc

For more details please read the Readme file, starting from the `Path` section.

Note: The Path Editor only works with the first `ClassConfiguration.Paths` for now.

Media:

Frontend Changes:

**Path Selector** Changes
For each Path there's a corresponding Path Selector component to override the base path. In this instance there are 3 paths.
![image](https://github.com/Xian55/WowClassicGrindBot/assets/367101/b6401043-a614-454d-8183-922d34257f0f)

**GoapGoalView** Changes
For each path there's a corresponding `FollowRouteGoal` where the Requirements are visible
![image](https://github.com/Xian55/WowClassicGrindBot/assets/367101/5b9217fb-18fc-4ddc-9cfc-c3c1174893b8)

**Class Configuration** Tab Changes
For each path there's a corresponding `PathSettings`, mostly to change `PathThereAndBack` and `PathReduceSteps`
![image](https://github.com/Xian55/WowClassicGrindBot/assets/367101/d1102d70-6607-46d0-8a88-1022a2b8acb0)

**Raw Values** Tab Changes
Session Stats added.
![image](https://github.com/Xian55/WowClassicGrindBot/assets/367101/ac40818f-a56b-469f-925c-2776ccd19630)

**Route** Component Changes
It shows the last actively used Path, also updates the symbol which is driven by the `PathSettings.PathThereAndBack`
![image](https://github.com/Xian55/WowClassicGrindBot/assets/367101/b98e3160-2113-478f-9df8-dca18c9a3a4c)

Bug Introduced:
* https://github.com/Xian55/WowClassicGrindBot/commit/fd68885e951b7d2e1c9075aee9ef53ad9f737a7d
