### PR TITLE
Addon: [1.9.4] - Fix event registration errors on older WoW clients (#747)

### DIFF
--- a/Addons/DataToColor/AuraCache.lua
+++ b/Addons/DataToColor/AuraCache.lua
@@ -304,7 +304,7 @@ function DataToColor:RegisterAuraCacheEvents()
     cacheInitialized = true
 
     -- Register UNIT_AURA for all units
-    self:RegisterEvent("UNIT_AURA", OnUnitAura)
+    DataToColor:RegisterEvent("UNIT_AURA", OnUnitAura)
 
     -- Register unit change events
     -- NOTE: These events are registered in EventHandlers.lua to avoid AceEvent overwrites:
@@ -315,13 +315,10 @@ function DataToColor:RegisterAuraCacheEvents()
     -- - PLAYER_SOFT_INTERACT_CHANGED -> OnPlayerSoftInteractChanged -> AuraCache.refresh("softinteract")
 
     -- Soft target events (only the ones not handled elsewhere)
-    if self.RegisterEvent then
-        pcall(function()
-            self:RegisterEvent("PLAYER_SOFT_ENEMY_CHANGED", OnSoftTargetChanged)
-            self:RegisterEvent("PLAYER_SOFT_FRIEND_CHANGED", OnSoftTargetChanged)
-            -- NOTE: PLAYER_SOFT_INTERACT_CHANGED is handled by EventHandlers.lua
-        end)
-    end
+    -- Use safe registration since these events don't exist in all WoW versions
+    DataToColor:SafeRegisterEvent("PLAYER_SOFT_ENEMY_CHANGED", OnSoftTargetChanged)
+    DataToColor:SafeRegisterEvent("PLAYER_SOFT_FRIEND_CHANGED", OnSoftTargetChanged)
+    -- NOTE: PLAYER_SOFT_INTERACT_CHANGED is handled by EventHandlers.lua
 
     -- Initial cache population
     for _, unit in ipairs(trackedUnits) do

--- a/Addons/DataToColor/BitCache.lua
+++ b/Addons/DataToColor/BitCache.lua
@@ -421,7 +421,7 @@ end
 
 function DataToColor:Bits1Cached()
     if not BITCACHE_ENABLED or not cacheInitialized then
-        return self:Bits1()  -- Fallback to original
+        return DataToColor:Bits1()  -- Fallback to original
     end
 
     -- Update polled values
@@ -437,7 +437,7 @@ function DataToColor:Bits1Cached()
         (bits1Cache.petIsAlive and 2 or 0) ^ 6 +
         (bits1Cache.mainHandEnchant and 2 or 0) ^ 7 +
         (bits1Cache.offHandEnchant and 2 or 0) ^ 8 +
-        (self:GetInventoryBroken() ^ 9) +  -- Keep original for bit 9 (returns 0 or 2)
+        (DataToColor:GetInventoryBroken() ^ 9) +  -- Keep original for bit 9 (returns 0 or 2)
         (bits1Cache.onTaxi and 2 or 0) ^ 10 +
         (bits1Cache.isSwimming and 2 or 0) ^ 11 +
         (bits1Cache.petIsHappy and 2 or 0) ^ 12 +
@@ -456,12 +456,12 @@ end
 
 function DataToColor:Bits2Cached()
     if not BITCACHE_ENABLED or not cacheInitialized then
-        return self:Bits2()  -- Fallback to original
+        return DataToColor:Bits2()  -- Fallback to original
     end
 
     return
         (bits2Cache.isBreathHeld and 1 or 0) +
-        (self.corpseInRange ^ 1) +  -- Keep original
+        (DataToColor.corpseInRange ^ 1) +  -- Keep original
         (bits2Cache.isIndoors and 2 or 0) ^ 2 +
         (bits2Cache.focusExists and 2 or 0) ^ 3 +
         (bits2Cache.focusInCombat and 2 or 0) ^ 4 +
@@ -488,7 +488,7 @@ end
 
 function DataToColor:Bits3Cached()
     if not BITCACHE_ENABLED or not cacheInitialized then
-        return self:Bits3()  -- Fallback to original
+        return DataToColor:Bits3()  -- Fallback to original
     end
 
     return

--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -5,7 +5,7 @@
 -- Trigger between emitting game data and frame location data
 local SETUP_SEQUENCE = false
 -- Total number of data frames generated
-local NUMBER_OF_FRAMES = 112
+local NUMBER_OF_FRAMES = 113
 -- Set number of pixel rows
 local FRAME_ROWS = 1
 -- Size of data squares in px. Varies based on rounding errors as well as dimension size. Use as a guideline, but not 100% accurate.

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Legacy Cataclysm 4.3.0)
-## Version: 1.9.3
+## Version: 1.9.4
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, cTimerBackport
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor_Classic.toc
+++ b/Addons/DataToColor/DataToColor_Classic.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic)
-## Version: 1.9.3
+## Version: 1.9.4
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor_TBC.toc
+++ b/Addons/DataToColor/DataToColor_TBC.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic TBC)
-## Version: 1.9.3
+## Version: 1.9.4
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/EventHandlers.lua
+++ b/Addons/DataToColor/EventHandlers.lua
@@ -141,9 +141,7 @@ function DataToColor:RegisterEvents()
     DataToColor:RegisterEvent('CHAT_MSG_PARTY_LEADER', 'OnMessageParty')
 
     -- allows to use the addon with older client version
-    pcall(function()
-        DataToColor:RegisterEvent("PLAYER_SOFT_INTERACT_CHANGED", "OnPlayerSoftInteractChanged")
-    end)
+    DataToColor:SafeRegisterEvent("PLAYER_SOFT_INTERACT_CHANGED", "OnPlayerSoftInteractChanged")
 
     -- Season of mastery / vanilla
     if WOW_PROJECT_ID == WOW_PROJECT_CLASSIC then
@@ -172,7 +170,7 @@ function DataToColor:RegisterEvents()
     DataToColor:RegisterEvent('UNIT_INVENTORY_CHANGED', 'OnInventoryChanged_BitCache')
     DataToColor:RegisterEvent('UPDATE_INVENTORY_DURABILITY', 'OnDurabilityChanged_BitCache')
     DataToColor:RegisterEvent('CHARACTER_POINTS_CHANGED', 'OnTalentChanged_BitCache')
-    DataToColor:RegisterEvent('PLAYER_TALENT_UPDATE', 'OnTalentChanged_BitCache')
+    DataToColor:SafeRegisterEvent('PLAYER_TALENT_UPDATE', 'OnTalentChanged_BitCache')
     DataToColor:RegisterEvent('START_AUTOREPEAT_SPELL', 'OnSpellStateChanged_BitCache')
     DataToColor:RegisterEvent('STOP_AUTOREPEAT_SPELL', 'OnSpellStateChanged_BitCache')
     DataToColor:RegisterEvent('CURRENT_SPELL_CAST_CHANGED', 'OnSpellStateChanged_BitCache')

--- a/Addons/DataToColor/Mail.lua
+++ b/Addons/DataToColor/Mail.lua
@@ -476,16 +476,16 @@ end
 -- Can be removed once all C# code uses the new API
 function DataToColor:StartMailSending(recipient, minGoldToKeep, minQuality, excludedIds, sendItems, sendGold)
     -- Use the new API internally
-    self:SMC(recipient, minGoldToKeep, minQuality, sendGold and 1 or 0)
+    DataToColor:SMC(recipient, minGoldToKeep, minQuality, sendGold and 1 or 0)
 
     -- Parse excluded IDs
     if excludedIds and excludedIds ~= "" then
-        self:AEI(excludedIds)
+        DataToColor:AEI(excludedIds)
     end
 
     -- Start sending
     if sendItems ~= false then
-        self:SMS()
+        DataToColor:SMS()
     elseif sendGold then
         -- Gold only mode
         mGoldToSend = true

--- a/Addons/DataToColor/Query.lua
+++ b/Addons/DataToColor/Query.lua
@@ -224,7 +224,7 @@ function DataToColor:getAuraMaskForClass(func, unitId, tbl)
     local k, v = next(tbl)
     while k do
         for i = 1, 24 do
-            local name, texture = self:GetCachedAuraInfo(isBuff, unitId, i)
+            local name, texture = DataToColor:GetCachedAuraInfo(isBuff, unitId, i)
             if not name then
                 break
             end
@@ -257,7 +257,7 @@ function DataToColor:populateAuraTimer(func, unitId, queue)
     local isBuff = (func == UnitBuff)
 
     for i = 1, 40 do
-        local name, texture, duration, expirationTime = self:GetCachedAuraInfo(isBuff, unitId, i)
+        local name, texture, duration, expirationTime = DataToColor:GetCachedAuraInfo(isBuff, unitId, i)
         if not name then
             break
         end

--- a/Addons/DataToColor/Versions.lua
+++ b/Addons/DataToColor/Versions.lua
@@ -60,6 +60,7 @@ end
 local LibClassicCasterino
 if DataToColor.IsClassic() then
   LibClassicCasterino = _G.LibStub("LibClassicCasterino")
+  LibClassicCasterino.callbacks:OnUsed()
 end
 
 local Som140 = DataToColor.IsClassic() and buildVersion == 11400 or buildVersion == 11401 or buildVersion == 11402
@@ -221,15 +222,15 @@ end
 function DataToColor:GetCachedAuraInfo(isBuff, unit, index)
     local name, texture, count, _, duration, expirationTime
     if isBuff then
-        name, texture, count, _, duration, expirationTime = self:GetCachedBuff(unit, index)
+        name, texture, count, _, duration, expirationTime = DataToColor:GetCachedBuff(unit, index)
     else
-        name, texture, count, _, duration, expirationTime = self:GetCachedDebuff(unit, index)
+        name, texture, count, _, duration, expirationTime = DataToColor:GetCachedDebuff(unit, index)
     end
 
     if not name then return nil end
 
     -- Normalize texture (same as GetAuraInfo)
-    texture = self:NormalizeTexture(texture)
+    texture = DataToColor:NormalizeTexture(texture)
 
     return name, texture, duration or 0, expirationTime or 0
 end
@@ -489,7 +490,7 @@ if DataToColor.IsLegacy() then
     local hex = uuid:match("^0x(%x+)$")
     local npcId = tonumber(npc_hex, 16)
     local spawn = hex:sub(-8)  -- "0000355D"
-    return self:uniqueGuid(npcId, spawn)
+    return DataToColor:uniqueGuid(npcId, spawn)
   end
 
   -- Extract NPC ID from UUID
@@ -621,4 +622,46 @@ else
   function DataToColor:PlayerIsMoving()
     return DataToColor.moving
   end
+end
+
+--------------------------------------------------------------------------------
+-- SAFE EVENT REGISTRATION
+-- Pre-validates event existence before AceEvent registration to avoid errors
+--------------------------------------------------------------------------------
+
+local eventTestFrame = CreateFrame("Frame")
+local validatedEvents = {}
+
+-- Check if an event exists in this WoW version
+-- Uses raw frame registration which returns silently for unknown events
+function DataToColor.IsEventSupported(eventName)
+    if validatedEvents[eventName] ~= nil then
+        return validatedEvents[eventName]
+    end
+
+    -- Try to register on raw frame - this doesn't error for unknown events
+    local success = pcall(function()
+        eventTestFrame:RegisterEvent(eventName)
+    end)
+
+    if success then
+        -- Check if it was actually registered (some versions silently fail)
+        local isRegistered = eventTestFrame:IsEventRegistered(eventName)
+        eventTestFrame:UnregisterEvent(eventName)
+        validatedEvents[eventName] = isRegistered
+        return isRegistered
+    end
+
+    validatedEvents[eventName] = false
+    return false
+end
+
+-- Safe wrapper for AceEvent registration
+-- Only registers if the event exists in this WoW version
+function DataToColor:SafeRegisterEvent(eventName, handler)
+    if DataToColor.IsEventSupported(eventName) then
+        DataToColor:RegisterEvent(eventName, handler)
+        return true
+    end
+    return false
 end


### PR DESCRIPTION
- Add `SafeRegisterEvent()` to pre-validate events before `AceEvent` registration
- Prevents `"Attempt to register unknown event"` errors for version-specific events
- Events affected: `PLAYER_SOFT_*`, `PLAYER_TALENT_UPDATE`
- Fix `LibClassicCasterino` initialization with `callbacks:OnUsed()`
- Fix self: to `DataToColor:` for consistent method calls
- Increase frame count to 113