### PR TITLE
Addon: [1.7.64] - Improved LootGoal state - many small fixes and optimizations

### DIFF
--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -95,6 +95,8 @@ local GetItemInfo = GetItemInfo
 local GetCoinTextureString = GetCoinTextureString
 local UseContainerItem = DataToColor.UseContainerItem
 
+local GetNumLootItems = GetNumLootItems
+
 -- initialization
 local globalTick = 0
 local initPhase = 10
@@ -254,6 +256,7 @@ end
 function DataToColor:Reset()
     DataToColor.S.playerSpellBookName = {}
     DataToColor.S.playerSpellBookId = {}
+    DataToColor.S.playerSpellBookIdHighest = {}
     DataToColor.S.playerSpellBookIconId = {}
 
     DataToColor.playerGUID = UnitGUID(DataToColor.C.unitPlayer)
@@ -408,6 +411,10 @@ function DataToColor:PopulateSpellBookInfo()
                 DataToColor.S.playerSpellBookName[texture] = name
                 DataToColor.S.playerSpellBookIconToId[texture] = id
 
+                if not DataToColor.S.playerSpellBookIdHighest[texture] or id > DataToColor.S.playerSpellBookIdHighest[texture] then
+                    DataToColor.S.playerSpellBookIdHighest[texture] = id
+                end
+
                 num = num + 1
             end
         end
@@ -426,6 +433,10 @@ function DataToColor:PopulateSpellBookInfo()
                     DataToColor.S.playerSpellBookName[texture] = name
                     DataToColor.S.playerSpellBookIconToId[texture] = id
 
+                    if not DataToColor.S.playerSpellBookIdHighest[texture] or id > DataToColor.S.playerSpellBookIdHighest[texture] then
+                        DataToColor.S.playerSpellBookIdHighest[texture] = id
+                    end
+
                     num = num + 1
                 end
             end
@@ -434,7 +445,7 @@ function DataToColor:PopulateSpellBookInfo()
 end
 
 function DataToColor:InitSpellBookQueue()
-    for id, _ in pairs(DataToColor.S.playerSpellBookId) do
+    for _, id in pairs(DataToColor.S.playerSpellBookIdHighest) do
         DataToColor.spellBookQueue:push(id)
     end
 end
@@ -877,10 +888,11 @@ function DataToColor:CreateFrames()
 
             -- Timers
             if DataToColor.lastLoot == DataToColor.C.Loot.Closed and
-                DataToColor.globalTime - DataToColor.lastLootResetStart > LOOT_RESET_RATE then
+                DataToColor.globalTime - DataToColor.lastLootResetStart >= LOOT_RESET_RATE then
                 DataToColor.lastLoot = DataToColor.C.Loot.Corpse
             end
-            Pixel(int, DataToColor.lastLoot, 97)
+            local lootItemCount = GetNumLootItems()
+            Pixel(int, lootItemCount * 10 + DataToColor.lastLoot, 97)
 
             local e = DataToColor.ChatQueue:peek()
             if e == nil then

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -3,7 +3,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors
-## Version: 1.7.63
+## Version: 1.7.64
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/EventHandlers.lua
+++ b/Addons/DataToColor/EventHandlers.lua
@@ -167,7 +167,7 @@ end
 
 function DataToColor:OnUIErrorMessage(_, _, message)
     if ignoreErrorListMessages[message] then
-        UIErrorsFrame:AddMessage(message, 0.7, 0.7, 0.7) -- show as grey messasge
+        UIErrorsFrame:AddMessage(message, 0.7, 0.7, 0.7) -- show as grey message
         return
     end
 
@@ -175,14 +175,15 @@ function DataToColor:OnUIErrorMessage(_, _, message)
     if code > 0 then
         DataToColor.uiErrorMessage = code
         DataToColor.uiErrorMessageTime = DataToColor.globalTime
-        UIErrorsFrame:AddMessage(message, 0, 1, 0) -- show as green messasge
+        --UIErrorsFrame:AddMessage(code .. " " .. message, 0, 1, 0) -- show as green message
+        UIErrorsFrame:AddMessage(message, 0, 1, 0) -- show as green message
         return
     else
         for i, v in pairs(specialErrorS) do
             if string.find(message, i) then
                 DataToColor.uiErrorMessage = v
                 DataToColor.uiErrorMessageTime = DataToColor.globalTime
-                UIErrorsFrame:AddMessage(message, 0, 1, 0) -- show as green messasge
+                UIErrorsFrame:AddMessage(message, 0, 1, 0) -- show as green message
                 return
             end
         end

--- a/Addons/DataToColor/Query.lua
+++ b/Addons/DataToColor/Query.lua
@@ -51,6 +51,8 @@ local UnitAttackSpeed = UnitAttackSpeed
 local UnitRangedDamage = UnitRangedDamage
 
 local GameMenuFrame = GameMenuFrame
+local LootFrame = LootFrame
+local ChatFrame1EditBox = ChatFrame1EditBox
 
 local HasPetUI = HasPetUI
 
@@ -124,11 +126,11 @@ function DataToColor:Bits1()
         (UnitIsVisible(DataToColor.C.unitPet) and not UnitIsDead(DataToColor.C.unitPet) and 2 or 0) ^ 6 +
         (mainHandEnchant and 2 or 0) ^ 7 +
         (offHandEnchant and 2 or 0) ^ 8 +
-        DataToColor:GetInventoryBroken() ^ 9 +
+        (DataToColor:GetInventoryBroken() ^ 9) +
         (UnitOnTaxi(DataToColor.C.unitPlayer) and 2 or 0) ^ 10 +
         (IsSwimming() and 2 or 0) ^ 11 +
-        (GetPetHappiness() == 3 and 2 or 0) ^ 12 +
-        (GetInventoryItemCount(DataToColor.C.unitPlayer, ammoSlot) > 0 and 2 or 0) ^ 13 +
+        (DataToColor:PetHappy() and 2 or 0) ^ 12 +
+        (DataToColor:HasAmmo() and 2 or 0) ^ 13 +
         (UnitAffectingCombat(DataToColor.C.unitPlayer) and 2 or 0) ^ 14 +
         (DataToColor:IsUnitsTargetIsPlayerOrPet(DataToColor.C.unitTarget, DataToColor.C.unitTargetTarget) and 2 or 0) ^ 15 +
         (IsAutoRepeatSpell(DataToColor.C.Spell.AutoShotId) and 2 or 0) ^ 16 +
@@ -163,11 +165,11 @@ function DataToColor:Bits2()
         (DataToColor:IsUnitsTargetIsPlayerOrPet(DataToColor.C.unitmouseover, DataToColor.C.unitmouseovertarget) and 2 or 0) ^ 16 +
         (UnitPlayerControlled(DataToColor.C.unitmouseover) and 2 or 0) ^ 17 +
         (UnitPlayerControlled(DataToColor.C.unitTarget) and 2 or 0) ^ 18 +
-        ((DataToColor.autoFollow) and 2 or 0) ^ 19 +
-        ((GameMenuFrame:IsShown() and 2 or 0)) ^ 20 +
-        ((IsFlying() and 2 or 0)) ^ 21 +
-        ((DataToColor.moving and 2 or 0)) ^ 22 +
-        ((DataToColor:PetIsDefensive() and 2 or 0)) ^ 23
+        (DataToColor.autoFollow and 2 or 0) ^ 19 +
+        (GameMenuFrame:IsShown() and 2 or 0) ^ 20 +
+        (IsFlying() and 2 or 0) ^ 21 +
+        (DataToColor.moving and 2 or 0) ^ 22 +
+        (DataToColor:PetIsDefensive() and 2 or 0) ^ 23
 end
 
 function DataToColor:Bits3()
@@ -180,7 +182,9 @@ function DataToColor:Bits3()
         (UnitIsTapDenied(DataToColor.C.unitSoftInteract) and 2 or 0) ^ 4 +
         (UnitAffectingCombat(DataToColor.C.unitSoftInteract) and 2 or 0) ^ 5 +
         (DataToColor:IsUnitHostile(DataToColor.C.unitPlayer, DataToColor.C.unitSoftInteract) and 2 or 0) ^ 6 +
-        ((DataToColor.channeling and 2 or 0)) ^ 7
+        (DataToColor.channeling and 2 or 0) ^ 7 +
+        (LootFrame:IsShown() and 2 or 0) ^ 8 +
+        (ChatFrame1EditBox:IsVisible() and 2 or 0) ^ 9
     )
 end
 
@@ -600,6 +604,25 @@ function DataToColor:UnitTargetsPartyOrPet(unittarget)
         if name == UnitName(unittarget) then return true end
     end
     return false
+end
+
+function DataToColor:HasAmmo()
+    -- After Cataclysm, ammo slot was removed
+    if DataToColor:IsClassicPreCata() == false then
+        return true
+    end
+
+    local count = GetInventoryItemCount(DataToColor.C.unitPlayer, ammoSlot)
+    return count > 0
+end
+
+function DataToColor:PetHappy()
+    -- After Cataclysm, pet always happy :)
+    if DataToColor:IsClassicPreCata() == false then
+        return true
+    end
+
+    return GetPetHappiness() == 3
 end
 
 -- Returns true if target of our target is us

--- a/Addons/DataToColor/Storage.lua
+++ b/Addons/DataToColor/Storage.lua
@@ -12,6 +12,7 @@ DataToColor.S.playerAuraMap = {}
 
 DataToColor.S.playerSpellBookName = {}
 DataToColor.S.playerSpellBookId = {}
+DataToColor.S.playerSpellBookIdHighest = {}
 DataToColor.S.playerSpellBookIconToId = {}
 
 function DataToColor:InitStorage()

--- a/Addons/DataToColor/Versions.lua
+++ b/Addons/DataToColor/Versions.lua
@@ -40,6 +40,11 @@ function DataToColor.IsRetail()
   return WOW_PROJECT_ID == WOW_PROJECT_MAINLINE
 end
 
+function DataToColor.IsClassicPreCata()
+  return DataToColor.IsClassic() or DataToColor.IsClassic_BCC() or DataToColor.IsClassic_Wrath()
+end
+
+
 local LibClassicCasterino
 if DataToColor.IsClassic() then
   LibClassicCasterino = _G.LibStub("LibClassicCasterino")

--- a/Core/Actionbar/ActionBarCooldownReader.cs
+++ b/Core/Actionbar/ActionBarCooldownReader.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 
 using static Core.ActionBar;
-using static System.DateTime;
+using static System.Diagnostics.Stopwatch;
 using static System.Math;
 
 namespace Core;
@@ -11,11 +11,11 @@ public sealed class ActionBarCooldownReader : IReader
     private readonly struct Data
     {
         private readonly float durationSec;
-        private readonly DateTime start;
+        private readonly long start;
 
-        public DateTime End => start.AddSeconds(durationSec);
+        public long End => start + (long)(durationSec * TimeSpan.TicksPerSecond);
 
-        public Data(float durationSec, DateTime start)
+        public Data(float durationSec, long start)
         {
             this.durationSec = durationSec;
             this.start = start;
@@ -43,13 +43,13 @@ public sealed class ActionBarCooldownReader : IReader
         int slotIdx = (value / ACTION_SLOT_MUL) - 1;
         float durationSec = value % ACTION_SLOT_MUL / FRACTION_PART;
 
-        data[slotIdx] = new(durationSec, UtcNow);
+        data[slotIdx] = new(durationSec, GetTimestamp());
     }
 
     public void Reset()
     {
         var span = data.AsSpan();
-        span.Fill(new(0, UtcNow));
+        span.Fill(new(0, GetTimestamp()));
     }
 
     public int Get(KeyAction keyAction)
@@ -58,6 +58,6 @@ public sealed class ActionBarCooldownReader : IReader
 
         ref readonly Data d = ref data[index];
 
-        return Max((int)(d.End - UtcNow).TotalMilliseconds, 0);
+        return Max((int)((d.End - GetTimestamp()) / TimeSpan.TicksPerMillisecond), 0);
     }
 }

--- a/Core/Addon/AuraTimeReader.cs
+++ b/Core/Addon/AuraTimeReader.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
+
+using static System.Diagnostics.Stopwatch;
 
 namespace Core;
 
@@ -22,10 +25,13 @@ public sealed class AuraTimeReader<T> : IAuraTimeReader, IReader
 {
     public readonly struct Data
     {
-        public int DurationSec { get; }
-        public DateTime StartTime { get; }
+        private long StartTime { get; }
 
-        public Data(int duration, DateTime startTime)
+        public int DurationSec { get; }
+
+        public long End => StartTime + (DurationSec * TimeSpan.TicksPerSecond);
+
+        public Data(int duration, long startTime)
         {
             DurationSec = duration;
             StartTime = startTime;
@@ -37,7 +43,7 @@ public sealed class AuraTimeReader<T> : IAuraTimeReader, IReader
     private readonly int cTextureId;
     private readonly int cDurationSec;
 
-    private readonly Dictionary<int, Data> data = new();
+    private readonly Dictionary<int, Data> data = [];
 
     public AuraTimeReader(int cTextureId, int cDurationSec)
     {
@@ -52,7 +58,7 @@ public sealed class AuraTimeReader<T> : IAuraTimeReader, IReader
         if (textureId == 0) return;
 
         int durationSec = reader.GetInt(cDurationSec);
-        data[textureId] = new(durationSec, DateTime.UtcNow);
+        data[textureId] = new(durationSec, GetTimestamp());
     }
 
     public void Reset()
@@ -63,7 +69,7 @@ public sealed class AuraTimeReader<T> : IAuraTimeReader, IReader
     public int GetRemainingTimeMs(int textureId)
     {
         return data.TryGetValue(textureId, out Data d) ?
-            Math.Max(0, d.DurationSec >= UNLIMITED ? 1 : (int)(d.StartTime.AddSeconds(d.DurationSec) - DateTime.UtcNow).TotalMilliseconds)
+            Math.Max(0, d.DurationSec >= UNLIMITED ? 1 : (int)((d.End - GetTimestamp()) / TimeSpan.TicksPerMillisecond))
             : 0;
     }
 

--- a/Core/Addon/Loot.cs
+++ b/Core/Addon/Loot.cs
@@ -20,7 +20,11 @@ public static class Loot_Extensions
 
 public static class Loot
 {
-    public const int LOOTFRAME_AUTOLOOT_DELAY = 300;
+    public const int LOOTFRAME_AUTOLOOT_DELAY_MS = 300;
 
-    public const int LOOT_RESET_UPDATE_COUNT = 5;
+    public const int LOOTFRAME_OPEN_TIME_MS = 2000;
+
+    public const int LOOT_PER_ITEM_TIME_MS = 1000;
+
+    public const int RESET_UPDATE_COUNT = 5;
 }

--- a/Core/Addon/PlayerReader.cs
+++ b/Core/Addon/PlayerReader.cs
@@ -1,5 +1,4 @@
-﻿using Core.AddonComponent;
-using Core.Database;
+﻿using Core.Database;
 
 using SharedLib;
 

--- a/Core/AddonComponent/AddonBits.cs
+++ b/Core/AddonComponent/AddonBits.cs
@@ -103,4 +103,8 @@ public sealed class AddonBits : IReader, IGameMenuWindowShown
     public bool SoftInteract_Hostile() => v3[Mask._6];
 
     public bool Channeling() => v3[Mask._7];
+
+    public bool LootFrameShown() => v3[Mask._8];
+
+    public bool ChatInputIsVisible() => v3[Mask._9];
 }

--- a/Core/AddonComponent/CombatLog.cs
+++ b/Core/AddonComponent/CombatLog.cs
@@ -19,8 +19,12 @@ public sealed class CombatLog : IReader
     public HashSet<int> DamageTaken { get; } = [];
     public HashSet<int> EvadeMobs { get; } = [];
 
+    public HashSet<int> ToPull { get; } = [];
+
     public int DamageTakenCount() => DamageTaken.Count;
     public int DamageDoneCount() => DamageDone.Count;
+
+    public int ToPullCount() => ToPull.Count;
 
     public RecordInt DamageDoneGuid { get; }
     public RecordInt DamageTakenGuid { get; }
@@ -92,6 +96,7 @@ public sealed class CombatLog : IReader
             int deadGuid = DeadGuid.Value;
             DamageDone.Remove(deadGuid);
             DamageTaken.Remove(deadGuid);
+            ToPull.Remove(deadGuid);
 
             if (deadGuid == PLAYER_DEATH_EVENT)
             {
@@ -108,6 +113,7 @@ public sealed class CombatLog : IReader
             // left combat
             DamageTaken.Clear();
             DamageDone.Clear();
+            ToPull.Clear();
         }
 
         wasInCombat = combat;

--- a/Core/AddonComponent/GuidType.cs
+++ b/Core/AddonComponent/GuidType.cs
@@ -1,4 +1,4 @@
-﻿namespace Core.AddonComponent;
+﻿namespace Core;
 
 public enum GuidType
 {

--- a/Core/AddonComponent/LevelTracker.cs
+++ b/Core/AddonComponent/LevelTracker.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 
+using static System.Diagnostics.Stopwatch;
+
 namespace Core;
 
 public sealed class LevelTracker : IDisposable
 {
     private readonly PlayerReader playerReader;
 
-    private DateTime levelStartTime = DateTime.UtcNow;
+    private long levelStartTime;
     private int levelStartXP;
 
     public TimeSpan TimeToLevel { get; private set; } = TimeSpan.Zero;
@@ -15,6 +17,8 @@ public sealed class LevelTracker : IDisposable
     public LevelTracker(PlayerReader playerReader)
     {
         this.playerReader = playerReader;
+
+        levelStartTime = GetTimestamp();
 
         playerReader.Level.Changed += PlayerLevel_Changed;
         playerReader.PlayerXp.Changed += PlayerExp_Changed;
@@ -33,13 +37,13 @@ public sealed class LevelTracker : IDisposable
 
     private void PlayerLevel_Changed()
     {
-        levelStartTime = DateTime.UtcNow;
+        levelStartTime = GetTimestamp();
         levelStartXP = playerReader.PlayerXp.Value;
     }
 
     public void UpdateExpPerHour()
     {
-        double runningSeconds = (DateTime.UtcNow - levelStartTime).TotalSeconds;
+        double runningSeconds = GetElapsedTime(levelStartTime).TotalSeconds;
         double xpPerSecond = (playerReader.PlayerXp.Value - levelStartXP) / runningSeconds;
         double secondsLeft = (playerReader.PlayerMaxXp - playerReader.PlayerXp.Value) / xpPerSecond;
 

--- a/Core/ClassConfig/KeyAction.cs
+++ b/Core/ClassConfig/KeyAction.cs
@@ -170,7 +170,9 @@ public sealed partial class KeyAction
 
     public static int LastKeyClicked()
     {
-        return (DateTime.UtcNow - LastKeyTime).TotalSeconds > 2
+        const int SECONDS_TO_SHOW_AS_ACTIVE = 2;
+
+        return (DateTime.UtcNow - LastKeyTime).TotalSeconds > SECONDS_TO_SHOW_AS_ACTIVE
             ? (int)ConsoleKey.NoName
             : LastKey;
     }

--- a/Core/GOAP/GoapAgent.cs
+++ b/Core/GOAP/GoapAgent.cs
@@ -271,7 +271,7 @@ public sealed partial class GoapAgent : IDisposable
             (B(mountHandler.IsMounted()) << (int)GoapKey.ismounted) |
             (B(playerReader.WithInPullRange()) << (int)GoapKey.withinpullrange) |
             (B(playerReader.WithInCombatRange()) << (int)GoapKey.incombatrange) |
-            // pulled always false
+            (B(bits.Combat() && bits.Target_Combat() && combatLog.ToPullCount() > 0) << (int)GoapKey.pulled) |
             (B(b.Dead()) << (int)GoapKey.isdead) |
             (B(State.LootableCorpseCount > 0) << (int)GoapKey.shouldloot) |
             (B(State.GatherableCorpseCount > 0) << (int)GoapKey.shouldgather) |
@@ -280,7 +280,7 @@ public sealed partial class GoapAgent : IDisposable
             (B(b.Swimming()) << (int)GoapKey.isswimming) |
             (B(b.Items_Broken()) << (int)GoapKey.itemsbroken) |
             (B(State.Gathering) << (int)GoapKey.gathering) |
-            (B(b.Target_Hostile()) << (int)GoapKey.targethostile) |
+            (B(b.Target_Hostile() || (bits.Target() && combatLog.ToPull.Contains(playerReader.TargetGuid))) << (int)GoapKey.targethostile) |
             (B(b.Focus()) << (int)GoapKey.hasfocus) |
             (B(b.FocusTarget()) << (int)GoapKey.focushastarget) |
             (B(State.ConsumableCorpseCount > 0) << (int)GoapKey.consumablecorpsenearby)

--- a/Core/Goals/ApproachTargetGoal.cs
+++ b/Core/Goals/ApproachTargetGoal.cs
@@ -1,16 +1,16 @@
-using Core.AddonComponent;
-using Core.GOAP;
+﻿using Core.GOAP;
 
 using Microsoft.Extensions.Logging;
 
 using System;
-using System.Numerics;
+
+using static System.Diagnostics.Stopwatch;
 
 #pragma warning disable 162
 
 namespace Core.Goals;
 
-public sealed class ApproachTargetGoal : GoapGoal, IGoapEventListener
+public sealed partial class ApproachTargetGoal : GoapGoal, IGoapEventListener
 {
     private const bool debug = true;
     private const double STUCK_INTERVAL_MS = 400; // cant be lower than Approach.Cooldown
@@ -25,27 +25,27 @@ public sealed class ApproachTargetGoal : GoapGoal, IGoapEventListener
     private readonly PlayerReader playerReader;
     private readonly AddonBits bits;
     private readonly StopMoving stopMoving;
-    private readonly CombatUtil combatUtil;
+    private readonly CombatTracker combatTracker;
     private readonly IMountHandler mountHandler;
     private readonly IBlacklist targetBlacklist;
+    private readonly CombatLog combatLog;
 
-    private DateTime approachStart;
+    private long approachStart;
 
     private double nextStuckCheckTime;
-    private Vector3 playerMap;
 
     private int initialTargetGuid;
     private float initialMinRange;
 
-    private double ApproachDurationMs =>
-        (DateTime.UtcNow - approachStart).TotalMilliseconds;
+    private double ApproachDurationMs => GetElapsedTime(approachStart).TotalMilliseconds;
 
     public ApproachTargetGoal(ILogger<ApproachTargetGoal> logger,
         ConfigurableInput input, Wait wait,
         PlayerReader playerReader, AddonBits addonBits,
-        StopMoving stopMoving, CombatUtil combatUtil,
+        StopMoving stopMoving, CombatTracker combatTracker,
         IBlacklist blacklist,
-        IMountHandler mountHandler)
+        IMountHandler mountHandler,
+        CombatLog combatLog)
         : base(nameof(ApproachTargetGoal))
     {
         this.logger = logger;
@@ -56,9 +56,10 @@ public sealed class ApproachTargetGoal : GoapGoal, IGoapEventListener
         this.bits = addonBits;
 
         this.stopMoving = stopMoving;
-        this.combatUtil = combatUtil;
+        this.combatTracker = combatTracker;
         this.mountHandler = mountHandler;
         this.targetBlacklist = blacklist;
+        this.combatLog = combatLog;
 
         AddPrecondition(GoapKey.hastarget, true);
         AddPrecondition(GoapKey.targetisalive, true);
@@ -72,7 +73,7 @@ public sealed class ApproachTargetGoal : GoapGoal, IGoapEventListener
     {
         if (e.GetType() == typeof(ResumeEvent))
         {
-            approachStart = DateTime.UtcNow;
+            approachStart = GetTimestamp();
         }
     }
 
@@ -80,11 +81,8 @@ public sealed class ApproachTargetGoal : GoapGoal, IGoapEventListener
     {
         initialTargetGuid = playerReader.TargetGuid;
         initialMinRange = playerReader.MinRange();
-        playerMap = playerReader.MapPos;
 
-        combatUtil.Update();
-
-        approachStart = DateTime.UtcNow;
+        approachStart = GetTimestamp();
         SetNextStuckTimeCheck();
     }
 
@@ -97,15 +95,17 @@ public sealed class ApproachTargetGoal : GoapGoal, IGoapEventListener
     {
         wait.Update();
 
-        if (combatUtil.EnteredCombat() && !bits.Target_Combat() &&
+        if (bits.Combat() && !bits.Target_Combat() &&
             !combatLog.ToPull.Contains(playerReader.TargetGuid))
         {
             stopMoving.Stop();
 
+            LogPreventExtraPull(logger);
+
             input.PressClearTarget();
             wait.Update();
 
-            combatUtil.AcquiredTarget(5000);
+            combatTracker.AcquiredTarget(5000);
             return;
         }
 
@@ -128,20 +128,19 @@ public sealed class ApproachTargetGoal : GoapGoal, IGoapEventListener
         {
             SetNextStuckTimeCheck();
 
-            Vector3 last = playerMap;
-            playerMap = playerReader.MapPos;
             if (!bits.Moving())
             {
-                if (playerReader.LastUIError == UI_ERROR.ERR_AUTOFOLLOW_TOO_FAR)
+                if (playerReader.LastUIError is
+                    UI_ERROR.ERR_AUTOFOLLOW_TOO_FAR or UI_ERROR.ERR_BADATTACKPOS)
                 {
                     playerReader.LastUIError = UI_ERROR.NONE;
 
-                    if (debug)
-                        Log($"Too far ({playerReader.MinRange()} yard), start moving forward!");
-
+                    Log($"Target is too far({playerReader.MinRange()} yard) for interact, start moving forward!");
                     input.StartForward(false);
+
                     return;
                 }
+                // TODO: not sure why this is here!
                 else if (playerReader.LastUIError == UI_ERROR.ERR_ATTACK_PACIFIED)
                 {
                     playerReader.LastUIError = UI_ERROR.NONE;
@@ -149,7 +148,6 @@ public sealed class ApproachTargetGoal : GoapGoal, IGoapEventListener
                     if (mountHandler.IsMounted())
                     {
                         mountHandler.Dismount();
-                        wait.Fixed(playerReader.DoubleNetworkLatency);
 
                         wait.While(bits.Falling);
 
@@ -162,12 +160,11 @@ public sealed class ApproachTargetGoal : GoapGoal, IGoapEventListener
                     }
                 }
 
-                if (debug)
-                    Log($"Seems stuck! Clear Target.");
+                Log($"Seems stuck! Clear Target.");
 
                 input.PressClearTarget();
-                wait.Update();
                 input.TurnRandomDir(250 + Random.Shared.Next(250));
+                wait.Update();
 
                 return;
             }
@@ -175,12 +172,11 @@ public sealed class ApproachTargetGoal : GoapGoal, IGoapEventListener
 
         if (ApproachDurationMs > MAX_APPROACH_DURATION_MS)
         {
-            if (debug)
-                Log("Too long time. Clear Target. Turn away.");
+            logger.LogWarning("Too long time. Clear Target. Turn away.");
 
             input.PressClearTarget();
-            wait.Update();
             input.TurnRandomDir(250 + Random.Shared.Next(250));
+            wait.Update();
 
             return;
         }
@@ -194,39 +190,34 @@ public sealed class ApproachTargetGoal : GoapGoal, IGoapEventListener
                 wait.Update();
             }
 
-            if (playerReader.TargetGuid != initialTargetGuid)
+            if (bits.Target() && playerReader.TargetGuid != initialTargetGuid)
             {
-                if (bits.Target() && !targetBlacklist.Is())
+                if (targetBlacklist.Is())
                 {
-                    if (playerReader.MinRange() < initialTargetMinRange)
-                    {
-                        if (debug)
-                            Log($"Found a closer target! {playerReader.MinRange()} < {initialTargetMinRange}");
+                    logger.LogWarning($"Losing the target due blacklist!");
+                    return;
+                }
 
-                        initialMinRange = playerReader.MinRange();
-                    }
-                    else
-                    {
-                        initialTargetGuid = -1;
-                        if (debug)
-                            Log("Stick to initial target!");
+                if (playerReader.MinRange() < initialTargetMinRange)
+                {
+                    logger.LogWarning($"Found a closer target! {playerReader.MinRange()} < {initialTargetMinRange}");
 
-                        input.PressLastTarget();
-                        wait.Update();
-                    }
+                    initialMinRange = playerReader.MinRange();
                 }
                 else
                 {
-                    if (debug)
-                        Log($"Lost the target due blacklist!");
+                    initialTargetGuid = -1;
+                    logger.LogWarning("Stick to initial target!");
+
+                    input.PressLastTarget();
+                    wait.Update();
                 }
             }
         }
 
         if (ApproachDurationMs > MIN_TIME_TILL_IDLE && initialMinRange < playerReader.MinRange())
         {
-            if (debug)
-                Log($"Going away from the target! {initialMinRange} < {playerReader.MinRange()}");
+            Log($"Going away from the target! {initialMinRange} < {playerReader.MinRange()}");
 
             input.PressClearTarget();
             wait.Update();
@@ -244,6 +235,7 @@ public sealed class ApproachTargetGoal : GoapGoal, IGoapEventListener
             input.Jump.SinceLastClickMs > Random.Shared.Next(5000, 25_000))
         {
             input.PressJump();
+            wait.Update();
         }
     }
 
@@ -260,4 +252,15 @@ public sealed class ApproachTargetGoal : GoapGoal, IGoapEventListener
     {
         logger.LogDebug(text);
     }
+
+
+    #region Logging
+
+    [LoggerMessage(
+        EventId = 4001,
+        Level = LogLevel.Warning,
+        Message = "Clear current target as not in combat!")]
+    static partial void LogPreventExtraPull(ILogger logger);
+
+    #endregion
 }

--- a/Core/Goals/ApproachTargetGoal.cs
+++ b/Core/Goals/ApproachTargetGoal.cs
@@ -1,4 +1,4 @@
-﻿using Core.AddonComponent;
+using Core.AddonComponent;
 using Core.GOAP;
 
 using Microsoft.Extensions.Logging;
@@ -97,7 +97,8 @@ public sealed class ApproachTargetGoal : GoapGoal, IGoapEventListener
     {
         wait.Update();
 
-        if (combatUtil.EnteredCombat() && !bits.Target_Combat())
+        if (combatUtil.EnteredCombat() && !bits.Target_Combat() &&
+            !combatLog.ToPull.Contains(playerReader.TargetGuid))
         {
             stopMoving.Stop();
 

--- a/Core/Goals/CombatGoal.cs
+++ b/Core/Goals/CombatGoal.cs
@@ -141,10 +141,9 @@ public sealed class CombatGoal : GoapGoal, IGoapEventListener
                 continue;
             }
 
-            if (castingHandler.CastIfReady(keyAction,
-                keyAction.Interrupts.Count > 0
-                ? keyAction.CanBeInterrupted
-                : bits.Target_Alive))
+            bool interrupt() => bits.Target_Alive() && keyAction.CanBeInterrupted();
+
+            if (castingHandler.CastIfReady(keyAction, interrupt))
             {
                 break;
             }

--- a/Core/Goals/CorpseConsumedGoal.cs
+++ b/Core/Goals/CorpseConsumedGoal.cs
@@ -54,13 +54,13 @@ public sealed partial class CorpseConsumedGoal : GoapGoal
 
         if (goapAgentState.LastCombatKillCount > 1)
         {
-            wait.Fixed(Loot.LOOTFRAME_AUTOLOOT_DELAY);
+            wait.Fixed(Loot.LOOTFRAME_AUTOLOOT_DELAY_MS);
         }
 
         if (!lootEnabled)
         {
             SendGoapEvent(new RemoveClosestPoi(CorpseEvent.NAME));
-            wait.Fixed(Loot.LOOTFRAME_AUTOLOOT_DELAY / 2);
+            wait.Fixed(Loot.LOOTFRAME_AUTOLOOT_DELAY_MS / 2);
         }
     }
 

--- a/Core/Goals/FollowRouteGoal.cs
+++ b/Core/Goals/FollowRouteGoal.cs
@@ -277,7 +277,7 @@ public sealed class FollowRouteGoal : GoapGoal, IGoapEventListener, IRouteProvid
                 }
             }
 
-            sideActivityCts.Token.WaitHandle.WaitOne(1);
+            wait.Update();
             sideActivityManualReset.Wait();
         }
 

--- a/Core/Goals/LootGoal.cs
+++ b/Core/Goals/LootGoal.cs
@@ -1,5 +1,4 @@
-using Core.AddonComponent;
-using Core.Database;
+﻿using Core.Database;
 using Core.GOAP;
 
 using Microsoft.Extensions.Logging;
@@ -21,7 +20,6 @@ public sealed partial class LootGoal : GoapGoal, IGoapEventListener
     public override float Cost => 4.6f;
 
     private const int MAX_TIME_TO_REACH_MELEE = 10000;
-    private const int MAX_TIME_TO_DETECT_LOOT = 2 * CastingHandler.GCD;
 
     private readonly ILogger<LootGoal> logger;
     private readonly ConfigurableInput input;
@@ -44,8 +42,6 @@ public sealed partial class LootGoal : GoapGoal, IGoapEventListener
 
     private bool canGather;
     private int targetId;
-    private int bagHashNewOrStackGain;
-    private int money;
 
     public LootGoal(ILogger<LootGoal> logger,
         ConfigurableInput input, Wait wait,
@@ -80,12 +76,16 @@ public sealed partial class LootGoal : GoapGoal, IGoapEventListener
 
     public override void OnEnter()
     {
+        float e = wait.UntilCount(Loot.RESET_UPDATE_COUNT, LootReset);
+        if (e < 0)
+        {
+            LogWarnWindowStillOpen(logger, playerReader.LootWindowCount.Value, e);
+        }
+
         if (combatLog.DamageTakenCount() == 0)
         {
             WaitForLosingTarget();
         }
-
-        CaptureStateBeforeLoot();
 
         CheckInventoryFull();
 
@@ -105,46 +105,29 @@ public sealed partial class LootGoal : GoapGoal, IGoapEventListener
 
     private void WaitForLosingTarget()
     {
-        float elapsedMs = wait.Until(
-            Loot.LOOTFRAME_AUTOLOOT_DELAY, bits.NoTarget);
+        float elapsedMs = wait.Until(playerReader.DoubleNetworkLatency, bits.NoTarget);
 
         LogLostTarget(logger, elapsedMs);
     }
 
-    private void CaptureStateBeforeLoot()
-    {
-        bagHashNewOrStackGain = bagReader.HashNewOrStackGain;
-        money = playerReader.Money;
-    }
-
     private void CheckInventoryFull()
     {
-        ClearTargetIfNeeded();
         if (!bagReader.BagsFull())
             return;
 
         logger.LogWarning("Inventory is full");
     }
 
-    private bool ShouldTryKeyboardLoot()
-    {
-        return input.KeyboardOnly || state.LastCombatKillCount == 1;
-    }
-
     private bool TryLoot()
     {
-        if (ShouldTryKeyboardLoot())
+        bool keyboardSuccessful = LootKeyboard();
+        if (!keyboardSuccessful)
         {
-            bool success = LootKeyboard();
-            if (!success && state.LastCombatKillCount == 1)
-            {
-                LogKeyboardLootFailed(logger, bits.Target());
-            }
-
-            if (success)
-            {
-                return true;
-            }
+            LogKeyboardLootFailed(logger, bits.Target());
+        }
+        else
+        {
+            return true;
         }
 
         return !input.KeyboardOnly && LootMouse();
@@ -152,24 +135,42 @@ public sealed partial class LootGoal : GoapGoal, IGoapEventListener
 
     private void HandleSuccessfulLoot()
     {
-        float elapsedMs = wait.Until(MAX_TIME_TO_DETECT_LOOT,
-            LootWindowClosedOrMoneyChanged,
-            PressApproachOnCooldown);
+        int maxTimeLootWindowOpenMs =
+            Math.Max(playerReader.DoubleNetworkLatency, Loot.LOOTFRAME_OPEN_TIME_MS);
 
-        bool success = elapsedMs >= 0;
-        if (success && !bagReader.BagsFull())
+        float windowOpenElapsedMs = wait.Until(maxTimeLootWindowOpenMs,
+            LootWindowOpen,
+            TryPressSafeApproachOnCooldownIfNeeded);
+
+        int availableItems = playerReader.LootWindowCount.Value;
+        state.RecentlyLooted.Add(playerReader.TargetGuid);
+
+        int maxTimeLootWindowClosedMs =
+            Math.Max(playerReader.LootWindowCount.Value, 1) *
+            (playerReader.DoubleNetworkLatency + Loot.LOOT_PER_ITEM_TIME_MS);
+
+        float windowClosedElapsedMs = wait.Until(maxTimeLootWindowClosedMs, LootWindowClosed);
+
+        bool success = windowOpenElapsedMs >= 0 && windowClosedElapsedMs >= 0;
+        if (success)
         {
-            LogLootSuccess(logger, elapsedMs);
+            LogLootSuccess(logger, availableItems, windowOpenElapsedMs, windowClosedElapsedMs);
         }
         else
         {
             SendGoapEvent(ScreenCaptureEvent.Default);
-            LogLootFailed(logger, elapsedMs);
+            LogLootFailed(logger, windowOpenElapsedMs, windowClosedElapsedMs);
         }
 
         if (success)
         {
             GatherCorpseIfNeeded();
+        }
+
+        if (bits.LootFrameShown())
+        {
+            input.PressESC();
+            wait.Update();
         }
     }
 
@@ -211,8 +212,11 @@ public sealed partial class LootGoal : GoapGoal, IGoapEventListener
             return;
         }
 
-        input.PressClearTarget();
-        wait.Update();
+        if (bits.Target_Dead())
+        {
+            input.PressInteract();
+            wait.Update();
+        }
 
         if (bits.Target())
         {
@@ -250,7 +254,7 @@ public sealed partial class LootGoal : GoapGoal, IGoapEventListener
 
         CheckForCanGather();
 
-        return playerReader.MinRangeZero() || MoveToTargetAndReached();
+        return (bits.Target() && playerReader.MinRangeZero()) || MoveToTargetAndReached();
     }
 
     private CorpseEvent? GetClosestCorpse()
@@ -293,13 +297,13 @@ public sealed partial class LootGoal : GoapGoal, IGoapEventListener
         (config.Mine && area.minable.AsSpan().BinarySearch(npcId) >= 0) ||
         (config.Salvage && area.salvegable.AsSpan().BinarySearch(npcId) >= 0);
 
-    private bool LootWindowClosedOrMoneyChanged()
+    private bool LootWindowOpen()
     {
-        // hack: warlock soul shard mechanic marks loot success prematurely
-        return //bagHashNewOrStackGain != bagReader.HashNewOrStackGain ||
-            money != playerReader.Money ||
-            (LootStatus)playerReader.LootEvent.Value is LootStatus.CLOSED;
+        return playerReader.LootWindowCount.Value > 0 ||
+            (LootStatus)playerReader.LootEvent.Value is LootStatus.READY;
     }
+
+    private bool LootWindowClosed() => !bits.LootFrameShown();
 
     private bool LootMouse()
     {
@@ -355,7 +359,7 @@ public sealed partial class LootGoal : GoapGoal, IGoapEventListener
             }
         }
 
-        if (EligibleSoftTargetExists() && !state.RecentlyLooted.Contains(playerReader.SoftInteract_Guid))
+        if (EligibleCorpseSoftTargetExists() && !state.RecentlyLooted.Contains(playerReader.SoftInteract_Guid))
         {
             Log($"Keyboard soft target found!");
 
@@ -381,17 +385,16 @@ public sealed partial class LootGoal : GoapGoal, IGoapEventListener
 
         CheckForCanGather();
 
-        if (!bits.SoftInteract() || EligibleSoftTargetExists())
+        if (!bits.SoftInteract() || EligibleCorpseSoftTargetExists())
         {
             input.PressInteract();
             wait.Update();
         }
 
-        return playerReader.MinRangeZero() || MoveToTargetAndReached();
+        return (bits.Target() && playerReader.MinRangeZero()) || MoveToTargetAndReached();
     }
 
-    private bool EligibleSoftTargetExists() =>
-        //!bits.Target() &&
+    private bool EligibleCorpseSoftTargetExists() =>
         bits.SoftInteract() &&
         bits.SoftInteract_Hostile() &&
         bits.SoftInteract_Dead() &&
@@ -400,30 +403,42 @@ public sealed partial class LootGoal : GoapGoal, IGoapEventListener
 
     private bool MoveToTargetAndReached()
     {
-        wait.While(input.Approach.OnCooldown);
+        if (!bits.Moving())
+        {
+            logger.LogInformation("Moving to corpse...");
+            wait.While(input.Approach.OnCooldown);
+            wait.Update();
+        }
 
-        float elapsedMs = wait.Until(MAX_TIME_TO_REACH_MELEE,
-            bits.NotMoving, PressApproachOnCooldown);
+        float elapsedMs = wait.Until(MAX_TIME_TO_REACH_MELEE, //UntilWithoutRepeat
+            NotMovingOrLootAvailable, TryPressSafeApproachOnCooldownIfNeeded);
 
-        LogReachedCorpse(logger, bits.Target(), elapsedMs);
+        LogReachedCorpse(logger, bits.Target(), bits.Moving(), elapsedMs);
 
         return bits.Target() && playerReader.MinRangeZero();
     }
 
-    private void PressApproachOnCooldown()
-    {
-        if (playerReader.TargetGuid > 0 &&
-            !state.RecentlyLooted.Contains(playerReader.TargetGuid) &&
-            (LootStatus)playerReader.LootEvent.Value == LootStatus.READY)
-        {
-            state.RecentlyLooted.Add(playerReader.TargetGuid);
-            Log($"Recently looted {playerReader.TargetGuid}");
-        }
+    private bool NotMovingOrLootAvailable() => !bits.Target() || bits.NotMoving() || playerReader.LootWindowCount.Value > 0;
 
-        if (bits.Target() && (!bits.SoftInteract() || EligibleSoftTargetExists()))
+    private void TryPressSafeApproachOnCooldownIfNeeded()
+    {
+        if (bits.Target() && (!bits.SoftInteract() || EligibleCorpseSoftTargetExists()))
         {
-            input.PressApproachOnCooldown();
+            if (!bits.Moving())
+            {
+                input.PressApproachOnCooldown();
+                if (input.Approach.OnCooldown())
+                {
+                    wait.Update();
+                    wait.Update();
+                }
+            }
         }
+    }
+
+    private bool LootReset()
+    {
+        return (LootStatus)playerReader.LootEvent.Value == LootStatus.CORPSE;
     }
 
     #region Logging
@@ -441,14 +456,14 @@ public sealed partial class LootGoal : GoapGoal, IGoapEventListener
     [LoggerMessage(
         EventId = 0130,
         Level = LogLevel.Information,
-        Message = "Loot Successful {elapsedMs}ms")]
-    static partial void LogLootSuccess(ILogger logger, float elapsedMs);
+        Message = "Loot Successful items: {count} - open: {openElapsedMs}ms - close: {closedElapsedMs}ms")]
+    static partial void LogLootSuccess(ILogger logger, int count, float openElapsedMs, float closedElapsedMs);
 
     [LoggerMessage(
         EventId = 0131,
         Level = LogLevel.Information,
-        Message = "Loot Failed {elapsedMs}ms")]
-    static partial void LogLootFailed(ILogger logger, float elapsedMs);
+        Message = "Loot Failed open: {openElapsedMs}ms - close: {closedElapsedMs}ms")]
+    static partial void LogLootFailed(ILogger logger, float openElapsedMs, float closedElapsedMs);
 
     [LoggerMessage(
         EventId = 0132,
@@ -459,8 +474,8 @@ public sealed partial class LootGoal : GoapGoal, IGoapEventListener
     [LoggerMessage(
         EventId = 0133,
         Level = LogLevel.Information,
-        Message = "Has target ? {hasTarget} | Reached corpse ? {elapsedMs}ms")]
-    static partial void LogReachedCorpse(ILogger logger, bool hasTarget, float elapsedMs);
+        Message = "Has target ? {hasTarget} | moving ? {moving} | Reached corpse ? {elapsedMs}ms")]
+    static partial void LogReachedCorpse(ILogger logger, bool hasTarget, bool moving, float elapsedMs);
 
     [LoggerMessage(
         EventId = 0134,
@@ -479,6 +494,12 @@ public sealed partial class LootGoal : GoapGoal, IGoapEventListener
         Level = LogLevel.Error,
         Message = "Keyboard loot failed! Has target ? {hasTarget}")]
     static partial void LogKeyboardLootFailed(ILogger logger, bool hasTarget);
+
+    [LoggerMessage(
+        EventId = 0147,
+        Level = LogLevel.Warning,
+        Message = "OnEnter window still open! Available Loot: {count} {elapsedMs}ms")]
+    static partial void LogWarnWindowStillOpen(ILogger logger, int count, float elapsedMs);
 
     #endregion
 }

--- a/Core/Goals/PullTargetGoal.cs
+++ b/Core/Goals/PullTargetGoal.cs
@@ -218,10 +218,9 @@ public sealed class PullTargetGoal : GoapGoal, IGoapEventListener
                 return;
             }
         }
-        else if (bits.Combat())
+        else if (bits.Target())
         {
-            SendGoapEvent(new GoapStateEvent(GoapKey.pulled, true));
-            return;
+            combatLog.ToPull.Add(playerReader.TargetGuid);
         }
 
         if (castAny || spellInQueue || playerReader.IsCasting())

--- a/Core/Goals/PullTargetGoal.cs
+++ b/Core/Goals/PullTargetGoal.cs
@@ -6,6 +6,8 @@ using SharedLib.NpcFinder;
 
 using System;
 
+using static System.Diagnostics.Stopwatch;
+
 namespace Core.Goals;
 
 public sealed class PullTargetGoal : GoapGoal, IGoapEventListener
@@ -14,6 +16,7 @@ public sealed class PullTargetGoal : GoapGoal, IGoapEventListener
 
     private const int AcquireTargetTimeMs = 5000;
     private const int MAX_PULL_DURATION = 15_000;
+
     private readonly ILogger<PullTargetGoal> logger;
     private readonly ConfigurableInput input;
     private readonly ClassConfiguration classConfig;
@@ -26,7 +29,7 @@ public sealed class PullTargetGoal : GoapGoal, IGoapEventListener
     private readonly NpcNameTargeting npcNameTargeting;
     private readonly CastingHandler castingHandler;
     private readonly IMountHandler mountHandler;
-    private readonly CombatUtil combatUtil;
+    private readonly CombatTracker combatTracker;
     private readonly IBlacklist targetBlacklist;
 
     private readonly KeyAction? approachKey;
@@ -34,9 +37,9 @@ public sealed class PullTargetGoal : GoapGoal, IGoapEventListener
 
     private readonly bool requiresNpcNameFinder;
 
-    private DateTime pullStart;
+    private long pullStart;
 
-    private double PullDurationMs => (DateTime.UtcNow - pullStart).TotalMilliseconds;
+    private double PullDurationMs => GetElapsedTime(pullStart).TotalMilliseconds;
 
     public PullTargetGoal(ILogger<PullTargetGoal> logger, ConfigurableInput input,
         Wait wait, CombatLog combatlog, PlayerReader playerReader,
@@ -44,7 +47,7 @@ public sealed class PullTargetGoal : GoapGoal, IGoapEventListener
         IBlacklist targetBlacklist,
         StopMoving stopMoving, CastingHandler castingHandler,
         IMountHandler mountHandler, NpcNameTargeting npcNameTargeting,
-        StuckDetector stuckDetector, CombatUtil combatUtil,
+        StuckDetector stuckDetector, CombatTracker combatTracker,
         ClassConfiguration classConfig)
         : base(nameof(PullTargetGoal))
     {
@@ -59,7 +62,7 @@ public sealed class PullTargetGoal : GoapGoal, IGoapEventListener
         this.mountHandler = mountHandler;
         this.npcNameTargeting = npcNameTargeting;
         this.stuckDetector = stuckDetector;
-        this.combatUtil = combatUtil;
+        this.combatTracker = combatTracker;
         this.targetBlacklist = targetBlacklist;
         this.classConfig = classConfig;
 
@@ -83,11 +86,10 @@ public sealed class PullTargetGoal : GoapGoal, IGoapEventListener
             }
         }
 
-        AddPrecondition(GoapKey.incombat, false);
+        AddPrecondition(GoapKey.targettargetsus, false);
         AddPrecondition(GoapKey.hastarget, true);
         AddPrecondition(GoapKey.targetisalive, true);
         AddPrecondition(GoapKey.targethostile, true);
-        AddPrecondition(GoapKey.pulled, false);
         AddPrecondition(GoapKey.withinpullrange, true);
 
         AddEffect(GoapKey.pulled, true);
@@ -95,7 +97,6 @@ public sealed class PullTargetGoal : GoapGoal, IGoapEventListener
 
     public override void OnEnter()
     {
-        combatUtil.Update();
         wait.Update();
         stuckDetector.Reset();
 
@@ -116,7 +117,7 @@ public sealed class PullTargetGoal : GoapGoal, IGoapEventListener
             npcNameTargeting.ChangeNpcType(NpcNames.Enemy);
         }
 
-        pullStart = DateTime.UtcNow;
+        pullStart = GetTimestamp();
     }
 
     public override void OnExit()
@@ -131,19 +132,13 @@ public sealed class PullTargetGoal : GoapGoal, IGoapEventListener
     {
         if (e.GetType() == typeof(ResumeEvent))
         {
-            pullStart = DateTime.UtcNow;
+            pullStart = GetTimestamp();
         }
     }
 
     public override void Update()
     {
         wait.Update();
-
-        if (combatLog.DamageDoneCount() > 0)
-        {
-            SendGoapEvent(new GoapStateEvent(GoapKey.pulled, true));
-            return;
-        }
 
         if (PullDurationMs > MAX_PULL_DURATION)
         {
@@ -166,9 +161,11 @@ public sealed class PullTargetGoal : GoapGoal, IGoapEventListener
 
         bool castAny = false;
         bool spellInQueue = false;
-        for (int i = 0; i < Keys.Length; i++)
+
+        ReadOnlySpan<KeyAction> keys = Keys;
+        for (int i = 0; i < keys.Length; i++)
         {
-            KeyAction keyAction = Keys[i];
+            KeyAction keyAction = keys[i];
 
             if (keyAction.Name.Equals(input.Approach.Name,
                 StringComparison.OrdinalIgnoreCase))
@@ -183,13 +180,14 @@ public sealed class PullTargetGoal : GoapGoal, IGoapEventListener
                 break;
             }
 
-            if (castAny = castingHandler.Cast(keyAction, PullPrevention))
-            {
+            bool interrupt() => keyAction.CanBeInterrupted() || PullPrevention();
 
+            if (castAny = castingHandler.Cast(keyAction, interrupt))
+            {
+                castAny = !keyAction.BaseAction;
             }
             else if (PullPrevention() &&
-                (playerReader.IsCasting() ||
-                 bits.Any_AutoAttack()))
+                (playerReader.IsCasting() || bits.Any_AutoAttack()))
             {
                 Log("Preventing pulling possible tagged target!");
                 input.PressStopAttack();
@@ -199,46 +197,24 @@ public sealed class PullTargetGoal : GoapGoal, IGoapEventListener
             }
         }
 
-        if (combatUtil.EnteredCombat())
+        if (bits.Target() && combatLog.EvadeMobs.Contains(playerReader.TargetGuid))
         {
-            if (wait.Until(AcquireTargetTimeMs, CombatLogChanged) >= 0)
-            {
-                if (combatLog.DamageTakenCount() > 0 && !bits.Target_Combat())
-                {
-                    stopMoving.Stop();
+            Log("Evading mob");
 
-                    input.PressClearTarget();
-                    wait.Update();
-
-                    combatUtil.AcquiredTarget(AcquireTargetTimeMs);
-                    return;
-                }
-
-                SendGoapEvent(new GoapStateEvent(GoapKey.pulled, true));
-                return;
-            }
+            input.PressStopAttack();
+            input.PressClearTarget();
+            wait.Update();
+            return;
         }
         else if (bits.Target())
         {
             combatLog.ToPull.Add(playerReader.TargetGuid);
         }
 
-        if (castAny || spellInQueue || playerReader.IsCasting())
+        if (castAny || spellInQueue || playerReader.IsCasting() || (bits.AutoShot() && !playerReader.IsInMeleeRange()))
             return;
 
         approachAction();
-    }
-
-    private bool CombatLogChanged()
-    {
-        return
-            bits.Target_Combat() ||
-            combatLog.DamageDoneCount() > 0 ||
-            combatLog.DamageTakenCount() > 0 ||
-            playerReader.TargetTarget is
-            UnitsTarget.Me or
-            UnitsTarget.Pet or
-            UnitsTarget.PartyOrPet;
     }
 
     private void DefaultApproach()
@@ -246,10 +222,14 @@ public sealed class PullTargetGoal : GoapGoal, IGoapEventListener
         if (input.Approach.OnCooldown())
             return;
 
+        if (!bits.SoftInteract() || EligibleEnemySoftTargetExists())
+        {
+            input.PressApproach();
+            wait.Update();
+        }
+
         if (!stuckDetector.IsMoving())
             stuckDetector.Update();
-
-        input.PressApproach();
     }
 
     private void ConditionalApproach()
@@ -264,16 +244,6 @@ public sealed class PullTargetGoal : GoapGoal, IGoapEventListener
         DefaultApproach();
     }
 
-    private bool SuccessfulPull()
-    {
-        return playerReader.TargetTarget is
-            UnitsTarget.Me or
-            UnitsTarget.Pet or
-            UnitsTarget.PartyOrPet ||
-            combatLog.DamageDoneGuid.ElapsedMs() < CastingHandler.GCD ||
-            playerReader.IsInMeleeRange();
-    }
-
     private bool PullPrevention()
     {
         return targetBlacklist.Is() &&
@@ -283,6 +253,13 @@ public sealed class PullTargetGoal : GoapGoal, IGoapEventListener
             UnitsTarget.Pet or
             UnitsTarget.PartyOrPet;
     }
+
+    private bool EligibleEnemySoftTargetExists() =>
+        bits.SoftInteract() &&
+        bits.SoftInteract_Hostile() &&
+        !bits.SoftInteract_Dead() &&
+        !bits.SoftInteract_Tagged() &&
+        playerReader.SoftInteract_Type == GuidType.Creature;
 
     private void Log(string text)
     {

--- a/Core/Goals/SkinningGoal.cs
+++ b/Core/Goals/SkinningGoal.cs
@@ -31,7 +31,7 @@ public sealed partial class SkinningGoal : GoapGoal, IGoapEventListener, IDispos
     private readonly BagReader bagReader;
     private readonly EquipmentReader equipmentReader;
     private readonly NpcNameTargeting npcNameTargeting;
-    private readonly CombatUtil combatUtil;
+    private readonly CombatTracker combatTracker;
     private readonly GoapAgentState state;
     private readonly CancellationToken token;
 
@@ -44,7 +44,7 @@ public sealed partial class SkinningGoal : GoapGoal, IGoapEventListener, IDispos
         PlayerReader playerReader, CombatLog combatLog,
         BagReader bagReader, EquipmentReader equipmentReader,
         AddonBits bits, Wait wait, StopMoving stopMoving,
-        NpcNameTargeting npcNameTargeting, CombatUtil combatUtil,
+        NpcNameTargeting npcNameTargeting, CombatTracker combatTracker,
         GoapAgentState state, ClassConfiguration classConfig,
         CancellationTokenSource cts)
         : base(nameof(SkinningGoal))
@@ -61,7 +61,7 @@ public sealed partial class SkinningGoal : GoapGoal, IGoapEventListener, IDispos
         this.equipmentReader = equipmentReader;
 
         this.npcNameTargeting = npcNameTargeting;
-        this.combatUtil = combatUtil;
+        this.combatTracker = combatTracker;
         this.state = state;
 
         this.token = cts.Token;
@@ -96,14 +96,22 @@ public sealed partial class SkinningGoal : GoapGoal, IGoapEventListener, IDispos
 
     public override void OnEnter()
     {
-        combatUtil.Update();
-
-        float e = wait.UntilCount(Loot.LOOT_RESET_UPDATE_COUNT, LootReset);
+        float e = wait.UntilCount(Loot.RESET_UPDATE_COUNT, LootReset);
         if (e < 0)
         {
-            LogWarnWindowStillOpen(logger, e);
-            ExitInterruptOrFailed(false);
-            return;
+            LogWarnWindowStillOpen(logger, playerReader.LootWindowCount.Value, e);
+
+            if (bits.LootFrameShown())
+            {
+                input.PressESC();
+                wait.Update();
+            }
+
+            if (bits.LootFrameShown())
+            {
+                ExitInterruptOrFailed(false);
+                return;
+            }
         }
 
         bagHashNewOrStackGain = bagReader.HashNewOrStackGain;
@@ -151,7 +159,6 @@ public sealed partial class SkinningGoal : GoapGoal, IGoapEventListener, IDispos
             if (!foundTarget && !input.KeyboardOnly)
             {
                 stopMoving.Stop();
-                combatUtil.Update();
 
                 npcNameTargeting.ChangeNpcType(NpcNames.Corpse);
                 e = wait.Until(MAX_TIME_TO_WAIT_NPC_NAME, npcNameTargeting.FoundAny);
@@ -170,6 +177,8 @@ public sealed partial class SkinningGoal : GoapGoal, IGoapEventListener, IDispos
 
                 input.PressInteract();
                 wait.Update();
+
+                foundTarget = true;
 
                 interact = false;
             }
@@ -206,7 +215,7 @@ public sealed partial class SkinningGoal : GoapGoal, IGoapEventListener, IDispos
             else if ((e < 0 || playerReader.LastUIError == UI_ERROR.ERR_LOOT_LOCKED) && !playerReader.IsCasting())
             {
                 int delay = playerReader.LastUIError == UI_ERROR.ERR_LOOT_LOCKED
-                    ? Loot.LOOTFRAME_AUTOLOOT_DELAY
+                    ? Loot.LOOTFRAME_AUTOLOOT_DELAY_MS
                     : playerReader.NetworkLatency;
 
                 wait.Fixed(delay);
@@ -238,7 +247,6 @@ public sealed partial class SkinningGoal : GoapGoal, IGoapEventListener, IDispos
             else
             {
                 if (combatLog.DamageTakenCount() > 0 ||
-                    combatUtil.EnteredCombat() ||
                     playerReader.LastUIError == UI_ERROR.ERR_SPELL_FAILED_INTERRUPTED
                     )
                 {
@@ -248,7 +256,7 @@ public sealed partial class SkinningGoal : GoapGoal, IGoapEventListener, IDispos
                 }
 
                 LogWarnGatherFailed(logger, playerReader.CastState.ToStringF(), attempts);
-                wait.Fixed(Loot.LOOTFRAME_AUTOLOOT_DELAY);
+                wait.Fixed(Loot.LOOTFRAME_AUTOLOOT_DELAY_MS);
 
                 attempts++;
 
@@ -427,8 +435,8 @@ public sealed partial class SkinningGoal : GoapGoal, IGoapEventListener, IDispos
     [LoggerMessage(
         EventId = 0140,
         Level = LogLevel.Warning,
-        Message = "Loot window still open! {elapsedMs}ms")]
-    static partial void LogWarnWindowStillOpen(ILogger logger, float elapsedMs);
+        Message = "OnEnter window still open! Available Loot: {count} {elapsedMs}ms")]
+    static partial void LogWarnWindowStillOpen(ILogger logger, int count, float elapsedMs);
 
     [LoggerMessage(
         EventId = 0141,

--- a/Core/GoalsComponent/CastingHandler.cs
+++ b/Core/GoalsComponent/CastingHandler.cs
@@ -581,6 +581,8 @@ public sealed partial class CastingHandler
             AfterCastWaitMeleeRange(MAX_WAIT_MELEE_RANGE,
                 lastKnownHealth, wait, playerReader, token);
 
+            wait.Update();
+
             static float AfterCastWaitMeleeRange(int duration,
                 int lastKnownHealth, Wait wait, PlayerReader playerReader,
                 CancellationToken token)

--- a/Core/GoalsComponent/CombatTracker.cs
+++ b/Core/GoalsComponent/CombatTracker.cs
@@ -1,55 +1,63 @@
 ﻿using Microsoft.Extensions.Logging;
 
+using System;
+using System.Diagnostics;
+
 namespace Core;
 
-public sealed class CombatUtil
+public sealed partial class CombatTracker : IDisposable
 {
-    private readonly ILogger<CombatUtil> logger;
+    private const bool DEBUG = true;
+
+    private readonly ILogger<CombatTracker> logger;
+    private readonly AddonReader addonReader;
     private readonly PlayerReader playerReader;
     private readonly CombatLog combatLog;
     private readonly AddonBits bits;
     private readonly ConfigurableInput input;
     private readonly Wait wait;
 
-    private const bool debug = true;
+    private bool inCombat;
 
-    private bool outOfCombat;
+    public long Started { get; private set; }
 
-    public CombatUtil(ILogger<CombatUtil> logger, ConfigurableInput input,
+    public CombatTracker(ILogger<CombatTracker> logger,
+        AddonReader addonReader,
+        ConfigurableInput input,
         AddonBits bits, Wait wait, PlayerReader playerReader, CombatLog combatLog)
     {
         this.logger = logger;
+        this.addonReader = addonReader;
         this.input = input;
         this.wait = wait;
         this.playerReader = playerReader;
         this.bits = bits;
         this.combatLog = combatLog;
 
-        outOfCombat = !bits.Combat();
+        inCombat = bits.Combat();
+        Started = Stopwatch.GetTimestamp();
+
+        addonReader.GlobalTime.Changed += Update;
     }
 
-    public void Update()
+    public void Dispose()
     {
-        outOfCombat = !bits.Combat();
+        addonReader.GlobalTime.Changed -= Update;
     }
 
-    public bool EnteredCombat()
+    private void Update()
     {
-        if (!outOfCombat && !bits.Combat())
+        if (inCombat && !bits.Combat())
         {
-            Log("Combat Leave");
-            outOfCombat = true;
-            return false;
+            LogLeftCombat(logger, Stopwatch.GetElapsedTime(Started).TotalSeconds);
+        }
+        else if (!inCombat && bits.Combat())
+        {
+            Started = Stopwatch.GetTimestamp();
+            LogEnteredCombat(logger);
         }
 
-        if (outOfCombat && bits.Combat())
-        {
-            Log("Combat Enter");
-            outOfCombat = false;
-            return true;
-        }
-
-        return false;
+        inCombat = bits.Combat();
     }
 
     public bool AcquiredTarget(int maxTimeMs = 400)
@@ -67,6 +75,7 @@ public sealed class CombatUtil
                 Log($"{nameof(AcquiredTarget)}: Found target by pet");
                 input.PressTargetOfTarget();
                 wait.Update();
+
                 return true;
             }
         }
@@ -79,7 +88,8 @@ public sealed class CombatUtil
             (bits.TargetTarget_PlayerOrPet() ||
             combatLog.DamageTaken.Contains(playerReader.TargetGuid)))
         {
-            Log("Found target");
+            Log("Found new target");
+
             return true;
         }
 
@@ -89,12 +99,14 @@ public sealed class CombatUtil
         if (!wait.Till(maxTimeMs, PlayerOrPetHasTarget))
         {
             Log($"{nameof(AcquiredTarget)}: Someone started attacking me!");
+
             return true;
         }
 
         Log($"{nameof(AcquiredTarget)}: No target found after {maxTimeMs}ms");
         input.PressClearTarget();
         wait.Update();
+
         return false;
     }
 
@@ -105,9 +117,26 @@ public sealed class CombatUtil
 
     private void Log(string text)
     {
-        if (debug)
+        if (DEBUG)
         {
             logger.LogDebug($"{text}");
         }
     }
+
+
+    #region Logging
+
+    [LoggerMessage(
+        EventId = 1200,
+        Level = LogLevel.Information,
+        Message = "Entered Combat")]
+    static partial void LogEnteredCombat(ILogger logger);
+
+    [LoggerMessage(
+        EventId = 1201,
+        Level = LogLevel.Information,
+        Message = "Left Combat after {elapsedSec:0.00}sec")]
+    static partial void LogLeftCombat(ILogger logger, double elapsedSec);
+
+    #endregion
 }

--- a/Core/GoalsFactory/GoalFactory.cs
+++ b/Core/GoalsFactory/GoalFactory.cs
@@ -73,7 +73,7 @@ public static class GoalFactory
         services.AddScoped<CastingHandlerInterruptWatchdog>();
         services.AddScoped<CastingHandler>();
         services.AddScoped<StuckDetector>();
-        services.AddScoped<CombatUtil>();
+        services.AddScoped<CombatTracker>();
         services.AddScoped<SafeSpotCollector>();
 
         var playerReader = sp.GetRequiredService<PlayerReader>();

--- a/Core/Requirement/RequirementFactory.cs
+++ b/Core/Requirement/RequirementFactory.cs
@@ -185,7 +185,8 @@ public sealed partial class RequirementFactory
             { Flying, bits.Flying },
             { "Dead", bits.Dead },
 
-            { "MenuOpen", bits.GameMenuWindowShown }
+            { "MenuOpen", bits.GameMenuWindowShown },
+            { "ChatInputVisible", bits.ChatInputIsVisible }
         };
 
         AddAura("", boolVariables, playerBuffs);

--- a/README.md
+++ b/README.md
@@ -1724,6 +1724,7 @@ Allow requirements about what buffs/debuffs you have or the target has or in gen
 | `"Falling"` | The player is currently falling down, not touching the ground. |
 | `"Flying"` | The player is currently flying, not touching the ground. |
 | `"MenuOpen"` | Returns true if the Game Menu window is open (ESC) |
+| `"ChatInputVisible"` | Returns true if the Chat inputbox is open (ENTER) |
 | `"Dead"` | The player is currently dead. |
 | `"Has Pet"` | The player's pet is alive |
 | `"Pet HasTarget"` | Players pet has target |


### PR DESCRIPTION
Changes:

* Addon: Obtain `GetNumLootItems`
* Addon: While collecting spellbook only extract the highest rank `SpellId`. This can help speed up InitState for high level characters.
* Fix: Addon: `LOOT_RESET`/`LOOT_CORPSE` were not properly awaited.
* Addon: Bits for `LootFrame` and `ChatFrame` edit box is visible
* Fix: Addon: `Cataclysm`: Ammo and Pet happiness always returned false - however should have been the opposite
* Fix: Core: `ApproachTargetGoal`: While the `PullTargetGoal` was in progress and for some reason entered `ApproachTargetGoal`, if the target was not yet entered combat, prematurely cleared target.
* Core: `RequirementFactory`: Added `'MenuOpen'` and `'ChatInputVisible'`
* Core: `GoapAgent`: sets `GoapKey.pulled`
* Refactor: Core: `LootGoal`: `SkinningGoal`: If the loot window still open `OnEnter`. It just logs the state dont early return. Significantly refactored Loot in order to keep track better of the states. More verbose logging. From now on also considers SoftInteract and its shenanigans like a herb or mining node is in the way...
* Core: `CombatGoal`: better support for `KeyAction` interruption 
* Core: `ApproachTargetGoal`: Better blacklist detection. `CombatTracker` better integration
* Core: `PullTargetGoal`: Less likely to become stuck during the pull. The thread blocked less likely. Better detection the pull state
