### PR TITLE
Added mDNS advertising for simple LAN access to UI

### DIFF
--- a/BlazorServer/BlazorServer.csproj
+++ b/BlazorServer/BlazorServer.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Makaretu.Dns.Multicast" />
+    <PackageReference Include="Makaretu.Dns.Multicast.New" />
     <PackageReference Include="Serilog.AspNetCore" />
     <PackageReference Include="Serilog.Enrichers.Environment" />
     <PackageReference Include="Serilog.Enrichers.Process" />

--- a/BlazorServer/BlazorServer.csproj
+++ b/BlazorServer/BlazorServer.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Makaretu.Dns.Multicast" />
     <PackageReference Include="Serilog.AspNetCore" />
     <PackageReference Include="Serilog.Enrichers.Environment" />
     <PackageReference Include="Serilog.Enrichers.Process" />

--- a/BlazorServer/MdnsAdvertisingService.cs
+++ b/BlazorServer/MdnsAdvertisingService.cs
@@ -5,6 +5,9 @@ using Microsoft.Extensions.Logging;
 
 using System;
 using System.Linq;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -12,7 +15,7 @@ namespace BlazorServer;
 
 /// <summary>
 /// Background service that advertises the Blazor Server via mDNS,
-/// making it accessible at http://wowbot.local
+/// making it accessible at http://wowbot.local or whatever is set at MDNS_HOSTNAME
 /// </summary>
 public sealed class MdnsAdvertisingService : IHostedService, IDisposable
 {
@@ -23,89 +26,269 @@ public sealed class MdnsAdvertisingService : IHostedService, IDisposable
     private MulticastService? _multicastService;
     private ServiceDiscovery? _serviceDiscovery;
     private ServiceProfile? _serviceProfile;
+    private bool _isAdvertising;
+
+    // Cached IP addresses - refreshed when network interfaces change
+    private IPAddress[] _cachedAddresses = [];
+    private readonly object _addressLock = new();
 
     public MdnsAdvertisingService(ILogger<MdnsAdvertisingService> logger)
     {
         _logger = logger;
-        _hostname = "wowbot";
+        _hostname = Environment.GetEnvironmentVariable("MDNS_HOSTNAME") ?? "wowbot";
         _port = GetServerPort();
+
+        // Subscribe to network address changes
+        NetworkChange.NetworkAddressChanged += OnNetworkAddressChanged;
+    }
+
+    private void OnNetworkAddressChanged(object? sender, EventArgs e)
+    {
+        _logger.LogDebug("mDNS: Network address changed, refreshing IP cache");
+        RefreshIPAddressCache();
+
+        // Re-announce with new addresses
+        if (_isAdvertising)
+        {
+            AnnounceHostname();
+        }
+    }
+
+    private void RefreshIPAddressCache()
+    {
+        var addresses = new System.Collections.Generic.List<IPAddress>();
+
+        foreach (var netInterface in NetworkInterface.GetAllNetworkInterfaces())
+        {
+            if (netInterface.OperationalStatus != OperationalStatus.Up)
+                continue;
+
+            if (netInterface.NetworkInterfaceType == NetworkInterfaceType.Loopback)
+                continue;
+
+            var ipProps = netInterface.GetIPProperties();
+            foreach (var addr in ipProps.UnicastAddresses)
+            {
+                if (addr.Address.AddressFamily == AddressFamily.InterNetwork ||
+                    addr.Address.AddressFamily == AddressFamily.InterNetworkV6)
+                {
+                    addresses.Add(addr.Address);
+                }
+            }
+        }
+
+        lock (_addressLock)
+        {
+            _cachedAddresses = addresses.ToArray();
+        }
+    }
+
+    private IPAddress[] GetCachedAddresses()
+    {
+        lock (_addressLock)
+        {
+            return _cachedAddresses;
+        }
     }
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
         try
         {
+            // Initialize IP address cache
+            RefreshIPAddressCache();
+
             _multicastService = new MulticastService();
             _serviceDiscovery = new ServiceDiscovery(_multicastService);
 
-            // Log discovered network interfaces
-            _multicastService.NetworkInterfaceDiscovered += (s, e) =>
-            {
-                foreach (var nic in e.NetworkInterfaces)
-                {
-                    _logger.LogDebug("[mDNS             ] Discovered NIC '{NicName}'", nic.Name);
-                }
-            };
+            // Respond to direct hostname queries (e.g., ping wowbot.local)
+            _multicastService.QueryReceived += OnQueryReceived;
 
-            // Log available IP addresses
-            foreach (var ip in MulticastService.GetIPAddresses())
-            {
-                _logger.LogDebug("[mDNS             ] Available IP: {IpAddress}", ip);
-            }
-
-            // Create service profile - this automatically handles hostname and IP resolution
+            // Create service profile
             _serviceProfile = new ServiceProfile(
                 instanceName: _hostname,
                 serviceName: "_http._tcp",
                 port: (ushort)_port);
 
-            // Add TXT records with service info
+            // Add TXT records
             _serviceProfile.AddProperty("path", "/");
             _serviceProfile.AddProperty("server", "BlazorServer");
 
+            // Start the multicast service
             _multicastService.Start();
+            _logger.LogInformation("mDNS: Multicast service started");
 
-            // Probe to check if name is available, then advertise and announce
-            if (!_serviceDiscovery.Probe(_serviceProfile))
+            // Advertise and announce the service
+            _serviceDiscovery.Advertise(_serviceProfile);
+            _serviceDiscovery.Announce(_serviceProfile);
+            _isAdvertising = true;
+
+            // Also announce our hostname A record
+            AnnounceHostname();
+
+            if(_logger.IsEnabled(LogLevel.Information)) 
             {
-                _serviceDiscovery.Advertise(_serviceProfile);
-                _serviceDiscovery.Announce(_serviceProfile);
-
                 _logger.LogInformation(
-                    "[mDNS             ] Advertising service at http://{Hostname}.local:{Port}",
+                    "mDNS: Service advertised at http://{Hostname}.local:{Port}",
                     _hostname, _port);
-            }
-            else
-            {
-                _logger.LogWarning(
-                    "[mDNS             ] Service name '{Hostname}' already in use on network",
-                    _hostname);
             }
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "[mDNS             ] Failed to start mDNS advertising");
+            _logger.LogError(ex, "mDNS: Failed to start advertising");
         }
 
         return Task.CompletedTask;
     }
 
+    private void OnQueryReceived(object? sender, MessageEventArgs e)
+    {
+        var domainName = $"{_hostname}.local";
+
+        foreach (var question in e.Message.Questions)
+        {
+            // Check if someone is asking for our hostname
+            if (question.Name.ToString().Equals(domainName, StringComparison.OrdinalIgnoreCase))
+            {
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug("mDNS: Received query for {Name} (Type: {Type})", question.Name, question.Type);
+                }
+
+                var response = e.Message.CreateResponse();
+                var addresses = GetCachedAddresses();
+
+                foreach (var ip in addresses)
+                {
+                    if (question.Type == DnsType.A && ip.AddressFamily == AddressFamily.InterNetwork)
+                    {
+                        response.Answers.Add(new ARecord
+                        {
+                            Name = domainName,
+                            Address = ip,
+                            TTL = TimeSpan.FromMinutes(2)
+                        });
+                        if (_logger.IsEnabled(LogLevel.Debug))
+                        {
+                            _logger.LogDebug("mDNS: Responding with A record: {Ip}", ip);
+                        }
+                    }
+                    else if (question.Type == DnsType.AAAA && ip.AddressFamily == AddressFamily.InterNetworkV6)
+                    {
+                        response.Answers.Add(new AAAARecord
+                        {
+                            Name = domainName,
+                            Address = ip,
+                            TTL = TimeSpan.FromMinutes(2)
+                        });
+                        if (_logger.IsEnabled(LogLevel.Debug))
+                        {
+                            _logger.LogDebug("mDNS: Responding with AAAA record: {Ip}", ip);
+                        }
+                    }
+                    else if (question.Type == DnsType.ANY)
+                    {
+                        if (ip.AddressFamily == AddressFamily.InterNetwork)
+                        {
+                            response.Answers.Add(new ARecord
+                            {
+                                Name = domainName,
+                                Address = ip,
+                                TTL = TimeSpan.FromMinutes(2)
+                            });
+                        }
+                        else if (ip.AddressFamily == AddressFamily.InterNetworkV6 && !ip.IsIPv6LinkLocal)
+                        {
+                            response.Answers.Add(new AAAARecord
+                            {
+                                Name = domainName,
+                                Address = ip,
+                                TTL = TimeSpan.FromMinutes(2)
+                            });
+                        }
+                    }
+                }
+
+                if (response.Answers.Count > 0)
+                {
+                    _multicastService?.SendAnswer(response);
+                }
+            }
+        }
+    }
+
+    private void AnnounceHostname()
+    {
+        if (_multicastService == null) return;
+
+        var domainName = $"{_hostname}.local";
+        var response = new Message();
+        response.QR = true; // This is a response
+        response.AA = true; // Authoritative answer
+
+        foreach (var ip in GetCachedAddresses())
+        {
+            if (ip.AddressFamily == AddressFamily.InterNetwork)
+            {
+                response.Answers.Add(new ARecord
+                {
+                    Name = domainName,
+                    Address = ip,
+                    TTL = TimeSpan.FromMinutes(2)
+                });
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug("mDNS: Announcing A record: {Hostname} -> {Ip}", domainName, ip);
+                }
+            }
+            else if (ip.AddressFamily == AddressFamily.InterNetworkV6 && !ip.IsIPv6LinkLocal)
+            {
+                response.Answers.Add(new AAAARecord
+                {
+                    Name = domainName,
+                    Address = ip,
+                    TTL = TimeSpan.FromMinutes(2)
+                });
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug("mDNS: Announcing AAAA record: {Hostname} -> {Ip}", domainName, ip);
+                }
+            }
+        }
+
+        if (response.Answers.Count > 0)
+        {
+            _multicastService.SendAnswer(response);
+        }
+    }
+
     public Task StopAsync(CancellationToken cancellationToken)
     {
-        _logger.LogInformation("[mDNS             ] Stopping mDNS advertising");
+        _logger.LogInformation("mDNS: Stopping advertising");
+
+        // Unsubscribe from network changes
+        NetworkChange.NetworkAddressChanged -= OnNetworkAddressChanged;
 
         try
         {
-            if (_serviceProfile != null)
+            if (_isAdvertising && _serviceProfile != null && _serviceDiscovery != null)
             {
-                _serviceDiscovery?.Unadvertise(_serviceProfile);
+                _serviceDiscovery.Unadvertise(_serviceProfile);
+                _isAdvertising = false;
             }
-            _serviceDiscovery?.Dispose();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "mDNS: Error during unadvertise");
+        }
+
+        try
+        {
             _multicastService?.Stop();
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "[mDNS             ] Error during mDNS shutdown");
+            _logger.LogDebug(ex, "mDNS: Error stopping multicast service");
         }
 
         return Task.CompletedTask;
@@ -113,7 +296,6 @@ public sealed class MdnsAdvertisingService : IHostedService, IDisposable
 
     private static int GetServerPort()
     {
-        // Default Kestrel port; can be overridden via configuration
         var urls = Environment.GetEnvironmentVariable("ASPNETCORE_URLS");
         if (!string.IsNullOrEmpty(urls))
         {
@@ -126,7 +308,7 @@ public sealed class MdnsAdvertisingService : IHostedService, IDisposable
             }
         }
 
-        return 5000; // Default port
+        return 5000;
     }
 
     public void Dispose()

--- a/BlazorServer/MdnsAdvertisingService.cs
+++ b/BlazorServer/MdnsAdvertisingService.cs
@@ -1,0 +1,199 @@
+using Makaretu.Dns;
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+using System;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BlazorServer;
+
+/// <summary>
+/// Background service that advertises the Blazor Server via mDNS,
+/// making it accessible at http://wowbot.local
+/// </summary>
+public sealed class MdnsAdvertisingService : IHostedService, IDisposable
+{
+    private readonly ILogger<MdnsAdvertisingService> _logger;
+    private readonly int _port;
+    private readonly string _hostname;
+
+    private MulticastService? _multicastService;
+    private ServiceDiscovery? _serviceDiscovery;
+    private ServiceProfile? _serviceProfile;
+
+    public MdnsAdvertisingService(ILogger<MdnsAdvertisingService> logger)
+    {
+        _logger = logger;
+        _hostname = "wowbot";
+        _port = GetServerPort();
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            _multicastService = new MulticastService();
+
+            // Advertise the hostname (wowbot.local)
+            AdvertiseHostname();
+
+            // Advertise the HTTP service
+            AdvertiseHttpService();
+
+            _multicastService.Start();
+
+            _logger.LogInformation(
+                "[mDNS             ] Advertising service at http://{Hostname}.local:{Port}",
+                _hostname, _port);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[mDNS             ] Failed to start mDNS advertising");
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("[mDNS             ] Stopping mDNS advertising");
+
+        try
+        {
+            _serviceDiscovery?.Unadvertise(_serviceProfile);
+            _serviceDiscovery?.Dispose();
+            _multicastService?.Stop();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "[mDNS             ] Error during mDNS shutdown");
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void AdvertiseHostname()
+    {
+        if (_multicastService == null) return;
+
+        // Register A records for each network interface IP
+        _multicastService.QueryReceived += (s, e) =>
+        {
+            var query = e.Message;
+            foreach (var question in query.Questions)
+            {
+                if (question.Name.ToString().Equals($"{_hostname}.local", StringComparison.OrdinalIgnoreCase))
+                {
+                    var response = query.CreateResponse();
+
+                    foreach (var ip in GetLocalIPAddresses())
+                    {
+                        if (ip.AddressFamily == AddressFamily.InterNetwork)
+                        {
+                            response.Answers.Add(new ARecord
+                            {
+                                Name = $"{_hostname}.local",
+                                Address = ip,
+                                TTL = TimeSpan.FromMinutes(2)
+                            });
+                        }
+                        else if (ip.AddressFamily == AddressFamily.InterNetworkV6)
+                        {
+                            response.Answers.Add(new AAAARecord
+                            {
+                                Name = $"{_hostname}.local",
+                                Address = ip,
+                                TTL = TimeSpan.FromMinutes(2)
+                            });
+                        }
+                    }
+
+                    if (response.Answers.Count > 0)
+                    {
+                        _multicastService.SendAnswer(response);
+                    }
+                }
+            }
+        };
+    }
+
+    private void AdvertiseHttpService()
+    {
+        if (_multicastService == null) return;
+
+        _serviceDiscovery = new ServiceDiscovery(_multicastService);
+
+        // Create service profile for HTTP
+        _serviceProfile = new ServiceProfile(
+            instanceName: _hostname,
+            serviceName: "_http._tcp",
+            port: (ushort)_port);
+
+        _serviceProfile.HostName = $"{_hostname}.local";
+
+        // Add TXT records with service info
+        _serviceProfile.AddProperty("path", "/");
+        _serviceProfile.AddProperty("server", "BlazorServer");
+
+        _serviceDiscovery.Advertise(_serviceProfile);
+    }
+
+    private static IPAddress[] GetLocalIPAddresses()
+    {
+        var addresses = new List<IPAddress>();
+
+        foreach (var netInterface in NetworkInterface.GetAllNetworkInterfaces())
+        {
+            if (netInterface.OperationalStatus != OperationalStatus.Up)
+                continue;
+
+            if (netInterface.NetworkInterfaceType == NetworkInterfaceType.Loopback)
+                continue;
+
+            var ipProps = netInterface.GetIPProperties();
+            foreach (var addr in ipProps.UnicastAddresses)
+            {
+                if (addr.Address.AddressFamily == AddressFamily.InterNetwork ||
+                    addr.Address.AddressFamily == AddressFamily.InterNetworkV6)
+                {
+                    // Skip link-local IPv6 addresses
+                    if (addr.Address.IsIPv6LinkLocal)
+                        continue;
+
+                    addresses.Add(addr.Address);
+                }
+            }
+        }
+
+        return addresses.ToArray();
+    }
+
+    private static int GetServerPort()
+    {
+        // Default Kestrel port; can be overridden via configuration
+        var urls = Environment.GetEnvironmentVariable("ASPNETCORE_URLS");
+        if (!string.IsNullOrEmpty(urls))
+        {
+            foreach (var url in urls.Split(';'))
+            {
+                if (Uri.TryCreate(url, UriKind.Absolute, out var uri))
+                {
+                    return uri.Port;
+                }
+            }
+        }
+
+        return 5000; // Default port
+    }
+
+    public void Dispose()
+    {
+        _serviceDiscovery?.Dispose();
+        _multicastService?.Dispose();
+    }
+}

--- a/BlazorServer/MdnsAdvertisingService.cs
+++ b/BlazorServer/MdnsAdvertisingService.cs
@@ -4,9 +4,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 using System;
-using System.Net;
-using System.Net.NetworkInformation;
-using System.Net.Sockets;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -38,18 +36,51 @@ public sealed class MdnsAdvertisingService : IHostedService, IDisposable
         try
         {
             _multicastService = new MulticastService();
+            _serviceDiscovery = new ServiceDiscovery(_multicastService);
 
-            // Advertise the hostname (wowbot.local)
-            AdvertiseHostname();
+            // Log discovered network interfaces
+            _multicastService.NetworkInterfaceDiscovered += (s, e) =>
+            {
+                foreach (var nic in e.NetworkInterfaces)
+                {
+                    _logger.LogDebug("[mDNS             ] Discovered NIC '{NicName}'", nic.Name);
+                }
+            };
 
-            // Advertise the HTTP service
-            AdvertiseHttpService();
+            // Log available IP addresses
+            foreach (var ip in MulticastService.GetIPAddresses())
+            {
+                _logger.LogDebug("[mDNS             ] Available IP: {IpAddress}", ip);
+            }
+
+            // Create service profile - this automatically handles hostname and IP resolution
+            _serviceProfile = new ServiceProfile(
+                instanceName: _hostname,
+                serviceName: "_http._tcp",
+                port: (ushort)_port);
+
+            // Add TXT records with service info
+            _serviceProfile.AddProperty("path", "/");
+            _serviceProfile.AddProperty("server", "BlazorServer");
 
             _multicastService.Start();
 
-            _logger.LogInformation(
-                "[mDNS             ] Advertising service at http://{Hostname}.local:{Port}",
-                _hostname, _port);
+            // Probe to check if name is available, then advertise and announce
+            if (!_serviceDiscovery.Probe(_serviceProfile))
+            {
+                _serviceDiscovery.Advertise(_serviceProfile);
+                _serviceDiscovery.Announce(_serviceProfile);
+
+                _logger.LogInformation(
+                    "[mDNS             ] Advertising service at http://{Hostname}.local:{Port}",
+                    _hostname, _port);
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "[mDNS             ] Service name '{Hostname}' already in use on network",
+                    _hostname);
+            }
         }
         catch (Exception ex)
         {
@@ -65,7 +96,10 @@ public sealed class MdnsAdvertisingService : IHostedService, IDisposable
 
         try
         {
-            _serviceDiscovery?.Unadvertise(_serviceProfile);
+            if (_serviceProfile != null)
+            {
+                _serviceDiscovery?.Unadvertise(_serviceProfile);
+            }
             _serviceDiscovery?.Dispose();
             _multicastService?.Stop();
         }
@@ -75,102 +109,6 @@ public sealed class MdnsAdvertisingService : IHostedService, IDisposable
         }
 
         return Task.CompletedTask;
-    }
-
-    private void AdvertiseHostname()
-    {
-        if (_multicastService == null) return;
-
-        // Register A records for each network interface IP
-        _multicastService.QueryReceived += (s, e) =>
-        {
-            var query = e.Message;
-            foreach (var question in query.Questions)
-            {
-                if (question.Name.ToString().Equals($"{_hostname}.local", StringComparison.OrdinalIgnoreCase))
-                {
-                    var response = query.CreateResponse();
-
-                    foreach (var ip in GetLocalIPAddresses())
-                    {
-                        if (ip.AddressFamily == AddressFamily.InterNetwork)
-                        {
-                            response.Answers.Add(new ARecord
-                            {
-                                Name = $"{_hostname}.local",
-                                Address = ip,
-                                TTL = TimeSpan.FromMinutes(2)
-                            });
-                        }
-                        else if (ip.AddressFamily == AddressFamily.InterNetworkV6)
-                        {
-                            response.Answers.Add(new AAAARecord
-                            {
-                                Name = $"{_hostname}.local",
-                                Address = ip,
-                                TTL = TimeSpan.FromMinutes(2)
-                            });
-                        }
-                    }
-
-                    if (response.Answers.Count > 0)
-                    {
-                        _multicastService.SendAnswer(response);
-                    }
-                }
-            }
-        };
-    }
-
-    private void AdvertiseHttpService()
-    {
-        if (_multicastService == null) return;
-
-        _serviceDiscovery = new ServiceDiscovery(_multicastService);
-
-        // Create service profile for HTTP
-        _serviceProfile = new ServiceProfile(
-            instanceName: _hostname,
-            serviceName: "_http._tcp",
-            port: (ushort)_port);
-
-        _serviceProfile.HostName = $"{_hostname}.local";
-
-        // Add TXT records with service info
-        _serviceProfile.AddProperty("path", "/");
-        _serviceProfile.AddProperty("server", "BlazorServer");
-
-        _serviceDiscovery.Advertise(_serviceProfile);
-    }
-
-    private static IPAddress[] GetLocalIPAddresses()
-    {
-        var addresses = new List<IPAddress>();
-
-        foreach (var netInterface in NetworkInterface.GetAllNetworkInterfaces())
-        {
-            if (netInterface.OperationalStatus != OperationalStatus.Up)
-                continue;
-
-            if (netInterface.NetworkInterfaceType == NetworkInterfaceType.Loopback)
-                continue;
-
-            var ipProps = netInterface.GetIPProperties();
-            foreach (var addr in ipProps.UnicastAddresses)
-            {
-                if (addr.Address.AddressFamily == AddressFamily.InterNetwork ||
-                    addr.Address.AddressFamily == AddressFamily.InterNetworkV6)
-                {
-                    // Skip link-local IPv6 addresses
-                    if (addr.Address.IsIPv6LinkLocal)
-                        continue;
-
-                    addresses.Add(addr.Address);
-                }
-            }
-        }
-
-        return addresses.ToArray();
     }
 
     private static int GetServerPort()

--- a/BlazorServer/MdnsAdvertisingService.cs
+++ b/BlazorServer/MdnsAdvertisingService.cs
@@ -107,7 +107,8 @@ public sealed class MdnsAdvertisingService : IHostedService, IDisposable
         {
             // Initialize IP address cache
             RefreshIPAddressCache();
-
+            
+            // Using Application started event to get the port from Kestral
             _startedRegistration = _lifetime.ApplicationStarted.Register(() =>
             {
                 var addressFeature = _server.Features.Get<IServerAddressesFeature>();

--- a/BlazorServer/MdnsAdvertisingService.cs
+++ b/BlazorServer/MdnsAdvertisingService.cs
@@ -3,6 +3,9 @@ using Makaretu.Dns;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+
 using System;
 using System.Linq;
 using System.Net;
@@ -20,9 +23,11 @@ namespace BlazorServer;
 public sealed class MdnsAdvertisingService : IHostedService, IDisposable
 {
     private readonly ILogger<MdnsAdvertisingService> _logger;
-    private readonly int _port;
+    private int _port;
     private readonly string _hostname;
-
+    private readonly IServer _server;
+    private readonly IHostApplicationLifetime _lifetime;
+    private CancellationTokenRegistration _startedRegistration;
     private MulticastService? _multicastService;
     private ServiceDiscovery? _serviceDiscovery;
     private ServiceProfile? _serviceProfile;
@@ -32,11 +37,16 @@ public sealed class MdnsAdvertisingService : IHostedService, IDisposable
     private IPAddress[] _cachedAddresses = [];
     private readonly Lock _addressLock = new();
 
-    public MdnsAdvertisingService(ILogger<MdnsAdvertisingService> logger)
+    public MdnsAdvertisingService(
+        ILogger<MdnsAdvertisingService> logger, 
+        IServer server,
+        IHostApplicationLifetime lifetime)
     {
         _logger = logger;
+        _server = server;
+        _lifetime = lifetime;
         _hostname = Environment.GetEnvironmentVariable("MDNS_HOSTNAME") ?? "wowbot";
-        _port = GetServerPort();
+        _port = 5000;
 
         // Subscribe to network address changes
         NetworkChange.NetworkAddressChanged += OnNetworkAddressChanged;
@@ -98,40 +108,57 @@ public sealed class MdnsAdvertisingService : IHostedService, IDisposable
             // Initialize IP address cache
             RefreshIPAddressCache();
 
-            _multicastService = new MulticastService();
-            _serviceDiscovery = new ServiceDiscovery(_multicastService);
-
-            // Respond to direct hostname queries (e.g., ping wowbot.local)
-            _multicastService.QueryReceived += OnQueryReceived;
-
-            // Create service profile
-            _serviceProfile = new ServiceProfile(
-                instanceName: _hostname,
-                serviceName: "_http._tcp",
-                port: (ushort)_port);
-
-            // Add TXT records
-            _serviceProfile.AddProperty("path", "/");
-            _serviceProfile.AddProperty("server", "BlazorServer");
-
-            // Start the multicast service
-            _multicastService.Start();
-            _logger.LogInformation("mDNS: Multicast service started");
-
-            // Advertise and announce the service
-            _serviceDiscovery.Advertise(_serviceProfile);
-            _serviceDiscovery.Announce(_serviceProfile);
-            _isAdvertising = true;
-
-            // Also announce our hostname A record
-            AnnounceHostname();
-
-            if(_logger.IsEnabled(LogLevel.Information)) 
+            _startedRegistration = _lifetime.ApplicationStarted.Register(() =>
             {
-                _logger.LogInformation(
-                    "mDNS: Service advertised at http://{Hostname}.local:{Port}",
-                    _hostname, _port);
-            }
+                var addressFeature = _server.Features.Get<IServerAddressesFeature>();
+                if (addressFeature != null)
+                {
+                    foreach (var address in addressFeature.Addresses)
+                    {
+                        if (Uri.TryCreate(address, UriKind.Absolute, out var uri))
+                        {
+                            _port = uri.Port;
+                            _logger.LogDebug("mDNS: Detected server port {Port} from {Address}", _port, address);
+                            break;
+                        }
+                    }
+                }
+
+                _multicastService = new MulticastService();
+                _serviceDiscovery = new ServiceDiscovery(_multicastService);
+
+                // Respond to direct hostname queries (e.g., ping wowbot.local)
+                _multicastService.QueryReceived += OnQueryReceived;
+
+                // Create service profile
+                _serviceProfile = new ServiceProfile(
+                    instanceName: _hostname,
+                    serviceName: "_http._tcp",
+                    port: (ushort)_port);
+
+                // Add TXT records
+                _serviceProfile.AddProperty("path", "/");
+                _serviceProfile.AddProperty("server", "BlazorServer");
+
+                // Start the multicast service
+                _multicastService.Start();
+                _logger.LogInformation("mDNS: Multicast service started");
+
+                // Advertise and announce the service
+                _serviceDiscovery.Advertise(_serviceProfile);
+                _serviceDiscovery.Announce(_serviceProfile);
+                _isAdvertising = true;
+
+                // Also announce our hostname A record
+                AnnounceHostname();
+
+                if(_logger.IsEnabled(LogLevel.Information)) 
+                {
+                    _logger.LogInformation(
+                        "mDNS: Service advertised at http://{Hostname}.local:{Port}",
+                        _hostname, _port);
+                }
+            });
         }
         catch (Exception ex)
         {
@@ -292,23 +319,6 @@ public sealed class MdnsAdvertisingService : IHostedService, IDisposable
         }
 
         return Task.CompletedTask;
-    }
-
-    private static int GetServerPort()
-    {
-        var urls = Environment.GetEnvironmentVariable("ASPNETCORE_URLS");
-        if (!string.IsNullOrEmpty(urls))
-        {
-            foreach (var url in urls.Split(';'))
-            {
-                if (Uri.TryCreate(url, UriKind.Absolute, out var uri))
-                {
-                    return uri.Port;
-                }
-            }
-        }
-
-        return 5000;
     }
 
     public void Dispose()

--- a/BlazorServer/MdnsAdvertisingService.cs
+++ b/BlazorServer/MdnsAdvertisingService.cs
@@ -30,7 +30,7 @@ public sealed class MdnsAdvertisingService : IHostedService, IDisposable
 
     // Cached IP addresses - refreshed when network interfaces change
     private IPAddress[] _cachedAddresses = [];
-    private readonly object _addressLock = new();
+    private readonly Lock _addressLock = new();
 
     public MdnsAdvertisingService(ILogger<MdnsAdvertisingService> logger)
     {
@@ -77,7 +77,7 @@ public sealed class MdnsAdvertisingService : IHostedService, IDisposable
             }
         }
 
-        lock (_addressLock)
+        using (_addressLock.EnterScope())
         {
             _cachedAddresses = addresses.ToArray();
         }
@@ -85,7 +85,7 @@ public sealed class MdnsAdvertisingService : IHostedService, IDisposable
 
     private IPAddress[] GetCachedAddresses()
     {
-        lock (_addressLock)
+        using (_addressLock.EnterScope())
         {
             return _cachedAddresses;
         }

--- a/BlazorServer/Program.cs
+++ b/BlazorServer/Program.cs
@@ -144,7 +144,10 @@ public static class Program
         });
 
         // Register mDNS advertising service for http://wowbot.local access
-        services.AddHostedService<MdnsAdvertisingService>();
+        if(Environment.GetEnvironmentVariable("USE_MDNS") != null)
+        {
+            services.AddHostedService<MdnsAdvertisingService>();
+        }
 
         services.AddControllers().AddJsonOptions(options =>
         {

--- a/BlazorServer/Program.cs
+++ b/BlazorServer/Program.cs
@@ -143,6 +143,9 @@ public static class Program
             o.ShutdownTimeout = TimeSpan.FromSeconds(1);
         });
 
+        // Register mDNS advertising service for http://wowbot.local access
+        services.AddHostedService<MdnsAdvertisingService>();
+
         services.AddControllers().AddJsonOptions(options =>
         {
             options.JsonSerializerOptions.PropertyNameCaseInsensitive = true;

--- a/BlazorServer/Properties/launchSettings.json
+++ b/BlazorServer/Properties/launchSettings.json
@@ -22,7 +22,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:5000"
+      "applicationUrl": "http://*:5000"
     }
   }
 }

--- a/BlazorServer/appsettings.json
+++ b/BlazorServer/appsettings.json
@@ -6,7 +6,8 @@
         "Microsoft": "Warning",
         "Microsoft.Hosting.Lifetime": "Information",
         "Game.WowProcessInput": "Warning",
-        "Core.ConfigurableInput": "Warning"
+        "Core.ConfigurableInput": "Warning",
+        "BlazorServer.MdnsAdvertisingService": "Information"
       }
     }
   },

--- a/BlazorServer/run.bat
+++ b/BlazorServer/run.bat
@@ -1,4 +1,4 @@
-start "" "http://localhost:5000"
+start "" "http://wowbot.local:5000"
 cd /D "%~dp0"
 dotnet run --configuration Release --no-build
 

--- a/BlazorServer/run.bat
+++ b/BlazorServer/run.bat
@@ -1,4 +1,4 @@
-start "" "http://wowbot.local:5000"
+start "" "http://localhost:5000"
 cd /D "%~dp0"
 dotnet run --configuration Release --no-build
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,7 +27,7 @@
     <PackageVersion Include="GameOverlay.Net" Version="4.3.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
-    <PackageVersion Include="Makaretu.Dns.Multicast" Version="0.27.0" />
+    <PackageVersion Include="Makaretu.Dns.Multicast.New" Version="0.38.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="System.Drawing.Common" Version="10.0.0" />
     <PackageVersion Include="BlazorTable" Version="1.17.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,9 +25,9 @@
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Net.Http.Json" Version="9.0.9" />
     <PackageVersion Include="GameOverlay.Net" Version="4.3.1" />
+    <PackageVersion Include="Makaretu.Dns.Multicast.New" Version="0.38.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
-    <PackageVersion Include="Makaretu.Dns.Multicast.New" Version="0.38.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="System.Drawing.Common" Version="10.0.0" />
     <PackageVersion Include="BlazorTable" Version="1.17.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,6 +27,7 @@
     <PackageVersion Include="GameOverlay.Net" Version="4.3.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
+    <PackageVersion Include="Makaretu.Dns.Multicast" Version="0.27.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="System.Drawing.Common" Version="10.0.0" />
     <PackageVersion Include="BlazorTable" Version="1.17.0" />

--- a/README.md
+++ b/README.md
@@ -2341,6 +2341,12 @@ The available modes are:
 
 The user interface is shown in a browser on port **5000** [http://wowbot.local:5000](http://wowbot.local:5000). This allows you to view it from another device on your lan.
 
+If you are running multiple bots on the same network, you can use a custom name per bot, in powershell run:
+
+```$env:MDNS_HOSTNAME = 'yourcustomname'```
+
+Now the UI will be available at [http://yourcustomname.local:5000](http://yourcustomname.local:5000).
+
 If you do not accept the "Allow" prompt when you first start the BlazorServer app you will need to open up port **5000** in your firewall.
 
 Control Panel\System and Security\Windows Defender Firewall - Advanced Settings

--- a/README.md
+++ b/README.md
@@ -2339,7 +2339,13 @@ The available modes are:
 
 ## Other devices
 
-The user interface is shown in a browser on port **5000** [http://wowbot.local:5000](http://wowbot.local:5000). This allows you to view it from another device on your lan.
+The user interface is shown in a browser on port **5000** [http://localhost:5000](http://localhost:5000).
+
+If you would like to easily access the UI from elsewhere in your LAN. in powershell run:
+
+```$env:USE_MDNS = 'true'```
+
+once you run the batch file you will now be able to access the UI via [http://wowbot.local:5000](http://wowbot.local:5000).
 
 If you are running multiple bots on the same network, you can use a custom name per bot, in powershell run:
 

--- a/README.md
+++ b/README.md
@@ -2339,9 +2339,9 @@ The available modes are:
 
 ## Other devices
 
-The user interface is shown in a browser on port **5000** [http://localhost:5000](http://localhost:5000). This allows you to view it from another device on your lan.
+The user interface is shown in a browser on port **5000** [http://wowbot.local:5000](http://wowbot.local:5000). This allows you to view it from another device on your lan.
 
-To access you PC port **5000** from another device, you will need to open up port **5000** in your firewall.
+If you do not accept the "Allow" prompt when you first start the BlazorServer app you will need to open up port **5000** in your firewall.
 
 Control Panel\System and Security\Windows Defender Firewall - Advanced Settings
 


### PR DESCRIPTION
Added basic mDNS advertising to the BlazorServer setup. 
UI will now advertise on the LAN at http://wowbot.local:5000.

This makes the prompt properly pop up from Windows to allow access to the program and makes accessing the UI significantly easier from remote devices.