### PR TITLE
Addon: [1.7.69] - Track Player Debuffs times. Adding 'TDebuff_'

### DIFF
--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -5,7 +5,7 @@
 -- Trigger between emitting game data and frame location data
 local SETUP_SEQUENCE = false
 -- Total number of data frames generated
-local NUMBER_OF_FRAMES = 106
+local NUMBER_OF_FRAMES = 108
 -- Set number of pixel rows
 local FRAME_ROWS = 1
 -- Size of data squares in px. Varies based on rounding errors as well as dimension size. Use as a guideline, but not 100% accurate.
@@ -193,6 +193,7 @@ local chatMsgHead = -2
 DataToColor.playerPetSummons = {}
 
 DataToColor.playerBuffTime = DataToColor.struct:new(AURA_DURATION_ITERATION_FRAME_CHANGE_RATE)
+DataToColor.playerDebuffTime = DataToColor.struct:new(AURA_DURATION_ITERATION_FRAME_CHANGE_RATE)
 DataToColor.targetBuffTime = DataToColor.struct:new(AURA_DURATION_ITERATION_FRAME_CHANGE_RATE)
 DataToColor.targetDebuffTime = DataToColor.struct:new(AURA_DURATION_ITERATION_FRAME_CHANGE_RATE)
 DataToColor.focusBuffTime = DataToColor.struct:new(AURA_DURATION_ITERATION_FRAME_CHANGE_RATE)
@@ -305,6 +306,7 @@ function DataToColor:Reset()
     DataToColor.actionBarCooldownQueue = DataToColor.struct:new(ACTION_BAR_ITERATION_FRAME_CHANGE_RATE)
 
     DataToColor.playerBuffTime = DataToColor.struct:new(AURA_DURATION_ITERATION_FRAME_CHANGE_RATE)
+    DataToColor.playerDebuffTime = DataToColor.struct:new(AURA_DURATION_ITERATION_FRAME_CHANGE_RATE)
     DataToColor.targetBuffTime = DataToColor.struct:new(AURA_DURATION_ITERATION_FRAME_CHANGE_RATE)
     DataToColor.targetDebuffTime = DataToColor.struct:new(AURA_DURATION_ITERATION_FRAME_CHANGE_RATE)
     DataToColor.focusBuffTime = DataToColor.struct:new(AURA_DURATION_ITERATION_FRAME_CHANGE_RATE)
@@ -721,7 +723,7 @@ function DataToColor:CreateFrames()
             Pixel(int, DataToColor:getAvgEquipmentDurability() * 100 + ((DataToColor.C.CHARACTER_CLASS_ID == 2 and UnitPower(DataToColor.C.unitPlayer, Enum.PowerType.HolyPower) or GetComboPoints(DataToColor.C.unitPlayer, DataToColor.C.unitTarget)) or 0), 54)                                                                                                                                                                                                                                                -- for paladin holy power or combo points
 
             local playerBuffCount = DataToColor:populateAuraTimer(UnitBuff, DataToColor.C.unitPlayer, DataToColor.playerBuffTime)
-            local playerDebuffCount = DataToColor:populateAuraTimer(UnitDebuff, DataToColor.C.unitPlayer, nil)
+            local playerDebuffCount = DataToColor:populateAuraTimer(UnitDebuff, DataToColor.C.unitPlayer, DataToColor.playerDebuffTime)
             local targetDebuffCount = DataToColor:populateAuraTimer(UnitDebuff, DataToColor.C.unitTarget, DataToColor.targetDebuffTime)
             local targetBuffCount = DataToColor:populateAuraTimer(UnitBuff, DataToColor.C.unitTarget, DataToColor.targetBuffTime)
             local focusBuffCount = DataToColor:populateAuraTimer(UnitBuff, DataToColor.C.unitFocus, DataToColor.focusBuffTime)
@@ -880,8 +882,6 @@ function DataToColor:CreateFrames()
             Pixel(int, UnitHealthMax(DataToColor.C.unitFocus), 89)
             Pixel(int, UnitHealth(DataToColor.C.unitFocus), 90)
             Pixel(int, DataToColor:getAuraMaskForClass(UnitBuff, DataToColor.C.unitFocus, DataToColor.S.playerBuffs), 91)
-            -- 92 used
-            -- 93 used
 
             -- 94 last cast GCD
             Pixel(int, DataToColor.lastCastGCD, 94)
@@ -939,6 +939,25 @@ function DataToColor:CreateFrames()
             Pixel(int, DataToColor:getGuidFromUUID(DataToColor.softInteractGuid), 101)
             Pixel(int, DataToColor:getNpcIdFromUUID(DataToColor.softInteractGuid), 102)
             Pixel(int, DataToColor:getTypeFromUUID(DataToColor.softInteractGuid), 103)
+
+            -- player debuff
+            textureId, expireTime = DataToColor.playerDebuffTime:getTimed(globalTick)
+            if textureId then
+                DataToColor.playerDebuffTime:setDirtyAfterTime(textureId, globalTick)
+
+                local durationSec = max(0, ceil(expireTime - GetTime()))
+                --DataToColor:Print("player debuff update  ", textureId, " ", durationSec)
+                Pixel(int, textureId, 104)
+                Pixel(int, durationSec, 105)
+
+                if durationSec == 0 then
+                    DataToColor.playerDebuffTime:removeWhenExpired(textureId, globalTick)
+                    --DataToColor:Print("player debuff expired ", textureId, " ", durationSec)
+                end
+            else
+                Pixel(int, 0, 104)
+                Pixel(int, 0, 105)
+            end
 
             UpdateGlobalTime()
             -- NUMBER_OF_FRAMES - 1 reserved for validation

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -3,7 +3,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors
-## Version: 1.7.68
+## Version: 1.7.69
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Core/Addon/AuraTimeReader.cs
+++ b/Core/Addon/AuraTimeReader.cs
@@ -15,6 +15,8 @@ public interface IAuraTimeReader
 
 public interface IPlayerBuffTimeReader : IAuraTimeReader { }
 
+public interface IPlayerDebuffTimeReader : IAuraTimeReader { }
+
 public interface ITargetDebuffTimeReader : IAuraTimeReader { }
 
 public interface ITargetBuffTimeReader : IAuraTimeReader { }

--- a/Core/DependencyInjection.cs
+++ b/Core/DependencyInjection.cs
@@ -67,6 +67,8 @@ public static class DependencyInjection
             x => new(83, 84));
         s.ForwardSingleton<AuraTimeReader<IFocusBuffTimeReader>, IReader>(
             x => new(92, 93));
+        s.ForwardSingleton<AuraTimeReader<IPlayerDebuffTimeReader>, IReader>(
+            x => new(104, 105));
 
         return s;
     }
@@ -135,6 +137,7 @@ public static class DependencyInjection
         s.ForwardSingleton<ActionBarBits<IUsableAction>>(sp);
 
         s.ForwardSingleton<AuraTimeReader<IPlayerBuffTimeReader>>(sp);
+        s.ForwardSingleton<AuraTimeReader<IPlayerDebuffTimeReader>>(sp);
         s.ForwardSingleton<AuraTimeReader<ITargetDebuffTimeReader>>(sp);
         s.ForwardSingleton<AuraTimeReader<ITargetBuffTimeReader>>(sp);
         s.ForwardSingleton<AuraTimeReader<IFocusBuffTimeReader>>(sp);

--- a/Core/Requirement/RequirementFactory.cs
+++ b/Core/Requirement/RequirementFactory.cs
@@ -103,6 +103,7 @@ public sealed partial class RequirementFactory
         combatLog = sp.GetRequiredService<CombatLog>();
 
         var playerBuff = sp.GetRequiredService<AuraTimeReader<IPlayerBuffTimeReader>>();
+        var playerDebuff = sp.GetRequiredService<AuraTimeReader<IPlayerDebuffTimeReader>>();
         var targetDebuff = sp.GetRequiredService<AuraTimeReader<ITargetDebuffTimeReader>>();
         var targetBuff = sp.GetRequiredService<AuraTimeReader<ITargetBuffTimeReader>>();
         var focusBuff = sp.GetRequiredService<AuraTimeReader<IFocusBuffTimeReader>>();
@@ -232,6 +233,7 @@ public sealed partial class RequirementFactory
             //"Buff_{textureId}"
             //"Debuff_{textureId}"
             //"TBuff_{textureId}"
+            //"TDebuff_{textureId}"
             //"FBuff_{textureId}"
             { "MainHandSpeed", playerReader.MainHandSpeedMs },
             { "MainHandSwing", MainHandSwing },
@@ -255,7 +257,8 @@ public sealed partial class RequirementFactory
         BindPathSettingsIntVariables(classConfig.Paths);
 
         InitUserDefinedIntVariables(classConfig.IntVariables,
-            playerBuff, targetDebuff,
+            playerBuff, playerDebuff,
+            targetDebuff,
             targetBuff, focusBuff);
     }
 
@@ -406,6 +409,7 @@ public sealed partial class RequirementFactory
 
     public void InitUserDefinedIntVariables(Dictionary<string, int> intKeyValues,
         AuraTimeReader<IPlayerBuffTimeReader> playerBuffTimeReader,
+        AuraTimeReader<IPlayerDebuffTimeReader> playerDebuffTimeReader,
         AuraTimeReader<ITargetDebuffTimeReader> targetDebuffTimeReader,
         AuraTimeReader<ITargetBuffTimeReader> targetBuffTimeReader,
         AuraTimeReader<IFocusBuffTimeReader> focusBuffTimeReader)
@@ -425,6 +429,11 @@ public sealed partial class RequirementFactory
                 intVariables.TryAdd($"{value}", l);
             }
             else if (key.StartsWith("Debuff_", StringComparison.InvariantCultureIgnoreCase))
+            {
+                int l() => playerDebuffTimeReader.GetRemainingTimeMs(value);
+                intVariables.TryAdd($"{value}", l);
+            }
+            else if (key.StartsWith("TDebuff_", StringComparison.InvariantCultureIgnoreCase))
             {
                 int l() => targetDebuffTimeReader.GetRemainingTimeMs(value);
                 intVariables.TryAdd($"{value}", l);

--- a/Json/class/DeathKnight_70_Unholy.json
+++ b/Json/class/DeathKnight_70_Unholy.json
@@ -11,8 +11,8 @@
     "MIN_HP_FOOD%": 40,
     "MIN_RUNE_TO_DUMP": 40,
     "ITEM_CORPSE_DUST": 37201,
-    "Debuff_Frost Fever": 237522,
-    "Debuff_Blood Plague": 237514,
+    "TDebuff_Frost Fever": 237522,
+    "TDebuff_Blood Plague": 237514,
     "MIN_TIME_REFRESH": 3500,
     "USE_TRINKET_1": 1,
     "USE_TRINKET_2": 1
@@ -192,7 +192,7 @@
         "Cooldown": 2000,
         "Requirements": [
           "MobCount < 2",
-          "Debuff_Frost Fever > MIN_TIME_REFRESH && Debuff_Blood Plague > MIN_TIME_REFRESH",
+          "TDebuff_Frost Fever > MIN_TIME_REFRESH && TDebuff_Blood Plague > MIN_TIME_REFRESH",
           "InMeleeRange"
         ]
       },
@@ -243,7 +243,7 @@
         "WhenUsable": true,
         "Requirements": [
           "MobCount == 1",
-          "Frost Fever && Blood Plague && (Debuff_Frost Fever < MIN_TIME_REFRESH || Debuff_Blood Plague < MIN_TIME_REFRESH)",
+          "Frost Fever && Blood Plague && (TDebuff_Frost Fever < MIN_TIME_REFRESH || TDebuff_Blood Plague < MIN_TIME_REFRESH)",
           "InMeleeRange"
         ]
       },

--- a/Json/class/DeathKnight_80_Frost.json
+++ b/Json/class/DeathKnight_80_Frost.json
@@ -9,8 +9,8 @@
   "IntVariables": {
     "MIN_HP_FOOD%": 40,
     "MIN_RUNE_TO_DUMP": 40,
-    "Debuff_Frost Fever": 237522,
-    "Debuff_Blood Plague": 237514,
+    "TDebuff_Frost Fever": 237522,
+    "TDebuff_Blood Plague": 237514,
     "MIN_TIME_REFRESH": 3500
   },
   "Form": {
@@ -111,7 +111,7 @@
         "Key": "F6",
         "WhenUsable": true,
         "Requirements": [
-          "Frost Fever && Blood Plague && (Debuff_Frost Fever < MIN_TIME_REFRESH || Debuff_Blood Plague < MIN_TIME_REFRESH)",
+          "Frost Fever && Blood Plague && (TDebuff_Frost Fever < MIN_TIME_REFRESH || TDebuff_Blood Plague < MIN_TIME_REFRESH)",
           "InMeleeRange"
         ]
       },
@@ -197,7 +197,7 @@
         "Cooldown": 2000,
         "Requirements": [
           "MobCount < 2",
-          "Debuff_Frost Fever > MIN_TIME_REFRESH && Debuff_Blood Plague > MIN_TIME_REFRESH",
+          "TDebuff_Frost Fever > MIN_TIME_REFRESH && TDebuff_Blood Plague > MIN_TIME_REFRESH",
           "InMeleeRange"
         ]
       },

--- a/Json/class/DeathKnight_80_Unholy.json
+++ b/Json/class/DeathKnight_80_Unholy.json
@@ -11,8 +11,8 @@
     "MIN_HP_FOOD%": 40,
     "MIN_RUNE_TO_DUMP": 40,
     "ITEM_CORPSE_DUST": 37201,
-    "Debuff_Frost Fever": 237522,
-    "Debuff_Blood Plague": 237514,
+    "TDebuff_Frost Fever": 237522,
+    "TDebuff_Blood Plague": 237514,
     "MIN_TIME_REFRESH": 3500
   },
   "Form": {
@@ -160,7 +160,7 @@
         "Cooldown": 2000,
         "Requirements": [
           "MobCount < 2",
-          "Debuff_Frost Fever > MIN_TIME_REFRESH && Debuff_Blood Plague > MIN_TIME_REFRESH",
+          "TDebuff_Frost Fever > MIN_TIME_REFRESH && TDebuff_Blood Plague > MIN_TIME_REFRESH",
           "InMeleeRange"
         ]
       },
@@ -197,7 +197,7 @@
         "Key": "7",
         "Requirements": [
           "MobCount > 1",
-          "Frost Fever && Blood Plague && (Debuff_Frost Fever < MIN_TIME_REFRESH || Debuff_Blood Plague < MIN_TIME_REFRESH)",
+          "Frost Fever && Blood Plague && (TDebuff_Frost Fever < MIN_TIME_REFRESH || TDebuff_Blood Plague < MIN_TIME_REFRESH)",
           "InMeleeRange"
         ]
       },

--- a/Json/class/Druid_60_cat_bear.json
+++ b/Json/class/Druid_60_cat_bear.json
@@ -11,8 +11,8 @@
     "MIN_TARGET_HP_DOT%": 20,
     "MIN_TARGET_HP_CD%": 75,
     "Item_Clam": 7973,
-    "Debuff_Faerie Fire": 136033,
-    "Debuff_Mangle": 132135
+    "TDebuff_Faerie Fire": 136033,
+    "TDebuff_Mangle": 132135
   },
   "Form": {
     "Sequence": [
@@ -116,7 +116,7 @@
           "MobCount < 2",
           "Form:Druid_Cat",
           "Talent:Mangle",
-          "Debuff_Mangle <= 0 || Energy >= 95"
+          "TDebuff_Mangle <= 0 || Energy >= 95"
         ],
         "Form": "Druid_Cat"
       },
@@ -250,7 +250,7 @@
         "Usable": true,
         "Requirements": [
           "Form:Druid_Cat || Form:Druid_Bear",
-          "Debuff_Faerie Fire < 2000",
+          "TDebuff_Faerie Fire < 2000",
           "Spell:Faerie Fire"
         ]
       },

--- a/Json/class/Druid_80_moonkin_assist.json
+++ b/Json/class/Druid_80_moonkin_assist.json
@@ -13,8 +13,8 @@
   "IntVariables": {
     "MIN_TARGET_HP_DOT%": 20,
     "MIN_TARGET_HP_CD%": 75,
-    "Debuff_Faerie Fire": 136033,
-    "Debuff_Mangle": 132135,
+    "TDebuff_Faerie Fire": 136033,
+    "TDebuff_Mangle": 132135,
     "FBuff_Mount": 132239,
     "USE_TRINKET_1": 1,
     "USE_TRINKET_2": 1

--- a/Json/class/Paladin_20.json
+++ b/Json/class/Paladin_20.json
@@ -1,10 +1,26 @@
 {
   "ClassName": "Paladin",
+  "Mode": "AttendedGrind",
   "PathFilename": "_pack\\1-20\\Human\\19-21_Duskwood_Hushed Bank.json",
   "IntVariables": {
     "MIN_SPEED_SEAL": 3000,
     "MIN_TARGET_HP%": 20,
-    "MIN_HP_BEFORE_HEAL%": 20
+    "MIN_HP_BEFORE_HEAL%": 20,
+    "Debuff_POISON1": 136006,
+    "Debuff_POISON2": 136007,
+    "Debuff_POISON3": 136016,
+    "Debuff_POISON4": 136064,
+    "Debuff_POISON5": 136067,
+    "Debuff_POISON6": 136077,
+    "Debuff_POISON7": 136093,
+    "Debuff_POISON8": 134437,
+    "Debuff_POISON9": 132273,
+    "Debuff_POISON10": 132274,
+    "Debuff_POISON11": 132105,
+    "Debuff_DISEASE1": 136127,
+    "Debuff_DISEASE2": 136134,
+    "Debuff_DISEASE3": 134324,
+    "Debuff_DISEASE4": 135914
   },
   "Pull": {
     "Sequence": [
@@ -33,115 +49,6 @@
   "Combat": {
     "Sequence": [
       {
-        "Name": "Divine Protection",
-        "Key": "N1",
-        "WhenUsable": true,
-        "Requirements": [
-          "Health% < MIN_HP_BEFORE_HEAL%",
-          "!Blessing of Protection"
-        ]
-      },
-      {
-        "Name": "Blessing of Protection",
-        "Key": "N2",
-        "WhenUsable": true,
-        "Requirements": [
-          "Health% < MIN_HP_BEFORE_HEAL%",
-          "!Divine Protection"
-        ]
-      },
-      {
-        "Name": "Lay on Hands",
-        "Key": "N3",
-        "WhenUsable": true,
-        "Requirements": [
-          "Health% < MIN_HP_BEFORE_HEAL%",
-          "!Blessing of Protection && CD_Blessing of Protection > 0",
-          "!Divine Protection && CD_Divine Protection > 0"
-        ]
-      },
-      {
-        "Name": "Holy Light",
-        "Key": "3",
-        "HasCastBar": true,
-        "WhenUsable": true,
-        "Requirements": [
-          "Health% < 75",
-          "(Blessing of Protection || Divine Protection)"
-        ]
-      },
-      {
-        "Name": "Flash of Light",
-        "Key": "8",
-        "HasCastBar": true,
-        "WhenUsable": true,
-        "Requirements": [
-          "Health% < 60",
-          "!Blessing of Protection && CD_Blessing of Protection > 0 && !Divine Protection && CD_Divine Protection > 0",
-          "MobCount < 2",
-          "LastMainHandMs <= 1000"
-        ],
-        "Cooldown": 6000
-      },
-      {
-        "Name": "Consecration",
-        "Key": "0",
-        "WhenUsable": true,
-        "Requirements": [
-          "Mana% > 50",
-          "MobCount > 1"
-        ]
-      },
-      {
-        "Name": "Seal of the Crusader",
-        "Key": "6",
-        "Requirements": [
-          "!Seal of the Crusader",
-          "!Judgement of the Crusader",
-          "TargetHealth% > MIN_TARGET_HP%"
-        ]
-      },
-      {
-        "Name": "Judgement",
-        "Key": "1",
-        "WhenUsable": true,
-        "Requirements": [
-          "!Judgement of the Crusader || Hammer of Justice || CD_Hammer of Justice > CD_Judgement",
-          "Seal of Command || Seal of Righteousness || Seal of the Crusader"
-        ],
-        "AfterCastDelay": 25
-      },
-      {
-        "Name": "Hammer of Justice",
-        "Key": "7",
-        "WhenUsable": true,
-        "Requirements": [
-          "Judgement of the Crusader && CD_Judgement <= GCD && TargetHealth% > MIN_TARGET_HP% || TargetCastingSpell"
-        ]
-      },
-      {
-        "Name": "Seal of Command",
-        "Key": "9",
-        "WhenUsable": true,
-        "Requirements": [
-          "Talent:Seal of Command && MainHandSpeed > MIN_SPEED_SEAL",
-          "!Seal of Command",
-          "Judgement of the Crusader",
-          "TargetHealth% > MIN_TARGET_HP%"
-        ]
-      },
-      {
-        "Name": "Seal of Righteousness",
-        "Key": "2",
-        "WhenUsable": true,
-        "Requirements": [
-          "!Talent:Seal of Command || MainHandSpeed < MIN_SPEED_SEAL",
-          "!Seal of Righteousness",
-          "Judgement of the Crusader",
-          "TargetHealth% > MIN_TARGET_HP%"
-        ]
-      },
-      {
         "Name": "AutoAttack",
         "Requirements": [
           "!Divine Protection",
@@ -157,17 +64,6 @@
   "Adhoc": {
     "Sequence": [
       {
-        "Name": "Blessing of Might",
-        "Key": "4",
-        "Requirement": "!Blessing of Might"
-      },
-      {
-        /*
-#showtooltip
-/use Heavy Weightstone
-/use 16
-/click StaticPopup1Button1
-*/
         "Name": "sharpen",
         "Key": "F1",
         "WhenUsable": true,
@@ -177,10 +73,14 @@
         "AfterCastAuraExpected": true
       },
       {
-        "Name": "Retribution Aura",
-        "Key": "5",
-        "Requirement": "!Form:Paladin_Retribution_Aura",
-        "AfterCastAuraExpected": true
+        "Cost": 3.1,
+        "Name": "Stoneform",
+        "Key": "9",
+        "InCombat": "i dont care",
+        "WhenUsable": true,
+        "Requirements": [
+          "Debuff_POISON1 > 1 || Debuff_POISON2 > 1 || Debuff_POISON3 > 1 || Debuff_POISON4 > 1 || Debuff_POISON5 > 1 || Debuff_POISON6 > 1 || Debuff_POISON7 > 1 || Debuff_POISON8 > 1 || Debuff_POISON9 > 1 || Debuff_POISON10 > 1 || Debuff_POISON11 > 1 || Debuff_DISEASE1 > 1 || Debuff_DISEASE2 > 1 || Debuff_DISEASE3 > 1 || Debuff_DISEASE4 > 1"
+        ]
       }
     ]
   },

--- a/README.md
+++ b/README.md
@@ -605,8 +605,12 @@ For example look at the Warlock profiles.
 ```json
 "IntVariables": {
     "DOT_MIN_HEALTH%": 35,
-    "Debuff_Frost Fever": 237522,   // iconId https://www.wowhead.com/icons
-    "Debuff_Blood Plague": 237514,  // iconId https://www.wowhead.com/icons
+    "TDebuff_Frost Fever": 237522,   // iconId https://www.wowhead.com/icons
+    "TDebuff_Blood Plague": 237514,  // iconId https://www.wowhead.com/icons
+    "FBuff_Rejunevation": 12345,
+    "Buff_Slice and Dice": 99999,
+    "Debuff_Poision": 135368,
+    "TBuff_Dispell on Target": 16846,
     "Item_Soul_Shard": 6265,
 }
 ```
@@ -1383,8 +1387,15 @@ Formula: `[Keyword] [Operator] [Numeric integer value]`
 | `CD` | Returns the context [KeyAction](#keyaction) **in-game** cooldown in milliseconds |
 | `CD_{KeyAction.Name}` | Returns the given `{KeyAction.Name}` **in-game** cooldown in milliseconds |
 | `Cost_{KeyAction.Name}` | Returns the given `{KeyAction.Name}` cost value |
-| `Buff_{IntVariable_Name}` | Returns the given `{IntVariable_Name}` remaining player buff up time |
-| `Debuff_{IntVariable_Name}` | Returns the given `{IntVariable_Name}` remaining target debuff up time |
+| --- | --- |
+| `Buff_{IntVariable_Name}` | Returns the given `{IntVariable_Name}` remaining **player buff** up time in miliseconds |
+| `Debuff_{IntVariable_Name}` | Returns the given `{IntVariable_Name}` remaining **player debuff** up time in miliseconds |
+| --- | --- |
+| `TBuff_{IntVariable_Name}` | Returns the given `{IntVariable_Name}` remaining **target debuff** up time in miliseconds |
+| `TDebuff_{IntVariable_Name}` | Returns the given `{IntVariable_Name}` remaining **target debuff** up time in miliseconds |
+| --- | --- |
+| `FBuff_{IntVariable_Name}` | Returns the given `{IntVariable_Name}` remaining **focus buff** up time in miliseconds |
+| --- | --- |
 | `CurGCD` | Returns the player current remaining GCD time |
 | `GCD` | Alias for `1500` value |
 | `Kills` | In the current session how many mobs have been killed by the player. |
@@ -1642,17 +1653,57 @@ e.g.
 }     
 ```
 ---
-### **Target Debuff remaining time requirements**
+### **Player Debuff remaining time requirements**
 
-First in the `IntVariables` have to mention the buff icon id such as `Debuff_{your fancy name}: {icon_id}`
+First in the `IntVariables` have to mention the buff icon id such as `Debuff_{your fancy name}: {icon_id}`.
 
 It is important, the addon keeps track of the **icon_id**! Not **spell_id**
 
 e.g.
 ```json
 "IntVariables": {
-    "Debuff_Blood Plague": 237514,
-    "Debuff_Frost Fever": 237522
+    "Debuff_POISON1": 136006,
+    "Debuff_POISON2": 136007,
+    "Debuff_POISON3": 136016,
+    "Debuff_POISON4": 136064,
+    "Debuff_POISON5": 136067,
+    "Debuff_POISON6": 136077,
+    "Debuff_POISON7": 136093,
+    "Debuff_POISON8": 134437,
+    "Debuff_POISON9": 132273,
+    "Debuff_POISON10": 132274,
+    "Debuff_POISON11": 132105,
+    "Debuff_DISEASE1": 136127,
+    "Debuff_DISEASE2": 136134,
+    "Debuff_DISEASE3": 134324,
+    "Debuff_DISEASE4": 135914
+},
+```
+
+Then in [KeyAction](#keyaction) you can use the following requirement:
+
+e.g.
+```json
+{
+    "Name": "Stoneform",
+    "Key": "F11",
+    "Requirements": [
+        "Debuff_POISON1 > 1 || Debuff_POISON2 > 1 || Debuff_POISON3 > 1 || Debuff_POISON4 > 1 || Debuff_POISON5 > 1 || Debuff_POISON6 > 1 || Debuff_POISON7 > 1 || Debuff_POISON8 > 1 || Debuff_POISON9 > 1 || Debuff_POISON10 > 1 || Debuff_POISON11 > 1 || Debuff_DISEASE1 > 1 || Debuff_DISEASE2 > 1 || Debuff_DISEASE3 > 1 || Debuff_DISEASE4 > 1"
+    ]
+}  
+```
+---
+### **Target Debuff remaining time requirements**
+
+First in the `IntVariables` have to mention the debuff icon id such as `TDebuff_{your fancy name}: {icon_id}`
+
+It is important, the addon keeps track of the **icon_id**! Not **spell_id**
+
+e.g.
+```json
+"IntVariables": {
+    "TDebuff_Blood Plague": 237514,
+    "TDebuff_Frost Fever": 237522
 },
 ```
 
@@ -1665,7 +1716,7 @@ e.g.
     "Key": "F6",
     "WhenUsable": true,
     "Requirements": [
-        "Frost Fever && Blood Plague && (Debuff_Frost Fever < 2000 || Debuff_Blood Plague < 2000)",   // Frost Fever and Blood Plague is up
+        "Frost Fever && Blood Plague && (TDebuff_Frost Fever < 2000 || TDebuff_Blood Plague < 2000)",   // Frost Fever and Blood Plague is up
         "InMeleeRange"                                                                                // and their duration less then 2 seconds
     ]
 }


### PR DESCRIPTION
Breaking change:

* In prior `Debuff_` was meant to keep track of those Aura times which are inflicted the player on the target - Debuffs.

Since this version
* `Debuff_`  -> keep tracks the player debuffs. Those auras which are inflicted by the enemy on the player.
* `TDebuff_`  -> keep tracks the target debuffs. Those auras which are inflicted by the player on the enemy.

To migrate search for
```
Debuff_
```
and replace it to
```
TDebuff_
```


To keep the naming consistent.

---

example usage as Dwarf [Stonform](https://www.wowhead.com/classic/spell=20594/stoneform)

```json
  "IntVariables": {
    "MIN_SPEED_SEAL": 3000,
    "MIN_TARGET_HP%": 20,
    "MIN_HP_BEFORE_HEAL%": 20,
    "Debuff_POISON1": 136006,
    "Debuff_POISON2": 136007,
    "Debuff_POISON3": 136016,
    "Debuff_POISON4": 136064,
    "Debuff_POISON5": 136067,
    "Debuff_POISON6": 136077,
    "Debuff_POISON7": 136093,
    "Debuff_POISON8": 134437,
    "Debuff_POISON9": 132273,
    "Debuff_POISON10": 132274,
    "Debuff_POISON11": 132105,
    "Debuff_DISEASE1": 136127,
    "Debuff_DISEASE2": 136134,
    "Debuff_DISEASE3": 134324,
    "Debuff_DISEASE4": 135914
  },
  ```
  
  ```json
  {
  "Cost": 3.1,
  "Name": "Stoneform",
  "Key": "9",
  "InCombat": "i dont care",
  "WhenUsable": true,
  "Requirements": [
    "Debuff_POISON1 > 1 || Debuff_POISON2 > 1 || Debuff_POISON3 > 1 || Debuff_POISON4 > 1 || Debuff_POISON5 > 1 || Debuff_POISON6 > 1 || Debuff_POISON7 > 1 || Debuff_POISON8 > 1 || Debuff_POISON9 > 1 || Debuff_POISON10 > 1 || Debuff_POISON11 > 1 || Debuff_DISEASE1 > 1 || Debuff_DISEASE2 > 1 || Debuff_DISEASE3 > 1 || Debuff_DISEASE4 > 1"
  ]
}
```
  

