### PR TITLE
Frontend: PathSelector: AutoComplete dropdown search result preview image

### DIFF
--- a/BlazorServer/App.razor
+++ b/BlazorServer/App.razor
@@ -36,6 +36,7 @@
     <script src="@Assets["_content/Frontend/script/panzoom.min.js"]"></script>
     <script src="@Assets["_content/Frontend/script/gather.js"]"></script>
     <script src="@Assets["_content/Frontend/script/route.js"]"></script>
+    <script src="@Assets["_content/Frontend/script/autocomplete-image-injector.js"]"></script>
 
     <script src="@Assets["_content/Frontend/leaflet/leaflet.js"]" ></script>
 

--- a/Frontend/Pages/PathSelectorComponent.razor
+++ b/Frontend/Pages/PathSelectorComponent.razor
@@ -1,43 +1,17 @@
 ﻿@using System.IO
+@using Microsoft.AspNetCore.Components
+@using Microsoft.JSInterop
 
 @inject IBotController botController
 @inject DataConfig dataConfig
+@inject IJSRuntime JSRuntime
 
 @implements IDisposable
 
 <style>
-    .thumbnail {
-    position: relative;
-    z-index: 0;
-    text-decoration: none;
-    }
-
-    .thumbnail:hover {
-    background-color: transparent;
-    z-index: 50;
-    }
-
-    .thumbnail .thumbnail-img {
-    /*CSS for enlarged image*/
-    position: absolute;
-    padding: 5px;
-    visibility: hidden;
-    text-decoration: none;
-    }
-
-    .thumbnail .thumbnail-img img {
-    padding: 2px;
-    }
-
-    .thumbnail:hover .thumbnail-img {
-    /*CSS for enlarged image on hover*/
-    visibility: visible;
-    transform: scale(2);
-    transform-origin: top left;
-    position: fixed;
-    top: 5px;
-    left: 5px;
-    pointer-events: none;
+    #path-autocomplete-container .dropdown-menu {
+        max-height: 600px !important;
+        overflow-y: auto;
     }
 </style>
 
@@ -47,7 +21,7 @@
             <div class="p-2 bd-highlight">
                 Path Profile
             </div>
-            <div class="p-2 flex-grow-1 bd-highlight">
+            <div class="p-2 flex-grow-1 bd-highlight" id="path-autocomplete-container">
                 <AutoComplete @bind-Value="Selected"
                 TItem="AutoCompleteItem"
                 DataProvider="DataProvider"
@@ -77,7 +51,6 @@
 
     private IEnumerable<string> Files { get; set; } = null!;
 
-    private int VisibleNum { get; set; } = 10;
     private string Selected { get; set; } = new("");
     private bool ButtonDisabled { get; set; } = true;
 
@@ -113,9 +86,31 @@
         Selected = Target?.FileName ?? string.Empty;
     }
 
-    protected override void OnAfterRender(bool firstRender)
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        base.OnAfterRender(firstRender);
+        await base.OnAfterRenderAsync(firstRender);
+
+        if (firstRender)
+        {
+            await InitializeImageInjectorAsync();
+        }
+    }
+
+    private async Task InitializeImageInjectorAsync()
+    {
+        if (Files == null || !Files.Any())
+        {
+            await JSRuntime.InvokeVoidAsync("PathAutocompleteImageInjector.init", []);
+            return;
+        }
+
+        var allItems = Files
+            .Select(name => {
+                return new { name, imagePath = GetImagePath(name) };
+            })
+            .ToList();
+
+        await JSRuntime.InvokeVoidAsync("PathAutocompleteImageInjector.init", allItems);
     }
 
     public void Dispose()
@@ -144,11 +139,6 @@
         base.InvokeAsync(StateHasChanged);
     }
 
-    private void OnTextChanged(string text)
-    {
-        VisibleNum = string.IsNullOrEmpty(text) ? 10 : 50;
-    }
-
     private void OnChanged(object? sender, FileSystemEventArgs e)
     {
         GetData();
@@ -174,19 +164,45 @@
         {
             Selected = selected ?? string.Empty;
         }
+
+        // Update image map when files change
+        _ = UpdateImageMapAsync();
+    }
+
+    private async Task UpdateImageMapAsync()
+    {
+        if (Files == null || !Files.Any())
+            return;
+
+        var allItems = Files
+            .Select(name => new { name, imagePath = GetImagePath(name) ?? "" })
+            .ToList();
+
+        await JSRuntime.InvokeVoidAsync("PathAutocompleteImageInjector.update", allItems);
     }
 
     private async Task<AutoCompleteDataProviderResult<AutoCompleteItem>> DataProvider(AutoCompleteDataProviderRequest<AutoCompleteItem> request)
     {
         GetData();
 
-        var items = Files.Select(x => new AutoCompleteItem(x));
+        var items = Files.Select(x => new AutoCompleteItem(x, GetImagePath(x)));
 
         return await Task.FromResult(request.ApplyTo(items.OrderBy(i => i.Name)));
     }
 
-    public sealed class AutoCompleteItem(string name)
+    private string GetImagePath(string profileName)
+    {
+        if (string.IsNullOrEmpty(profileName))
+            return string.Empty;
+
+        var jpgFileName = Path.ChangeExtension(profileName, ".jpg");
+
+        return Path.Combine("path", jpgFileName);
+    }
+
+    public sealed class AutoCompleteItem(string name, string imagePath)
     {
         public string Name { get; set; } = name;
+        public string ImagePath { get; set; } = imagePath;
     }
 }

--- a/Frontend/wwwroot/script/autocomplete-image-injector.js
+++ b/Frontend/wwwroot/script/autocomplete-image-injector.js
@@ -1,0 +1,146 @@
+window.PathAutocompleteImageInjector = (function () {
+    let observer = null;
+    let imageMap = null;
+
+    function updateImageMap(itemsWithImages) {
+        imageMap = new Map(
+            itemsWithImages
+                .filter(item => item.imagePath && item.imagePath.length > 0)
+                .map(item => [item.name, item.imagePath])
+        );
+    }
+
+    function initPathAutocompleteImageInjector(itemsWithImages) {
+
+        const container = document.getElementById('path-autocomplete-container');
+        if (!container) {
+            console.warn('Container path-autocomplete-container not found');
+            return;
+        }
+
+        // Initialize or update image map
+        updateImageMap(itemsWithImages);
+
+        // Disconnect existing observer
+        if (observer) {
+            observer.disconnect();
+        }
+
+        // Observe the dropdown list for changes
+        observer = new MutationObserver(() => {
+            const dropdown = container.querySelector('.dropdown-menu');
+            if (!dropdown) return;
+
+            //console.log('Dropdown detected, processing items...');
+            const items = dropdown.querySelectorAll('.dropdown-item');
+            //console.log('Found', items.length, 'dropdown items');
+
+            items.forEach(item => {
+                if (item.dataset.imageProcessed) return;
+
+                const text = item.textContent.trim();
+                //console.log('Processing item:', text);
+                const imagePath = imageMap.get(text);
+                //console.log('Image path:', imagePath);
+
+                if (imagePath) {
+                    //console.log('Injecting image for:', text);
+                    item.dataset.imageProcessed = 'true';
+
+                    // Wrap the existing content
+                    const wrapper = document.createElement('div');
+                    wrapper.className = 'd-flex align-items-center';
+                    wrapper.style.width = '100%';
+
+                    // Create small thumbnail image
+                    const smallImg = document.createElement('img');
+                    smallImg.src = imagePath;
+                    smallImg.alt = '';
+                    smallImg.style.width = '24px';
+                    smallImg.style.height = '24px';
+                    smallImg.style.marginRight = '8px';
+                    smallImg.style.objectFit = 'cover';
+                    smallImg.style.cursor = 'pointer';
+
+                    // Create hover preview that will be appended to body
+                    const hoverPreview = document.createElement('div');
+                    hoverPreview.style.cssText = `
+                        position: fixed;
+                        top: 10px;
+                        left: 10px;
+                        border: 2px solid #333;
+                        box-shadow: 0 4px 8px rgba(0,0,0,0.3);
+                        z-index: 99999;
+                        display: none;
+                        pointer-events: none;
+                    `;
+
+                    const largeImg = document.createElement('img');
+                    largeImg.src = imagePath;
+                    largeImg.alt = '';
+                    largeImg.style.cssText = `
+                        max-width: 90vw;
+                        max-height: 90vh;
+                        width: auto;
+                        height: auto;
+                        display: block;
+                    `;
+
+                    hoverPreview.appendChild(largeImg);
+                    document.body.appendChild(hoverPreview);
+
+                    // Add hover events to show/hide the preview
+                    smallImg.addEventListener('mouseenter', () => {
+                        hoverPreview.style.display = 'block';
+                    });
+
+                    smallImg.addEventListener('mouseleave', () => {
+                        hoverPreview.style.display = 'none';
+                    });
+
+                    // Also show on item hover
+                    item.addEventListener('mouseenter', () => {
+                        hoverPreview.style.display = 'block';
+                    });
+
+                    item.addEventListener('mouseleave', () => {
+                        hoverPreview.style.display = 'none';
+                    });
+
+                    // Cleanup when dropdown is removed or item is removed
+                    const cleanup = () => {
+                        if (hoverPreview.parentNode) {
+                            hoverPreview.remove();
+                        }
+                    };
+
+                    // Store cleanup function for later
+                    item._cleanupPreview = cleanup;
+
+                    // Create text span
+                    const textSpan = document.createElement('span');
+                    textSpan.textContent = text;
+
+                    wrapper.appendChild(smallImg);
+                    wrapper.appendChild(textSpan);
+
+                    item.textContent = '';
+                    item.appendChild(wrapper);
+                    //console.log('Image injected successfully for:', text);
+                } else {
+                    //console.log('No image path found for:', text);
+                }
+            });
+        });
+
+        observer.observe(container, {
+            childList: true,
+            subtree: true
+        });
+    }
+
+    return {
+        init: initPathAutocompleteImageInjector,
+        update: updateImageMap
+    };
+})();


### PR DESCRIPTION
Last time when i did the migration to [BlazorBootstrap.AutoComplete](https://demos.blazorbootstrap.com/form/autocomplete) the old functionality was lost. Let's bring it back! With some hacks and workaround...

Yellow highlight

<img width="2227" height="1167" alt="image" src="https://github.com/user-attachments/assets/b83c56b1-b759-4283-8653-f9baf9b9bae4" />

