### PR TITLE
Addon: [1.7.58] - Fix: #589 Spell ranges prefer to use Spell Icon Id over Spell Id

### DIFF
--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -227,6 +227,7 @@ function DataToColor:OnInitialize()
     DataToColor:CreateFrames()
     DataToColor:RegisterSlashCommands()
 
+    DataToColor:PopulateSpellBookInfo()
     DataToColor:InitStorage()
 
     UIErrorsFrame:UnregisterEvent("UI_ERROR_MESSAGE")
@@ -252,6 +253,7 @@ end
 function DataToColor:Reset()
     DataToColor.S.playerSpellBookName = {}
     DataToColor.S.playerSpellBookId = {}
+    DataToColor.S.playerSpellBookIconId = {}
 
     DataToColor.playerGUID = UnitGUID(DataToColor.C.unitPlayer)
     DataToColor.petGUID = UnitGUID(DataToColor.C.unitPet)
@@ -307,6 +309,7 @@ function DataToColor:FushState()
 
     DataToColor:Reset()
 
+    DataToColor:PopulateSpellBookInfo()
     DataToColor:InitUpdateQueues()
 
     DataToColor:Print('Flush State')
@@ -389,7 +392,7 @@ function DataToColor:InitActionBarCostQueue()
     end
 end
 
-function DataToColor:InitSpellBookQueue()
+function DataToColor:PopulateSpellBookInfo()
     local num, type = 1, 1
     if GetNumSpellTabs == nil then
         while true do
@@ -400,10 +403,10 @@ function DataToColor:InitSpellBookQueue()
 
             if id ~= nil then
                 local texture = GetSpellBookItemTexture(num, type)
-                DataToColor.S.playerSpellBookName[texture] = name
                 DataToColor.S.playerSpellBookId[id] = true
+                DataToColor.S.playerSpellBookName[texture] = name
+                DataToColor.S.playerSpellBookIconToId[texture] = id
 
-                DataToColor.spellBookQueue:push(id)
                 num = num + 1
             end
         end
@@ -411,21 +414,27 @@ function DataToColor:InitSpellBookQueue()
         for i = 1, GetNumSpellTabs() do
             local offset, numSlots = select(3, GetSpellTabInfo(i))
             for j = offset+1, offset+numSlots do
-                local name, _, id = GetSpellBookItemName(num, type)
+                local name, _, id = GetSpellBookItemName(j, type)
                 if not name then
                     break
                 end
 
                 if id ~= nil then
-                    local texture = GetSpellBookItemTexture(num, type)
-                    DataToColor.S.playerSpellBookName[texture] = name
+                    local texture = GetSpellBookItemTexture(j, type)
                     DataToColor.S.playerSpellBookId[id] = true
+                    DataToColor.S.playerSpellBookName[texture] = name
+                    DataToColor.S.playerSpellBookIconToId[texture] = id
 
-                    DataToColor.spellBookQueue:push(id)
                     num = num + 1
                 end
             end
         end
+    end
+end
+
+function DataToColor:InitSpellBookQueue()
+    for id, _ in pairs(DataToColor.S.playerSpellBookId) do
+        DataToColor.spellBookQueue:push(id)
     end
 end
 

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -3,7 +3,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors
-## Version: 1.7.57
+## Version: 1.7.58
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/Query.lua
+++ b/Addons/DataToColor/Query.lua
@@ -424,7 +424,8 @@ function DataToColor:areSpellsInRange()
     local inRange = 0
     local targetCount = #DataToColor.S.spellInRangeTarget
     for i = 1, targetCount do
-        local spellId = DataToColor.S.spellInRangeTarget[i]
+        local spellIconId = DataToColor.S.spellInRangeTarget[i]
+        local spellId = DataToColor.S.playerSpellBookIconToId[spellIconId] or spellIconId -- fallback to spellId
         local spellName = GetSpellInfo(spellId)
         if spellName ~= nil then
             if IsSpellInRange(spellName, DataToColor.C.unitTarget) == 1 then
@@ -437,7 +438,9 @@ function DataToColor:areSpellsInRange()
 
     for i = 1, #DataToColor.S.spellInRangeUnit do
         local data = DataToColor.S.spellInRangeUnit[i]
-        if IsSpellInRange(GetSpellInfo(data[1]), data[2]) == 1 then
+        local spellId = DataToColor.S.playerSpellBookIconToId[data[1]]
+        local unit = data[2]
+        if IsSpellInRange(GetSpellInfo(spellId), unit) == 1 then
             inRange = inRange + (2 ^ (targetCount + i - 1))
         end
     end

--- a/Addons/DataToColor/Storage.lua
+++ b/Addons/DataToColor/Storage.lua
@@ -12,6 +12,7 @@ DataToColor.S.playerAuraMap = {}
 
 DataToColor.S.playerSpellBookName = {}
 DataToColor.S.playerSpellBookId = {}
+DataToColor.S.playerSpellBookIconToId = {}
 
 function DataToColor:InitStorage()
     CreateSpellInRangeTarget()
@@ -24,92 +25,95 @@ function DataToColor:InitStorage()
     CreatePlayerAuraMap()
 end
 
+-- Using spell IconId over SpellId
+-- Since Cataclysm Spell Ranks have been removed
+-- In special cases uses SpellId such as Shoot/Wand or Auto Shot
 function CreateSpellInRangeTarget()
     if DataToColor.C.CHARACTER_CLASS == "ROGUE" then
         DataToColor.S.spellInRangeTarget = {
-            1752, -- "Sinister Strike"
-            2764, -- "Throw"
-            3018, -- "Shoot" for classic -> 7918, -- "Shoot Gun"
+            136189, -- 1752, -- "Sinister Strike"
+            132324, -- 2764, -- "Throw"
+            132222, -- 3018, -- "Shoot" for classic -> 7918, -- "Shoot Gun"
         }
     elseif DataToColor.C.CHARACTER_CLASS == "DRUID" then
         DataToColor.S.spellInRangeTarget = {
-            5176, -- "Wrath"
-            5211, -- "Bash"
-            1079, -- "Rip"
-            6807, -- "Maul"
-            5185, -- "Healing Touch"
-            1126, -- "Mark of the Wild"
-            8936, -- "Regrowth"
-            774, -- "Rejuvenation",
-            467, -- "Thorns"
+            136006, -- 5176, -- "Wrath"
+            132114, -- 5211, -- "Bash"
+            132152, -- 1079, -- "Rip"
+            132136, -- 6807, -- "Maul"
+            136041, -- 5185, -- "Healing Touch"
+            136078, -- 1126, -- "Mark of the Wild"
+            136085, -- 8936, -- "Regrowth"
+            136081, -- 774, -- "Rejuvenation",
+            136104, -- 467, -- "Thorns"
         }
     elseif DataToColor.C.CHARACTER_CLASS == "WARRIOR" then
         DataToColor.S.spellInRangeTarget = {
-            100, -- "Charge"
-            772, -- "Rend"
-            3018, -- "Shoot" for classic -> 7918, -- "Shoot Gun"
-            2764, -- "Throw"
+            132337, -- 100, -- "Charge"
+            132155, -- 772, -- "Rend"
+            132222, -- 3018, -- "Shoot" for classic -> 7918, -- "Shoot Gun"
+            132324, -- 2764, -- "Throw"
         }
     elseif DataToColor.C.CHARACTER_CLASS == "PRIEST" then
         DataToColor.S.spellInRangeTarget = {
-            589, -- "Shadow Word: Pain"
-            5019, -- "Shoot"
-            15407, -- "Mind Flay"
-            8092, -- "Mind Blast"
-            585, -- "Smite"
-            14752, -- "Divine Spirit"
-            1243, -- "Power World: Fortitude"
-            17, -- Power Word: Shield
-            2050, -- "Lesser Heal"
-            33076, -- "Prayer of Mending"
-            139, -- "Renew"
-            976, -- "Shadow Protection"
+            136207, -- 589, -- "Shadow Word: Pain"
+            5019, -- "Shoot" -- special case changes with equipped weapon
+            136208, -- 15407, -- "Mind Flay"
+            136224, -- 8092, -- "Mind Blast"
+            135924, -- 585, -- "Smite"
+            135898, -- 14752, -- "Divine Spirit"
+            135987, -- 1243, -- "Power World: Fortitude"
+            135940, -- 17, -- Power Word: Shield
+            135929, -- 2050, -- "Lesser Heal"
+            135944, -- 33076, -- "Prayer of Mending"
+            135953, -- 139, -- "Renew"
+            136121, -- 976, -- "Shadow Protection"
         }
     elseif DataToColor.C.CHARACTER_CLASS == "PALADIN" then
         DataToColor.S.spellInRangeTarget = {
-            20271, -- "Judgement" / "Judgement of Light"
-            879, -- "Exorcism"
-            19750, -- "Flash Heal"
-            635, -- "Holy Light"
-            19740, -- "Blessing of Might"
-            25782, -- "Greater Blessing of Might"
+            135959, -- 20271, -- "Judgement" / "Judgement of Light"
+            135903, -- 879, -- "Exorcism"
+            135907, -- 19750, -- "Flash Heal"
+            135920, -- 635, -- "Holy Light"
+            135906, -- 19740, -- "Blessing of Might"
+            135908, -- 25782, -- "Greater Blessing of Might"
         }
     elseif DataToColor.C.CHARACTER_CLASS == "MAGE" then
         DataToColor.S.spellInRangeTarget = {
-            133, -- "Fireball"
-            5019, -- "Shoot"
-            11366, -- "Pyroblast"
-            116, -- "Frostbolt"
-            2136, -- "Fire Blast"
+            135812, -- 133, -- "Fireball"
+            5019, -- "Shoot" -- special case changes with equipped weapon
+            135808, -- 11366, -- "Pyroblast"
+            135846, -- 116, -- "Frostbolt"
+            135807, -- 2136, -- "Fire Blast"
         }
     elseif DataToColor.C.CHARACTER_CLASS == "HUNTER" then
         DataToColor.S.spellInRangeTarget = {
-            2973, -- "Raptor Strike"
-            75, -- "Auto Shot"
-            1978, -- "Serpent Sting"
+            132223, -- 2973, -- "Raptor Strike"
+            75, -- "Auto Shot" special case icon updates based on weapon so use SpellId
+            132204, -- 1978, -- "Serpent Sting"
         }
     elseif DataToColor.C.CHARACTER_CLASS == "WARLOCK" then
         DataToColor.S.spellInRangeTarget = {
-            686, -- "Shadow Bolt",
-            5019, -- "Shoot"
+            136197, -- 686, -- "Shadow Bolt",
+            5019, -- "Shoot" -- special case changes with equipped weapon
         }
     elseif DataToColor.C.CHARACTER_CLASS == "SHAMAN" then
         DataToColor.S.spellInRangeTarget = {
-            403, -- "Lightning Bolt",
-            8042, -- "Earth Shock"
-            331, -- "Healing Wave"
-            8004, -- "Lesser Healing Wave"
-            131, -- "Water Breathing"
-            1064, -- "Chain Heal"
-            974, -- "Earth Shield"
+            136048, -- 403, -- "Lightning Bolt",
+            136026, -- 8042, -- "Earth Shock"
+            136052, -- 331, -- "Healing Wave"
+            136043, -- 8004, -- "Lesser Healing Wave"
+            136148, -- 131, -- "Water Breathing"
+            136042, -- 1064, -- "Chain Heal"
+            136089, -- 974, -- "Earth Shield"
         }
     elseif DataToColor.C.CHARACTER_CLASS == "DEATHKNIGHT" then
         DataToColor.S.spellInRangeTarget = {
-            49903, -- "Icy Touch"
-            49893, -- "Death Coil"
-            49576, -- "Death Grip"
-            56222, -- "Dark Command",
-            46584 -- "Raise Dead"
+            237526, -- 49903, -- "Icy Touch"
+            136145, -- 49893, -- "Death Coil"
+            237532, -- 49576, -- "Death Grip"
+            136088, -- 56222, -- "Dark Command",
+            136119, -- 46584 -- "Raise Dead"
         }
     end
 end
@@ -117,11 +121,11 @@ end
 function CreateSpellInRangeUnit()
     if DataToColor.C.CHARACTER_CLASS == "HUNTER" then
         DataToColor.S.spellInRangeUnit = {
-            { 6991, DataToColor.C.unitPet } -- "Feed pet"
+            { 132165, DataToColor.C.unitPet } -- 6991 "Feed pet"
         }
     elseif DataToColor.C.CHARACTER_CLASS == "WARLOCK" then
         DataToColor.S.spellInRangeUnit = {
-            { 755, DataToColor.C.unitPet }, -- "Health Funnel"
+            { 136168, DataToColor.C.unitPet }, -- 755 "Health Funnel"
         }
     end
 end

--- a/Core/AddonComponent/SpellInRange.cs
+++ b/Core/AddonComponent/SpellInRange.cs
@@ -132,7 +132,7 @@ public sealed class SpellInRange : IReader
     public bool WithinCombatRange(PlayerReader playerReader, UnitClass @class) => @class switch
     {
         UnitClass.Warrior => (playerReader.Level.Value >= 4 && Warrior_Rend) || playerReader.IsInMeleeRange(),
-        UnitClass.Rogue => Rogue_SinisterStrike,
+        UnitClass.Rogue => Rogue_SinisterStrike || playerReader.IsInMeleeRange(),
         UnitClass.Priest => Priest_Smite,
         UnitClass.Druid => Druid_Wrath || playerReader.IsInMeleeRange(),
         UnitClass.Paladin => (playerReader.Level.Value >= 4 && Paladin_Judgement) || playerReader.IsInMeleeRange(),
@@ -140,7 +140,7 @@ public sealed class SpellInRange : IReader
         UnitClass.Hunter => (playerReader.Level.Value >= 4 && Hunter_SerpentSting) || Hunter_AutoShoot || playerReader.IsInMeleeRange(),
         UnitClass.Warlock => Warlock_ShadowBolt,
         UnitClass.Shaman => Shaman_LightningBolt,
-        UnitClass.DeathKnight => DeathKnight_IcyTouch,
+        UnitClass.DeathKnight => DeathKnight_IcyTouch || playerReader.IsInMeleeRange(),
         _ => true
     };
 }

--- a/Game/WoWProcess/WowProcess.cs
+++ b/Game/WoWProcess/WowProcess.cs
@@ -10,13 +10,13 @@ namespace Game;
 
 public sealed class WowProcess
 {
-    private static readonly string[] defaultProcessNames = new string[] {
+    private static readonly string[] defaultProcessNames = [
         "Wow",
         "WowClassic",
         "WowClassicT",
         "Wow-64",
         "WowClassicB"
-    };
+    ];
 
     private readonly Thread thread;
     private readonly CancellationToken token;


### PR DESCRIPTION
Since Cataclysm spell ranks have been removed. There are few exceptions such as Shoot/Wand and Auto Shot.