### PR TITLE
Addon: [1.7.70] - GossipOptions orderIndex - SOM 140 and TBC 252

### DIFF
--- a/Addons/DataToColor/Constants.lua
+++ b/Addons/DataToColor/Constants.lua
@@ -74,6 +74,20 @@ DataToColor.C.GossipIcon = {
     [132060] = 10,  --vendor
 }
 
+DataToColor.C.Gossip = {
+    ["banker"] = 0,
+    ["battlemaster"] = 1,
+    ["binder"] = 2,
+    ["gossip"] = 3,
+    ["healer"] = 4,
+    ["petition"] = 5,
+    ["tabard"] = 6,
+    ["taxi"] = 7,
+    ["trainer"] = 8,
+    ["unlearn"] = 9,
+    ["vendor"] = 10,
+}
+
 -- Gossips
 DataToColor.C.GuidType = {
     ["None"] = 0,

--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -893,6 +893,9 @@ function DataToColor:CreateFrames()
             if globalTick % LATENCY_ITERATION_FRAME_CHANGE_RATE == 0 then
                 local _, _, lagHome, lagWorld = GetNetStats()
 
+                -- artificially increase lagWorld to avoid skipping timers
+                lagWorld = max(lagWorld, 10)
+
                 local lag = min(max(lagHome, lagWorld), 9999)
 
                 Pixel(int, 10000 * SpellQueueWindow + lag, 96)

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -3,7 +3,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors
-## Version: 1.7.69
+## Version: 1.7.70
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/EventHandlers.lua
+++ b/Addons/DataToColor/EventHandlers.lua
@@ -42,8 +42,8 @@ local CAST_SUCCESS = 999999
 local MERCHANT_SHOW_V = 9999999
 local MERCHANT_CLOSED_V = 9999998
 
-local GOSSIP_START = 69
-local GOSSIP_END = 9999994
+DataToColor.GOSSIP_START = 69
+DataToColor.GOSSIP_END = 9999994
 
 local som_spellId = 0
 
@@ -110,7 +110,7 @@ function DataToColor:RegisterEvents()
     DataToColor:RegisterEvent('MERCHANT_CLOSED', 'OnMerchantClosed')
     DataToColor:RegisterEvent('PLAYER_TARGET_CHANGED', 'OnPlayerTargetChanged')
     DataToColor:RegisterEvent('PLAYER_EQUIPMENT_CHANGED', 'OnPlayerEquipmentChanged')
-    DataToColor:RegisterEvent('GOSSIP_SHOW', 'OnGossipShow')
+    DataToColor:RegisterEvent('GOSSIP_SHOW', 'OnGossipShow') -- defined in Versions.lua
     DataToColor:RegisterEvent('SPELLS_CHANGED', 'OnSpellsChanged')
     DataToColor:RegisterEvent('ACTIONBAR_SLOT_CHANGED', 'ActionbarSlotChanged')
     DataToColor:RegisterEvent('CORPSE_IN_RANGE', 'CorpseInRangeEvent')
@@ -555,6 +555,7 @@ function DataToColor:OnPlayerEquipmentChanged(event, equipmentSlot, hasCurrent)
     --DataToColor:Print("OnPlayerEquipmentChanged "..equipmentSlot.." -> "..c)
 end
 
+--[[
 function DataToColor:OnGossipShow(event)
     local options = GetGossipOptions()
     if not options then
@@ -571,6 +572,7 @@ function DataToColor:OnGossipShow(event)
     end
     DataToColor.gossipQueue:push(GOSSIP_END)
 end
+]]--
 
 function DataToColor:OnSpellsChanged(event)
     DataToColor:InitTalentQueue()

--- a/Addons/DataToColor/Versions.lua
+++ b/Addons/DataToColor/Versions.lua
@@ -149,3 +149,43 @@ DataToColor.UnitLevelSafe = function(unit, playerLevel)
 
   return level
 end
+
+DataToColor.OnGossipShow = function(event)
+  if Som140 or TBC252 then
+    local options = { DataToColor:GetGossipOptions() }
+    local count = #options / 2
+    if count == 0 then
+      return
+    end
+
+    DataToColor.gossipQueue:push(DataToColor.GOSSIP_START)
+    -- returns variable string - format of one entry
+    -- [1] localized name
+    -- [2] gossip_type
+    for k, v in pairs(options) do
+      if k % 2 == 0 then
+        DataToColor.gossipQueue:push(10000 * count + 100 * (k / 2) + DataToColor.C.Gossip[v])
+      end
+    end
+  else
+    local options = DataToColor:GetGossipOptions()
+    if not options then
+      return
+    end
+
+    table.sort(options, function(a, b)
+      return (a.orderIndex or 0) < (b.orderIndex or 0)
+    end)
+
+    DataToColor.gossipQueue:push(DataToColor.GOSSIP_START)
+
+    local count = #options
+    for i, v in pairs(options) do
+      local hash = 10000 * count + 100 * i + DataToColor.C.GossipIcon[v.icon]
+      --DataToColor:Print(i .. " " .. v.icon .. " " .. DataToColor.C.GossipIcon[v.icon] .. " " .. v.name .. " " .. hash)
+      DataToColor.gossipQueue:push(hash)
+    end
+  end
+
+  DataToColor.gossipQueue:push(DataToColor.GOSSIP_END)
+end


### PR DESCRIPTION
Key Changes:
* In modern client the GossipOptions are reordered based on orderIndex. 
* Meanwhile bring back to support old GossipOptions at Som 140 and TBC 252 client