### PR TITLE
Refactor NpcNameFinder with GPU compute shader for color matching

### DIFF
--- a/BlazorServer/appsettings.json
+++ b/BlazorServer/appsettings.json
@@ -23,7 +23,8 @@
     "Id": -1
   },
   "Reader": {
-    "Type": "DXGI"
+    "Type": "DXGI",
+    "UseGpu": true
   },
   "Diagnostics": {
     "Enabled": false

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -12,10 +12,15 @@
 
   <ItemGroup>
     <PackageReference Include="GameOverlay.Net" />
+    <PackageReference Include="Vortice.D3DCompiler" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="System.Drawing.Common" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="WoWScreen\Shaders\NpcColorMatch.hlsl" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Core/DependencyInjection.cs
+++ b/Core/DependencyInjection.cs
@@ -259,6 +259,23 @@ public static class DependencyInjection
         s.AddSingleton<FrameConfigurator>();
 
         s.AddSingleton<INpcResetEvent, NpcResetEvent>();
+        s.AddSingleton<CpuLineSegmentProvider>();
+        s.AddSingleton<INpcLineSegmentProvider>(x =>
+        {
+            CpuLineSegmentProvider cpuProvider = x.GetRequiredService<CpuLineSegmentProvider>();
+
+            StartupConfigReader config = x.GetRequiredService<IOptions<StartupConfigReader>>().Value;
+            IWowScreen screen = x.GetRequiredService<IWowScreen>();
+
+            if (config.UseGpu && screen is IGpuTextureProvider gpuTextureProvider)
+            {
+                ILogger gpuLogger = x.GetRequiredService<ILoggerFactory>()
+                    .CreateLogger<GpuLineSegmentProvider>();
+                return new GpuLineSegmentProvider(gpuLogger, gpuTextureProvider, cpuProvider);
+            }
+
+            return cpuProvider;
+        });
         s.AddSingleton<NpcNameFinder>();
 
         s.AddSingleton<NpcNameTargetingLocations>();

--- a/Core/Minimap/MinimapRowOperation.cs
+++ b/Core/Minimap/MinimapRowOperation.cs
@@ -56,6 +56,7 @@ internal readonly struct MinimapRowOperation : IRowOperation<Point>
         ReadOnlySpan<Bgra32> row = source.DangerousGetRowSpan(y);
 
         int i = 0;
+        int bufferLen = span.Length;
 
         for (int x = minX; x < maxX; x++)
         {
@@ -68,19 +69,22 @@ internal readonly struct MinimapRowOperation : IRowOperation<Point>
 
             if (IsMatch(pixel.R, pixel.G, pixel.B))
             {
-                if (i >= SIZE)
+                if (i + 1 >= bufferLen)
                     break;
 
-                points[i++] = new(x, y);
+                span[i++] = new(x, y);
             }
         }
 
         if (i == 0)
             return;
 
-        Interlocked.Add(ref counter.count, i);
+        int newCount = Interlocked.Add(ref counter.count, i);
+        int startIndex = newCount - i;
+        if (newCount > points.Length)
+            return;
 
-        span[..i].CopyTo(points.AsSpan(counter.count, i));
+        span[..i].CopyTo(points.AsSpan(startIndex, i));
 
         static bool IsValidSquareLocation(int x, int y, Point center, float width)
         {

--- a/Core/WoWScreen/GpuLineSegmentProvider.cs
+++ b/Core/WoWScreen/GpuLineSegmentProvider.cs
@@ -1,0 +1,325 @@
+using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+
+using Game;
+
+using Microsoft.Extensions.Logging;
+
+using SharedLib.NpcFinder;
+
+using SixLabors.ImageSharp;
+
+using Vortice.Direct3D11;
+
+using static SharedLib.NpcFinder.NpcNameColors;
+
+namespace Core;
+
+/// <summary>
+/// GPU-accelerated line segment provider using a DirectX 11 compute shader.
+/// Falls back to CPU provider on initialization or dispatch failure.
+/// </summary>
+public sealed class GpuLineSegmentProvider : IConfigurableLineSegmentProvider, IDisposable
+{
+    private const int MAX_SEGMENTS = 4096;
+    private const int MAX_COLORS = 5;
+    private const int RESOLUTION = 16;
+
+    private readonly ILogger logger;
+    private readonly IGpuTextureProvider gpuProvider;
+    private readonly CpuLineSegmentProvider cpuFallback;
+    private readonly NpcGpuResources? gpuResources;
+
+    private const int FALLBACK_COOLDOWN = 100;
+    private bool permanentFallback;
+    private int fallbackFramesLeft;
+
+    private SearchMode searchMode;
+    private NpcNames nameType;
+
+    private LineSegment[]? segments;
+
+    public GpuLineSegmentProvider(
+        ILogger logger,
+        IGpuTextureProvider gpuProvider,
+        CpuLineSegmentProvider cpuFallback)
+    {
+        this.logger = logger;
+        this.gpuProvider = gpuProvider;
+        this.cpuFallback = cpuFallback;
+
+        try
+        {
+            gpuResources = new NpcGpuResources(logger,
+                gpuProvider.Device, gpuProvider.DeviceContext);
+
+            if (!gpuResources.Initialize())
+            {
+                permanentFallback = true;
+                logger.LogWarning("[GpuLineSegmentProvider] Initialization failed, using CPU fallback");
+            }
+            else
+            {
+                logger.LogInformation("[GpuLineSegmentProvider] GPU compute shader initialized");
+            }
+        }
+        catch (Exception ex)
+        {
+            permanentFallback = true;
+            logger.LogWarning(ex, "[GpuLineSegmentProvider] Failed to create GPU resources, using CPU fallback");
+        }
+    }
+
+    public void Configure(SearchMode searchMode, NpcNames nameType)
+    {
+        this.searchMode = searchMode;
+        this.nameType = nameType;
+        cpuFallback.Configure(searchMode, nameType);
+    }
+
+    [SkipLocalsInit]
+    public ReadOnlySpan<LineSegment> GetLineSegments(
+        Rectangle area, float minLength, float minEndLength)
+    {
+        if (permanentFallback || gpuResources == null || !gpuResources.IsInitialized)
+        {
+            return cpuFallback.GetLineSegments(area, minLength, minEndLength);
+        }
+
+        if (fallbackFramesLeft > 0)
+        {
+            fallbackFramesLeft--;
+            return cpuFallback.GetLineSegments(area, minLength, minEndLength);
+        }
+
+        ID3D11Texture2D? capturedTexture = gpuProvider.GetCapturedTexture();
+        if (capturedTexture == null)
+        {
+            return cpuFallback.GetLineSegments(area, minLength, minEndLength);
+        }
+
+        try
+        {
+            return ExecuteGpu(capturedTexture, area, minLength, minEndLength);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "[GpuLineSegmentProvider] GPU dispatch failed, falling back to CPU for {Frames} frames", FALLBACK_COOLDOWN);
+            fallbackFramesLeft = FALLBACK_COOLDOWN;
+            return cpuFallback.GetLineSegments(area, minLength, minEndLength);
+        }
+    }
+
+    [SkipLocalsInit]
+    private ReadOnlySpan<LineSegment> ExecuteGpu(
+        ID3D11Texture2D capturedTexture,
+        Rectangle area, float minLength, float minEndLength)
+    {
+        // 1. Copy captured texture to SRV-capable texture
+        gpuResources!.CopySourceTexture(capturedTexture);
+
+        // 2. Build constant buffer
+        ScanParamsCB cb = BuildScanParams(area, minLength, minEndLength);
+        gpuResources.UpdateConstants(cb);
+
+        // 3. Reset counter
+        gpuResources.ResetCounter();
+
+        // 4. Dispatch -- scan every row in the area (matches CPU ParallelRowIterator behavior)
+        int areaWidth = area.Right - area.Left;
+        int numRows = area.Bottom - area.Top;
+        gpuResources.Dispatch(areaWidth, numRows);
+
+        // 5. Read results
+        var pooler = ArrayPool<LineSegment>.Shared;
+        segments = pooler.Rent(MAX_SEGMENTS);
+
+        int count = gpuResources.ReadResults(segments);
+
+        if (count > 1)
+        {
+            // 6. Sort by (Y, XStart) — GPU output order is nondeterministic
+            //    and downstream grouping in DetermineNpcs assumes Y-ascending order.
+            Span<LineSegment> span = new(segments, 0, count);
+            span.Sort(static (a, b) =>
+            {
+                int cmp = a.Y.CompareTo(b.Y);
+                return cmp != 0 ? cmp : a.XStart.CompareTo(b.XStart);
+            });
+
+            // 7. Merge adjacent segments on the same row split at GROUP_SIZE
+            //    boundaries. Matches CPU gap-bridging logic (LineSegmentOperation:72).
+            int merged = 0;
+            for (int i = 1; i < count; i++)
+            {
+                ref readonly LineSegment prev = ref span[merged];
+                ref readonly LineSegment curr = ref span[i];
+
+                if (curr.Y == prev.Y && (curr.XStart - prev.XEnd) < (int)minLength)
+                {
+                    span[merged] = new LineSegment(prev.XStart, curr.XEnd, prev.Y);
+                }
+                else
+                {
+                    span[++merged] = curr;
+                }
+            }
+            count = merged + 1;
+        }
+
+        pooler.Return(segments);
+        return new ReadOnlySpan<LineSegment>(segments, 0, count);
+    }
+
+    private ScanParamsCB BuildScanParams(
+        Rectangle area, float minLength, float minEndLength)
+    {
+        ScanParamsCB cb = new()
+        {
+            AreaLeft = area.Left,
+            AreaTop = area.Top,
+            AreaRight = area.Right,
+            AreaBottom = area.Bottom,
+            MinLength = minLength,
+            MinEndLength = minEndLength,
+            MaxSegments = MAX_SEGMENTS
+        };
+
+        // Map NPC name type + search mode to target colors
+        GetTargetColors(searchMode, nameType, ref cb);
+
+        return cb;
+    }
+
+    private static void GetTargetColors(SearchMode mode, NpcNames names, ref ScanParamsCB cb)
+    {
+        // Convert byte colors to [0,1] float space for the shader
+        const float inv = 1f / 255f;
+
+        bool hasEnemy = (names & NpcNames.Enemy) != 0;
+        bool hasFriendly = (names & NpcNames.Friendly) != 0;
+        bool hasNeutral = (names & NpcNames.Neutral) != 0;
+        bool hasCorpse = (names & NpcNames.Corpse) != 0;
+        bool hasNamePlate = (names & NpcNames.NamePlate) != 0;
+
+        int colorIdx = 0;
+        float fuzzSqr;
+
+        if (mode == SearchMode.Fuzzy)
+        {
+            const int fuzz = 40;
+            // Fuzz in normalized space: (fuzz/255)^2
+            fuzzSqr = (fuzz * inv) * (fuzz * inv);
+            float fuzzCorpseSqr = (fuzzCorpse * inv) * (fuzzCorpse * inv);
+
+            if (hasEnemy && colorIdx < MAX_COLORS)
+            {
+                SetColor(ref cb, colorIdx++, fE_R * inv, fE_G * inv, fE_B * inv, fuzzSqr);
+            }
+            if (hasNeutral && colorIdx < MAX_COLORS)
+            {
+                SetColor(ref cb, colorIdx++, fN_R * inv, fN_G * inv, fN_B * inv, fuzzSqr);
+            }
+            if (hasFriendly && colorIdx < MAX_COLORS)
+            {
+                SetColor(ref cb, colorIdx++, fF_R * inv, fF_G * inv, fF_B * inv, fuzzSqr);
+            }
+            if (hasCorpse && colorIdx < MAX_COLORS)
+            {
+                SetColor(ref cb, colorIdx++, fC_RGB * inv, fC_RGB * inv, fC_RGB * inv, fuzzCorpseSqr);
+            }
+            if (hasNamePlate)
+            {
+                // NamePlate_Normal: white (254,254,254)
+                if (colorIdx < MAX_COLORS)
+                {
+                    SetColor(ref cb, colorIdx++, sNamePlate_N * inv, sNamePlate_N * inv, sNamePlate_N * inv, fuzzCorpseSqr);
+                }
+                // NamePlate_Hostile: yellow (254,254,0)
+                if (colorIdx < MAX_COLORS)
+                {
+                    SetColor(ref cb, colorIdx++, sNamePlate_H_R * inv, sNamePlate_H_G * inv, sNamePlate_H_B * inv, fuzzCorpseSqr);
+                }
+            }
+        }
+        else
+        {
+            // Simple mode: tight fuzz
+            fuzzSqr = (5f * inv) * (5f * inv);
+            float fuzzCorpseSqr = (fuzzCorpse * inv) * (fuzzCorpse * inv);
+
+            if (hasEnemy && colorIdx < MAX_COLORS)
+            {
+                SetColor(ref cb, colorIdx++, sE_R * inv, sE_G * inv, sE_B * inv, fuzzSqr);
+            }
+            if (hasNeutral && colorIdx < MAX_COLORS)
+            {
+                SetColor(ref cb, colorIdx++, sN_R * inv, sN_G * inv, sN_B * inv, fuzzSqr);
+            }
+            if (hasFriendly && colorIdx < MAX_COLORS)
+            {
+                SetColor(ref cb, colorIdx++, sF_R * inv, sF_G * inv, sF_B * inv, fuzzSqr);
+            }
+            if (hasCorpse && colorIdx < MAX_COLORS)
+            {
+                SetColor(ref cb, colorIdx++, fC_RGB * inv, fC_RGB * inv, fC_RGB * inv, fuzzCorpseSqr);
+            }
+            if (hasNamePlate)
+            {
+                // NamePlate_Normal: white (254,254,254)
+                if (colorIdx < MAX_COLORS)
+                {
+                    SetColor(ref cb, colorIdx++, sNamePlate_N * inv, sNamePlate_N * inv, sNamePlate_N * inv, fuzzSqr);
+                }
+                // NamePlate_Hostile: yellow (254,254,0)
+                if (colorIdx < MAX_COLORS)
+                {
+                    SetColor(ref cb, colorIdx++, sNamePlate_H_R * inv, sNamePlate_H_G * inv, sNamePlate_H_B * inv, fuzzSqr);
+                }
+            }
+        }
+
+        if (colorIdx == 0)
+        {
+            // No colors -- set impossible match
+            SetColor(ref cb, 0, -1f, -1f, -1f, 0f);
+            colorIdx = 1;
+        }
+
+        cb.NumColors = colorIdx;
+    }
+
+    private static void SetColor(ref ScanParamsCB cb, int index,
+        float r, float g, float b, float fuzzSqr)
+    {
+        switch (index)
+        {
+            case 0:
+                cb.TargetColor0 = new Vector4F(r, g, b, 0);
+                cb.FuzzSqr0 = fuzzSqr;
+                break;
+            case 1:
+                cb.TargetColor1 = new Vector4F(r, g, b, 0);
+                cb.FuzzSqr1 = fuzzSqr;
+                break;
+            case 2:
+                cb.TargetColor2 = new Vector4F(r, g, b, 0);
+                cb.FuzzSqr2 = fuzzSqr;
+                break;
+            case 3:
+                cb.TargetColor3 = new Vector4F(r, g, b, 0);
+                cb.FuzzSqr3 = fuzzSqr;
+                break;
+            case 4:
+                cb.TargetColor4 = new Vector4F(r, g, b, 0);
+                cb.FuzzSqr4 = fuzzSqr;
+                break;
+        }
+    }
+
+    public void Dispose()
+    {
+        gpuResources?.Dispose();
+    }
+}

--- a/Core/WoWScreen/NpcGpuResources.cs
+++ b/Core/WoWScreen/NpcGpuResources.cs
@@ -1,0 +1,393 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+using Microsoft.Extensions.Logging;
+
+using SharedLib.NpcFinder;
+
+using Vortice.D3DCompiler;
+using Vortice.Direct3D;
+using Vortice.Direct3D11;
+using Vortice.DXGI;
+
+namespace Core;
+
+/// <summary>
+/// GPU-side line segment for the compute shader output.
+/// Must match the HLSL GpuLineSegment struct layout.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+internal struct GpuLineSegment
+{
+    public int XStart;
+    public int XEnd;
+    public int Y;
+    public int Pad;
+}
+
+/// <summary>
+/// Constant buffer layout for the compute shader.
+/// Must match the HLSL ScanParams cbuffer layout exactly.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+internal struct ScanParamsCB
+{
+    public int AreaLeft;
+    public int AreaTop;
+    public int AreaRight;
+    public int AreaBottom;
+    public float MinLength;
+    public float MinEndLength;
+    public int NumColors;
+    public int Pad0;
+
+    public Vector4F TargetColor0;
+    public float FuzzSqr0;
+    public Vector3F Pad1;
+
+    public Vector4F TargetColor1;
+    public float FuzzSqr1;
+    public Vector3F Pad2;
+
+    public Vector4F TargetColor2;
+    public float FuzzSqr2;
+    public Vector3F Pad3;
+
+    public Vector4F TargetColor3;
+    public float FuzzSqr3;
+    public Vector3F Pad5;
+
+    public Vector4F TargetColor4;
+    public float FuzzSqr4;
+    public Vector3F Pad6;
+
+    public int MaxSegments;
+    public int Pad4X;
+    public int Pad4Y;
+    public int Pad4Z;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct Vector4F
+{
+    public float X, Y, Z, W;
+
+    public Vector4F(float x, float y, float z, float w)
+    {
+        X = x; Y = y; Z = z; W = w;
+    }
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct Vector3F
+{
+    public float X, Y, Z;
+}
+
+/// <summary>
+/// Manages all GPU resources needed for NPC color matching compute shader.
+/// Created once and reused per frame.
+/// </summary>
+internal sealed class NpcGpuResources : IDisposable
+{
+    private const int MAX_SEGMENTS = 4096;
+    private const int GROUP_SIZE = 256;
+    private const string SHADER_RESOURCE_NAME = "Core.WoWScreen.Shaders.NpcColorMatch.hlsl";
+
+    private readonly ILogger logger;
+    private readonly ID3D11Device device;
+    private readonly ID3D11DeviceContext context;
+
+    // Shader
+    private ID3D11ComputeShader? computeShader;
+
+    // CS-input texture (ShaderResource bind, Default usage)
+    private ID3D11Texture2D? srvTexture;
+    private ID3D11ShaderResourceView? srvView;
+    private int srvWidth;
+    private int srvHeight;
+
+    // Output structured buffer
+    private ID3D11Buffer? outputBuffer;
+    private ID3D11UnorderedAccessView? outputUav;
+
+    // Counter buffer (RWByteAddressBuffer, 4 bytes)
+    private ID3D11Buffer? counterBuffer;
+    private ID3D11UnorderedAccessView? counterUav;
+
+    // Staging readback buffer
+    private ID3D11Buffer? readbackBuffer;
+    private ID3D11Buffer? counterReadbackBuffer;
+
+    // Constant buffer
+    private ID3D11Buffer? constantBuffer;
+
+    public bool IsInitialized { get; private set; }
+
+    public NpcGpuResources(ILogger logger, ID3D11Device device, ID3D11DeviceContext context)
+    {
+        this.logger = logger;
+        this.device = device;
+        this.context = context;
+    }
+
+    public bool Initialize()
+    {
+        try
+        {
+            CompileShader();
+            CreateOutputBuffers();
+            CreateConstantBuffer();
+            IsInitialized = true;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to initialize GPU NPC resources -- falling back to CPU");
+            IsInitialized = false;
+            return false;
+        }
+    }
+
+    private void CompileShader()
+    {
+        Assembly assembly = typeof(NpcGpuResources).Assembly;
+        using Stream? stream = assembly.GetManifestResourceStream(SHADER_RESOURCE_NAME);
+
+        if (stream == null)
+            throw new InvalidOperationException(
+                $"Embedded shader resource '{SHADER_RESOURCE_NAME}' not found");
+
+        using MemoryStream ms = new();
+        stream.CopyTo(ms);
+        byte[] source = ms.ToArray();
+
+        Compiler.Compile(source, "CSMain", SHADER_RESOURCE_NAME,
+            "cs_5_0", out Blob shaderBlob, out Blob? errorBlob);
+
+        if (shaderBlob.BufferPointer == IntPtr.Zero)
+        {
+            string errors = errorBlob != null
+                ? Marshal.PtrToStringAnsi(errorBlob.BufferPointer) ?? "Unknown error"
+                : "Unknown error";
+
+            errorBlob?.Dispose();
+            throw new InvalidOperationException($"Shader compilation failed: {errors}");
+        }
+
+        errorBlob?.Dispose();
+
+        computeShader = device.CreateComputeShader(shaderBlob.AsSpan());
+        shaderBlob.Dispose();
+
+        logger.LogDebug("NPC compute shader compiled successfully");
+    }
+
+    private void CreateOutputBuffers()
+    {
+        // Output structured buffer for segments
+        BufferDescription outputDesc = new()
+        {
+            ByteWidth = (uint)(MAX_SEGMENTS * Unsafe.SizeOf<GpuLineSegment>()),
+            Usage = ResourceUsage.Default,
+            BindFlags = BindFlags.UnorderedAccess,
+            MiscFlags = ResourceOptionFlags.BufferStructured,
+            StructureByteStride = (uint)Unsafe.SizeOf<GpuLineSegment>()
+        };
+        outputBuffer = device.CreateBuffer(outputDesc);
+
+        UnorderedAccessViewDescription outputUavDesc = new()
+        {
+            Format = Format.Unknown,
+            ViewDimension = UnorderedAccessViewDimension.Buffer,
+            Buffer = new BufferUnorderedAccessView
+            {
+                NumElements = MAX_SEGMENTS
+            }
+        };
+        outputUav = device.CreateUnorderedAccessView(outputBuffer, outputUavDesc);
+
+        // Counter buffer (RWByteAddressBuffer)
+        BufferDescription counterDesc = new()
+        {
+            ByteWidth = 4,
+            Usage = ResourceUsage.Default,
+            BindFlags = BindFlags.UnorderedAccess,
+            MiscFlags = ResourceOptionFlags.BufferAllowRawViews
+        };
+        counterBuffer = device.CreateBuffer(counterDesc);
+
+        UnorderedAccessViewDescription counterUavDesc = new()
+        {
+            Format = Format.R32_Typeless,
+            ViewDimension = UnorderedAccessViewDimension.Buffer,
+            Buffer = new BufferUnorderedAccessView
+            {
+                NumElements = 1,
+                Flags = BufferUnorderedAccessViewFlags.Raw
+            }
+        };
+        counterUav = device.CreateUnorderedAccessView(counterBuffer, counterUavDesc);
+
+        // Staging readback for output segments
+        BufferDescription readbackDesc = new()
+        {
+            ByteWidth = (uint)(MAX_SEGMENTS * Unsafe.SizeOf<GpuLineSegment>()),
+            Usage = ResourceUsage.Staging,
+            CPUAccessFlags = CpuAccessFlags.Read
+        };
+        readbackBuffer = device.CreateBuffer(readbackDesc);
+
+        // Staging readback for counter
+        BufferDescription counterReadbackDesc = new()
+        {
+            ByteWidth = 4,
+            Usage = ResourceUsage.Staging,
+            CPUAccessFlags = CpuAccessFlags.Read
+        };
+        counterReadbackBuffer = device.CreateBuffer(counterReadbackDesc);
+    }
+
+    private void CreateConstantBuffer()
+    {
+        BufferDescription cbDesc = new()
+        {
+            ByteWidth = (uint)AlignTo16(Unsafe.SizeOf<ScanParamsCB>()),
+            Usage = ResourceUsage.Default,
+            BindFlags = BindFlags.ConstantBuffer
+        };
+        constantBuffer = device.CreateBuffer(cbDesc);
+    }
+
+    public void EnsureSrvTexture(int width, int height)
+    {
+        if (srvTexture != null && srvWidth == width && srvHeight == height)
+            return;
+
+        srvView?.Dispose();
+        srvTexture?.Dispose();
+
+        Texture2DDescription desc = new()
+        {
+            Width = (uint)width,
+            Height = (uint)height,
+            MipLevels = 1,
+            ArraySize = 1,
+            Format = Format.B8G8R8A8_UNorm,
+            SampleDescription = new SampleDescription(1, 0),
+            Usage = ResourceUsage.Default,
+            BindFlags = BindFlags.ShaderResource
+        };
+
+        srvTexture = device.CreateTexture2D(desc);
+        srvView = device.CreateShaderResourceView(srvTexture);
+        srvWidth = width;
+        srvHeight = height;
+    }
+
+    public void CopySourceTexture(ID3D11Texture2D capturedTexture)
+    {
+        Texture2DDescription desc = capturedTexture.Description;
+        EnsureSrvTexture((int)desc.Width, (int)desc.Height);
+        context.CopyResource(srvTexture!, capturedTexture);
+    }
+
+    [SkipLocalsInit]
+    public void UpdateConstants(ScanParamsCB parameters)
+    {
+        context.UpdateSubresource(parameters, constantBuffer!);
+    }
+
+    public void ResetCounter()
+    {
+        // Clear counter to zero
+        uint[] zero = [0];
+        context.UpdateSubresource<uint>(zero, counterBuffer!);
+    }
+
+    public void Dispatch(int areaWidth, int numRows)
+    {
+        int groupsPerRow = (areaWidth + GROUP_SIZE - 1) / GROUP_SIZE;
+        int totalGroups = groupsPerRow * numRows;
+
+        context.CSSetShader(computeShader!);
+        context.CSSetShaderResource(0, srvView!);
+        context.CSSetUnorderedAccessViews(0, [outputUav!, counterUav!]);
+        context.CSSetConstantBuffer(0, constantBuffer!);
+
+        context.Dispatch((uint)totalGroups, 1, 1);
+
+        // Unbind
+        context.CSSetShader(null);
+        context.CSSetShaderResource(0, null);
+        context.CSSetUnorderedAccessViews(0, [null, null]);
+    }
+
+    [SkipLocalsInit]
+    public unsafe int ReadResults(Span<LineSegment> output)
+    {
+        // Copy results to staging buffers
+        context.CopyResource(counterReadbackBuffer!, counterBuffer!);
+        context.CopyResource(readbackBuffer!, outputBuffer!);
+
+        // Read counter
+        MappedSubresource counterMap = context.Map(counterReadbackBuffer!, 0,
+            MapMode.Read, Vortice.Direct3D11.MapFlags.None);
+        int segmentCount;
+        try
+        {
+            segmentCount = Marshal.ReadInt32(counterMap.DataPointer);
+        }
+        finally
+        {
+            context.Unmap(counterReadbackBuffer!, 0);
+        }
+
+        segmentCount = Math.Min(segmentCount, MAX_SEGMENTS);
+        segmentCount = Math.Min(segmentCount, output.Length);
+
+        if (segmentCount == 0)
+            return 0;
+
+        // Read segments
+        MappedSubresource segMap = context.Map(readbackBuffer!, 0,
+            MapMode.Read, Vortice.Direct3D11.MapFlags.None);
+        try
+        {
+            ReadOnlySpan<GpuLineSegment> gpuSegments = MemoryMarshal.CreateReadOnlySpan(
+                ref Unsafe.AsRef<GpuLineSegment>((void*)segMap.DataPointer),
+                segmentCount);
+
+            for (int i = 0; i < segmentCount; i++)
+            {
+                ref readonly GpuLineSegment gs = ref gpuSegments[i];
+                output[i] = new LineSegment(gs.XStart, gs.XEnd, gs.Y);
+            }
+        }
+        finally
+        {
+            context.Unmap(readbackBuffer!, 0);
+        }
+
+        return segmentCount;
+    }
+
+    public void Dispose()
+    {
+        computeShader?.Dispose();
+        srvView?.Dispose();
+        srvTexture?.Dispose();
+        outputUav?.Dispose();
+        outputBuffer?.Dispose();
+        counterUav?.Dispose();
+        counterBuffer?.Dispose();
+        readbackBuffer?.Dispose();
+        counterReadbackBuffer?.Dispose();
+        constantBuffer?.Dispose();
+    }
+
+    private static int AlignTo16(int value) => (value + 15) & ~15;
+}

--- a/Core/WoWScreen/Shaders/NpcColorMatch.hlsl
+++ b/Core/WoWScreen/Shaders/NpcColorMatch.hlsl
@@ -1,0 +1,214 @@
+// NPC Color Match Compute Shader
+// Scans rows of a captured screen texture for NPC name colors (red, green, yellow, gray)
+// and produces line segments (xStart, xEnd, y) for matching pixel runs.
+//
+// Thread strategy:
+//   Dispatch: ceil(rowWidth / 256) groups per row, numRows groups vertically
+//   numthreads(256, 1, 1) -- each thread checks one pixel
+//   Thread 0 of each group scans shared memory to extract contiguous segments
+
+// Input texture (B8G8R8A8_UNorm, automatically swizzled to RGBA by SRV)
+Texture2D<float4> InputTexture : register(t0);
+
+// Output structured buffer for line segments
+struct GpuLineSegment
+{
+    int xStart;
+    int xEnd;
+    int y;
+    int _pad;
+};
+
+RWStructuredBuffer<GpuLineSegment> OutputSegments : register(u0);
+
+// Atomic counter for output segments
+RWByteAddressBuffer Counter : register(u1);
+
+// Constant buffer with scan parameters
+cbuffer ScanParams : register(b0)
+{
+    int AreaLeft;
+    int AreaTop;
+    int AreaRight;
+    int AreaBottom;
+    float MinLength;
+    float MinEndLength;
+
+    // Up to 5 target colors with squared fuzz thresholds
+    int NumColors;
+    int _pad0;
+
+    float4 TargetColor0;   // xyz = RGB [0,1], w = unused
+    float FuzzSqr0;        // squared distance threshold in [0,1] space
+    float3 _pad1;
+
+    float4 TargetColor1;
+    float FuzzSqr1;
+    float3 _pad2;
+
+    float4 TargetColor2;
+    float FuzzSqr2;
+    float3 _pad3;
+
+    float4 TargetColor3;
+    float FuzzSqr3;
+    float3 _pad5;
+
+    float4 TargetColor4;
+    float FuzzSqr4;
+    float3 _pad6;
+
+    int MaxSegments;
+    int3 _pad4;
+};
+
+#define GROUP_SIZE 256
+
+groupshared uint g_match[GROUP_SIZE];
+
+bool ColorMatch(float3 pixel)
+{
+    float3 d0 = pixel - TargetColor0.xyz;
+    float dist0 = dot(d0, d0);
+    if (dist0 <= FuzzSqr0)
+        return true;
+
+    if (NumColors > 1)
+    {
+        float3 d1 = pixel - TargetColor1.xyz;
+        float dist1 = dot(d1, d1);
+        if (dist1 <= FuzzSqr1)
+            return true;
+    }
+
+    if (NumColors > 2)
+    {
+        float3 d2 = pixel - TargetColor2.xyz;
+        float dist2 = dot(d2, d2);
+        if (dist2 <= FuzzSqr2)
+            return true;
+    }
+
+    if (NumColors > 3)
+    {
+        float3 d3 = pixel - TargetColor3.xyz;
+        float dist3 = dot(d3, d3);
+        if (dist3 <= FuzzSqr3)
+            return true;
+    }
+
+    if (NumColors > 4)
+    {
+        float3 d4 = pixel - TargetColor4.xyz;
+        float dist4 = dot(d4, d4);
+        if (dist4 <= FuzzSqr4)
+            return true;
+    }
+
+    return false;
+}
+
+[numthreads(GROUP_SIZE, 1, 1)]
+void CSMain(
+    uint3 groupId : SV_GroupID,
+    uint groupIndex : SV_GroupIndex,
+    uint3 dispatchId : SV_DispatchThreadID)
+{
+    // Calculate which row this group is scanning
+    int areaWidth = AreaRight - AreaLeft;
+    int groupsPerRow = (areaWidth + GROUP_SIZE - 1) / GROUP_SIZE;
+    int row = groupId.x / groupsPerRow;
+    int groupInRow = groupId.x % groupsPerRow;
+
+    int y = AreaTop + row;
+    int x = AreaLeft + groupInRow * GROUP_SIZE + (int)groupIndex;
+
+    // Check if this pixel is in bounds and matches
+    bool isMatch = false;
+    if (x < AreaRight && y < AreaBottom)
+    {
+        // SRV swizzles B8G8R8A8_UNorm to float4(R, G, B, A)
+        float4 pixel = InputTexture.Load(int3(x, y, 0));
+        isMatch = ColorMatch(pixel.rgb);
+    }
+
+    g_match[groupIndex] = isMatch ? 1u : 0u;
+
+    GroupMemoryBarrierWithGroupSync();
+
+    // Thread 0 scans shared memory to extract line segments
+    if (groupIndex != 0)
+        return;
+
+    int segXStart = -1;
+    int segXEnd = -1;
+    int scanEnd = min((int)(groupInRow * GROUP_SIZE + GROUP_SIZE), areaWidth);
+    int scanStart = groupInRow * GROUP_SIZE;
+
+    int localCount = 0;
+    GpuLineSegment localSegs[8]; // max segments per group
+
+    for (int lx = 0; lx < GROUP_SIZE && (scanStart + lx) < areaWidth; lx++)
+    {
+        int globalX = AreaLeft + scanStart + lx;
+
+        if (g_match[lx] == 0u)
+        {
+            // Skip non-matching pixels (same as CPU path).
+            // Text characters have small gaps; only the matching-pixel
+            // gap check (MinLength) should terminate a segment.
+            continue;
+        }
+
+        // Pixel matches
+        if (segXStart >= 0 && (globalX - segXEnd) < (int)MinLength)
+        {
+            // Extend current segment (gap within tolerance)
+        }
+        else
+        {
+            // Start new segment (or emit old one)
+            if (segXStart >= 0 && (segXEnd - segXStart) > MinEndLength)
+            {
+                if (localCount < 8)
+                {
+                    localSegs[localCount].xStart = segXStart;
+                    localSegs[localCount].xEnd = segXEnd;
+                    localSegs[localCount].y = y;
+                    localSegs[localCount]._pad = 0;
+                    localCount++;
+                }
+            }
+            segXStart = globalX;
+        }
+        segXEnd = globalX;
+    }
+
+    // Emit final segment if in progress
+    if (segXStart >= 0 && (segXEnd - segXStart) > MinEndLength)
+    {
+        if (localCount < 8)
+        {
+            localSegs[localCount].xStart = segXStart;
+            localSegs[localCount].xEnd = segXEnd;
+            localSegs[localCount].y = y;
+            localSegs[localCount]._pad = 0;
+            localCount++;
+        }
+    }
+
+    if (localCount == 0)
+        return;
+
+    // Atomically reserve space in the output buffer
+    uint baseIndex;
+    Counter.InterlockedAdd(0, (uint)localCount, baseIndex);
+
+    if ((int)baseIndex + localCount > MaxSegments)
+        return;
+
+    for (int s = 0; s < localCount; s++)
+    {
+        OutputSegments[baseIndex + s] = localSegs[s];
+    }
+}

--- a/Core/WoWScreen/WowScreenDXGI.cs
+++ b/Core/WoWScreen/WowScreenDXGI.cs
@@ -27,7 +27,7 @@ using static WinAPI.NativeMethods;
 
 namespace Core;
 
-public sealed class WowScreenDXGI : IWowScreen, IAddonDataProvider
+public sealed class WowScreenDXGI : IWowScreen, IAddonDataProvider, IGpuTextureProvider
 {
     private readonly ILogger<WowScreenDXGI> logger;
     private readonly WowProcess process;
@@ -74,6 +74,13 @@ public sealed class WowScreenDXGI : IWowScreen, IAddonDataProvider
     private readonly IDXGIOutputDuplication duplication;
 
     private readonly bool windowedMode;
+
+    // IGpuTextureProvider
+    private ID3D11Texture2D? lastCapturedTexture;
+
+    ID3D11Device IGpuTextureProvider.Device => device;
+    ID3D11DeviceContext IGpuTextureProvider.DeviceContext => device.ImmediateContext;
+    ID3D11Texture2D? IGpuTextureProvider.GetCapturedTexture() => lastCapturedTexture;
 
     // IAddonDataProvider
 
@@ -178,6 +185,7 @@ public sealed class WowScreenDXGI : IWowScreen, IAddonDataProvider
         try { duplication?.ReleaseFrame(); } catch { }
         try { duplication?.Dispose(); } catch { }
 
+        try { lastCapturedTexture?.Dispose(); } catch { }
         try { minimapTexture.Dispose(); } catch { }
         try { addonTexture.Dispose(); } catch { }
         try { screenTexture.Dispose(); } catch { }
@@ -258,6 +266,9 @@ public sealed class WowScreenDXGI : IWowScreen, IAddonDataProvider
         ID3D11Texture2D texture
             = idxgiResource.QueryInterface<ID3D11Texture2D>();
 
+        lastCapturedTexture?.Dispose();
+        lastCapturedTexture = texture;
+
         if (frames.Length > 2)
             UpdateAddonImage(texture);
 
@@ -266,8 +277,6 @@ public sealed class WowScreenDXGI : IWowScreen, IAddonDataProvider
 
         if (MinimapEnabled)
             UpdateMinimapImage(texture);
-
-        texture.Dispose();
     }
 
     [SkipLocalsInit]

--- a/Core/WoWScreen/WowScreenWGC.cs
+++ b/Core/WoWScreen/WowScreenWGC.cs
@@ -20,6 +20,7 @@ using System.Threading;
 using Vortice.Direct3D;
 using Vortice.Direct3D11;
 using Vortice.DXGI;
+using Vortice.Mathematics;
 
 using WinAPI;
 
@@ -37,7 +38,7 @@ namespace Core;
 /// Supports capturing WoW window even when it's behind other windows.
 /// Requires Windows 10 version 2004 (build 19041) or later for borderless capture.
 /// </summary>
-public sealed class WowScreenWGC : IWowScreen, IAddonDataProvider
+public sealed class WowScreenWGC : IWowScreen, IAddonDataProvider, IGpuTextureProvider
 {
     private readonly ILogger<WowScreenWGC> logger;
     private readonly WowProcess process;
@@ -90,6 +91,14 @@ public sealed class WowScreenWGC : IWowScreen, IAddonDataProvider
     private SizeInt32 latestFrameSize;
     private bool hasNewFrame;
     private bool processingFrame;
+
+    // IGpuTextureProvider -- Default-usage copy for GPU compute shader
+    private ID3D11Texture2D? gpuTextureCopy;
+    private SizeInt32 gpuTextureSize;
+
+    ID3D11Device IGpuTextureProvider.Device => device;
+    ID3D11DeviceContext IGpuTextureProvider.DeviceContext => deviceContext;
+    ID3D11Texture2D? IGpuTextureProvider.GetCapturedTexture() => gpuTextureCopy;
 
     // Client area offset (WGC captures full window including title bar)
     private Point clientOffset;
@@ -224,6 +233,38 @@ public sealed class WowScreenWGC : IWowScreen, IAddonDataProvider
 
                 deviceContext.CopyResource(writeStagingTexture, frameTexture);
 
+                // Copy client area only to GPU texture for compute shader
+                // (WGC captures full window including title bar; match CPU path)
+                if (gpuTextureCopy == null ||
+                    gpuTextureSize.Width != screenRect.Width ||
+                    gpuTextureSize.Height != screenRect.Height)
+                {
+                    gpuTextureCopy?.Dispose();
+
+                    Texture2DDescription gpuDesc = frameTexture.Description;
+                    gpuDesc.Width = (uint)screenRect.Width;
+                    gpuDesc.Height = (uint)screenRect.Height;
+                    gpuDesc.Usage = ResourceUsage.Default;
+                    gpuDesc.BindFlags = BindFlags.ShaderResource;
+                    gpuDesc.CPUAccessFlags = CpuAccessFlags.None;
+                    gpuDesc.MiscFlags = ResourceOptionFlags.None;
+
+                    gpuTextureCopy = device.CreateTexture2D(gpuDesc);
+                    gpuTextureSize = new SizeInt32
+                    {
+                        Width = screenRect.Width,
+                        Height = screenRect.Height
+                    };
+                }
+
+                Box clientBox = new(
+                    clientOffset.X, clientOffset.Y, 0,
+                    clientOffset.X + screenRect.Width,
+                    clientOffset.Y + screenRect.Height, 1);
+                deviceContext.CopySubresourceRegion(
+                    gpuTextureCopy, 0, 0, 0, 0,
+                    frameTexture, 0, clientBox);
+
                 // Only swap if Update() isn't actively reading from readStagingTexture.
                 // If processingFrame is true, we just overwrote writeStagingTexture in place
                 // and the next Update() call will pick up the latest frame after swap.
@@ -276,6 +317,7 @@ public sealed class WowScreenWGC : IWowScreen, IAddonDataProvider
         StopCapture();
 
         winrtDevice?.Dispose();
+        gpuTextureCopy?.Dispose();
         writeStagingTexture?.Dispose();
         readStagingTexture?.Dispose();
         deviceContext?.Dispose();

--- a/CoreTests/NpcNameFinder/Test_NpcNameFinder.cs
+++ b/CoreTests/NpcNameFinder/Test_NpcNameFinder.cs
@@ -24,7 +24,7 @@ internal sealed class Test_NpcNameFinder : IDisposable
     private const bool saveImage = false;
     private const bool showOverlay = true;
 
-    private const bool LogEachUpdate = false;
+    private const bool LogEachUpdate = true;
     private const bool LogEachDetail = false;
 
     private const bool debugTargeting = false;
@@ -41,12 +41,14 @@ internal sealed class Test_NpcNameFinder : IDisposable
     private readonly StringBuilder stringBuilder;
 
     private readonly NpcNameOverlay? npcNameOverlay;
+    private readonly INpcLineSegmentProvider provider;
 
     private DateTime lastNpcUpdate;
     private double updateDuration;
 
     public Test_NpcNameFinder(ILogger logger, WowProcess process,
-        IWowScreen screen, ILoggerFactory loggerFactory, NpcNames types)
+        IWowScreen screen, ILoggerFactory loggerFactory, NpcNames types,
+        bool useGpu = false)
     {
         this.logger = logger;
         this.screen = screen;
@@ -54,7 +56,22 @@ internal sealed class Test_NpcNameFinder : IDisposable
         stringBuilder = new();
 
         INpcResetEvent npcResetEvent = new NpcResetEvent();
-        npcNameFinder = new(logger, screen, npcResetEvent);
+        CpuLineSegmentProvider cpuProvider = new(screen);
+
+        INpcLineSegmentProvider provider;
+        if (useGpu && screen is IGpuTextureProvider gpuTextureProvider)
+        {
+            provider = new GpuLineSegmentProvider(
+                loggerFactory.CreateLogger<GpuLineSegmentProvider>(),
+                gpuTextureProvider, cpuProvider);
+        }
+        else
+        {
+            provider = cpuProvider;
+        }
+
+        this.provider = provider;
+        npcNameFinder = new(logger, screen, npcResetEvent, provider);
 
         locations = new(npcNameFinder);
 
@@ -83,6 +100,7 @@ internal sealed class Test_NpcNameFinder : IDisposable
 
     public void Dispose()
     {
+        (provider as IDisposable)?.Dispose();
         npcNameOverlay?.Dispose();
     }
 

--- a/CoreTests/Program.cs
+++ b/CoreTests/Program.cs
@@ -28,9 +28,10 @@ internal sealed class Program
 
     private static CancellationTokenSource cts;
     private static WowProcess process;
-    private static WowScreenDXGI screen;
+    private static WowScreenWGC screen;
 
     private const bool LogOverallTimes = false;
+    private const bool UseGpu = true;
     private const int delay = 150;
 
     public static void Main()
@@ -61,7 +62,8 @@ internal sealed class Program
 
         cts = new CancellationTokenSource();
         process = new(cts, Options.Create<StartupConfigPid>(new() { Id = -1 }));
-        screen = new WowScreenDXGI(loggerFactory.CreateLogger<WowScreenDXGI>(), process, mockFrames);
+        //screen = new WowScreenDXGI(loggerFactory.CreateLogger<WowScreenDXGI>(), process, mockFrames);
+        screen = new WowScreenWGC(loggerFactory.CreateLogger<WowScreenWGC>(), process, mockFrames);
 
         Test_NPCNameFinder();
         //Test_Input();
@@ -70,6 +72,7 @@ internal sealed class Program
         //Test_MinimapNodeFinder();
         //Test_FindTargetByCursor();
 
+        Log.CloseAndFlush();
         Environment.Exit(0);
     }
 
@@ -82,7 +85,7 @@ internal sealed class Program
         //NpcNames types = NpcNames.Enemy | NpcNames.Neutral | NpcNames.NamePlate;
         //NpcNames types = NpcNames.Friendly | NpcNames.Neutral;
 
-        using Test_NpcNameFinder test = new(logger, process, screen, loggerFactory, types);
+        using Test_NpcNameFinder test = new(logger, process, screen, loggerFactory, types, UseGpu);
         int count = 100;
         int i = 0;
 
@@ -240,7 +243,7 @@ internal sealed class Program
         //NpcNames types = NpcNames.Enemy | NpcNames.Neutral;
         NpcNames types = NpcNames.Friendly | NpcNames.Neutral;
 
-        using Test_NpcNameFinder test = new(logger, process, screen, loggerFactory, types);
+        using Test_NpcNameFinder test = new(logger, process, screen, loggerFactory, types, UseGpu);
 
         int count = 2;
         int i = 0;

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,6 +35,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="10.0.0" />
     <PackageVersion Include="System.Text.Json" Version="8.0.4" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageVersion Include="Vortice.D3DCompiler" Version="3.6.2" />
     <PackageVersion Include="Vortice.Direct3D11" Version="3.6.2" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.0" />

--- a/Game/WoWScreen/IGpuTextureProvider.cs
+++ b/Game/WoWScreen/IGpuTextureProvider.cs
@@ -1,0 +1,17 @@
+using Vortice.Direct3D11;
+
+namespace Game;
+
+public interface IGpuTextureProvider
+{
+    ID3D11Device Device { get; }
+    ID3D11DeviceContext DeviceContext { get; }
+
+    /// <summary>
+    /// Gets the most recently captured GPU texture.
+    /// Returns null if no frame is available.
+    /// The texture may have Staging usage and no ShaderResource bind flag --
+    /// callers should copy to a ShaderResource-capable texture before binding to shaders.
+    /// </summary>
+    ID3D11Texture2D? GetCapturedTexture();
+}

--- a/HeadlessServer/DependencyInjection.cs
+++ b/HeadlessServer/DependencyInjection.cs
@@ -31,7 +31,7 @@ public static class DependencyInjection
         var options = sp.GetRequiredService<RunOptions>();
 
         return Options.Create<StartupConfigReader>(
-            new() { Type = options.Reader.ToString() });
+            new() { Type = options.Reader.ToString(), UseGpu = options.UseGpu });
     }
 
     private static IOptions<StartupConfigPid> StartupConfigPidFactory(IServiceProvider sp)

--- a/HeadlessServer/RunOptions.cs
+++ b/HeadlessServer/RunOptions.cs
@@ -94,6 +94,12 @@ public sealed class RunOptions
         HelpText = $"Disable PathVisualization in RemoteV1")]
     public bool PathVisualizer { get; set; }
 
+    [Option('g', "gpu",
+        Required = false,
+        Default = true,
+        HelpText = "Use GPU compute shader for NPC name finding")]
+    public bool UseGpu { get; set; }
+
     [Option("loadonly",
         Required = false,
         Default = false,

--- a/README.md
+++ b/README.md
@@ -572,6 +572,7 @@ For normal quick startup of `HeadlessServer` please look at the `HeadlessServer\
 | `-t`<br>`-otargeting` | While overlay enabled, show Targeting points | `false` | - |
 | `-s`<br>`-oskinning` | While overlay enabled, show Skinning points | `false` | - |
 | `-v`<br>`-otargetvsadd` | While overlay enabled, show Target vs Add points | `false` | - |
+| `-g`<br>`--gpu` | Use GPU compute shader for NPC name finding | `true` | `true` or `false` |
 | `--loadonly` | Loads the given class profile then exits | `false` | - |
 
 e.g. run from Powershell without any optional parameter

--- a/SharedLib/NpcFinder/ColorMatchers.cs
+++ b/SharedLib/NpcFinder/ColorMatchers.cs
@@ -1,0 +1,156 @@
+using System.Runtime.CompilerServices;
+
+using static SharedLib.NpcFinder.NpcNameColors;
+
+namespace SharedLib.NpcFinder;
+
+#region Simple matchers
+
+public readonly struct SimpleEnemyMatcher : IColorMatcher
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsMatch(byte r, byte g, byte b) =>
+        r > sE_R && g <= sE_G && b <= sE_B;
+}
+
+public readonly struct SimpleFriendlyMatcher : IColorMatcher
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsMatch(byte r, byte g, byte b) =>
+        r == sF_R && g > sF_G && b == sF_B;
+}
+
+public readonly struct SimpleNeutralMatcher : IColorMatcher
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsMatch(byte r, byte g, byte b) =>
+        r > sN_R && g > sN_G && b == sN_B;
+}
+
+public readonly struct SimpleCorpseMatcher : IColorMatcher
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsMatch(byte r, byte g, byte b) =>
+        r == fC_RGB && g == fC_RGB && b == fC_RGB;
+}
+
+public readonly struct SimpleNamePlateMatcher : IColorMatcher
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsMatch(byte r, byte g, byte b) =>
+        r is sNamePlate_N or sNamePlate_H_R &&
+        g is sNamePlate_N or sNamePlate_H_G &&
+        b is sNamePlate_N or sNamePlate_H_B;
+}
+
+public readonly struct SimpleEnemyNeutralMatcher : IColorMatcher
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsMatch(byte r, byte g, byte b) =>
+        (r > sE_R && g <= sE_G && b <= sE_B) ||
+        (r > sN_R && g > sN_G && b == sN_B);
+}
+
+public readonly struct SimpleFriendlyNeutralMatcher : IColorMatcher
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsMatch(byte r, byte g, byte b) =>
+        (r == sF_R && g > sF_G && b == sF_B) ||
+        (r > sN_R && g > sN_G && b == sN_B);
+}
+
+public readonly struct NoMatchMatcher : IColorMatcher
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsMatch(byte r, byte g, byte b) => false;
+}
+
+#endregion
+
+#region Fuzzy matchers
+
+file static class FuzzyHelper
+{
+    public const int colorFuzz = 40;
+    public const int colorFuzzSqr = colorFuzz * colorFuzz;
+    public const int fuzzCorpseSqr = fuzzCorpse * fuzzCorpse;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool FuzzyMatch(
+        byte rr, byte gg, byte bb,
+        byte r, byte g, byte b,
+        int fuzzSqr)
+    {
+        unchecked
+        {
+            int dr = rr - r;
+            int dg = gg - g;
+            int db = bb - b;
+            return (dr * dr) + (dg * dg) + (db * db) <= fuzzSqr;
+        }
+    }
+}
+
+public readonly struct FuzzyEnemyMatcher : IColorMatcher
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsMatch(byte r, byte g, byte b) =>
+        FuzzyHelper.FuzzyMatch(fE_R, fE_G, fE_B, r, g, b, FuzzyHelper.colorFuzzSqr);
+}
+
+public readonly struct FuzzyFriendlyMatcher : IColorMatcher
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsMatch(byte r, byte g, byte b) =>
+        FuzzyHelper.FuzzyMatch(fF_R, fF_G, fF_B, r, g, b, FuzzyHelper.colorFuzzSqr);
+}
+
+public readonly struct FuzzyNeutralMatcher : IColorMatcher
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsMatch(byte r, byte g, byte b) =>
+        FuzzyHelper.FuzzyMatch(fN_R, fN_G, fN_B, r, g, b, FuzzyHelper.colorFuzzSqr);
+}
+
+public readonly struct FuzzyCorpseMatcher : IColorMatcher
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsMatch(byte r, byte g, byte b) =>
+        FuzzyHelper.FuzzyMatch(fC_RGB, fC_RGB, fC_RGB, r, g, b, FuzzyHelper.fuzzCorpseSqr);
+}
+
+public readonly struct FuzzyNamePlateMatcher : IColorMatcher
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsMatch(byte r, byte g, byte b) =>
+        FuzzyHelper.FuzzyMatch(sNamePlate_N, sNamePlate_N, sNamePlate_N, r, g, b, FuzzyHelper.fuzzCorpseSqr) ||
+        FuzzyHelper.FuzzyMatch(sNamePlate_H_R, sNamePlate_H_G, sNamePlate_H_B, r, g, b, FuzzyHelper.fuzzCorpseSqr);
+}
+
+public readonly struct FuzzyEnemyNeutralMatcher : IColorMatcher
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsMatch(byte r, byte g, byte b) =>
+        FuzzyHelper.FuzzyMatch(fE_R, fE_G, fE_B, r, g, b, FuzzyHelper.colorFuzzSqr) ||
+        FuzzyHelper.FuzzyMatch(fN_R, fN_G, fN_B, r, g, b, FuzzyHelper.colorFuzzSqr);
+}
+
+public readonly struct FuzzyEnemyNeutralNamePlateMatcher : IColorMatcher
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsMatch(byte r, byte g, byte b) =>
+        FuzzyHelper.FuzzyMatch(fE_R, fE_G, fE_B, r, g, b, FuzzyHelper.colorFuzzSqr) ||
+        FuzzyHelper.FuzzyMatch(fN_R, fN_G, fN_B, r, g, b, FuzzyHelper.colorFuzzSqr) ||
+        FuzzyHelper.FuzzyMatch(sNamePlate_N, sNamePlate_N, sNamePlate_N, r, g, b, FuzzyHelper.fuzzCorpseSqr) ||
+        FuzzyHelper.FuzzyMatch(sNamePlate_H_R, sNamePlate_H_G, sNamePlate_H_B, r, g, b, FuzzyHelper.fuzzCorpseSqr);
+}
+
+public readonly struct FuzzyFriendlyNeutralMatcher : IColorMatcher
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsMatch(byte r, byte g, byte b) =>
+        FuzzyHelper.FuzzyMatch(fF_R, fF_G, fF_B, r, g, b, FuzzyHelper.colorFuzzSqr) ||
+        FuzzyHelper.FuzzyMatch(fN_R, fN_G, fN_B, r, g, b, FuzzyHelper.colorFuzzSqr);
+}
+
+#endregion

--- a/SharedLib/NpcFinder/CpuLineSegmentProvider.cs
+++ b/SharedLib/NpcFinder/CpuLineSegmentProvider.cs
@@ -1,0 +1,169 @@
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Advanced;
+using SixLabors.ImageSharp.Memory;
+using SixLabors.ImageSharp.PixelFormats;
+
+using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+
+namespace SharedLib.NpcFinder;
+
+public sealed class CpuLineSegmentProvider : IConfigurableLineSegmentProvider
+{
+    private const int RESOLUTION = 16;
+
+    private readonly IScreenImageProvider imageProvider;
+    private readonly ArrayCounter counter = new();
+
+    private SearchMode searchMode;
+    private NpcNames nameType;
+
+    private LineSegment[]? segments;
+
+    public CpuLineSegmentProvider(IScreenImageProvider imageProvider)
+    {
+        this.imageProvider = imageProvider;
+    }
+
+    public void Configure(SearchMode searchMode, NpcNames nameType)
+    {
+        this.searchMode = searchMode;
+        this.nameType = nameType;
+    }
+
+    [SkipLocalsInit]
+    public ReadOnlySpan<LineSegment> GetLineSegments(
+        Rectangle area, float minLength, float minEndLength)
+    {
+        int rowSize = (area.Right - area.Left) / RESOLUTION;
+        int height = (area.Bottom - area.Top) / RESOLUTION;
+        int totalSize = rowSize * height;
+
+        var pooler = ArrayPool<LineSegment>.Shared;
+        segments = pooler.Rent(totalSize);
+
+        Rectangle rectangle = new(area.X, area.Y, area.Width, area.Height);
+        Buffer2D<Bgra32> pixelBuffer = imageProvider.ScreenImage.Frames[0].PixelBuffer;
+
+        counter.count = 0;
+
+        switch (searchMode)
+        {
+            case SearchMode.Fuzzy:
+                DispatchFuzzy(segments, rowSize, rectangle,
+                    minLength, minEndLength, pixelBuffer);
+                break;
+            case SearchMode.Simple:
+                DispatchSimple(segments, rowSize, rectangle,
+                    minLength, minEndLength, pixelBuffer);
+                break;
+        }
+
+        pooler.Return(segments);
+        return new(segments, 0, Math.Min(segments.Length, counter.count));
+    }
+
+    private void DispatchFuzzy(
+        LineSegment[] segments, int rowSize, Rectangle rectangle,
+        float minLength, float minEndLength, Buffer2D<Bgra32> pixelBuffer)
+    {
+        switch (nameType)
+        {
+            case NpcNames.Enemy | NpcNames.Neutral | NpcNames.NamePlate:
+                RunOperation<FuzzyEnemyNeutralNamePlateMatcher>(
+                    segments, rowSize, rectangle, minLength, minEndLength, pixelBuffer);
+                break;
+            case NpcNames.Enemy | NpcNames.Neutral:
+                RunOperation<FuzzyEnemyNeutralMatcher>(
+                    segments, rowSize, rectangle, minLength, minEndLength, pixelBuffer);
+                break;
+            case NpcNames.Friendly | NpcNames.Neutral:
+                RunOperation<FuzzyFriendlyNeutralMatcher>(
+                    segments, rowSize, rectangle, minLength, minEndLength, pixelBuffer);
+                break;
+            case NpcNames.Enemy:
+                RunOperation<FuzzyEnemyMatcher>(
+                    segments, rowSize, rectangle, minLength, minEndLength, pixelBuffer);
+                break;
+            case NpcNames.Friendly:
+                RunOperation<FuzzyFriendlyMatcher>(
+                    segments, rowSize, rectangle, minLength, minEndLength, pixelBuffer);
+                break;
+            case NpcNames.Neutral:
+                RunOperation<FuzzyNeutralMatcher>(
+                    segments, rowSize, rectangle, minLength, minEndLength, pixelBuffer);
+                break;
+            case NpcNames.Corpse:
+                RunOperation<FuzzyCorpseMatcher>(
+                    segments, rowSize, rectangle, minLength, minEndLength, pixelBuffer);
+                break;
+            case NpcNames.NamePlate:
+                RunOperation<FuzzyNamePlateMatcher>(
+                    segments, rowSize, rectangle, minLength, minEndLength, pixelBuffer);
+                break;
+        }
+    }
+
+    private void DispatchSimple(
+        LineSegment[] segments, int rowSize, Rectangle rectangle,
+        float minLength, float minEndLength, Buffer2D<Bgra32> pixelBuffer)
+    {
+        switch (nameType)
+        {
+            case NpcNames.Enemy | NpcNames.Neutral:
+                RunOperation<SimpleEnemyNeutralMatcher>(
+                    segments, rowSize, rectangle, minLength, minEndLength, pixelBuffer);
+                break;
+            case NpcNames.Friendly | NpcNames.Neutral:
+                RunOperation<SimpleFriendlyNeutralMatcher>(
+                    segments, rowSize, rectangle, minLength, minEndLength, pixelBuffer);
+                break;
+            case NpcNames.Enemy:
+                RunOperation<SimpleEnemyMatcher>(
+                    segments, rowSize, rectangle, minLength, minEndLength, pixelBuffer);
+                break;
+            case NpcNames.Friendly:
+                RunOperation<SimpleFriendlyMatcher>(
+                    segments, rowSize, rectangle, minLength, minEndLength, pixelBuffer);
+                break;
+            case NpcNames.Neutral:
+                RunOperation<SimpleNeutralMatcher>(
+                    segments, rowSize, rectangle, minLength, minEndLength, pixelBuffer);
+                break;
+            case NpcNames.Corpse:
+                RunOperation<SimpleCorpseMatcher>(
+                    segments, rowSize, rectangle, minLength, minEndLength, pixelBuffer);
+                break;
+            case NpcNames.NamePlate:
+                RunOperation<SimpleNamePlateMatcher>(
+                    segments, rowSize, rectangle, minLength, minEndLength, pixelBuffer);
+                break;
+            case NpcNames.None:
+                RunOperation<NoMatchMatcher>(
+                    segments, rowSize, rectangle, minLength, minEndLength, pixelBuffer);
+                break;
+        }
+    }
+
+    private void RunOperation<TMatcher>(
+        LineSegment[] segments, int rowSize, Rectangle rectangle,
+        float minLength, float minEndLength, Buffer2D<Bgra32> pixelBuffer)
+        where TMatcher : struct, IColorMatcher
+    {
+        LineSegmentOperation<TMatcher> operation = new(
+            segments,
+            rowSize,
+            rectangle,
+            minLength,
+            minEndLength,
+            counter,
+            default,
+            pixelBuffer);
+
+        ParallelRowIterator.IterateRows<LineSegmentOperation<TMatcher>, LineSegment>(
+            Configuration.Default,
+            rectangle,
+            in operation);
+    }
+}

--- a/SharedLib/NpcFinder/IColorMatcher.cs
+++ b/SharedLib/NpcFinder/IColorMatcher.cs
@@ -1,0 +1,9 @@
+using System.Runtime.CompilerServices;
+
+namespace SharedLib.NpcFinder;
+
+public interface IColorMatcher
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    bool IsMatch(byte r, byte g, byte b);
+}

--- a/SharedLib/NpcFinder/INpcLineSegmentProvider.cs
+++ b/SharedLib/NpcFinder/INpcLineSegmentProvider.cs
@@ -1,0 +1,15 @@
+using SixLabors.ImageSharp;
+
+using System;
+
+namespace SharedLib.NpcFinder;
+
+public interface INpcLineSegmentProvider
+{
+    ReadOnlySpan<LineSegment> GetLineSegments(Rectangle area, float minLength, float minEndLength);
+}
+
+public interface IConfigurableLineSegmentProvider : INpcLineSegmentProvider
+{
+    void Configure(SearchMode searchMode, NpcNames nameType);
+}

--- a/SharedLib/NpcFinder/LineSegmentOperation.cs
+++ b/SharedLib/NpcFinder/LineSegmentOperation.cs
@@ -1,4 +1,4 @@
-﻿using SixLabors.ImageSharp;
+using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.PixelFormats;
@@ -9,7 +9,8 @@ using System.Threading;
 
 namespace SharedLib.NpcFinder;
 
-internal readonly struct LineSegmentOperation : IRowOperation<LineSegment>
+internal readonly struct LineSegmentOperation<TMatcher> : IRowOperation<LineSegment>
+    where TMatcher : struct, IColorMatcher
 {
     private readonly Buffer2D<Bgra32> source;
 
@@ -19,7 +20,7 @@ internal readonly struct LineSegmentOperation : IRowOperation<LineSegment>
     private readonly float minLength;
     private readonly float minEndLength;
 
-    private readonly Func<byte, byte, byte, bool> colorMatcher;
+    private readonly TMatcher colorMatcher;
 
     private readonly LineSegment[] segments;
 
@@ -32,7 +33,7 @@ internal readonly struct LineSegmentOperation : IRowOperation<LineSegment>
         float minLength,
         float minEndLength,
         ArrayCounter counter,
-        Func<byte, byte, byte, bool> colorMatcher,
+        TMatcher colorMatcher,
         Buffer2D<Bgra32> source)
     {
         this.segments = segments;
@@ -65,7 +66,7 @@ internal readonly struct LineSegmentOperation : IRowOperation<LineSegment>
         {
             ref readonly Bgra32 pixel = ref row[x];
 
-            if (!colorMatcher(pixel.R, pixel.G, pixel.B))
+            if (!colorMatcher.IsMatch(pixel.R, pixel.G, pixel.B))
                 continue;
 
             if (xStart > -1 && (x - xEnd) < minLength)
@@ -96,9 +97,10 @@ internal readonly struct LineSegmentOperation : IRowOperation<LineSegment>
             return;
 
         int newCount = Interlocked.Add(ref counter.count, i);
-        if (counter.count + newCount > segments.Length)
+        int startIndex = newCount - i;
+        if (newCount > segments.Length)
             return;
 
-        span[..i].CopyTo(segments.AsSpan(counter.count, newCount));
+        span[..i].CopyTo(segments.AsSpan(startIndex, i));
     }
 }

--- a/SharedLib/NpcFinder/NpcNameFinder.cs
+++ b/SharedLib/NpcFinder/NpcNameFinder.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.Logging;
 using SharedLib.Extensions;
 
 using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Advanced;
 
 using System;
 using System.Buffers;
@@ -12,8 +11,6 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
-using static SharedLib.NpcFinder.NpcNameColors;
-
 namespace SharedLib.NpcFinder;
 
 public sealed partial class NpcNameFinder
@@ -21,6 +18,7 @@ public sealed partial class NpcNameFinder
     private readonly ILogger logger;
     private readonly IScreenImageProvider bitmapProvider;
     private readonly INpcResetEvent resetEvent;
+    private readonly INpcLineSegmentProvider lineSegmentProvider;
 
     private const int bytesPerPixel = 4;
 
@@ -53,11 +51,8 @@ public sealed partial class NpcNameFinder
 
     public DateTime LastPotentialAddsSeen { get; private set; }
 
-    private Func<byte, byte, byte, bool> colorMatcher;
-
     private readonly NpcPositionComparer npcPosComparer;
 
-    private const int colorFuzz = 40;
     private const int topOffset = 117;
     public int WidthDiff { get; set; } = 4;
 
@@ -67,16 +62,15 @@ public sealed partial class NpcNameFinder
     public int HeightOffset1 { get; set; } = 10;
     public int HeightOffset2 { get; set; } = 2;
 
-    private readonly ArrayCounter counter;
-
     public NpcNameFinder(ILogger logger, IScreenImageProvider bitmapProvider,
-        INpcResetEvent resetEvent)
+        INpcResetEvent resetEvent, INpcLineSegmentProvider lineSegmentProvider)
     {
         this.logger = logger;
         this.bitmapProvider = bitmapProvider;
         this.resetEvent = resetEvent;
+        this.lineSegmentProvider = lineSegmentProvider;
 
-        UpdateSearchMode();
+        ConfigureProvider();
 
         npcPosComparer = new(bitmapProvider);
 
@@ -95,8 +89,6 @@ public sealed partial class NpcNameFinder
         screenMidBuffer = screenWidth / 15;
         screenTargetBuffer = screenMidBuffer / 2;
         screenAddBuffer = screenMidBuffer * 3;
-
-        counter = new();
     }
 
     private float ScaleWidth(int value)
@@ -113,6 +105,14 @@ public sealed partial class NpcNameFinder
     {
         HeightMulti = nameType == NpcNames.Corpse ? 10 : 4;
         heightMul = ScaleHeight(HeightMulti);
+    }
+
+    private void ConfigureProvider()
+    {
+        if (lineSegmentProvider is IConfigurableLineSegmentProvider configurable)
+        {
+            configurable.Configure(searchMode, nameType);
+        }
     }
 
     public bool ChangeNpcType(NpcNames type)
@@ -139,7 +139,7 @@ public sealed partial class NpcNameFinder
         }
 
         CalculateHeightMultipiler();
-        UpdateSearchMode();
+        ConfigureProvider();
 
         LogTypeChanged(logger, type.ToStringF(), searchMode.ToStringF());
 
@@ -148,187 +148,6 @@ public sealed partial class NpcNameFinder
 
         return true;
     }
-
-    private void UpdateSearchMode()
-    {
-        switch (searchMode)
-        {
-            case SearchMode.Simple:
-                BakeSimpleColorMatcher();
-                break;
-            case SearchMode.Fuzzy:
-                BakeFuzzyColorMatcher();
-                break;
-        }
-    }
-
-
-    #region Simple Color matcher
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void BakeSimpleColorMatcher()
-    {
-        switch (nameType)
-        {
-            case NpcNames.Enemy | NpcNames.Neutral:
-                colorMatcher = CombinedEnemyNeutrual;
-                return;
-            case NpcNames.Friendly | NpcNames.Neutral:
-                colorMatcher = CombinedFriendlyNeutrual;
-                return;
-            case NpcNames.Enemy:
-                colorMatcher = SimpleColorEnemy;
-                return;
-            case NpcNames.Friendly:
-                colorMatcher = SimpleColorFriendly;
-                return;
-            case NpcNames.Neutral:
-                colorMatcher = SimpleColorNeutral;
-                return;
-            case NpcNames.Corpse:
-                colorMatcher = SimpleColorCorpse;
-                return;
-            case NpcNames.NamePlate:
-                colorMatcher = SimpleColorNamePlate;
-                return;
-            case NpcNames.None:
-                colorMatcher = NoMatch;
-                return;
-        }
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool SimpleColorEnemy(byte r, byte g, byte b)
-    {
-        return r > sE_R && g <= sE_G && b <= sE_B;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool SimpleColorFriendly(byte r, byte g, byte b)
-    {
-        return r == sF_R && g > sF_G && b == sF_B;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool SimpleColorNeutral(byte r, byte g, byte b)
-    {
-        return r > sN_R && g > sN_G && b == sN_B;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool SimpleColorCorpse(byte r, byte g, byte b)
-    {
-        return r == fC_RGB && g == fC_RGB && b == fC_RGB;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool SimpleColorNamePlate(byte r, byte g, byte b)
-    {
-        return
-            r is sNamePlate_N or sNamePlate_H_R &&
-            g is sNamePlate_N or sNamePlate_H_G &&
-            b is sNamePlate_N or sNamePlate_H_B;
-    }
-
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool CombinedFriendlyNeutrual(byte r, byte g, byte b)
-    {
-        return SimpleColorFriendly(r, g, b) || SimpleColorNeutral(r, g, b);
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool CombinedEnemyNeutrual(byte r, byte g, byte b)
-    {
-        return SimpleColorEnemy(r, g, b) || SimpleColorNeutral(r, g, b);
-    }
-
-    private static bool NoMatch(byte r, byte g, byte b)
-    {
-        return false;
-    }
-
-    #endregion
-
-
-    #region Color Fuzziness matcher
-
-    private void BakeFuzzyColorMatcher()
-    {
-        switch (nameType)
-        {
-            case NpcNames.Enemy | NpcNames.Neutral | NpcNames.NamePlate:
-                colorMatcher = FuzzyEnemyOrNeutralOrNamePlate;
-                return;
-            case NpcNames.Enemy | NpcNames.Neutral:
-                colorMatcher = FuzzyEnemyOrNeutral;
-                return;
-            case NpcNames.Friendly | NpcNames.Neutral:
-                colorMatcher = FuzzyFriendlyOrNeutral;
-                return;
-            case NpcNames.Enemy:
-                colorMatcher = FuzzyEnemy;
-                return;
-            case NpcNames.Friendly:
-                colorMatcher = FuzzyFriendly;
-                return;
-            case NpcNames.Neutral:
-                colorMatcher = FuzzyNeutral;
-                return;
-            case NpcNames.Corpse:
-                colorMatcher = FuzzyCorpse;
-                return;
-            case NpcNames.NamePlate:
-                colorMatcher = FuzzyNamePlate;
-                return;
-        }
-    }
-
-    [SkipLocalsInit]
-    private static bool FuzzyColor(
-        byte rr, byte gg, byte bb,
-        byte r, byte g, byte b,
-        int fuzzy)
-    {
-        unchecked
-        {
-            int sqrDistance =
-                ((rr - r) * (rr - r)) +
-                ((gg - g) * (gg - g)) +
-                ((bb - b) * (bb - b));
-            return sqrDistance <= fuzzy * fuzzy;
-        }
-    }
-
-    private static bool FuzzyEnemyOrNeutral(byte r, byte g, byte b) =>
-        FuzzyColor(fE_R, fE_G, fE_B, r, g, b, colorFuzz) ||
-        FuzzyColor(fN_R, fN_G, fN_B, r, g, b, colorFuzz);
-
-    private static bool FuzzyEnemyOrNeutralOrNamePlate(byte r, byte g, byte b) =>
-        FuzzyEnemyOrNeutral(r, g, b) ||
-        FuzzyNamePlate(r, g, b);
-
-    private static bool FuzzyFriendlyOrNeutral(byte r, byte g, byte b) =>
-        FuzzyColor(fF_R, fF_G, fF_B, r, g, b, colorFuzz) ||
-        FuzzyColor(fN_R, fN_G, fN_B, r, g, b, colorFuzz);
-
-    private static bool FuzzyEnemy(byte r, byte g, byte b) =>
-        FuzzyColor(fE_R, fE_G, fE_B, r, g, b, colorFuzz);
-
-    private static bool FuzzyFriendly(byte r, byte g, byte b) =>
-        FuzzyColor(fF_R, fF_G, fF_B, r, g, b, colorFuzz);
-
-    private static bool FuzzyNeutral(byte r, byte g, byte b) =>
-        FuzzyColor(fN_R, fN_G, fN_B, r, g, b, colorFuzz);
-
-    private static bool FuzzyCorpse(byte r, byte g, byte b) =>
-        FuzzyColor(fC_RGB, fC_RGB, fC_RGB, r, g, b, fuzzCorpse);
-
-    private static bool FuzzyNamePlate(byte r, byte g, byte b) =>
-        FuzzyColor(sNamePlate_N, sNamePlate_N, sNamePlate_N, r, g, b, fuzzCorpse) ||
-        FuzzyColor(sNamePlate_H_R, sNamePlate_H_G, sNamePlate_H_B, r, g, b, fuzzCorpse);
-
-    #endregion
 
     public void WaitForUpdate(CancellationToken token = default)
     {
@@ -340,9 +159,11 @@ public sealed partial class NpcNameFinder
         resetEvent.ChangeReset();
         resetEvent.Reset();
 
+        float minLength = ScaleWidth(MinHeight);
+        float minEndLength = minLength - ScaleWidth(WidthDiff);
+
         ReadOnlySpan<LineSegment> lineSegments =
-            PopulateLines(colorMatcher, Area,
-            ScaleWidth(MinHeight), ScaleWidth(WidthDiff));
+            lineSegmentProvider.GetLineSegments(Area, minLength, minEndLength);
 
         Npcs = DetermineNpcs(lineSegments);
 
@@ -519,43 +340,6 @@ public sealed partial class NpcNameFinder
     private int YOffset(Rectangle area, Rectangle npc)
     {
         return npc.Top / area.Top * MinHeight / 4;
-    }
-
-    [SkipLocalsInit]
-    private ReadOnlySpan<LineSegment> PopulateLines(
-        Func<byte, byte, byte, bool> colorMatcher,
-        Rectangle area, float minLength, float lengthDiff)
-    {
-        const int RESOLUTION = 16;
-        int rowSize = (area.Right - area.Left) / RESOLUTION;
-        int height = (area.Bottom - area.Top) / RESOLUTION;
-        int totalSize = rowSize * height;
-
-        var pooler = ArrayPool<LineSegment>.Shared;
-        LineSegment[] segments = pooler.Rent(totalSize);
-
-        float minEndLength = minLength - lengthDiff;
-
-        Rectangle rectangle = new(area.X, area.Y, area.Width, area.Height);
-
-        counter.count = 0;
-        LineSegmentOperation operation = new(
-            segments,
-            rowSize,
-            rectangle,
-            minLength,
-            minEndLength,
-            counter,
-            colorMatcher,
-            bitmapProvider.ScreenImage.Frames[0].PixelBuffer);
-
-        ParallelRowIterator.IterateRows<LineSegmentOperation, LineSegment>(
-            Configuration.Default,
-            rectangle,
-            in operation);
-
-        pooler.Return(segments);
-        return new(segments, 0, Math.Min(segments.Length, counter.count));
     }
 
     public Point ToScreenCoordinates()

--- a/SharedLib/StartupConfig/StartupConfigReader.cs
+++ b/SharedLib/StartupConfig/StartupConfigReader.cs
@@ -8,6 +8,8 @@ public sealed class StartupConfigReader
 
     public string Type { get; set; } = string.Empty;
 
+    public bool UseGpu { get; set; } = true;
+
     public AddonDataProviderType ReaderType =>
         System.Enum.TryParse(Type, out AddonDataProviderType m)
         ? m


### PR DESCRIPTION
Extract color matching and line segment scanning from NpcNameFinder into IColorMatcher/INpcLineSegmentProvider abstractions with both GPU and CPU implementations.

GPU path:
- GpuLineSegmentProvider uses D3D11 compute shader for NPC name color matching via NpcColorMatch.hlsl
- NpcGpuResources manages D3D11 device, buffers, and shader lifecycle
- WowScreenDXGI/WowScreenWGC implement IGpuTextureProvider to share captured textures with the GPU pipeline

CPU path:
- CpuLineSegmentProvider with generic LineSegmentOperation<TMatcher>
- Struct-based ColorMatchers avoid virtual dispatch overhead

Integration:
- DI wiring auto-selects GPU vs CPU based on --gpu CLI flag
- RunOptions adds --gpu flag, StartupConfigReader/appsettings.json expose UseGpu setting
- Vortice.D3DCompiler package added for runtime shader compilation

Bug fixes:
- Race condition fix in MinimapRowOperation
- LineSegmentOperation CopyTo index calculation fix