### PR TITLE
Addon: [1.7.56] - Fix: Addon: Cataclysm Issue when the unable to collect the spellbook contents.

### DIFF
--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -54,6 +54,7 @@ local GetSpellBookItemName = GetSpellBookItemName
 local GetNumTalentTabs = GetNumTalentTabs
 local GetNumTalents = GetNumTalents
 local GetTalentInfo = GetTalentInfo
+local GetNumSpellTabs = GetNumSpellTabs
 
 local GetPlayerFacing = GetPlayerFacing
 local UnitLevel = UnitLevel
@@ -390,18 +391,41 @@ end
 
 function DataToColor:InitSpellBookQueue()
     local num, type = 1, 1
-    while true do
-        local name, _, id = GetSpellBookItemName(num, type)
-        if not name then
-            break
+    if GetNumSpellTabs == nil then
+        while true do
+            local name, _, id = GetSpellBookItemName(num, type)
+            if not name then
+                break
+            end
+
+            if id ~= nil then
+                local texture = GetSpellBookItemTexture(num, type)
+                DataToColor.S.playerSpellBookName[texture] = name
+                DataToColor.S.playerSpellBookId[id] = true
+
+                DataToColor.spellBookQueue:push(id)
+                num = num + 1
+            end
         end
+    else
+        for i = 1, GetNumSpellTabs() do
+            local offset, numSlots = select(3, GetSpellTabInfo(i))
+            for j = offset+1, offset+numSlots do
+                local name, _, id = GetSpellBookItemName(num, type)
+                if not name then
+                    break
+                end
 
-        local texture = GetSpellBookItemTexture(num, type)
-        DataToColor.S.playerSpellBookName[texture] = name
-        DataToColor.S.playerSpellBookId[id] = true
+                if id ~= nil then
+                    local texture = GetSpellBookItemTexture(num, type)
+                    DataToColor.S.playerSpellBookName[texture] = name
+                    DataToColor.S.playerSpellBookId[id] = true
 
-        DataToColor.spellBookQueue:push(id)
-        num = num + 1
+                    DataToColor.spellBookQueue:push(id)
+                    num = num + 1
+                end
+            end
+        end
     end
 end
 

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -3,7 +3,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors
-## Version: 1.7.55
+## Version: 1.7.56
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:


### PR DESCRIPTION
Hunter's Call Pet ability does not have spell ID in Cataclysm. 

It seems like this item in the spell book act as a folder. The issue might be occurring for Shaman Totems as well.