### PR TITLE
UseMounts for AdhocNpcGoals while ClassConfig.UseMount is disabled

### DIFF
--- a/Core/ClassConfig/ActionMask.cs
+++ b/Core/ClassConfig/ActionMask.cs
@@ -22,4 +22,6 @@ public static class ActionMask
     public const int AfterCastWaitGCD = 1 << 15;
     public const int AfterCastAuraExpected = 1 << 16;
     public const int CancelOnInterrupt = 1 << 17;
+
+    public const int UseMount = 1 << 18;
 }

--- a/Core/ClassConfig/KeyAction.cs
+++ b/Core/ClassConfig/KeyAction.cs
@@ -155,6 +155,12 @@ public sealed partial class KeyAction
         set => features[ActionMask.CancelOnInterrupt] = value;
     }
 
+    public bool UseMount
+    {
+        get => features[ActionMask.UseMount];
+        set => features[ActionMask.UseMount] = value;
+    }
+
     public int AfterCastStepBack { get; set; }
 
     public string InCombat { get; set; } = "false";

--- a/Core/Goals/AdhocNPCGoal.cs
+++ b/Core/Goals/AdhocNPCGoal.cs
@@ -415,7 +415,7 @@ public sealed partial class AdhocNPCGoal : GoapGoal, IGoapEventListener, IRouteP
     {
         float totalDistance = VectorExt.TotalDistance<Vector3>(navigation.TotalRoute, VectorExt.WorldDistanceXY);
 
-        if (classConfig.UseMount && mountHandler.CanMount() &&
+        if ((classConfig.UseMount || key.UseMount) && mountHandler.CanMount() &&
             (MountHandler.ShouldMount(totalDistance) ||
             (navigation.TotalRoute.Length > 0 &&
             mountHandler.ShouldMount(navigation.TotalRoute[^1]))

--- a/README.md
+++ b/README.md
@@ -763,6 +763,7 @@ Can specify conditions with [Requirement(s)](#requirement) in order to create a 
 | `"CancelOnInterrupt"` | If the [Interrupt](#interrupt-requirement) [Requirement](#requirement) has met, shall **Cancel** current castbar spellcast (sending ESC) | `false` |
 | `"ResetOnNewTarget"` | Reset the Cooldown if the target changes | `false` |
 | `"Log"` | Related events should appear in the logs | `true` |
+| `"UseMount"` | Should use mount ? <br/>Limited to [AdhocNpcGoals](#npc-goals) such as `Repair`, `Sell`, `Vendor` routes. | `false` |
 | --- | Before keypress cast, ... | --- |
 | `"BeforeCastFaceTarget"` | Attempt to look directly at target.<br>**Note**: it may not work for every scenario. | `false` |
 | `"BeforeCastDelay"` | Delay in milliseconds. | `0` |
@@ -1186,6 +1187,7 @@ e.g. using a prerecoded path to follow
         "Name": "Repair",
         "Key": "C",
         "Requirement": "Items Broken",
+        "UseMount": true, // When ClassConfig.UseMount is disabled, still allows to use mounts
         "PathFilename": "Tanaris_GadgetzanKrinkleGoodsteel.json",
         "Cost": 6
     },
@@ -1193,6 +1195,7 @@ e.g. using a prerecoded path to follow
         "Name": "Sell",
         "Key": "C",
         "Requirement": "BagFull",
+        "UseMount": true, // When ClassConfig.UseMount is disabled, still allows to use mounts
         "PathFilename": "Tanaris_GadgetzanKrinkleGoodsteel.json",
         "Cost": 6
     }


### PR DESCRIPTION
While the global `ClassConfig.UseMount` is disabled, in general the bot wont use mounts.

However for (Repair, Vendor, Sell) goals it still can be enabled

Be sure to set the Global `UseMount` to false!

```json
"UseMount": false
```

---

```json
"NPC": {
    "Sequence": [
    {
        "Name": "Repair",
        "Key": "C",
        "Requirement": "Items Broken",
        "UseMount": true, // When ClassConfig.UseMount is disabled, still allows to use mounts
        "PathFilename": "Tanaris_GadgetzanKrinkleGoodsteel.json",
        "Cost": 6
    },
    {
        "Name": "Sell",
        "Key": "C",
        "Requirement": "BagFull",
        "UseMount": true, // When ClassConfig.UseMount is disabled, still allows to use mounts
        "PathFilename": "Tanaris_GadgetzanKrinkleGoodsteel.json",
        "Cost": 6
    }
    ]
}
```

Full example

```json
{
  "ClassName": "Warrior",
  "PathFilename": "_pack\\1-20\\Dwarf.Gnome\\1-4_Dun Morogh.json",
  "UseMount": false,                                  // <----------
  "Wait": {
    "Sequence": [
      {
        "Cost": 0.9,
        "Name": "User",
        "Requirement": "MenuOpen || ChatInputVisible"
      }
    ]
  },
  "Combat": {
    "Sequence": [
      {
        "Name": "Heroic Strike",
        "Key": "2",
        "WhenUsable": true,
        "AfterCastWaitSwing": true,
        "Requirement": "MainHandSwing > -400"
      },
      {
        "Name": "AutoAttack"
      },
      {
        "Name": "Approach",
        "Log": false
      }
    ]
  },
  "Adhoc": {
    "Sequence": [
      {
        "Name": "Food",
        "Key": "=",
        "Requirement": "Health% < 60",
        "Cost": 3
      }
    ]
  },
  "NPC": {
    "Sequence": [
      {
        "Name": "Repair",
        "Key": "C",
        "UseMount": true,                                           // <----------
        "Requirement": "Durability% < 35",
        "PathFilename": "1_Gnome_Vendor.json",
        "Cost": 6
      },
      {
        "Name": "Sell",
        "Key": "C",
        "Requirements": [
          "BagFull",
          "BagGreyItem"
        ],
        "UseMount": true,                                        // <----------
        "PathFilename": "1_Gnome_Vendor.json",
        "Cost": 6
      }
    ]
  }
}
```
