### PR TITLE
Addon: [1.9.1] - Addon: Add event-driven BitCache and AuraCache for major performance improvement

### DIFF
--- a/Addons/DataToColor/AuraCache.lua
+++ b/Addons/DataToColor/AuraCache.lua
@@ -328,7 +328,7 @@ function DataToColor:RegisterAuraCacheEvents()
         RefreshUnitAuras(unit)
     end
 
-    DataToColor:Print("AuraCache initialized - event-driven aura caching enabled")
+    --DataToColor:Print("AuraCache initialized - event-driven aura caching enabled")
 end
 
 -- Force refresh all caches (useful after loading screens)

--- a/Addons/DataToColor/AuraCache.lua
+++ b/Addons/DataToColor/AuraCache.lua
@@ -1,0 +1,371 @@
+--[[
+    AuraCache.lua - Event-Driven Aura Caching
+
+    This module caches UnitBuff/UnitDebuff results and only refreshes when
+    UNIT_AURA fires, dramatically reducing per-frame allocations.
+
+    Before: ~300 UnitBuff/UnitDebuff calls per frame (each returns strings)
+    After: 0 calls per frame (only on UNIT_AURA events)
+]]
+
+local Load = select(2, ...)
+local DataToColor = unpack(Load)
+
+-- Cache WoW API locally
+local UnitBuff = UnitBuff
+local UnitDebuff = UnitDebuff
+local UnitExists = UnitExists
+local UnitGUID = UnitGUID
+local GetTime = GetTime
+local next = next
+local wipe = wipe
+
+--------------------------------------------------------------------------------
+-- Cache Storage
+--------------------------------------------------------------------------------
+
+-- Pre-allocated cache tables per unit
+-- Structure: cache[unitId].buffs[index] = { name, texture, count, duration, expirationTime }
+-- Structure: cache[unitId].debuffs[index] = { name, texture, count, duration, expirationTime }
+local unitCache = {}
+
+-- Units we track
+local trackedUnits = {
+    "player",
+    "target",
+    "focus",
+    "pet",
+    "mouseover",
+    "softenemy",
+    "softfriend",
+    "softinteract",
+}
+
+-- Initialize cache structure for each unit
+for _, unit in ipairs(trackedUnits) do
+    unitCache[unit] = {
+        buffs = {},
+        debuffs = {},
+        buffCount = 0,
+        debuffCount = 0,
+        guid = nil,
+        lastUpdate = 0,
+    }
+end
+
+-- Reusable aura entry tables (object pool to avoid allocation)
+local auraPool = {}
+local poolSize = 0
+local MAX_POOL_SIZE = 200
+
+local function AcquireAuraEntry()
+    if poolSize > 0 then
+        local entry = auraPool[poolSize]
+        auraPool[poolSize] = nil
+        poolSize = poolSize - 1
+        return entry
+    end
+    return {}
+end
+
+local function ReleaseAuraEntry(entry)
+    if poolSize < MAX_POOL_SIZE then
+        -- Clear entry for reuse
+        entry.name = nil
+        entry.texture = nil
+        entry.count = nil
+        entry.duration = nil
+        entry.expirationTime = nil
+        poolSize = poolSize + 1
+        auraPool[poolSize] = entry
+    end
+end
+
+--------------------------------------------------------------------------------
+-- Cache Update Functions
+--------------------------------------------------------------------------------
+
+-- Refresh buff cache for a unit
+local function RefreshBuffCache(unitId)
+    local cache = unitCache[unitId]
+    if not cache then return end
+
+    -- Release old entries back to pool
+    for i = 1, cache.buffCount do
+        if cache.buffs[i] then
+            ReleaseAuraEntry(cache.buffs[i])
+            cache.buffs[i] = nil
+        end
+    end
+
+    cache.buffCount = 0
+
+    if not UnitExists(unitId) then
+        cache.guid = nil
+        return
+    end
+
+    cache.guid = UnitGUID(unitId)
+    cache.lastUpdate = GetTime()
+
+    -- Scan buffs (max 40)
+    for i = 1, 40 do
+        local name, texture, count, debuffType, duration, expirationTime = UnitBuff(unitId, i)
+        if not name then
+            break
+        end
+
+        local entry = AcquireAuraEntry()
+        entry.name = name
+        entry.texture = texture
+        entry.count = count or 0
+        entry.duration = duration or 0
+        entry.expirationTime = expirationTime or 0
+
+        cache.buffCount = cache.buffCount + 1
+        cache.buffs[cache.buffCount] = entry
+    end
+end
+
+-- Refresh debuff cache for a unit
+local function RefreshDebuffCache(unitId)
+    local cache = unitCache[unitId]
+    if not cache then return end
+
+    -- Release old entries back to pool
+    for i = 1, cache.debuffCount do
+        if cache.debuffs[i] then
+            ReleaseAuraEntry(cache.debuffs[i])
+            cache.debuffs[i] = nil
+        end
+    end
+
+    cache.debuffCount = 0
+
+    if not UnitExists(unitId) then
+        return
+    end
+
+    -- Scan debuffs (max 40)
+    for i = 1, 40 do
+        local name, texture, count, debuffType, duration, expirationTime = UnitDebuff(unitId, i)
+        if not name then
+            break
+        end
+
+        local entry = AcquireAuraEntry()
+        entry.name = name
+        entry.texture = texture
+        entry.count = count or 0
+        entry.duration = duration or 0
+        entry.expirationTime = expirationTime or 0
+
+        cache.debuffCount = cache.debuffCount + 1
+        cache.debuffs[cache.debuffCount] = entry
+    end
+end
+
+-- Refresh all auras for a unit
+local function RefreshUnitAuras(unitId)
+    RefreshBuffCache(unitId)
+    RefreshDebuffCache(unitId)
+end
+
+-- Clear cache for a unit (when unit no longer exists)
+local function ClearUnitCache(unitId)
+    local cache = unitCache[unitId]
+    if not cache then return end
+
+    for i = 1, cache.buffCount do
+        if cache.buffs[i] then
+            ReleaseAuraEntry(cache.buffs[i])
+            cache.buffs[i] = nil
+        end
+    end
+
+    for i = 1, cache.debuffCount do
+        if cache.debuffs[i] then
+            ReleaseAuraEntry(cache.debuffs[i])
+            cache.debuffs[i] = nil
+        end
+    end
+
+    cache.buffCount = 0
+    cache.debuffCount = 0
+    cache.guid = nil
+end
+
+--------------------------------------------------------------------------------
+-- Public API for Query.lua
+--------------------------------------------------------------------------------
+
+-- Get cached buff data (replacement for UnitBuff)
+-- Returns: name, texture, count, debuffType, duration, expirationTime
+function DataToColor:GetCachedBuff(unitId, index)
+    local cache = unitCache[unitId]
+    if not cache or index > cache.buffCount then
+        return nil
+    end
+
+    local entry = cache.buffs[index]
+    if not entry then
+        return nil
+    end
+
+    return entry.name, entry.texture, entry.count, nil, entry.duration, entry.expirationTime
+end
+
+-- Get cached debuff data (replacement for UnitDebuff)
+function DataToColor:GetCachedDebuff(unitId, index)
+    local cache = unitCache[unitId]
+    if not cache or index > cache.debuffCount then
+        return nil
+    end
+
+    local entry = cache.debuffs[index]
+    if not entry then
+        return nil
+    end
+
+    return entry.name, entry.texture, entry.count, nil, entry.duration, entry.expirationTime
+end
+
+-- Get cached buff count
+function DataToColor:GetCachedBuffCount(unitId)
+    local cache = unitCache[unitId]
+    return cache and cache.buffCount or 0
+end
+
+-- Get cached debuff count
+function DataToColor:GetCachedDebuffCount(unitId)
+    local cache = unitCache[unitId]
+    return cache and cache.debuffCount or 0
+end
+
+-- Wrapper functions that match UnitBuff/UnitDebuff signature for compatibility
+function DataToColor.CachedUnitBuff(unitId, index)
+    return DataToColor:GetCachedBuff(unitId, index)
+end
+
+function DataToColor.CachedUnitDebuff(unitId, index)
+    return DataToColor:GetCachedDebuff(unitId, index)
+end
+
+--------------------------------------------------------------------------------
+-- Event Handlers
+--------------------------------------------------------------------------------
+
+local function OnUnitAura(_, unitId)
+    -- Map unit tokens to our tracked units
+    local mappedUnit = unitId
+
+    -- Handle party/raid unit mapping if needed
+    if unitCache[mappedUnit] then
+        RefreshUnitAuras(mappedUnit)
+    end
+end
+
+local function OnTargetChanged()
+    RefreshUnitAuras("target")
+end
+
+local function OnFocusChanged()
+    RefreshUnitAuras("focus")
+end
+
+local function OnMouseoverChanged()
+    RefreshUnitAuras("mouseover")
+end
+
+local function OnPetChanged()
+    RefreshUnitAuras("pet")
+end
+
+local function OnSoftTargetChanged()
+    RefreshUnitAuras("softenemy")
+    RefreshUnitAuras("softfriend")
+    RefreshUnitAuras("softinteract")
+end
+
+--------------------------------------------------------------------------------
+-- Initialization
+--------------------------------------------------------------------------------
+
+local cacheInitialized = false
+
+function DataToColor:RegisterAuraCacheEvents()
+    if cacheInitialized then
+        -- Just refresh all caches
+        for _, unit in ipairs(trackedUnits) do
+            RefreshUnitAuras(unit)
+        end
+        return
+    end
+    cacheInitialized = true
+
+    -- Register UNIT_AURA for all units
+    self:RegisterEvent("UNIT_AURA", OnUnitAura)
+
+    -- Register unit change events
+    -- NOTE: These events are registered in EventHandlers.lua to avoid AceEvent overwrites:
+    -- - PLAYER_TARGET_CHANGED -> OnPlayerTargetChanged -> AuraCache.refresh("target")
+    -- - PLAYER_FOCUS_CHANGED -> OnFocusChanged_BitCache -> AuraCache.refresh("focus")
+    -- - UPDATE_MOUSEOVER_UNIT -> OnMouseoverChanged_BitCache -> AuraCache.refresh("mouseover")
+    -- - UNIT_PET -> OnPetChanged -> AuraCache.refresh("pet")
+    -- - PLAYER_SOFT_INTERACT_CHANGED -> OnPlayerSoftInteractChanged -> AuraCache.refresh("softinteract")
+
+    -- Soft target events (only the ones not handled elsewhere)
+    if self.RegisterEvent then
+        pcall(function()
+            self:RegisterEvent("PLAYER_SOFT_ENEMY_CHANGED", OnSoftTargetChanged)
+            self:RegisterEvent("PLAYER_SOFT_FRIEND_CHANGED", OnSoftTargetChanged)
+            -- NOTE: PLAYER_SOFT_INTERACT_CHANGED is handled by EventHandlers.lua
+        end)
+    end
+
+    -- Initial cache population
+    for _, unit in ipairs(trackedUnits) do
+        RefreshUnitAuras(unit)
+    end
+
+    DataToColor:Print("AuraCache initialized - event-driven aura caching enabled")
+end
+
+-- Force refresh all caches (useful after loading screens)
+function DataToColor:RefreshAllAuraCaches()
+    for _, unit in ipairs(trackedUnits) do
+        RefreshUnitAuras(unit)
+    end
+end
+
+--------------------------------------------------------------------------------
+-- Debug/Stats API
+--------------------------------------------------------------------------------
+
+DataToColor.AuraCache = {
+    isInitialized = function() return cacheInitialized end,
+    getPoolSize = function() return poolSize end,
+    getStats = function()
+        local stats = {}
+        for _, unit in ipairs(trackedUnits) do
+            local cache = unitCache[unit]
+            if cache then
+                stats[unit] = {
+                    buffs = cache.buffCount,
+                    debuffs = cache.debuffCount,
+                    lastUpdate = cache.lastUpdate,
+                }
+            end
+        end
+        return stats
+    end,
+    refresh = function(unit)
+        if unit then
+            RefreshUnitAuras(unit)
+        else
+            for _, u in ipairs(trackedUnits) do
+                RefreshUnitAuras(u)
+            end
+        end
+    end,
+}

--- a/Addons/DataToColor/BitCache.lua
+++ b/Addons/DataToColor/BitCache.lua
@@ -1,0 +1,547 @@
+--[[
+    BitCache.lua - Event-Driven Caching for Bits Functions
+
+    This module caches the values used by Bits1/2/3 functions and updates them
+    only when relevant events fire, reducing API calls from ~56 per frame to ~5.
+
+    Values that cannot be event-driven (IsFalling, IsSwimming, etc.) are polled
+    at a reduced rate using a throttled update.
+]]
+
+local Load = select(2, ...)
+local DataToColor = unpack(Load)
+
+-- Cache WoW API functions locally for performance
+local UnitAffectingCombat = UnitAffectingCombat
+local UnitIsDead = UnitIsDead
+local UnitIsDeadOrGhost = UnitIsDeadOrGhost
+local UnitExists = UnitExists
+local UnitIsVisible = UnitIsVisible
+local UnitIsPlayer = UnitIsPlayer
+local UnitPlayerControlled = UnitPlayerControlled
+local UnitCharacterPoints = UnitCharacterPoints
+local UnitOnTaxi = UnitOnTaxi
+local UnitReaction = UnitReaction
+local UnitIsFriend = UnitIsFriend
+local GetWeaponEnchantInfo = GetWeaponEnchantInfo
+local IsMounted = IsMounted
+local IsSwimming = IsSwimming
+local IsFalling = IsFalling
+local IsFlying = IsFlying
+local IsIndoors = IsIndoors
+local IsStealthed = IsStealthed
+local IsAutoRepeatSpell = IsAutoRepeatSpell
+local IsCurrentSpell = IsCurrentSpell
+local GetMirrorTimerInfo = GetMirrorTimerInfo
+local HasPetUI = HasPetUI
+local GetPetHappiness = GetPetHappiness
+local GetPetActionInfo = GetPetActionInfo
+local UnitIsTrivial = UnitIsTrivial
+
+--------------------------------------------------------------------------------
+-- Bit Cache Storage
+--------------------------------------------------------------------------------
+
+-- Pre-allocated cache tables to avoid runtime allocation
+local bits1Cache = {
+    targetInCombat = false,         -- bit 0
+    targetIsDead = false,           -- bit 1
+    playerIsDeadOrGhost = false,    -- bit 2
+    hasUnspentTalents = false,      -- bit 3
+    mouseoverExists = false,        -- bit 4
+    targetIsHostile = false,        -- bit 5
+    petIsAlive = false,             -- bit 6
+    mainHandEnchant = false,        -- bit 7
+    offHandEnchant = false,         -- bit 8
+    equipmentBroken = false,        -- bit 9 (uses existing method)
+    onTaxi = false,                 -- bit 10
+    isSwimming = false,             -- bit 11 (polled)
+    petIsHappy = false,             -- bit 12
+    hasAmmo = false,                -- bit 13
+    playerInCombat = false,         -- bit 14
+    targetTargetsPlayer = false,    -- bit 15
+    autoShotActive = false,         -- bit 16
+    targetExists = false,           -- bit 17
+    isMounted = false,              -- bit 18
+    shootActive = false,            -- bit 19
+    attackActive = false,           -- bit 20
+    targetIsPlayer = false,         -- bit 21
+    targetIsTapDenied = false,      -- bit 22
+    isFalling = false,              -- bit 23 (polled)
+}
+
+local bits2Cache = {
+    isBreathHeld = false,           -- bit 0
+    -- corpseInRange uses existing DataToColor.corpseInRange (bit 1)
+    isIndoors = false,              -- bit 2 (polled)
+    focusExists = false,            -- bit 3
+    focusInCombat = false,          -- bit 4
+    focusTargetExists = false,      -- bit 5
+    focusTargetInCombat = false,    -- bit 6
+    focusTargetIsHostile = false,   -- bit 7
+    mouseoverIsDead = false,        -- bit 8
+    petTargetIsDead = false,        -- bit 9
+    isStealthed = false,            -- bit 10
+    targetIsTrivial = false,        -- bit 11
+    mouseoverIsTrivial = false,     -- bit 12
+    mouseoverIsTapDenied = false,   -- bit 13
+    mouseoverIsHostile = false,     -- bit 14
+    mouseoverIsPlayer = false,      -- bit 15
+    mouseoverTargetsPlayer = false, -- bit 16
+    mouseoverPlayerControlled = false, -- bit 17
+    targetPlayerControlled = false, -- bit 18
+    -- autoFollow uses existing DataToColor.autoFollow (bit 19)
+    gameMenuShown = false,          -- bit 20 (polled)
+    isFlying = false,               -- bit 21 (polled)
+    isMoving = false,               -- bit 22 (polled)
+    petIsDefensive = false,         -- bit 23
+}
+
+local bits3Cache = {
+    softInteractExists = false,     -- bit 0
+    softInteractIsDead = false,     -- bit 1
+    softInteractIsDeadOrGhost = false, -- bit 2
+    softInteractIsPlayer = false,   -- bit 3
+    softInteractIsTapDenied = false, -- bit 4
+    softInteractInCombat = false,   -- bit 5
+    softInteractIsHostile = false,  -- bit 6
+    -- channeling uses existing DataToColor.channeling (bit 7)
+    lootFrameShown = false,         -- bit 8
+    chatInputActive = false,        -- bit 9 (polled)
+    softTargetEnabled = false,      -- bit 10
+}
+
+-- Track if cache has been initialized
+local cacheInitialized = false
+
+-- Debug flag to disable caching (for baseline memory testing)
+local BITCACHE_ENABLED = true
+
+--------------------------------------------------------------------------------
+-- Helper Functions
+--------------------------------------------------------------------------------
+
+local function IsUnitHostile(unit, target)
+    return UnitExists(target) and
+           (UnitReaction(unit, target) or 0) <= 4 and
+           not UnitIsFriend(unit, target)
+end
+
+local function IsUnitsTargetIsPlayerOrPet(unit, unitTarget)
+    local x = DataToColor:UnitsTargetAsNumber(unit, unitTarget)
+    return x == 1 or x == 4
+end
+
+--------------------------------------------------------------------------------
+-- Cache Update Functions (called by events)
+--------------------------------------------------------------------------------
+
+-- Update target-related bits
+local function UpdateTargetCache()
+    local target = DataToColor.C.unitTarget
+    local targetExists = UnitExists(target)
+
+    bits1Cache.targetExists = targetExists
+
+    if targetExists then
+        bits1Cache.targetInCombat = UnitAffectingCombat(target) or false
+        bits1Cache.targetIsDead = UnitIsDead(target) or false
+        bits1Cache.targetIsHostile = IsUnitHostile(DataToColor.C.unitPlayer, target)
+        bits1Cache.targetIsPlayer = UnitIsPlayer(target) or false
+        bits1Cache.targetIsTapDenied = DataToColor:UnitIsTapDenied(target) or false
+        bits2Cache.targetIsTrivial = UnitIsTrivial(target) or false
+        bits2Cache.targetPlayerControlled = UnitPlayerControlled(target) or false
+    else
+        bits1Cache.targetInCombat = false
+        bits1Cache.targetIsDead = false
+        bits1Cache.targetIsHostile = false
+        bits1Cache.targetIsPlayer = false
+        bits1Cache.targetIsTapDenied = false
+        bits2Cache.targetIsTrivial = false
+        bits2Cache.targetPlayerControlled = false
+    end
+end
+
+-- Update target's target
+local function UpdateTargetTargetCache()
+    if bits1Cache.targetExists then
+        bits1Cache.targetTargetsPlayer = IsUnitsTargetIsPlayerOrPet(
+            DataToColor.C.unitTarget,
+            DataToColor.C.unitTargetTarget
+        )
+    else
+        bits1Cache.targetTargetsPlayer = false
+    end
+end
+
+-- Update mouseover-related bits
+local function UpdateMouseoverCache()
+    local mouseover = DataToColor.C.unitmouseover
+    local exists = UnitExists(mouseover)
+
+    bits1Cache.mouseoverExists = exists
+
+    if exists then
+        bits2Cache.mouseoverIsDead = UnitIsDead(mouseover) or false
+        bits2Cache.mouseoverIsTrivial = UnitIsTrivial(mouseover) or false
+        bits2Cache.mouseoverIsTapDenied = DataToColor:UnitIsTapDenied(mouseover) or false
+        bits2Cache.mouseoverIsHostile = IsUnitHostile(DataToColor.C.unitPlayer, mouseover)
+        bits2Cache.mouseoverIsPlayer = UnitIsPlayer(mouseover) or false
+        bits2Cache.mouseoverTargetsPlayer = IsUnitsTargetIsPlayerOrPet(
+            mouseover,
+            DataToColor.C.unitmouseovertarget
+        )
+        bits2Cache.mouseoverPlayerControlled = UnitPlayerControlled(mouseover) or false
+    else
+        bits2Cache.mouseoverIsDead = false
+        bits2Cache.mouseoverIsTrivial = false
+        bits2Cache.mouseoverIsTapDenied = false
+        bits2Cache.mouseoverIsHostile = false
+        bits2Cache.mouseoverIsPlayer = false
+        bits2Cache.mouseoverTargetsPlayer = false
+        bits2Cache.mouseoverPlayerControlled = false
+    end
+end
+
+-- Update focus-related bits
+local function UpdateFocusCache()
+    local focus = DataToColor.C.unitFocus
+    local focusTarget = DataToColor.C.unitFocusTarget
+
+    bits2Cache.focusExists = UnitExists(focus) or false
+
+    if bits2Cache.focusExists then
+        bits2Cache.focusInCombat = UnitAffectingCombat(focus) or false
+        bits2Cache.focusTargetExists = UnitExists(focusTarget) or false
+
+        if bits2Cache.focusTargetExists then
+            bits2Cache.focusTargetInCombat = UnitAffectingCombat(focusTarget) or false
+            bits2Cache.focusTargetIsHostile = IsUnitHostile(DataToColor.C.unitPlayer, focusTarget)
+        else
+            bits2Cache.focusTargetInCombat = false
+            bits2Cache.focusTargetIsHostile = false
+        end
+    else
+        bits2Cache.focusInCombat = false
+        bits2Cache.focusTargetExists = false
+        bits2Cache.focusTargetInCombat = false
+        bits2Cache.focusTargetIsHostile = false
+    end
+end
+
+-- Update pet-related bits
+local function UpdatePetCache()
+    local pet = DataToColor.C.unitPet
+    local petVisible = UnitIsVisible(pet)
+    local petDead = UnitIsDead(pet)
+
+    bits1Cache.petIsAlive = petVisible and not petDead
+
+    -- Pet happiness (Classic only)
+    if DataToColor:IsClassicPreCata() then
+        bits1Cache.petIsHappy = GetPetHappiness() == 3
+    else
+        bits1Cache.petIsHappy = true
+    end
+
+    -- Pet target
+    bits2Cache.petTargetIsDead = UnitIsDead(DataToColor.C.unitPetTarget) or false
+
+    -- Pet defensive mode
+    if HasPetUI() then
+        bits2Cache.petIsDefensive = false
+        for i = 1, 10 do
+            local name, _, _, isActive = GetPetActionInfo(i)
+            if isActive and name == DataToColor.C.PET_MODE_DEFENSIVE then
+                bits2Cache.petIsDefensive = true
+                break
+            end
+        end
+    else
+        bits2Cache.petIsDefensive = false
+    end
+end
+
+-- Update player combat state
+local function UpdatePlayerCombatCache()
+    bits1Cache.playerInCombat = UnitAffectingCombat(DataToColor.C.unitPlayer) or false
+end
+
+-- Update player death state
+local function UpdatePlayerDeathCache()
+    bits1Cache.playerIsDeadOrGhost = UnitIsDeadOrGhost(DataToColor.C.unitPlayer) or false
+end
+
+-- Update mount state
+local function UpdateMountCache()
+    bits1Cache.isMounted = IsMounted() or false
+end
+
+-- Update taxi state
+local function UpdateTaxiCache()
+    bits1Cache.onTaxi = UnitOnTaxi(DataToColor.C.unitPlayer) or false
+end
+
+-- Update stealth state
+local function UpdateStealthCache()
+    bits2Cache.isStealthed = IsStealthed() or false
+end
+
+-- Update weapon enchants
+local function UpdateWeaponEnchantCache()
+    local mainHand, _, _, _, offHand = GetWeaponEnchantInfo()
+    bits1Cache.mainHandEnchant = mainHand or false
+    bits1Cache.offHandEnchant = offHand or false
+end
+
+-- Update equipment durability
+local function UpdateEquipmentCache()
+    bits1Cache.equipmentBroken = DataToColor:GetInventoryBroken() > 0
+
+    -- Ammo (Classic only)
+    if DataToColor:IsClassicPreCata() then
+        bits1Cache.hasAmmo = DataToColor:HasAmmo()
+    else
+        bits1Cache.hasAmmo = true
+    end
+end
+
+-- Update talent points
+local function UpdateTalentCache()
+    bits1Cache.hasUnspentTalents = UnitCharacterPoints(DataToColor.C.unitPlayer) > 0
+end
+
+-- Update auto-attack/spell states
+local function UpdateSpellStateCache()
+    bits1Cache.autoShotActive = IsAutoRepeatSpell(DataToColor.C.Spell.AutoShotId) or false
+    bits1Cache.shootActive = IsAutoRepeatSpell(DataToColor.C.Spell.ShootId) or false
+    bits1Cache.attackActive = IsCurrentSpell(DataToColor.C.Spell.AttackId) or false
+end
+
+-- Update breath/mirror timer
+local function UpdateMirrorTimerCache()
+    local timerType, _, _, scale = GetMirrorTimerInfo(2)
+    bits2Cache.isBreathHeld = timerType == DataToColor.C.MIRRORTIMER.BREATH and scale < 0
+end
+
+-- Update soft interact target
+local function UpdateSoftInteractCache()
+    local softInteract = DataToColor.C.unitSoftInteract
+    local exists = UnitExists(softInteract)
+
+    bits3Cache.softInteractExists = exists
+
+    if exists then
+        bits3Cache.softInteractIsDead = UnitIsDead(softInteract) or false
+        bits3Cache.softInteractIsDeadOrGhost = UnitIsDeadOrGhost(softInteract) or false
+        bits3Cache.softInteractIsPlayer = UnitIsPlayer(softInteract) or false
+        bits3Cache.softInteractIsTapDenied = DataToColor:UnitIsTapDenied(softInteract) or false
+        bits3Cache.softInteractInCombat = UnitAffectingCombat(softInteract) or false
+        bits3Cache.softInteractIsHostile = IsUnitHostile(DataToColor.C.unitPlayer, softInteract)
+    else
+        bits3Cache.softInteractIsDead = false
+        bits3Cache.softInteractIsDeadOrGhost = false
+        bits3Cache.softInteractIsPlayer = false
+        bits3Cache.softInteractIsTapDenied = false
+        bits3Cache.softInteractInCombat = false
+        bits3Cache.softInteractIsHostile = false
+    end
+
+    bits3Cache.softTargetEnabled = DataToColor:SoftTargetInteractEnabled()
+end
+
+-- Update loot frame state
+local function UpdateLootFrameCache()
+    bits3Cache.lootFrameShown = LootFrame:IsShown() or false
+end
+
+--------------------------------------------------------------------------------
+-- Polled Values (called every frame)
+-- These values cannot be reliably event-driven but are few enough
+-- that polling every frame is still a major improvement (56 → 7 API calls)
+--------------------------------------------------------------------------------
+
+local function UpdatePolledValues()
+    -- Movement/position states - must be real-time for accurate bot behavior
+    bits1Cache.isSwimming = IsSwimming() or false
+    bits1Cache.isFalling = IsFalling() or false
+    bits2Cache.isIndoors = IsIndoors() or false
+    bits2Cache.isFlying = IsFlying() or false
+    bits2Cache.isMoving = DataToColor:PlayerIsMoving() or false
+
+    -- UI states
+    bits2Cache.gameMenuShown = GameMenuFrame:IsShown() or false
+    bits3Cache.chatInputActive = DataToColor:IsChatInputActive() or false
+
+    -- Spell states - must be polled because bot checks these immediately after
+    -- sending key presses, faster than START/STOP_AUTOREPEAT_SPELL events fire
+    UpdateSpellStateCache()
+end
+
+--------------------------------------------------------------------------------
+-- Full Cache Initialization
+--------------------------------------------------------------------------------
+
+local function InitializeCache()
+    -- Update all caches
+    UpdateTargetCache()
+    UpdateTargetTargetCache()
+    UpdateMouseoverCache()
+    UpdateFocusCache()
+    UpdatePetCache()
+    UpdatePlayerCombatCache()
+    UpdatePlayerDeathCache()
+    UpdateMountCache()
+    UpdateTaxiCache()
+    UpdateStealthCache()
+    UpdateWeaponEnchantCache()
+    UpdateEquipmentCache()
+    UpdateTalentCache()
+    UpdateMirrorTimerCache()
+    UpdateSoftInteractCache()
+    UpdateLootFrameCache()
+
+    -- Initialize polled values (includes UpdateSpellStateCache)
+    UpdatePolledValues()
+
+    cacheInitialized = true
+end
+
+--------------------------------------------------------------------------------
+-- Cached Bits Functions
+--------------------------------------------------------------------------------
+
+function DataToColor:Bits1Cached()
+    if not BITCACHE_ENABLED or not cacheInitialized then
+        return self:Bits1()  -- Fallback to original
+    end
+
+    -- Update polled values
+    UpdatePolledValues()
+
+    return
+        (bits1Cache.targetInCombat and 1 or 0) +
+        (bits1Cache.targetIsDead and 2 or 0) ^ 1 +
+        (bits1Cache.playerIsDeadOrGhost and 2 or 0) ^ 2 +
+        (bits1Cache.hasUnspentTalents and 2 or 0) ^ 3 +
+        (bits1Cache.mouseoverExists and 2 or 0) ^ 4 +
+        (bits1Cache.targetIsHostile and 2 or 0) ^ 5 +
+        (bits1Cache.petIsAlive and 2 or 0) ^ 6 +
+        (bits1Cache.mainHandEnchant and 2 or 0) ^ 7 +
+        (bits1Cache.offHandEnchant and 2 or 0) ^ 8 +
+        (self:GetInventoryBroken() ^ 9) +  -- Keep original for bit 9 (returns 0 or 2)
+        (bits1Cache.onTaxi and 2 or 0) ^ 10 +
+        (bits1Cache.isSwimming and 2 or 0) ^ 11 +
+        (bits1Cache.petIsHappy and 2 or 0) ^ 12 +
+        (bits1Cache.hasAmmo and 2 or 0) ^ 13 +
+        (bits1Cache.playerInCombat and 2 or 0) ^ 14 +
+        (bits1Cache.targetTargetsPlayer and 2 or 0) ^ 15 +
+        (bits1Cache.autoShotActive and 2 or 0) ^ 16 +
+        (bits1Cache.targetExists and 2 or 0) ^ 17 +
+        (bits1Cache.isMounted and 2 or 0) ^ 18 +
+        (bits1Cache.shootActive and 2 or 0) ^ 19 +
+        (bits1Cache.attackActive and 2 or 0) ^ 20 +
+        (bits1Cache.targetIsPlayer and 2 or 0) ^ 21 +
+        (bits1Cache.targetIsTapDenied and 2 or 0) ^ 22 +
+        (bits1Cache.isFalling and 2 or 0) ^ 23
+end
+
+function DataToColor:Bits2Cached()
+    if not BITCACHE_ENABLED or not cacheInitialized then
+        return self:Bits2()  -- Fallback to original
+    end
+
+    return
+        (bits2Cache.isBreathHeld and 1 or 0) +
+        (self.corpseInRange ^ 1) +  -- Keep original
+        (bits2Cache.isIndoors and 2 or 0) ^ 2 +
+        (bits2Cache.focusExists and 2 or 0) ^ 3 +
+        (bits2Cache.focusInCombat and 2 or 0) ^ 4 +
+        (bits2Cache.focusTargetExists and 2 or 0) ^ 5 +
+        (bits2Cache.focusTargetInCombat and 2 or 0) ^ 6 +
+        (bits2Cache.focusTargetIsHostile and 2 or 0) ^ 7 +
+        (bits2Cache.mouseoverIsDead and 2 or 0) ^ 8 +
+        (bits2Cache.petTargetIsDead and 2 or 0) ^ 9 +
+        (bits2Cache.isStealthed and 2 or 0) ^ 10 +
+        (bits2Cache.targetIsTrivial and 2 or 0) ^ 11 +
+        (bits2Cache.mouseoverIsTrivial and 2 or 0) ^ 12 +
+        (bits2Cache.mouseoverIsTapDenied and 2 or 0) ^ 13 +
+        (bits2Cache.mouseoverIsHostile and 2 or 0) ^ 14 +
+        (bits2Cache.mouseoverIsPlayer and 2 or 0) ^ 15 +
+        (bits2Cache.mouseoverTargetsPlayer and 2 or 0) ^ 16 +
+        (bits2Cache.mouseoverPlayerControlled and 2 or 0) ^ 17 +
+        (bits2Cache.targetPlayerControlled and 2 or 0) ^ 18 +
+        (self.autoFollow and 2 or 0) ^ 19 +  -- Keep original
+        (bits2Cache.gameMenuShown and 2 or 0) ^ 20 +
+        (bits2Cache.isFlying and 2 or 0) ^ 21 +
+        (bits2Cache.isMoving and 2 or 0) ^ 22 +
+        (bits2Cache.petIsDefensive and 2 or 0) ^ 23
+end
+
+function DataToColor:Bits3Cached()
+    if not BITCACHE_ENABLED or not cacheInitialized then
+        return self:Bits3()  -- Fallback to original
+    end
+
+    return
+        (bits3Cache.softInteractExists and 1 or 0) +
+        (bits3Cache.softInteractIsDead and 2 or 0) ^ 1 +
+        (bits3Cache.softInteractIsDeadOrGhost and 2 or 0) ^ 2 +
+        (bits3Cache.softInteractIsPlayer and 2 or 0) ^ 3 +
+        (bits3Cache.softInteractIsTapDenied and 2 or 0) ^ 4 +
+        (bits3Cache.softInteractInCombat and 2 or 0) ^ 5 +
+        (bits3Cache.softInteractIsHostile and 2 or 0) ^ 6 +
+        (self.channeling and 2 or 0) ^ 7 +  -- Keep original
+        (bits3Cache.lootFrameShown and 2 or 0) ^ 8 +
+        (bits3Cache.chatInputActive and 2 or 0) ^ 9 +
+        (bits3Cache.softTargetEnabled and 2 or 0) ^ 10
+end
+
+--------------------------------------------------------------------------------
+-- Initialization
+-- NOTE: All events are registered in EventHandlers.lua to avoid AceEvent overwrites
+-- EventHandlers.lua calls the exported update functions (updateTarget, updateFocus, etc.)
+--------------------------------------------------------------------------------
+
+local cacheInitializedOnce = false
+
+function DataToColor:RegisterBitCacheEvents()
+    -- Initialize cache (events are registered in EventHandlers.lua)
+    InitializeCache()
+
+    if not cacheInitializedOnce then
+        cacheInitializedOnce = true
+        DataToColor:Print("BitCache initialized - event-driven caching enabled")
+    end
+end
+
+--------------------------------------------------------------------------------
+-- Public API for testing/debugging
+--------------------------------------------------------------------------------
+
+DataToColor.BitCache = {
+    bits1 = bits1Cache,
+    bits2 = bits2Cache,
+    bits3 = bits3Cache,
+    isInitialized = function() return cacheInitialized end,
+    isEnabled = function() return BITCACHE_ENABLED end,
+    setEnabled = function(enabled)
+        BITCACHE_ENABLED = enabled
+        DataToColor:Print("BitCache " .. (enabled and "ENABLED" or "DISABLED"))
+    end,
+    toggle = function()
+        BITCACHE_ENABLED = not BITCACHE_ENABLED
+        DataToColor:Print("BitCache " .. (BITCACHE_ENABLED and "ENABLED" or "DISABLED"))
+    end,
+    reinitialize = InitializeCache,
+    updateTarget = UpdateTargetCache,
+    updateTargetTarget = UpdateTargetTargetCache,
+    updateMouseover = UpdateMouseoverCache,
+    updateFocus = UpdateFocusCache,
+    updatePet = UpdatePetCache,
+    updateSoftInteract = UpdateSoftInteractCache,
+    updateWeaponEnchant = UpdateWeaponEnchantCache,
+    updateEquipment = UpdateEquipmentCache,
+    updateSpellState = UpdateSpellStateCache,
+    updateMirrorTimer = UpdateMirrorTimerCache,
+}

--- a/Addons/DataToColor/BitCache.lua
+++ b/Addons/DataToColor/BitCache.lua
@@ -511,7 +511,7 @@ function DataToColor:RegisterBitCacheEvents()
 
     if not cacheInitializedOnce then
         cacheInitializedOnce = true
-        DataToColor:Print("BitCache initialized - event-driven caching enabled")
+        --DataToColor:Print("BitCache initialized - event-driven caching enabled")
     end
 end
 

--- a/Addons/DataToColor/Collections.lua
+++ b/Addons/DataToColor/Collections.lua
@@ -9,6 +9,8 @@ local Load = select(2, ...)
 local DataToColor = unpack(Load)
 
 local GetTime = GetTime
+local next = next
+local pairs = pairs
 
 --------------------------------------------------------------------------------
 -- TimedQueue
@@ -127,9 +129,12 @@ function struct:set(key, value)
 end
 
 -- Gets a key-value pair that is not dirty or has expired.
+-- Uses next() directly to avoid pairs() iterator allocation
 function struct:getTimed(globalTick)
     local time = GetTime()
-    for k, v in pairs(self.entries) do
+    local entries = self.entries
+    local k, v = next(entries)
+    while k do
         if v.dirty == 0 or (v.dirty == 1 and v.value - time <= 0) then
             if self.lastKey ~= k then
                 self.lastKey = k
@@ -137,12 +142,15 @@ function struct:getTimed(globalTick)
             end
             return k, v.value
         end
+        k, v = next(entries, k)
     end
 end
 
 -- Gets a key-value pair, ignoring dirty status.
+-- Uses next() directly to avoid pairs() iterator allocation
 function struct:getForced(globalTick)
-    for k, v in pairs(self.entries) do
+    local k, v = next(self.entries)
+    if k then
         if self.lastKey ~= v.value then
             self.lastKey = v.value
             self.lastChangedTick = globalTick
@@ -152,9 +160,14 @@ function struct:getForced(globalTick)
     end
 end
 
+-- Uses next() directly to avoid pairs() iterator allocation
 function struct:forcedReset()
-    for _, v in pairs(self.table) do
-        v.value = GetTime()
+    local t = self.table
+    local time = GetTime()
+    local k, v = next(t)
+    while k do
+        v.value = time
+        k, v = next(t, k)
     end
 end
 
@@ -194,4 +207,9 @@ end
 
 function struct:iterator()
     return pairs(self.table)
+end
+
+-- Returns the underlying table for direct next() iteration (avoids pairs() allocation)
+function struct:getTable()
+    return self.table
 end

--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -277,12 +277,11 @@ function DataToColor:OnInitialize()
     DataToColor:RegisterEvents()
 
     UIErrorsFrame:UnregisterEvent("UI_ERROR_MESSAGE")
-
-    local version = GetAddOnMetadata('DataToColor', 'Version')
-    DataToColor:Print("Welcome. Using " .. version)
 end
 
 function DataToColor:OnEnteringWorld()
+    local version = GetAddOnMetadata('DataToColor', 'Version')
+    DataToColor:Print("Welcome. Using " .. version)
     DataToColor:InitializeErrorLists()
 
     DataToColor:PopulateSpellBookInfo()

--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -235,6 +235,15 @@ function DataToColor:RegisterSlashCommands()
     DataToColor:RegisterChatCommand('dcflush', 'FushState')
     DataToColor:RegisterChatCommand('dcbindings', 'SetDefaultBindings')
     DataToColor:RegisterChatCommand('dcactions', 'CreateSecureButtons')
+    DataToColor:RegisterChatCommand('dccache', 'ToggleBitCache')
+end
+
+function DataToColor:ToggleBitCache()
+    if DataToColor.BitCache and DataToColor.BitCache.toggle then
+        DataToColor.BitCache.toggle()
+    else
+        DataToColor:Print("BitCache not available")
+    end
 end
 
 function DataToColor:StartSetup()
@@ -282,6 +291,15 @@ function DataToColor:OnEnteringWorld()
     DataToColor:InitTrigger(DataToColor.customTrigger1)
 
     DataToColor.Libs.RangeCheck:activate()
+
+    -- Ensure UIErrorsFrame stays disabled after loading screens
+    UIErrorsFrame:UnregisterEvent("UI_ERROR_MESSAGE")
+
+    -- Initialize event-driven bit caching
+    DataToColor:RegisterBitCacheEvents()
+
+    -- Initialize event-driven aura caching
+    DataToColor:RegisterAuraCacheEvents()
 
     -- Deferred auto-setup of bindings (1 second delay to ensure everything is ready)
     DataToColor:ScheduleAutoSetup()
@@ -363,6 +381,16 @@ function DataToColor:Reset()
     DataToColor.focusBuffTime = DataToColor.struct:new(AURA_DURATION_ITERATION_FRAME_CHANGE_RATE)
 
     DataToColor.playerPetSummons = {}
+
+    -- Reinitialize bit cache
+    if DataToColor.BitCache and DataToColor.BitCache.reinitialize then
+        DataToColor.BitCache.reinitialize()
+    end
+
+    -- Refresh aura caches
+    if DataToColor.AuraCache and DataToColor.AuraCache.refresh then
+        DataToColor.AuraCache.refresh()
+    end
 end
 
 function DataToColor:Update()
@@ -662,8 +690,9 @@ function DataToColor:CreateFrames()
             Pixel(float, cy * 10, 7)
 
             -- Boolean variables
-            Pixel(int, DataToColor:Bits1(), 8)
-            Pixel(int, DataToColor:Bits2(), 9)
+            -- Use event-driven cached versions (reduces API calls from ~46 to ~5 per frame)
+            Pixel(int, DataToColor:Bits1Cached(), 8)
+            Pixel(int, DataToColor:Bits2Cached(), 9)
 
             Pixel(int, UnitHealthMax(DataToColor.C.unitPlayer), 10)
             Pixel(int, UnitHealth(DataToColor.C.unitPlayer), 11)
@@ -1052,7 +1081,7 @@ function DataToColor:CreateFrames()
                 end
             end
 
-            Pixel(int, DataToColor:Bits3(), 100)
+            Pixel(int, DataToColor:Bits3Cached(), 100)
 
             Pixel(int, DataToColor:getGuidFromUUID(DataToColor.softInteractGuid), 101)
             Pixel(int, DataToColor:getNpcIdFromUUID(DataToColor.softInteractGuid), 102)

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Legacy Cataclysm 4.3.0)
-## Version: 1.9.0
+## Version: 1.9.1
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, cTimerBackport
 ## SavedVariables:
@@ -20,6 +20,8 @@ Versions.lua
 
 Constants.lua
 Query.lua
+BitCache.lua
+AuraCache.lua
 
 Storage.lua
 

--- a/Addons/DataToColor/DataToColor_Classic.toc
+++ b/Addons/DataToColor/DataToColor_Classic.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic)
-## Version: 1.9.0
+## Version: 1.9.1
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:
@@ -17,6 +17,8 @@ Versions.lua
 
 Constants.lua
 Query.lua
+BitCache.lua
+AuraCache.lua
 
 Storage.lua
 

--- a/Addons/DataToColor/DataToColor_TBC.toc
+++ b/Addons/DataToColor/DataToColor_TBC.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic TBC)
-## Version: 1.9.0
+## Version: 1.9.1
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:
@@ -17,6 +17,8 @@ Versions.lua
 
 Constants.lua
 Query.lua
+BitCache.lua
+AuraCache.lua
 
 Storage.lua
 

--- a/Addons/DataToColor/EventHandlers.lua
+++ b/Addons/DataToColor/EventHandlers.lua
@@ -151,6 +151,39 @@ function DataToColor:RegisterEvents()
         DataToColor:RegisterEvent('UNIT_SPELLCAST_SUCCEEDED', 'SoM_OnCastSuccess')
         DataToColor:RegisterEvent('UNIT_SPELLCAST_FAILED', 'SoM_OnCastFailed')
     end
+
+    ---------------------------------------------------------------------------
+    -- BitCache events (centralized here to avoid AceEvent overwrites)
+    ---------------------------------------------------------------------------
+    DataToColor:RegisterEvent('UNIT_TARGET', 'OnUnitTarget_BitCache')
+    DataToColor:RegisterEvent('UPDATE_MOUSEOVER_UNIT', 'OnMouseoverChanged_BitCache')
+    DataToColor:RegisterEvent('PLAYER_FOCUS_CHANGED', 'OnFocusChanged_BitCache')
+    DataToColor:RegisterEvent('PLAYER_REGEN_DISABLED', 'OnEnteredCombat')
+    DataToColor:RegisterEvent('UNIT_FLAGS', 'OnUnitFlags_BitCache')
+    DataToColor:RegisterEvent('PLAYER_DEAD', 'OnPlayerDead_BitCache')
+    DataToColor:RegisterEvent('PLAYER_ALIVE', 'OnPlayerAlive_BitCache')
+    DataToColor:RegisterEvent('PLAYER_UNGHOST', 'OnPlayerUnghost_BitCache')
+    DataToColor:RegisterEvent('UNIT_HEALTH', 'OnUnitHealth_BitCache')
+    DataToColor:RegisterEvent('PET_BAR_UPDATE', 'OnPetBarUpdate_BitCache')
+    DataToColor:RegisterEvent('PLAYER_MOUNT_DISPLAY_CHANGED', 'OnMountChanged_BitCache')
+    DataToColor:RegisterEvent('PLAYER_CONTROL_GAINED', 'OnControlChanged_BitCache')
+    DataToColor:RegisterEvent('PLAYER_CONTROL_LOST', 'OnControlChanged_BitCache')
+    DataToColor:RegisterEvent('UPDATE_STEALTH', 'OnStealthChanged_BitCache')
+    DataToColor:RegisterEvent('UNIT_INVENTORY_CHANGED', 'OnInventoryChanged_BitCache')
+    DataToColor:RegisterEvent('UPDATE_INVENTORY_DURABILITY', 'OnDurabilityChanged_BitCache')
+    DataToColor:RegisterEvent('CHARACTER_POINTS_CHANGED', 'OnTalentChanged_BitCache')
+    DataToColor:RegisterEvent('PLAYER_TALENT_UPDATE', 'OnTalentChanged_BitCache')
+    DataToColor:RegisterEvent('START_AUTOREPEAT_SPELL', 'OnSpellStateChanged_BitCache')
+    DataToColor:RegisterEvent('STOP_AUTOREPEAT_SPELL', 'OnSpellStateChanged_BitCache')
+    DataToColor:RegisterEvent('CURRENT_SPELL_CAST_CHANGED', 'OnSpellStateChanged_BitCache')
+    DataToColor:RegisterEvent('MIRROR_TIMER_START', 'OnMirrorTimer_BitCache')
+    DataToColor:RegisterEvent('MIRROR_TIMER_STOP', 'OnMirrorTimer_BitCache')
+    DataToColor:RegisterEvent('LOOT_OPENED', 'OnLootOpened_BitCache')
+
+    -- Classic-only events
+    if DataToColor:IsClassicPreCata() then
+        DataToColor:RegisterEvent('UNIT_HAPPINESS', 'OnPetHappiness_BitCache')
+    end
 end
 
 -- Initialize error message lookup tables
@@ -556,6 +589,11 @@ function DataToColor:OnLootClosed(event)
     DataToColor.lastLoot = DataToColor.C.Loot.Closed
     DataToColor.lastLootResetStart = DataToColor.globalTime
     --DataToColor:Print("OnLootClosed:"..DataToColor.lastLoot)
+
+    -- Update BitCache loot frame state
+    if DataToColor.BitCache and DataToColor.BitCache.bits3 then
+        DataToColor.BitCache.bits3.lootFrameShown = false
+    end
 end
 
 function DataToColor:OnBagUpdate(event, containerID)
@@ -582,6 +620,17 @@ end
 
 function DataToColor:OnPlayerTargetChanged(event)
     DataToColor.targetChanged = true
+
+    -- Update BitCache target state
+    if DataToColor.BitCache and DataToColor.BitCache.updateTarget then
+        DataToColor.BitCache.updateTarget()
+        DataToColor.BitCache.updateTargetTarget()
+    end
+
+    -- Update AuraCache for target
+    if DataToColor.AuraCache and DataToColor.AuraCache.refresh then
+        DataToColor.AuraCache.refresh("target")
+    end
 end
 
 function DataToColor:OnPlayerEquipmentChanged(event, equipmentSlot, hasCurrent)
@@ -650,6 +699,16 @@ function DataToColor:OnPetChanged(event, unit)
     if unit == DataToColor.C.unitPlayer then
         DataToColor.petGUID = UnitGUID(DataToColor.C.unitPet)
     end
+
+    -- Update BitCache pet state
+    if DataToColor.BitCache and DataToColor.BitCache.updatePet then
+        DataToColor.BitCache.updatePet()
+    end
+
+    -- Update AuraCache for pet
+    if DataToColor.AuraCache and DataToColor.AuraCache.refresh then
+        DataToColor.AuraCache.refresh("pet")
+    end
 end
 
 function DataToColor:OnZoneChanged(event)
@@ -658,6 +717,11 @@ end
 
 function DataToColor:OnLeftCombat()
     DataToColor.eligibleKillCredit = {}
+
+    -- Update BitCache combat state (player left combat)
+    if DataToColor.BitCache and DataToColor.BitCache.bits1 then
+        DataToColor.BitCache.bits1.playerInCombat = false
+    end
 end
 
 function DataToColor:AutoFollowBegin()
@@ -722,6 +786,16 @@ end
 function DataToColor:OnPlayerSoftInteractChanged(event, old, new)
     DataToColor.softInteractGuid = new
     --print(event, old, "vs", new, DataToColor:getGuidFromUUID(new), DataToColor:getNpcIdFromUUID(new))
+
+    -- Update BitCache soft interact state
+    if DataToColor.BitCache and DataToColor.BitCache.updateSoftInteract then
+        DataToColor.BitCache.updateSoftInteract()
+    end
+
+    -- Update AuraCache for soft interact target
+    if DataToColor.AuraCache and DataToColor.AuraCache.refresh then
+        DataToColor.AuraCache.refresh("softinteract")
+    end
 end
 
 local CORPSE_RETRIEVAL_DISTANCE = 40
@@ -796,5 +870,155 @@ function DataToColor:ResurrectPlayer()
                 end
             end
         end
+    end
+end
+
+-------------------------------------------------------------------------------
+-- BitCache Event Handlers
+-- These delegate to BitCache update functions to keep event registration centralized
+-------------------------------------------------------------------------------
+
+function DataToColor:OnUnitTarget_BitCache(event, unit)
+    if DataToColor.BitCache and DataToColor.BitCache.updateTargetTarget then
+        if unit == "target" then
+            DataToColor.BitCache.updateTargetTarget()
+        elseif unit == "focus" then
+            DataToColor.BitCache.updateFocus()
+        elseif unit == "pet" then
+            DataToColor.BitCache.updatePet()
+        end
+    end
+end
+
+function DataToColor:OnMouseoverChanged_BitCache(event)
+    if DataToColor.BitCache and DataToColor.BitCache.updateMouseover then
+        DataToColor.BitCache.updateMouseover()
+    end
+    if DataToColor.AuraCache and DataToColor.AuraCache.refresh then
+        DataToColor.AuraCache.refresh("mouseover")
+    end
+end
+
+function DataToColor:OnFocusChanged_BitCache(event)
+    if DataToColor.BitCache and DataToColor.BitCache.updateFocus then
+        DataToColor.BitCache.updateFocus()
+    end
+    if DataToColor.AuraCache and DataToColor.AuraCache.refresh then
+        DataToColor.AuraCache.refresh("focus")
+    end
+end
+
+function DataToColor:OnEnteredCombat(event)
+    if DataToColor.BitCache and DataToColor.BitCache.bits1 then
+        DataToColor.BitCache.bits1.playerInCombat = true
+    end
+end
+
+function DataToColor:OnUnitFlags_BitCache(event, unit)
+    if not DataToColor.BitCache or not DataToColor.BitCache.bits1 then return end
+    if unit == "target" then
+        DataToColor.BitCache.bits1.targetInCombat = UnitAffectingCombat(unit) or false
+    elseif unit == "focus" then
+        DataToColor.BitCache.bits2.focusInCombat = UnitAffectingCombat(unit) or false
+    elseif unit == "focustarget" then
+        DataToColor.BitCache.bits2.focusTargetInCombat = UnitAffectingCombat(unit) or false
+    end
+end
+
+function DataToColor:OnPlayerDead_BitCache(event)
+    if DataToColor.BitCache and DataToColor.BitCache.bits1 then
+        DataToColor.BitCache.bits1.playerIsDeadOrGhost = true
+    end
+end
+
+function DataToColor:OnPlayerAlive_BitCache(event)
+    if DataToColor.BitCache and DataToColor.BitCache.bits1 then
+        DataToColor.BitCache.bits1.playerIsDeadOrGhost = UnitIsDeadOrGhost("player") or false
+    end
+end
+
+function DataToColor:OnPlayerUnghost_BitCache(event)
+    if DataToColor.BitCache and DataToColor.BitCache.bits1 then
+        DataToColor.BitCache.bits1.playerIsDeadOrGhost = UnitIsDeadOrGhost("player") or false
+    end
+end
+
+function DataToColor:OnUnitHealth_BitCache(event, unit)
+    if not DataToColor.BitCache or not DataToColor.BitCache.bits1 then return end
+    if unit == "target" then
+        DataToColor.BitCache.bits1.targetIsDead = UnitIsDead(unit) or false
+    elseif unit == "pet" then
+        DataToColor.BitCache.updatePet()
+    end
+end
+
+function DataToColor:OnPetBarUpdate_BitCache(event)
+    if DataToColor.BitCache and DataToColor.BitCache.updatePet then
+        DataToColor.BitCache.updatePet()
+    end
+end
+
+function DataToColor:OnMountChanged_BitCache(event)
+    if DataToColor.BitCache and DataToColor.BitCache.bits1 then
+        DataToColor.BitCache.bits1.isMounted = IsMounted() or false
+    end
+end
+
+function DataToColor:OnControlChanged_BitCache(event)
+    if DataToColor.BitCache and DataToColor.BitCache.bits1 then
+        DataToColor.BitCache.bits1.onTaxi = UnitOnTaxi("player") or false
+    end
+end
+
+function DataToColor:OnStealthChanged_BitCache(event)
+    if DataToColor.BitCache and DataToColor.BitCache.bits2 then
+        DataToColor.BitCache.bits2.isStealthed = IsStealthed() or false
+    end
+end
+
+function DataToColor:OnInventoryChanged_BitCache(event, unit)
+    if unit == "player" and DataToColor.BitCache then
+        if DataToColor.BitCache.updateWeaponEnchant then
+            DataToColor.BitCache.updateWeaponEnchant()
+        end
+        if DataToColor.BitCache.updateEquipment then
+            DataToColor.BitCache.updateEquipment()
+        end
+    end
+end
+
+function DataToColor:OnDurabilityChanged_BitCache(event)
+    if DataToColor.BitCache and DataToColor.BitCache.updateEquipment then
+        DataToColor.BitCache.updateEquipment()
+    end
+end
+
+function DataToColor:OnTalentChanged_BitCache(event)
+    if DataToColor.BitCache and DataToColor.BitCache.bits1 then
+        DataToColor.BitCache.bits1.hasUnspentTalents = UnitCharacterPoints("player") > 0
+    end
+end
+
+function DataToColor:OnSpellStateChanged_BitCache(event)
+    if DataToColor.BitCache and DataToColor.BitCache.updateSpellState then
+        DataToColor.BitCache.updateSpellState()
+    end
+end
+
+function DataToColor:OnMirrorTimer_BitCache(event)
+    if DataToColor.BitCache and DataToColor.BitCache.updateMirrorTimer then
+        DataToColor.BitCache.updateMirrorTimer()
+    end
+end
+
+function DataToColor:OnLootOpened_BitCache(event)
+    if DataToColor.BitCache and DataToColor.BitCache.bits3 then
+        DataToColor.BitCache.bits3.lootFrameShown = true
+    end
+end
+
+function DataToColor:OnPetHappiness_BitCache(event, unit)
+    if unit == "pet" and DataToColor.BitCache and DataToColor.BitCache.bits1 then
+        DataToColor.BitCache.bits1.petIsHappy = GetPetHappiness() == 3
     end
 end

--- a/Addons/DataToColor/Query.lua
+++ b/Addons/DataToColor/Query.lua
@@ -5,6 +5,7 @@ local Range = DataToColor.Libs.RangeCheck
 local bit = bit
 local band = bit.band
 local pcall = pcall
+local next = next
 
 local floor = math.floor
 
@@ -50,6 +51,7 @@ local UnitIsGhost = UnitIsGhost
 local C_DeathInfo = C_DeathInfo
 local UnitAttackSpeed = UnitAttackSpeed
 local UnitRangedDamage = UnitRangedDamage
+local UnitBuff = UnitBuff
 
 local GameMenuFrame = GameMenuFrame
 local LootFrame = LootFrame
@@ -211,11 +213,16 @@ function DataToColor:Set(trigger, input)
     end
 end
 
-function DataToColor:getAuraMaskForClass(func, unitId, table)
+-- Uses next() directly to avoid pairs() iterator allocation
+-- Uses cached aura data to avoid UnitBuff/UnitDebuff string allocations
+function DataToColor:getAuraMaskForClass(func, unitId, tbl)
     local mask = 0
-    for k, v in pairs(table) do
+    -- Determine if we're looking for buffs or debuffs based on the function
+    local isBuff = (func == UnitBuff)
+    local k, v = next(tbl)
+    while k do
         for i = 1, 24 do
-            local name, texture = func(unitId, i)
+            local name, texture = self:GetCachedAuraInfo(isBuff, unitId, i)
             if not name then
                 break
             end
@@ -224,22 +231,31 @@ function DataToColor:getAuraMaskForClass(func, unitId, table)
                 break
             end
         end
+        k, v = next(tbl, k)
     end
     return mask
 end
 
+-- Uses cached aura data to avoid UnitBuff/UnitDebuff string allocations
 function DataToColor:populateAuraTimer(func, unitId, queue)
     local count = 0
 
     self._existingAuras = self._existingAuras or {}
     local existingAuras = self._existingAuras
 
-    for k in pairs(existingAuras) do
+    -- Clear using next() to avoid pairs() iterator allocation
+    local k = next(existingAuras)
+    while k do
+        local nextK = next(existingAuras, k)
         existingAuras[k] = nil
+        k = nextK
     end
 
+    -- Determine if we're looking for buffs or debuffs based on the function
+    local isBuff = (func == UnitBuff)
+
     for i = 1, 40 do
-        local name, texture, duration, expirationTime = DataToColor:GetAuraInfo(func, unitId, i)
+        local name, texture, duration, expirationTime = self:GetCachedAuraInfo(isBuff, unitId, i)
         if not name then
             break
         end
@@ -265,12 +281,16 @@ function DataToColor:populateAuraTimer(func, unitId, queue)
 
     -- Remove unlimited duration Auras.
     -- Such as clickable Mounts and Buffs
+    -- Uses next() directly to avoid pairs() iterator allocation
     if queue then
-        for k in queue:iterator() do
+        local t = queue:getTable()
+        local k = next(t)
+        while k do
             if not existingAuras[k] then
                 --DataToColor:Print(k, " remove unlimited")
                 queue:set(k, GetTime())
             end
+            k = next(t, k)
         end
     end
 

--- a/Addons/DataToColor/Versions.lua
+++ b/Addons/DataToColor/Versions.lua
@@ -216,6 +216,24 @@ function DataToColor:GetAuraInfo(func, unit, index)
     return a1, texture, duration, expirationTime
 end
 
+-- Cached version of GetAuraInfo that reads from AuraCache instead of calling WoW API
+-- This avoids string allocations from UnitBuff/UnitDebuff every frame
+function DataToColor:GetCachedAuraInfo(isBuff, unit, index)
+    local name, texture, count, _, duration, expirationTime
+    if isBuff then
+        name, texture, count, _, duration, expirationTime = self:GetCachedBuff(unit, index)
+    else
+        name, texture, count, _, duration, expirationTime = self:GetCachedDebuff(unit, index)
+    end
+
+    if not name then return nil end
+
+    -- Normalize texture (same as GetAuraInfo)
+    texture = self:NormalizeTexture(texture)
+
+    return name, texture, duration or 0, expirationTime or 0
+end
+
 
 --------------------------------------------------------------------------------
 -- CONTAINER API COMPATIBILITY (Bag changes from 10.0)


### PR DESCRIPTION
## Summary
- Add BitCache.lua for event-driven caching of Bits1/2/3 state flags
- Add AuraCache.lua for event-driven aura/buff/debuff caching
- Centralize all event registrations in EventHandlers.lua to prevent AceEvent overwrites
- Fix duplicate UI error messages appearing after loading screens

## Performance Improvements
- **~17x reduction in memory allocation rate** (1.93 MB/s → 0.11 MB/s)
- Reduced API calls from ~56 per frame to ~10 per frame
- Less frequent garbage collection pauses
- Smoother gameplay with lower CPU overhead

## Technical Changes
- BitCache: Caches combat state, target info, spell states, movement flags
- AuraCache: Pools aura data structures to avoid per-frame allocations
- EventHandlers: Single owner for all events, delegates to cache update functions
- Fixed UIErrorsFrame re-registration issue during PLAYER_ENTERING_WORLD
- Toggle caching with /dccache command for debugging


## Measurements done by

```lua
/run UpdateAddOnMemoryUsage();local m=GetAddOnMemoryUsage("DataToColor");local c=DataToColor.BitCache and DataToColor.BitCache.isEnabled()and"ON"or"OFF";print(format("[%.1fs] DTC: %.2f KB (%.2f MB) Cache:%s",GetTime(),m,m/1024,c))
```

Memory Allocation Rate Analysis
```
  ┌─────────────────┬──────────┬─────────────────┬──────────────┬───────────────────┐
  │     Version     │ Duration │  Memory Growth  │     Rate     │       Notes       │
  ├─────────────────┼──────────┼─────────────────┼──────────────┼───────────────────┤
  │ old_data.logs   │ ~7 sec   │ 2.80 → 15.92 MB │ ~1.93 MB/sec │ Forced GC at 16MB │
  ├─────────────────┼──────────┼─────────────────┼──────────────┼───────────────────┤
  │ new_data.logs   │ ~15 sec  │ 1.90 → 3.79 MB  │ ~0.12 MB/sec │ Intermediate fix  │
  ├─────────────────┼──────────┼─────────────────┼──────────────┼───────────────────┤
  │ newest_data.log │ ~32 sec  │ 1.27 → 4.75 MB  │ ~0.11 MB/sec │ Latest version    │
  └─────────────────┴──────────┴─────────────────┴──────────────┴───────────────────┘
```

Improvement Summary
```
  ┌────────────────────────┬──────────────────────────────┐
  │         Metric         │          Old → New           │
  ├────────────────────────┼──────────────────────────────┤
  │ Memory allocation rate │ 1.93 → 0.11 MB/sec           │
  ├────────────────────────┼──────────────────────────────┤
  │ Improvement factor     │ ~17x reduction               │
  ├────────────────────────┼──────────────────────────────┤
  │ GC pressure            │ Heavy (GC at 16MB) → Minimal │
  └────────────────────────┴──────────────────────────────┘
```

  The old version was allocating memory so fast (~2 MB/second) that garbage collection had to kick in after just 7 seconds when it hit 16MB.