### PR TITLE
Addon: [1.9.3] - Fix dead soft target blocking combat with body-pulled mobs (#720)

### DIFF
--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -5,7 +5,7 @@
 -- Trigger between emitting game data and frame location data
 local SETUP_SEQUENCE = false
 -- Total number of data frames generated
-local NUMBER_OF_FRAMES = 111
+local NUMBER_OF_FRAMES = 112
 -- Set number of pixel rows
 local FRAME_ROWS = 1
 -- Size of data squares in px. Varies based on rounding errors as well as dimension size. Use as a guideline, but not 100% accurate.
@@ -212,6 +212,7 @@ DataToColor.gcdExpirationTime = 0
 
 DataToColor.lastAutoShot = 0
 DataToColor.lastMainHandMeleeSwing = 0
+DataToColor.lastDamageDoneTime = 0
 DataToColor.lastCastEvent = 0
 DataToColor.lastCastSpellId = 0
 DataToColor.lastCastGCD = 0
@@ -938,15 +939,6 @@ function DataToColor:CreateFrames()
 
             Pixel(int, DataToColor.talentQueue:shift(globalTick) or 0, 72)
 
-            -- Key bindings queue (slot 106)
-            Pixel(int, DataToColor.bindingQueue:shift(globalTick) or 0, 106)
-
-            -- Action bar texture queue (slot 107)
-            Pixel(int, DataToColor.actionBarTextureQueue:shift(globalTick) or 0, 107)
-
-            -- Action bar macro queue (slot 108)
-            Pixel(int, DataToColor.actionBarMacroQueue:shift(globalTick) or 0, 108)
-
             local gossipNum = DataToColor.gossipQueue:shift(globalTick)
             if gossipNum then
                 --DataToColor:Print("gossipQueue: ", gossipNum)
@@ -1145,6 +1137,18 @@ function DataToColor:CreateFrames()
                 Pixel(int, 0, 104)
                 Pixel(int, 0, 105)
             end
+
+
+            -- Key bindings queue (slot 106)
+            Pixel(int, DataToColor.bindingQueue:shift(globalTick) or 0, 106)
+
+            -- Action bar texture queue (slot 107)
+            Pixel(int, DataToColor.actionBarTextureQueue:shift(globalTick) or 0, 107)
+
+            -- Action bar macro queue (slot 108)
+            Pixel(int, DataToColor.actionBarMacroQueue:shift(globalTick) or 0, 108)
+
+            Pixel(int, DataToColor.lastDamageDoneTime, 109)
 
             UpdateGlobalTime()
             -- NUMBER_OF_FRAMES - 1 reserved for validation

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Legacy Cataclysm 4.3.0)
-## Version: 1.9.2
+## Version: 1.9.3
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, cTimerBackport
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor_Classic.toc
+++ b/Addons/DataToColor/DataToColor_Classic.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic)
-## Version: 1.9.2
+## Version: 1.9.3
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor_TBC.toc
+++ b/Addons/DataToColor/DataToColor_TBC.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic TBC)
-## Version: 1.9.2
+## Version: 1.9.3
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/EventHandlers.lua
+++ b/Addons/DataToColor/EventHandlers.lua
@@ -471,6 +471,7 @@ function DataToColor:OnCombatEvent(...)
             end
 
             DataToColor.CombatDamageDoneQueue:push(DataToColor:getGuidFromUUID(destGUID))
+            DataToColor.lastDamageDoneTime = DataToColor.globalTime
 
             if playerDamageMiss[subEvent] then
                 local missType = select(-2, ...)

--- a/Addons/DataToColor/SetupDefaultBindings.lua
+++ b/Addons/DataToColor/SetupDefaultBindings.lua
@@ -342,6 +342,9 @@ function DataToColor:SetEssentialBindings()
   wasChanged = TryBind("ALT-HOME", "INTERACTTARGET") or wasChanged
   wasChanged = TryBind("ALT-END", "INTERACTMOUSEOVER") or wasChanged
 
+  -- Combat: Start attack (bypasses soft target interaction)
+  wasChanged = TryBind("ALT-NUMPADPLUS", "STARTATTACK") or wasChanged
+
   -- Pet keys (only meaningful for pet classes)
   wasChanged = TryBind("NUMPADMULTIPLY",  "TARGETPET") or wasChanged
   wasChanged = TryBind("NUMPADMINUS",  "PETATTACK") or wasChanged

--- a/Core/Addon/PlayerReader.cs
+++ b/Core/Addon/PlayerReader.cs
@@ -308,4 +308,22 @@ public sealed partial class PlayerReader : IMouseOverReader, IReader
 
         GCD.Reset();
     }
+
+    public bool IsMeleeSwingingDefault() => IsMeleeSwinging(500);
+
+    public bool IsMeleeSwinging(int extraMarginMs)
+    {
+        // Only relevant when in melee range
+        if (!IsInMeleeRange())
+            return false;
+
+        // Check if swing timer shows recent activity
+        int swingSpeed = MainHandSpeedMs();
+        int elapsed = MainHandSwing.ElapsedMs();
+
+        // Buffer: swing speed + network latency + 250ms margin
+        int maxExpectedElapsed = swingSpeed + NetworkLatency + extraMarginMs;
+
+        return elapsed < maxExpectedElapsed;
+    }
 }

--- a/Core/AddonComponent/AddonBits.cs
+++ b/Core/AddonComponent/AddonBits.cs
@@ -110,6 +110,9 @@ public sealed class AddonBits : IReader, IGameMenuWindowShown
 
     public bool SoftInteract_Enabled() => v3[Mask._10];
 
+    public bool SoftInteract_CombatBlocker() =>
+        SoftInteract() && (SoftInteract_Dead() || SoftInteract_Tagged());
+
     public bool MailFrameShown() => v3[Mask._11];
 
     public bool NotMailFrameShown() => !MailFrameShown();

--- a/Core/AddonComponent/CombatLog.cs
+++ b/Core/AddonComponent/CombatLog.cs
@@ -33,6 +33,8 @@ public sealed class CombatLog : IReader
     public RecordInt TargetMissType { get; }
     public RecordInt TargetDodge { get; }
 
+    public RecordInt LastDamageDoneTime { get; }
+
     public CombatLog(AddonBits bits)
     {
         this.bits = bits;
@@ -40,6 +42,8 @@ public sealed class CombatLog : IReader
         DamageDoneGuid = new RecordInt(64);
         DamageTakenGuid = new RecordInt(65);
         DeadGuid = new RecordInt(66);
+
+        LastDamageDoneTime = new(109);
 
         TargetMissType = new(67);
         TargetDodge = new(67);
@@ -56,6 +60,8 @@ public sealed class CombatLog : IReader
         DamageTakenGuid.Reset();
         DeadGuid.Reset();
 
+        LastDamageDoneTime.Reset();
+
         TargetMissType.Reset();
         TargetDodge.Reset();
     }
@@ -63,6 +69,8 @@ public sealed class CombatLog : IReader
     public void Update(IAddonDataProvider reader)
     {
         bool combat = bits.Combat();
+
+        LastDamageDoneTime.Update(reader);
 
         if (combat && DamageTakenGuid.Updated(reader) && DamageTakenGuid.Value > 0)
         {

--- a/Core/ClassConfig/ClassConfigurationBaseActions.cs
+++ b/Core/ClassConfig/ClassConfigurationBaseActions.cs
@@ -41,9 +41,9 @@ public sealed partial class ClassConfiguration
     public KeyAction AutoAttack { get; } = new()
     {
         Name = nameof(AutoAttack),
-        BindingID = BindingID.INTERACTTARGET,
+        BindingID = BindingID.STARTATTACK,
         BaseAction = true,
-        Requirement = "!AutoAttacking && !SoftTargetDead"
+        Requirement = "!AutoAttacking && !MeleeSwinging"
     };
 
     public KeyAction TargetLastTarget { get; } = new()
@@ -132,5 +132,19 @@ public sealed partial class ClassConfiguration
         Name = nameof(Mount),
         BaseAction = true,
         Cooldown = 6000,
+    };
+
+    public KeyAction StrafeLeft { get; } = new()
+    {
+        Name = nameof(StrafeLeft),
+        BindingID = BindingID.STRAFELEFT,
+        BaseAction = true,
+    };
+
+    public KeyAction StrafeRight { get; } = new()
+    {
+        Name = nameof(StrafeRight),
+        BindingID = BindingID.STRAFERIGHT,
+        BaseAction = true,
     };
 }

--- a/Core/ClassConfig/KeyBindingDefaults.cs
+++ b/Core/ClassConfig/KeyBindingDefaults.cs
@@ -48,6 +48,7 @@ public static class KeyBindingDefaults
         // ALT-PAGEUP: TARGETFOCUS (TBC+) or TARGETPARTYMEMBER1 (Vanilla) - version dependent, modifiers come from runtime
 
         // ===== Combat =====
+        { BindingID.STARTATTACK, new(BindingID.STARTATTACK, "Add",      ConsoleKey.Add,      "NUMPADPLUS",  107) },
         { BindingID.PETATTACK,   new(BindingID.PETATTACK,   "Subtract", ConsoleKey.Subtract, "NUMPADMINUS", 109) },
 
         // ===== Interaction (ALT-HOME/ALT-END - modifiers come from runtime) =====
@@ -182,6 +183,7 @@ public static class KeyBindingDefaults
         // ALT-PAGEUP: TARGETFOCUS (TBC+) or TARGETPARTYMEMBER1 (Vanilla) - version dependent
 
         // Combat
+        { "Add", BindingID.STARTATTACK },
         { "Subtract", BindingID.PETATTACK },
 
         // Interaction (ALT-HOME/ALT-END)

--- a/Core/GOAP/GoapAgent.cs
+++ b/Core/GOAP/GoapAgent.cs
@@ -226,6 +226,8 @@ public sealed partial class GoapAgent : IDisposable
             else if (!wasEmpty)
             {
                 LogNewEmptyGoal(logger);
+                CurrentGoal?.OnExit();
+                CurrentGoal = null;
                 wasEmpty = true;
             }
 

--- a/Core/Goals/CombatGoal.cs
+++ b/Core/Goals/CombatGoal.cs
@@ -7,6 +7,8 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Numerics;
 
+using static System.MathF;
+
 namespace Core.Goals;
 
 public sealed class CombatGoal : GoapGoal, IGoapEventListener
@@ -109,7 +111,7 @@ public sealed class CombatGoal : GoapGoal, IGoapEventListener
     {
         wait.Update();
 
-        if (MathF.Abs(lastDirection - playerReader.Direction) > MathF.PI / 2)
+        if (Abs(lastDirection - playerReader.Direction) > PI / 2)
         {
             logger.LogInformation("Turning too fast!");
             stopMoving.Stop();
@@ -123,6 +125,11 @@ public sealed class CombatGoal : GoapGoal, IGoapEventListener
         {
             input.PressJump();
             return;
+        }
+
+        if (bits.SoftInteract_Enabled())
+        {
+            UnstuckDeadSoftTargetLock();
         }
 
         if (classConfig.AutoPetAttack &&
@@ -149,11 +156,6 @@ public sealed class CombatGoal : GoapGoal, IGoapEventListener
             {
                 break;
             }
-        }
-
-        if (bits.SoftInteract_Enabled())
-        {
-            DealWithSoftInteract();
         }
 
         if (!bits.Target() || (bits.Target() && bits.Target_Dead()))
@@ -213,7 +215,15 @@ public sealed class CombatGoal : GoapGoal, IGoapEventListener
 
         if (bits.Target() && !bits.Target_Dead() && bits.Target_Hostile())
         {
-            if (bits.Target_Combat() && bits.TargetTarget_PlayerOrPet())
+            if (!bits.Target_Combat())
+            {
+                logger.LogWarning("Dont pull non-hostile target!");
+                input.PressClearTarget();
+                wait.Update();
+                return;
+            }
+
+            if (bits.TargetTarget_PlayerOrPet() || combatLog.DamageTaken.Contains(playerReader.TargetGuid))
             {
                 ResetCooldowns();
 
@@ -221,15 +231,14 @@ public sealed class CombatGoal : GoapGoal, IGoapEventListener
                 wait.Update();
                 return;
             }
-
-            logger.LogWarning("Dont pull non-hostile target!");
-            input.PressClearTarget();
-            wait.Update();
         }
 
-        logger.LogWarning($"Waiting for target to exists or lose combat. Possible threats {combatLog.DamageTakenCount()}!");
-        wait.Till(CastingHandler.GCD * 2,
-            () => bits.Target_Alive() || !bits.Combat());
+        logger.LogWarning($"Possible threats {combatLog.DamageTakenCount()}!");
+
+        if (bits.SoftInteract_Enabled())
+        {
+            UnstuckDeadSoftTargetLock();
+        }
     }
 
     private Vector3 GetCorpseLocation(float distance)
@@ -237,54 +246,57 @@ public sealed class CombatGoal : GoapGoal, IGoapEventListener
         return PointEstimator.GetMapPos(playerReader.WorldMapArea, playerReader.WorldPos, playerReader.Direction, distance);
     }
 
-    private void DealWithSoftInteract()
+    private void UnstuckDeadSoftTargetLock()
     {
-        if (!playerReader.IsInMeleeRange() ||
-            playerReader.IsCasting() ||
-            !InvalidSoftInteractExists() ||
-            playerReader.TargetGuid == playerReader.SoftInteract_Guid)
+        if (!bits.SoftInteract() ||
+            !bits.SoftInteract_Dead() ||
+            !bits.Auto_Attack() ||
+            combatLog.LastDamageDoneTime.ElapsedMs() < playerReader.MainHandSpeedMs() * 2 ||
+            combatLog.DamageTakenCount() == 0)
         {
             return;
         }
 
-        // TODO: have to find a better way to deal with this
-        return;
+        logger.LogWarning("Turn away from dead softTarget due locking current target interaction!");
 
-        ConsoleKey key = Random.Shared.Next(2) == 0
+        float startDirection = playerReader.Direction;
+        float totalRotation = 0f;
+
+        ConsoleKey turnKey = Random.Shared.Next(2) == 0
             ? input.TurnLeftKey
             : input.TurnRightKey;
 
-        logger.LogWarning($"Invalid SoftInteract Detected Turn away({key}) then face target!");
+        input.SetKeyState(turnKey, true, false);
 
-        input.SetKeyState(key, true, false);
-        while (InvalidSoftInteractExists())
+        while (bits.SoftInteract() && bits.SoftInteract_Dead())
         {
             wait.Update();
+
+            float currentDirection = playerReader.Direction;
+            float delta = Abs(currentDirection - startDirection);
+            if (delta > PI)
+                delta = Tau - delta;
+
+            totalRotation = delta;
+
+            // Safety: if we've turned nearly 360°, soft target is everywhere - strafe instead
+            if (totalRotation >= Tau - 0.2f)
+            {
+                input.SetKeyState(turnKey, false, false);
+                logger.LogWarning("Full rotation without clearing soft target - strafe!");
+
+                KeyAction strafeAction = Random.Shared.Next(2) == 0
+                    ? input.StrafeLeft
+                    : input.StrafeRight;
+
+                input.PressFixed(strafeAction.ConsoleKey, 500, default);
+                wait.Update();
+
+                return;
+            }
         }
-        input.SetKeyState(key, false, false);
-        wait.Fixed(playerReader.DoubleNetworkLatency);
-        wait.Update();
 
-        if (bits.Target() && !InvalidSoftInteractExists())
-        {
-            input.PressFastInteract();
-
-            const int updateCount = 2;
-            float e = wait.AfterEquals(playerReader.SpellQueueTimeMs,
-                updateCount, playerReader._Direction);
-
-            stopMoving.StopForward();
-        }
-    }
-
-    private bool InvalidSoftInteractExists()
-    {
-        return
-            bits.SoftInteract() &&
-            (
-            playerReader.SoftInteract_Type != GuidType.Creature ||
-            bits.SoftInteract_Dead() ||
-            bits.SoftInteract_Tagged()
-            );
+        input.SetKeyState(turnKey, false, false);
+        logger.LogInformation($"Cleared dead soft target after {totalRotation * 180f / PI:F0}° turn");
     }
 }

--- a/Core/GoalsComponent/ReactCastError.cs
+++ b/Core/GoalsComponent/ReactCastError.cs
@@ -165,45 +165,61 @@ public sealed class ReactCastError
             case UI_ERROR.ERR_BADATTACKFACING:
 
                 bool wasAnyAuto = bits.Any_AutoAttack();
+                bool turnedWithInteract = false;
 
-                float beforeDir = playerReader.Direction;
+                // Try fast interact if no invalid soft target exists
+                if (!bits.SoftInteract_CombatBlocker())
+                {
+                    float beforeDir = playerReader.Direction;
+                    input.PressFastInteract();
 
-                input.PressFastInteract();
+                    const int updateCount = 4;
+                    float e = wait.AfterEquals(playerReader.SpellQueueTimeMs,
+                        updateCount, playerReader._Direction);
 
-                const int updateCount = 2;
-                float e = wait.AfterEquals(playerReader.SpellQueueTimeMs,
-                    updateCount, playerReader._Direction);
+                    float sampleTimeMs =
+                        updateCount * (float)addonReader.AvgUpdateLatency;
 
-                float sampleTimeMs =
-                    updateCount * (float)addonReader.AvgUpdateLatency;
+                    if (e > sampleTimeMs)
+                    {
+                        stopMoving.Stop();
+                        logger.LogInformation(
+                            $"React to {value.ToStringF()} - " +
+                            $"Fast turn with Interact {e}ms");
+                        turnedWithInteract = true;
+                    }
+                    else
+                    {
+                        logger.LogWarning(
+                            $"Unable to react to {value.ToStringF()} - " +
+                            $"Fast turn with Interact {e}ms");
 
-                if (e > sampleTimeMs)
+                        // Check if we turned at all (even if slowly)
+                        turnedWithInteract = beforeDir != playerReader.Direction;
+                    }
+                }
+
+                // Fallback: slow turn 180 degrees if interact didn't work or was skipped
+                if (!turnedWithInteract)
                 {
                     stopMoving.Stop();
+
+                    float targetDir = playerReader.Direction + PI;
+                    if (targetDir > Tau)
+                        targetDir -= Tau;
+
+                    direction.SetDirection(targetDir, Vector3.Zero);
+
+                    string reason = bits.SoftInteract_CombatBlocker()
+                        ? "invalid soft target"
+                        : "interact failed";
                     logger.LogInformation(
-                        $"React to {value.ToStringF()} - " +
-                        $"Fast turn with Interact {e}ms");
-                }
-                else
-                {
-                    logger.LogWarning(
-                        $"Unable to react to {value.ToStringF()} - " +
-                        $"Fast turn with Interact {e}ms");
+                        $"React to {value.ToStringF()} - Slow turn 180deg ({reason})");
                 }
 
                 if (!wasAnyAuto)
                     input.PressStopAttack();
 
-                if (e <= sampleTimeMs && beforeDir == playerReader.Direction)
-                {
-                    stopMoving.Stop();
-                    logger.LogInformation($"React to {value.ToStringF()} - " +
-                        $"Slow turn 180deg");
-                    float targetDir = playerReader.Direction + PI;
-                    if (targetDir > Tau)
-                        targetDir = -Tau;
-                    direction.SetDirection(targetDir, Vector3.Zero);
-                }
                 break;
             case UI_ERROR.SPELL_FAILED_MOVING:
                 logger.LogInformation($"React to {value.ToStringF()} -- Stop moving!");

--- a/Core/Input/ConfigurableInputClassConfig.cs
+++ b/Core/Input/ConfigurableInputClassConfig.cs
@@ -27,4 +27,6 @@ public sealed partial class ConfigurableInput
     public KeyAction TargetFocus => classConfig.TargetFocus;
     public KeyAction FollowTarget => classConfig.FollowTarget;
     public KeyAction Mount => classConfig.Mount;
+    public KeyAction StrafeLeft => classConfig.StrafeLeft;
+    public KeyAction StrafeRight => classConfig.StrafeRight;
 }

--- a/Core/Requirement/RequirementFactory.cs
+++ b/Core/Requirement/RequirementFactory.cs
@@ -169,6 +169,7 @@ public sealed partial class RequirementFactory
             { "AutoAttacking", bits.Auto_Attack },
             { "Shooting", bits.Shoot },
             { "AutoShot", bits.AutoShot },
+            { "MeleeSwinging", playerReader.IsMeleeSwingingDefault },
             
             // Temporary Enchants
             { "HasMainHandEnchant", bits.MainHandTempEnchant },


### PR DESCRIPTION
## Problem:
When a mob dies while fighting multiple enemies, the soft target system would lock onto the dead mob's corpse, preventing the player from attacking live mobs that were body-pulled during combat.

## Root Cause:
AutoAttack used `INTERACTTARGET` which respects soft target priority, causing attacks to be directed at the dead soft target instead of the current hard target.

## Solution:
Use `STARTATTACK` command which bypasses soft target interaction and directly engages the current hard target.

## Addon Changes (`v1.9.2` -> `v1.9.3`)

- Add `lastDamageDoneTime` tracking for time-based stuck detection
- Add `STARTATTACK` key binding (`ALT-NUMPADPLUS`)
- Increment `NUMBER_OF_FRAMES` to `112` for new data cell

## Core Changes

### Combat System
- AutoAttack now uses `STARTATTACK` instead of `INTERACTTARGET`
- AutoAttack requirement changed from `"!SoftTargetDead"` to `"!MeleeSwinging"`
- Add `IsMeleeSwinging()` to `PlayerReader` using swing timer + network latency
- Add `LastDamageDoneTime` to `CombatLog` for stuck detection

### CombatGoal Improvements
- Add `UnstuckDeadSoftTargetLock()` with time-based detection
  - Triggers after 2x main hand speed with no damage dealt
  - Turns away from dead soft target to clear it
  - Falls back to strafing if full 360° rotation doesn't clear
- Move stuck detection before spell casting loop
- `FindPossibleThreats` now checks `DamageTaken` for body-pulled mobs

### ReactCastError Improvements
- Skip fast interact turn when soft target blocks combat
- Fall back to slow 180° turn when interact fails
- Fix direction calculation bug (was `= -Tau`, now `-= Tau`)

### GoapAgent Fix
- Properly call `OnExit()` when goal becomes empty

### New Infrastructure
- Add `SoftInteract_CombatBlocker()` to `AddonBits`
- Add `StrafeLeft`/`StrafeRight` `KeyActions` for emergency unstuck
- Add `STARTATTACK` to `KeyBindingDefaults`

### New Requirements
| Requirement | Description |
|-------------|-------------|
| `MeleeSwinging` | Player is in melee range and actively swinging (based on swing timer + latency) |
| `LastDamageDealtMs` | Time since last damage was dealt to any target in milliseconds |

**Example usage:**
```json
"Requirement": "MeleeSwinging"           // Player is actively melee swinging
"Requirement": "LastDamageDealtMs < 2000" // Dealt damage within last 2 seconds
```

---

Side effects / Known issues:
* Since `INTERACTTARGET` no longer periodically pressed in combat but in Reaction to the system message bad facing, while the player is approaches the target, it might overshoot and stop over the enemy, then turn around 180* and goes back. 