### PR TITLE
Accept suggested improvements to handle Profile load and app shutdown more gracefully.

### DIFF
--- a/Core/BotController.cs
+++ b/Core/BotController.cs
@@ -323,10 +323,13 @@ public sealed partial class BotController : IBotController, IDisposable
         long startTime = GetTimestamp();
         try
         {
-            ClassConfig = ReadClassConfiguration(classFile);
-            ClassConfig.Initialise(serviceProvider, pathFiles);
+            var tryLoadConfig = ReadClassConfiguration(classFile);
+            tryLoadConfig.Initialise(serviceProvider, pathFiles);
 
-            LogProfileLoaded(logger, classFile, ClassConfig.PathFilename);
+            LogProfileLoaded(logger, classFile, tryLoadConfig.PathFilename);
+            ClassConfig = tryLoadConfig;
+
+            ClassConfig.FileName = classFile;
 
             CreateSession(ClassConfig);
         }

--- a/Core/ClassConfig/ClassConfiguration.cs
+++ b/Core/ClassConfig/ClassConfiguration.cs
@@ -28,6 +28,8 @@ public enum Mode
 
 public sealed partial class ClassConfiguration
 {
+    public string FileName { get; set; } = string.Empty;
+
     public bool Log { get; set; } = true;
     public bool LogBagChanges { get; set; } = true;
     public bool Loot { get; set; } = true;

--- a/Core/GOAP/GoapAgent.cs
+++ b/Core/GOAP/GoapAgent.cs
@@ -230,8 +230,20 @@ public sealed partial class GoapAgent : IDisposable
             }
 
             Thread.Sleep(2);
-            WaitHandle.WaitAny(waitHandles);
-            sessionPauseEvent.Wait(cts.Token);
+
+            try
+            {
+                WaitHandle.WaitAny(waitHandles);
+                sessionPauseEvent.Wait(cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (ObjectDisposedException)
+            {
+                break;
+            }
         }
 
         if (logger.IsEnabled(LogLevel.Debug))


### PR DESCRIPTION
Fix: Core: GoapAgent: During Dispose prevent crash, handle Dispose and Cancel gracefully
Fix: Core: BotController: Only set the global ClassConfig when the ClassProfile actually loads without any issue.