### PR TITLE
Core: Wait: Switch to `ManualResetEventSlim` from `AutoResetEvent` for thread synchronization.

### DIFF
--- a/Core/Addon/AddonReader.cs
+++ b/Core/Addon/AddonReader.cs
@@ -11,7 +11,7 @@ namespace Core;
 public sealed class AddonReader : IAddonReader
 {
     private readonly IAddonDataProvider reader;
-    private readonly AutoResetEvent resetEvent;
+    private readonly ManualResetEventSlim resetEvent;
 
     private readonly PlayerReader playerReader;
     private readonly CreatureDB creatureDb;
@@ -33,7 +33,7 @@ public sealed class AddonReader : IAddonReader
     public double AvgUpdateLatency { private set; get; }
 
     public AddonReader(IAddonDataProvider reader,
-        PlayerReader playerReader, AutoResetEvent resetEvent,
+        PlayerReader playerReader, ManualResetEventSlim resetEvent,
         CreatureDB creatureDb,
         CombatLog combatLog,
         DataFrame[] frames,

--- a/Core/DependencyInjection.cs
+++ b/Core/DependencyInjection.cs
@@ -198,7 +198,7 @@ public static class DependencyInjection
 
     public static IServiceCollection AddCoreBase(this IServiceCollection s)
     {
-        s.AddSingleton<AutoResetEvent>(x => new(false));
+        s.AddSingleton<ManualResetEventSlim>(x => new(false));
         s.AddSingleton<Wait>();
 
         s.AddSingleton<StartupClientVersion>();

--- a/Core/GoalsComponent/Wait.cs
+++ b/Core/GoalsComponent/Wait.cs
@@ -7,10 +7,10 @@ namespace Core;
 
 public sealed class Wait
 {
-    private readonly AutoResetEvent globalTime;
+    private readonly ManualResetEventSlim globalTime;
     private readonly CancellationToken token;
 
-    public Wait(AutoResetEvent globalTime, CancellationTokenSource cts)
+    public Wait(ManualResetEventSlim globalTime, CancellationTokenSource cts)
     {
         this.globalTime = globalTime;
         this.token = cts.Token;
@@ -18,12 +18,20 @@ public sealed class Wait
 
     public void Update()
     {
-        globalTime.WaitOne();
+        globalTime.Wait();
+        globalTime.Reset();
     }
 
-    public bool Update(int timeout)
+    public bool Update(int timeoutMs)
     {
-        return globalTime.WaitOne(timeout);
+        bool result = globalTime.Wait(timeoutMs);
+        if (!result)
+        {
+            return result;
+        }
+
+        globalTime.Reset();
+        return result;
     }
 
     public void Fixed(int durationMs)


### PR DESCRIPTION
Note: May result spiky CPU usage on a few occasions due the SpinLock, however it promises much less system calls, shall see