### PR TITLE
Fix: 684 - AssistFocus - bot doesn't join party1's combat encounter

### DIFF
--- a/Core/Goals/PullTargetGoal.cs
+++ b/Core/Goals/PullTargetGoal.cs
@@ -86,9 +86,12 @@ public sealed class PullTargetGoal : GoapGoal, IGoapEventListener
             }
         }
 
-        AddPrecondition(GoapKey.targettargetsus, false);
         AddPrecondition(GoapKey.hastarget, true);
         AddPrecondition(GoapKey.targetisalive, true);
+        if (classConfig.Mode != Mode.AssistFocus)
+        {
+            AddPrecondition(GoapKey.targettargetsus, false);
+        }
         AddPrecondition(GoapKey.targethostile, true);
         AddPrecondition(GoapKey.withinpullrange, true);
 

--- a/Core/Goals/TargetFocusTargetGoal.cs
+++ b/Core/Goals/TargetFocusTargetGoal.cs
@@ -35,8 +35,10 @@ public sealed class TargetFocusTargetGoal : GoapGoal
             return false;
 
         return
-            (bits.FocusTarget_Hostile() && bits.FocusTarget_Combat()) ||
-            !bits.FocusTarget_Hostile();
+            !bits.TargetTarget_PlayerOrPet() &&
+            ((bits.FocusTarget_Hostile() && bits.FocusTarget_Combat()) ||
+            !bits.FocusTarget_Hostile() ||
+            CanPull());
     }
 
     public override void OnEnter()
@@ -47,9 +49,9 @@ public sealed class TargetFocusTargetGoal : GoapGoal
 
     public override void Update()
     {
-        if (bits.FocusTarget_Hostile())
+        if (bits.FocusTarget_Hostile() || playerReader.IsTargetCasting())
         {
-            if (bits.FocusTarget_Combat())
+            if (bits.FocusTarget_Combat() || CanPull())
             {
                 input.PressTargetFocus();
                 input.PressTargetOfTarget();
@@ -72,5 +74,10 @@ public sealed class TargetFocusTargetGoal : GoapGoal
             input.PressClearTarget();
             wait.Update();
         }
+    }
+
+    private bool CanPull()
+    {
+        return bits.FocusTarget() && playerReader.IsTargetCasting();
     }
 }


### PR DESCRIPTION
Changes:
* Core: PullTargetGoal: While AssistFocus is active the enemy might not target the player but the playerfocus.
* Core: TargetFocusTargetGoal: When the playerfocus is casting - initiates the pull - the assistant may also engage

Known issue:
* While testing it in 1.14.0 client, the party1 unit does not reports casting status while the `party1` unit initiates spellcasting. Could be an issue with [LibClassicCasternino](https://github.com/rgd87/LibClassicCasterino) or just have to add extra watchers for the EventHandler.lua file `DataToColor:UnfilteredCombatEvent()` as while monitoring `/etrace` a `UnfilteredCombatEvent` was fired for `party1` `SPELL_CASTING_START`