### PR TITLE
Fix: SharedLib: LineSegmentOperation: bounds check before copying into span

### DIFF
--- a/CoreTests/NpcNameFinder/Test_NpcNameFinder.cs
+++ b/CoreTests/NpcNameFinder/Test_NpcNameFinder.cs
@@ -35,7 +35,6 @@ internal sealed class Test_NpcNameFinder : IDisposable
 
     private readonly IWowScreen screen;
 
-    private readonly Stopwatch stopwatch;
     private readonly StringBuilder stringBuilder;
 
     private readonly NpcNameOverlay? npcNameOverlay;
@@ -49,7 +48,6 @@ internal sealed class Test_NpcNameFinder : IDisposable
         this.logger = logger;
         this.screen = screen;
 
-        stopwatch = new();
         stringBuilder = new();
 
         INpcResetEvent npcResetEvent = new NpcResetEvent();

--- a/SharedLib/NpcFinder/LineSegmentOperation.cs
+++ b/SharedLib/NpcFinder/LineSegmentOperation.cs
@@ -95,8 +95,10 @@ internal readonly struct LineSegmentOperation : IRowOperation<LineSegment>
         if (i == 0)
             return;
 
-        Interlocked.Add(ref counter.count, i);
+        int newCount = Interlocked.Add(ref counter.count, i);
+        if (counter.count + newCount > segments.Length)
+            return;
 
-        span[..i].CopyTo(segments.AsSpan(counter.count, i));
+        span[..i].CopyTo(segments.AsSpan(counter.count, newCount));
     }
 }

--- a/SharedLib/NpcFinder/NpcNameFinder.cs
+++ b/SharedLib/NpcFinder/NpcNameFinder.cs
@@ -338,7 +338,7 @@ public sealed partial class NpcNameFinder
         resetEvent.Reset();
 
         ReadOnlySpan<LineSegment> lineSegments =
-            PopulateLines(bitmapProvider, Area, colorMatcher, Area,
+            PopulateLines(colorMatcher, Area,
             ScaleWidth(MinHeight), ScaleWidth(WidthDiff));
 
         Npcs = DetermineNpcs(lineSegments);
@@ -520,11 +520,10 @@ public sealed partial class NpcNameFinder
 
     [SkipLocalsInit]
     private ReadOnlySpan<LineSegment> PopulateLines(
-        IScreenImageProvider provider, Rectangle rect,
         Func<byte, byte, byte, bool> colorMatcher,
         Rectangle area, float minLength, float lengthDiff)
     {
-        const int RESOLUTION = 32;
+        const int RESOLUTION = 16;
         int rowSize = (area.Right - area.Left) / RESOLUTION;
         int height = (area.Bottom - area.Top) / RESOLUTION;
         int totalSize = rowSize * height;
@@ -553,7 +552,7 @@ public sealed partial class NpcNameFinder
             in operation);
 
         pooler.Return(segments);
-        return new(segments, 0, counter.count);
+        return new(segments, 0, Math.Min(segments.Length, counter.count));
     }
 
     public Point ToScreenCoordinates()


### PR DESCRIPTION
Changes:
* CoreTests: Remove unused variables.
* SharedLib: NpcNameFinder: Increase total capacity by factor of 2 (32 -> 16)

Repro case:
* Zoom in really close to a given NpcName
![image](https://github.com/user-attachments/assets/08d8f47d-8512-46f4-a2d4-b5705a36fbc9)
