### PR TITLE
CombatGoal sometimes missess to change target and bot becomes stuck.

### DIFF
--- a/Core/Goals/CombatGoal.cs
+++ b/Core/Goals/CombatGoal.cs
@@ -157,7 +157,7 @@ public sealed class CombatGoal : GoapGoal, IGoapEventListener
         {
             logger.LogInformation("Lost target!");
 
-            if (combatLog.DamageTakenCount() > 0 && !input.KeyboardOnly)
+            if (combatLog.DamageTakenCount() > 0)
             {
                 stopMoving.Stop();
                 FindNewTarget();


### PR DESCRIPTION
Fix it by removing !KeyboardOnly in the target change check.

