### PR TITLE
Core: RemoteV3 new branch of AmeisenNavigation `multi-version-guess-z-coord`

### DIFF
--- a/Core/PPather/IPathVizualizer.cs
+++ b/Core/PPather/IPathVizualizer.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+using PPather.Data;
+
+namespace Core;
+
+public interface IPathVizualizer : IDisposable
+{
+    HttpClient Client { get; }
+    JsonSerializerOptions Options { get; }
+
+    ValueTask DrawLines(List<LineArgs> lineArgs);
+    ValueTask DrawSphere(SphereArgs args);
+}

--- a/Core/PPather/NoPathVisualizer.cs
+++ b/Core/PPather/NoPathVisualizer.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+using PPather.Data;
+
+namespace Core;
+
+internal sealed class NoPathVisualizer : IPathVizualizer
+{
+    public HttpClient Client => throw new System.NotImplementedException();
+
+    public JsonSerializerOptions Options => throw new System.NotImplementedException();
+
+    public void Dispose() { }
+
+    public ValueTask DrawLines(List<LineArgs> lineArgs) => ValueTask.CompletedTask;
+
+    public ValueTask DrawSphere(SphereArgs args) => ValueTask.CompletedTask;
+}

--- a/Core/PPather/RemotePathingAPI.cs
+++ b/Core/PPather/RemotePathingAPI.cs
@@ -10,11 +10,10 @@ using System.Text;
 using System.Numerics;
 using SharedLib.Converters;
 using System.Net.Sockets;
-using System.Diagnostics;
 
 namespace Core;
 
-public sealed class RemotePathingAPI : IPPather, IDisposable
+public sealed class RemotePathingAPI : IPPather, IPathVizualizer, IDisposable
 {
     private readonly ILogger<RemotePathingAPI> logger;
 
@@ -22,8 +21,10 @@ public sealed class RemotePathingAPI : IPPather, IDisposable
     private readonly int port = 5001;
 
     private readonly JsonSerializerOptions options;
-
     private readonly HttpClient client;
+
+    public HttpClient Client => client;
+    public JsonSerializerOptions Options => options;
 
     public RemotePathingAPI(ILogger<RemotePathingAPI> logger,
         string host, int port)

--- a/Core/Path/RouteInfo.cs
+++ b/Core/Path/RouteInfo.cs
@@ -308,20 +308,20 @@ public sealed class RouteInfo : IDisposable
 
     public Vector3 NextPoint()
     {
-        var route = pathedRoutes
+        IRouteProvider? mostRecent = pathedRoutes
             .OrderByDescending(MostRecent)
             .FirstOrDefault();
 
-        if (route == null || !route.HasNext())
+        if (mostRecent == null || !mostRecent.HasNext())
             return Vector3.Zero;
 
         // dynamically update the path based on source
-        if (route.MapRoute() != Array.Empty<Vector3>())
+        if (mostRecent.MapRoute() != Array.Empty<Vector3>())
         {
-            RouteSrc = Route = route.MapRoute();
+            RouteSrc = Route = mostRecent.MapRoute();
         }
 
-        return route.NextMapPoint();
+        return mostRecent.NextMapPoint();
     }
 
     public string RenderNextPoint()

--- a/README.md
+++ b/README.md
@@ -21,11 +21,17 @@ Further detail about the architecture can be found in [Blog post](http://www.cod
 # Pathfinders
 
 * World map - Outdoor there are multiple solutions - *by default the app attempts to discover the available services in the following order*:
-    * **V3 Remote**: Out of process [AmeisenNavigation](https://github.com/Xian55/AmeisenNavigation/tree/feature/guess-z-coord-after-rewrite)
+    * **V3 Remote**: Out of process [AmeisenNavigation](https://github.com/Xian55/AmeisenNavigation/tree/feature/multi-version-guess-z-coord)
     * **V1 Remote**: Out of process [PathingAPI](https://github.com/Xian55/WowClassicGrindBot/tree/dev/PathingAPI) more info [here](#v1-remote-pathing---pathingapi)
     * **V1 Local**: In process [PPather](https://github.com/Xian55/WowClassicGrindBot/tree/dev/PPather)
 * World map - Indoors pathfinder only works properly if `PathFilename` is exists.
 * Dungeons / instances **not** supported!
+
+# Supporting Cataclysm Classic limitations
+
+With Cataclysm, the navigation will be limited. Only V3 Remote will be support for now.
+
+V1 Local and V1 Remote does not have the capability as of this moment to read the CASC files only works with MPQs.
 
 # Features
 
@@ -134,19 +140,19 @@ Technical details about **V1:**
 
 - Download the navmesh files.
 
-**Vanilla + TBC:**
 [**Vanilla + TBC**](https://mega.nz/file/7HgkHIyA#c_gzUeTadecWY0JDY3KT39ktfPGLs2vzt_90bMvhszk)
 
-**Vanilla + TBC + Wrath:**
 [**Vanilla + TBC + Wrath**](https://mega.nz/file/zWQ2XIKI#9EKWOPyyTMfY1LACkcP_wioZ0poVIuaGh2xcRh4V9dw)
 
+[**Vanilla + TBC + Wrath + Cataclysm** - work in progress](https://mega.nz/file/7Og32TDA#5HpxZ8Sh1XvDNCmWbI8H-cOFEJzDmh97Z6FGrO2p3X4)
+
 1. Extract and copy anywhere you want, like `C:\mmaps`
-2. Create a [build](https://github.com/Xian55/WowClassicGrindBot/issues/449) of [AmeisenNavigation](https://github.com/Xian55/AmeisenNavigation/tree/feature/guess-z-coord-after-rewrite)
-3. Navigate to the build location and find `config.cfg`
+2. Create a [build](https://github.com/Xian55/WowClassicGrindBot/issues/449) of [AmeisenNavigation](https://github.com/Xian55/AmeisenNavigation/tree/feature/multi-version-guess-z-coord)
+3. Navigate to the build location of `AmeisenNavigation.Server` and find `config.cfg`
 4. Edit the last line of the file to look like `sMmapsPath=C:\mmaps`
 
 Technical details about **V3:**
-- Uses another project called [AmeisenNavigation](https://github.com/Xian55/AmeisenNavigation/tree/feature/guess-z-coord-after-rewrite)
+- Uses another project called [AmeisenNavigation](https://github.com/Xian55/AmeisenNavigation/tree/feature/multi-version-guess-z-coord)
 - Under the hood uses [Recast and Detour](https://github.com/recastnavigation/recastnavigation)
 - Source code is written in **C++**
 - Uses `*.mmap` files as source


### PR DESCRIPTION
Changes: 
* Core: Added `PathVisualizer`. Currently `PPather` only works with Wotlk maps for viz. Not suitable for Cata maps.
* Core: While using `RemoteV3` and `RemoteV1` is available as well, the generated paths and player positions can be visualized.
* Core: RemoteV3 uses new build of `AmeisenNavigation` which is more performant during startup and supports multiple mmaps versions.

---

Its worth to point out that [AmeisenNavigation](https://github.com/Xian55/AmeisenNavigation/tree/feature/multi-version-guess-z-coord) uses a new branch called `multi-version-guess-z-coord`. This version of AmeisenNavigation can be built using Visual Studio 2022 but still requires the `C++` component!

**Install dependencies for `AmeisenNavigation.Server`**:
1. First you have to download **Visual Studio 2022**
1. Make sure to check the `Desktop development with C++` box
1. ![image](https://user-images.githubusercontent.com/367101/180349825-31d66a8d-cd8e-4700-b274-040a7caf7f2d.png)


**Steps to make make RemoteV3 / `AmeisenNavigation.Server` working**:
1. Extract the `mmaps` and copy anywhere you want, like `C:\mmaps`
1. Get the [multi-version-guess-z-coord branch](https://github.com/Xian55/AmeisenNavigation/tree/feature/multi-version-guess-z-coord)
1. Open the solution file.
1. Be sure to set Target platform from `Any CPU` to either `x86` or `x64`
1. Unload **AmeisenNavigation.Exporter** project(right click -> unload project)
1. ![image](https://github.com/Xian55/WowClassicGrindBot/assets/367101/df443648-bb57-4200-ac99-ee26e723f120)
1. Select **AmeisenNavigation.Server** Press rebuild.
1. Navigate to the `AmeisenNavigation.Server` build location and find `config.cfg`
1. Edit the last line of the file to look like `sMmapsPath=C:\mmaps`

If you have problem getting the AnTCP.Client nuget package, you have to install it manually from [here](https://github.com/Jnnshschl/AnTCP/releases).
