### PR TITLE
Addon: [1.9.5] - Add corpse tracking and Recent Kills UI component

### DIFF
--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Legacy Cataclysm 4.3.0)
-## Version: 1.9.4
+## Version: 1.9.5
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, cTimerBackport
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor_Classic.toc
+++ b/Addons/DataToColor/DataToColor_Classic.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic)
-## Version: 1.9.4
+## Version: 1.9.5
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor_TBC.toc
+++ b/Addons/DataToColor/DataToColor_TBC.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic TBC)
-## Version: 1.9.4
+## Version: 1.9.5
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/Versions.lua
+++ b/Addons/DataToColor/Versions.lua
@@ -457,7 +457,7 @@ if DataToColor.IsLegacy() then
   end
 
   -- Get unique GUID from unit
-  -- Legacy: Uses direct extraction of the last hex segment
+  -- Legacy: Uses uniqueGuid with NPC ID for bit-packed encoding
   function DataToColor:getGuidFromUnit(unit)
     if not UnitExists(unit) then
       return 0
@@ -466,13 +466,16 @@ if DataToColor.IsLegacy() then
     local guid = UnitGUID(unit)
     if not guid then return 0 end
 
-    -- Legacy format: Extract last segment (unique spawn ID) directly
-    local spawn_hex = guid:match("0xF[0-9A-F]+%x%x%x%x(%x%x%x%x%x%x)")
-    if spawn_hex then
-        return tonumber(spawn_hex, 16)
-    end
+    -- Legacy creature guid example: 0xF130C2CF0000355D
+    -- NPC ID is at position 5-8 (after 0xF130): C2CF = 49871
+    local npc_hex = guid:match("^0xF130(%x%x%x%x)")
+    local npcId = npc_hex and tonumber(npc_hex, 16) or 0
 
-    return 0
+    -- Spawn data is last 8 characters
+    local hex = guid:match("^0x(%x+)$")
+    local spawn = hex and hex:sub(-8) or nil
+
+    return DataToColor:uniqueGuid(npcId, spawn)
   end
 
   -- /dump DataToColor:getGuidFromUUID("0xF130C2CF0000355D")
@@ -597,18 +600,24 @@ else
 
 end
 
--- Unique GUID calculation (Modern Classic only)
--- This is called from modern client implementations only
+-- Unique GUID calculation - bit-packed encoding
+-- High 18 bits: NPC ID (max 262,143), Low 6 bits: spawn uniqueness hash (64 values)
+-- This allows C# to extract the NPC ID via: npcId = guid >> 6
 function DataToColor:uniqueGuid(npcId, spawn)
   npcId = tonumber(npcId, 10) or tonumber(npcId, 16) or 0
   if not spawn then
     return 0
   end
 
+  -- Extract spawn uniqueness from spawn string
   local spawnEpochOffset = band(tonumber(sub(spawn, 5), 16) or 0, 0x7fffff)
   local spawnIndex = band(tonumber(sub(spawn, 1, 5), 16) or 0, 0xffff8)
+  local spawnHash = band(spawnEpochOffset + spawnIndex, 0x3F)  -- 6 bits (0-63)
 
-  return (spawnEpochOffset + spawnIndex + npcId) % 0x1000000
+  -- Pack: NPC ID (18 bits) | spawn hash (6 bits)
+  -- bit.lshift(npcId, 6) puts NPC ID in high bits
+  -- bit.bor combines with spawn hash in low bits
+  return bit.bor(bit.lshift(band(npcId, 0x3FFFF), 6), spawnHash)
 end
 
 

--- a/Core/AddonComponent/CorpseTracker.cs
+++ b/Core/AddonComponent/CorpseTracker.cs
@@ -1,0 +1,120 @@
+using Core.Database;
+
+using SharedLib;
+
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+
+namespace Core;
+
+/// <summary>
+/// Tracks recent corpse locations for Cannibalize-type abilities.
+/// Uses bit-packed GUIDs to look up creature types in CreatureDB.
+/// </summary>
+public sealed class CorpseTracker
+{
+    private readonly record struct CorpseInfo(
+        int PackedGuid,
+        Vector3 MapLoc,
+        DateTime DeathTimeUtc);
+
+    public readonly record struct RecentKill(
+        int NpcId,
+        string NpcName,
+        DateTime KillTimeUtc);
+
+    private const int MAX_CORPSES = 10;
+    private const int CORPSE_EXPIRY_MS = 120_000;
+
+    private readonly CreatureDB creatureDb;
+    private readonly List<CorpseInfo> corpses = new(MAX_CORPSES);
+
+    public event Action? OnCorpseAdded;
+
+    public CorpseTracker(CreatureDB creatureDb)
+    {
+        this.creatureDb = creatureDb;
+    }
+
+    /// <summary>
+    /// Add a corpse to the tracker.
+    /// </summary>
+    /// <param name="packedGuid">Bit-packed GUID containing NPC ID.</param>
+    /// <param name="mapLoc">Estimated map location of the corpse.</param>
+    public void AddCorpse(int packedGuid, Vector3 mapLoc)
+    {
+        // Remove existing entry with same GUID (re-adding with updated position)
+        corpses.RemoveAll(c => c.PackedGuid == packedGuid);
+
+        corpses.Add(new CorpseInfo(packedGuid, mapLoc, DateTime.UtcNow));
+
+        // Maintain max size by removing oldest
+        if (corpses.Count > MAX_CORPSES)
+            corpses.RemoveAt(0);
+
+        OnCorpseAdded?.Invoke();
+    }
+
+    /// <summary>
+    /// Check if there's a Humanoid or Undead corpse within range of player position.
+    /// </summary>
+    /// <param name="playerWorldPos">Player's current world position.</param>
+    /// <param name="worldMapArea">Current world map area for coordinate conversion.</param>
+    /// <param name="range">Maximum range in yards (default 5 for Cannibalize).</param>
+    /// <returns>True if a valid corpse is within range.</returns>
+    public bool HasCannibalizeCorpseNearby(Vector3 playerWorldPos, in WorldMapArea worldMapArea, float range = 5f)
+    {
+        CleanupExpired();
+
+        float rangeSq = range * range;
+
+        foreach (CorpseInfo corpse in corpses)
+        {
+            int npcId = GuidUtils.GetNpcId(corpse.PackedGuid);
+
+            if (!creatureDb.Entries.TryGetValue(npcId, out Creature creature))
+                continue;
+
+            if (!CreatureTypes.IsCannibalizable(creature.Type))
+                continue;
+
+            Vector3 corpseWorldPos = WorldMapAreaDB.ToWorld_FlipXY(corpse.MapLoc, worldMapArea);
+            float distanceSq = Vector3.DistanceSquared(playerWorldPos, corpseWorldPos);
+            if (distanceSq <= rangeSq)
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Clear all tracked corpses.
+    /// </summary>
+    public void Clear() => corpses.Clear();
+
+    /// <summary>
+    /// Get recent kills with NPC names for UI display.
+    /// </summary>
+    public IReadOnlyList<RecentKill> GetRecentKills()
+    {
+        CleanupExpired();
+
+        List<RecentKill> kills = new(corpses.Count);
+        foreach (CorpseInfo corpse in corpses)
+        {
+            int npcId = GuidUtils.GetNpcId(corpse.PackedGuid);
+            if (creatureDb.Entries.TryGetValue(npcId, out Creature creature))
+            {
+                kills.Add(new RecentKill(npcId, creature.Name, corpse.DeathTimeUtc));
+            }
+        }
+        return kills;
+    }
+
+    private void CleanupExpired()
+    {
+        DateTime cutoff = DateTime.UtcNow.AddMilliseconds(-CORPSE_EXPIRY_MS);
+        corpses.RemoveAll(c => c.DeathTimeUtc < cutoff);
+    }
+}

--- a/Core/AddonComponent/GuidUtils.cs
+++ b/Core/AddonComponent/GuidUtils.cs
@@ -1,0 +1,21 @@
+namespace Core;
+
+/// <summary>
+/// Utility methods for extracting data from bit-packed GUIDs.
+/// GUID encoding: High 18 bits = NPC ID, Low 6 bits = spawn hash
+/// </summary>
+public static class GuidUtils
+{
+    private const int NPC_ID_SHIFT = 6;
+    private const int SPAWN_HASH_MASK = 0x3F;
+
+    /// <summary>
+    /// Extract NPC ID from packed GUID (high 18 bits).
+    /// </summary>
+    public static int GetNpcId(int packedGuid) => packedGuid >> NPC_ID_SHIFT;
+
+    /// <summary>
+    /// Extract spawn hash from packed GUID (low 6 bits).
+    /// </summary>
+    public static int GetSpawnHash(int packedGuid) => packedGuid & SPAWN_HASH_MASK;
+}

--- a/Core/DependencyInjection.cs
+++ b/Core/DependencyInjection.cs
@@ -44,6 +44,7 @@ public static class DependencyInjection
         s.ForwardSingleton<Stance, IReader>();
 
         s.ForwardSingleton<CombatLog, IReader>();
+        s.AddSingleton<CorpseTracker>();
         s.ForwardSingleton<EquipmentReader, IReader>();
         s.ForwardSingleton<BagReader, IReader>();
         s.ForwardSingleton<GossipReader, IReader>();
@@ -129,6 +130,7 @@ public static class DependencyInjection
 
         // Addon Components
         s.ForwardSingleton<CombatLog>(sp);
+        s.ForwardSingleton<CorpseTracker>(sp);
         s.ForwardSingleton<EquipmentReader>(sp);
         s.ForwardSingleton<BagReader>(sp);
         s.ForwardSingleton<GossipReader>(sp);

--- a/Core/GOAP/Events/CorpseEvent.cs
+++ b/Core/GOAP/Events/CorpseEvent.cs
@@ -15,11 +15,18 @@ public sealed class CorpseEvent : GoapEventArgs
 
     public Vector3 PlayerLocation { get; }
 
-    public CorpseEvent(Vector3 location, float radius, float playerFacing, Vector3 playerLocation)
+    /// <summary>
+    /// Bit-packed GUID containing NPC ID (high 18 bits) and spawn hash (low 6 bits).
+    /// Use GuidUtils.GetNpcId() to extract the NPC ID.
+    /// </summary>
+    public int PackedGuid { get; }
+
+    public CorpseEvent(Vector3 location, float radius, float playerFacing, Vector3 playerLocation, int packedGuid)
     {
         MapLoc = location;
         Radius = MathF.Max(1, radius);
         PlayerFacing = playerFacing;
         PlayerLocation = playerLocation;
+        PackedGuid = packedGuid;
     }
 }

--- a/Core/GOAP/GoapAgent.cs
+++ b/Core/GOAP/GoapAgent.cs
@@ -31,6 +31,7 @@ public sealed partial class GoapAgent : IDisposable
     private readonly ConfigurableInput input;
     private readonly IMountHandler mountHandler;
     private readonly CombatLog combatLog;
+    private readonly CorpseTracker corpseTracker;
 
     private readonly IGrindSessionHandler sessionHandler;
     private readonly StopMoving stopMoving;
@@ -114,6 +115,7 @@ public sealed partial class GoapAgent : IDisposable
         ConfigurableInput input,
         IMountHandler mountHandler,
         CombatLog combatLog,
+        CorpseTracker corpseTracker,
         IBagChangeTracker bagChangeTracker,
         SessionStat sessionStat,
         StopMoving stopMoving,
@@ -141,6 +143,7 @@ public sealed partial class GoapAgent : IDisposable
         this.mountHandler = mountHandler;
 
         this.combatLog = combatLog;
+        this.corpseTracker = corpseTracker;
         this.bagChangeTracker = bagChangeTracker;
 
         SessionStat = sessionStat;
@@ -328,6 +331,7 @@ public sealed partial class GoapAgent : IDisposable
         else if (e is CorpseEvent c)
         {
             routeInfo.PoiList.Add(new RouteInfoPoi(c.MapLoc, CorpseEvent.NAME, CorpseEvent.COLOR, c.Radius));
+            corpseTracker.AddCorpse(c.PackedGuid, c.MapLoc);
         }
         else if (e is SkinCorpseEvent s)
         {

--- a/Core/Goals/CombatGoal.cs
+++ b/Core/Goals/CombatGoal.cs
@@ -71,7 +71,8 @@ public sealed class CombatGoal : GoapGoal, IGoapEventListener
             // have to check range
             // ex. target died far away have to consider the range and approximate
             float distance = (lastMaxDistance + lastMinDistance) / 2f;
-            SendGoapEvent(new CorpseEvent(GetCorpseLocation(distance), distance, playerReader.Direction, playerReader.MapPos));
+            int packedGuid = combatLog.DeadGuid.Value;
+            SendGoapEvent(new CorpseEvent(GetCorpseLocation(distance), distance, playerReader.Direction, playerReader.MapPos, packedGuid));
         }
     }
 

--- a/Core/GoalsComponent/CastingHandler.cs
+++ b/Core/GoalsComponent/CastingHandler.cs
@@ -23,6 +23,8 @@ public sealed partial class CastingHandler
     public const int MIN_GCD = 1000;
     public const int SPELL_QUEUE = 400;
 
+    public const int SPELL_QUEUE_HALF = 200;
+
     private const int MAX_WAIT_MELEE_RANGE = 10_000;
 
     private readonly ILogger<CastingHandler> logger;
@@ -313,9 +315,10 @@ public sealed partial class CastingHandler
 
         // Channeling spells like Cannibalize
         // does not trigger the IsUsableAction
-        if (elapsedMs < 0.01f)
+        // less then 2 miliseconds
+        if (elapsedMs < 2)
         {
-            wait.Update(token);
+            wait.Fixed(Max(playerReader.DoubleNetworkLatency, SPELL_QUEUE_HALF));
             wait.Update(token);
         }
 

--- a/Core/Requirement/RequirementFactory.cs
+++ b/Core/Requirement/RequirementFactory.cs
@@ -33,6 +33,7 @@ public sealed partial class RequirementFactory
     private readonly CreatureDB creatureDb;
     private readonly ItemDB itemDb;
     private readonly CombatLog combatLog;
+    private readonly CorpseTracker corpseTracker;
 
     private readonly ClassConfiguration classConfig;
 
@@ -107,6 +108,7 @@ public sealed partial class RequirementFactory
         TargetDebuffStatus targetDebuffs = sp.GetRequiredService<TargetDebuffStatus>();
         SessionStat sessionStat = sp.GetRequiredService<SessionStat>();
         combatLog = sp.GetRequiredService<CombatLog>();
+        corpseTracker = sp.GetRequiredService<CorpseTracker>();
 
         var playerBuff = sp.GetRequiredService<AuraTimeReader<IPlayerBuffTimeReader>>();
         var playerDebuff = sp.GetRequiredService<AuraTimeReader<IPlayerDebuffTimeReader>>();
@@ -194,8 +196,14 @@ public sealed partial class RequirementFactory
             { "Dead", bits.Dead },
 
             { "MenuOpen", bits.GameMenuWindowShown },
-            { "ChatInputVisible", bits.ChatInputIsVisible }
+            { "ChatInputVisible", bits.ChatInputIsVisible },
+
+            // Corpse-based abilities
+            { "CannibalizeCorpse", CannibalizeCorpseNearby }
         };
+
+        bool CannibalizeCorpseNearby() =>
+            corpseTracker.HasCannibalizeCorpseNearby(playerReader.WorldPos, playerReader.WorldMapArea);
 
         AddAura("", boolVariables, playerBuffs);
         AddAura("F_", boolVariables, focusBuffs);

--- a/Frontend/Pages/Index.razor
+++ b/Frontend/Pages/Index.razor
@@ -48,6 +48,7 @@
                         <RouteComponent Size="400" />
                     </div>
                     <div class="right-panel">
+                        <RecentKillsComponent />
                         <BagChanges />
                     </div>
                 </div>

--- a/Frontend/Pages/RecentKillsComponent.razor
+++ b/Frontend/Pages/RecentKillsComponent.razor
@@ -1,0 +1,67 @@
+@using Core
+@using Core.Database
+@using SharedLib
+
+@inject CorpseTracker CorpseTracker
+@inject WApi Api
+
+@implements IDisposable
+
+<Card>
+    <CardHeader>
+        <div class="d-flex">
+            <div class="p-2 flex-grow-1">Recent Kills</div>
+            <div class="p-2 small text-muted">@kills.Count</div>
+        </div>
+    </CardHeader>
+    <CardBody Style="max-height: 200px; overflow-y: auto;">
+        @if (kills.Count == 0)
+        {
+            <div class="text-muted small">No recent kills</div>
+        }
+        else
+        {
+            @for (int i = kills.Count - 1; i >= 0; i--)
+            {
+                var kill = kills[i];
+                <div class="animate__animated animate__slideInDown d-flex small mb-1">
+                    <span class="text-muted" style="width: 70px;">
+                        @kill.KillTimeUtc.ToLocalTime().ToString("HH:mm:ss")
+                    </span>
+                    <a href="@($"{Api.NpcId}{kill.NpcId}")"
+                       target="_blank"
+                       data-wowhead="npc=@kill.NpcId"
+                       style="text-decoration:none">
+                        @kill.NpcName
+                    </a>
+                </div>
+            }
+        }
+    </CardBody>
+</Card>
+
+@code {
+    private IReadOnlyList<CorpseTracker.RecentKill> kills = [];
+
+    protected override void OnInitialized()
+    {
+        CorpseTracker.OnCorpseAdded += OnCorpseAdded;
+        RefreshKills();
+    }
+
+    public void Dispose()
+    {
+        CorpseTracker.OnCorpseAdded -= OnCorpseAdded;
+    }
+
+    private void OnCorpseAdded()
+    {
+        RefreshKills();
+        InvokeAsync(StateHasChanged);
+    }
+
+    private void RefreshKills()
+    {
+        kills = CorpseTracker.GetRecentKills();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -2416,6 +2416,7 @@ Allow requirements about what buffs/debuffs you have or the target has or in gen
 | `"MenuOpen"` | Returns true if the Game Menu window is open (ESC) |
 | `"ChatInputVisible"` | Returns true if the Chat inputbox is open (ENTER) |
 | `"Dead"` | The player is currently dead. |
+| `"CannibalizeCorpse"` | A Humanoid or Undead corpse is within 5 yards of the player. |
 | `"Has Pet"` | The player's pet is alive |
 | `"Pet HasTarget"` | Players pet has target |
 | `"Pet Happy"` | Pet happienss is green |

--- a/SharedLib/Data/Creature.cs
+++ b/SharedLib/Data/Creature.cs
@@ -16,3 +16,28 @@ public readonly record struct Creature
     public int Family { get; init; }
     public int Type { get; init; }
 }
+
+/// <summary>
+/// Creature type constants from WoW database.
+/// </summary>
+public static class CreatureTypes
+{
+    public const int Beast = 1;
+    public const int Dragonkin = 2;
+    public const int Demon = 3;
+    public const int Elemental = 4;
+    public const int Giant = 5;
+    public const int Undead = 6;
+    public const int Humanoid = 7;
+    public const int Critter = 8;
+    public const int Mechanical = 9;
+    public const int NotSpecified = 10;
+    public const int Totem = 11;
+    public const int NonCombatPet = 12;
+    public const int GasCloud = 13;
+
+    /// <summary>
+    /// Check if creature type is valid for Cannibalize (Humanoid or Undead).
+    /// </summary>
+    public static bool IsCannibalizable(int type) => type is Humanoid or Undead;
+}


### PR DESCRIPTION
Implements corpse tracking to support [Cannibalize](https://www.wowhead.com/spell=20577/cannibalize)-type abilities and displays recent kills in the frontend.

Changes:
- Update Lua addon (v1.9.5) to use bit-packed GUID encoding
- Add `GuidUtils` for bit-packed GUID extraction (18-bit NPC ID + 6-bit spawn hash)
- - Max NPC ID 262,143
- - Distinguish 64 different corpses after combat
- Add `CorpseTracker` to track corpse locations with NPC ID lookup
- Add `CreatureTypes` constants with `IsCannibalizable` check
- Add `CannibalizeCorpse` requirement for class profiles
- - "*A Humanoid or Undead corpse is within 5 yards of the player*"
- Add `RecentKillsComponent` with wowhead links and slide-in animation
- Fix channeling detection race condition in `CastingHandler`

Example KeyAction

```json
{
  "Name": "Cannibalize",
  "Key": 9,
  "WhenUsable": true,
  "HasCastBar": true,
  "AfterCastWaitCastbar": true,
  "Requirements": [
    "Race:Undead",
    "Health% < 80",
    "CannibalizeCorpse"
  ],
  "Interrupt": "Health% > 98"
}
```

---

Closes #749

## Media

<img width="333" height="267" alt="recentkills" src="https://github.com/user-attachments/assets/ee9db410-ae8d-49bd-b1d8-a9f9bd241d8e" />