### PR TITLE
PPather V1 pathfinding: SoA SpotManager, grid-based connectivity, wall and bridge falloff avoidance

### DIFF
--- a/Benchmarks/PPather/PPather_PathGraph_Performance.cs
+++ b/Benchmarks/PPather/PPather_PathGraph_Performance.cs
@@ -1,0 +1,250 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+
+using BenchmarkDotNet.Attributes;
+
+using PPather.Graph;
+
+namespace Benchmarks.PPather;
+
+/// <summary>
+/// Benchmarks for PathGraph and SpotManager performance improvements from SoA refactoring.
+///
+/// Measures:
+/// - SpotManager registration and lookup (array-based storage)
+/// - SearchBuffer allocation and reset (pooled search state)
+/// - Path scoring operations in tight A* loop
+/// - Overall memory allocation patterns
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(warmupCount: 3, iterationCount: 5)]
+public class PPather_PathGraph_Performance
+{
+    private const int SpotCount = 10000;
+    private const int SearchCount = 100;
+
+    private SpotManager spotManager = null!;
+    private List<Spot> testSpots = null!;
+    private GraphChunk dummyChunk = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // Create a SpotManager with capacity for test spots
+        spotManager = new SpotManager(capacity: SpotCount);
+        testSpots = new List<Spot>(SpotCount);
+
+        // Create a dummy chunk for spot registration
+        var logger = new Microsoft.Extensions.Logging.Abstractions.NullLogger<GraphChunk>();
+        dummyChunk = new GraphChunk(0f, 0f, 0, 0, logger, ".", spotManager);
+
+        // Create and register test spots (simulates loading a chunk)
+        var random = new Random(42);
+        for (int i = 0; i < SpotCount; i++)
+        {
+            var loc = new Vector3(
+                random.Next(0, 256),
+                random.Next(0, 256),
+                random.Next(-100, 100)
+            );
+
+            var spot = new Spot(loc) { flags = 0 };
+            testSpots.Add(spot);
+            dummyChunk.AddSpot(spot);
+        }
+    }
+
+    /// <summary>
+    /// Benchmark: SpotManager location lookups (hot path access)
+    /// Measures O(1) array lookups for spot locations
+    /// </summary>
+    [Benchmark]
+    public Vector3 SpotManager_Location_Lookups()
+    {
+        Vector3 result = Vector3.Zero;
+        var random = new Random(42);
+
+        for (int i = 0; i < 1000; i++)
+        {
+            int randomIdx = random.Next(testSpots.Count);
+            var spot = testSpots[randomIdx];
+            result = spotManager.GetLocation(spot);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Benchmark: SpotManager distance calculations (hot path in A* scoring)
+    /// Measures cache-friendly vector math on contiguous array data
+    /// </summary>
+    [Benchmark]
+    public float SpotManager_Distance_Calculations()
+    {
+        float totalDistance = 0f;
+        var random = new Random(42);
+
+        for (int i = 0; i < 1000; i++)
+        {
+            int idx1 = random.Next(testSpots.Count);
+            int idx2 = random.Next(testSpots.Count);
+
+            var dist = spotManager.GetDistance(testSpots[idx1], testSpots[idx2]);
+            totalDistance += dist;
+        }
+
+        return totalDistance;
+    }
+
+    /// <summary>
+    /// Benchmark: SearchBuffer allocation and reset (per-search overhead)
+    /// Measures pooling efficiency and array clearing performance
+    /// </summary>
+    [Benchmark]
+    public int SearchBuffer_Allocation_And_Reset()
+    {
+        int count = 0;
+
+        for (int search = 0; search < SearchCount; search++)
+        {
+            spotManager.InitializeSearch(search, testSpots[0]);
+            spotManager.CompleteSearch();
+            count++;
+        }
+
+        return count;
+    }
+
+    /// <summary>
+    /// Benchmark: Spot registration (eager registration via AddSpot)
+    /// Measures performance of registering spots when they're added to chunks
+    /// </summary>
+    [Benchmark]
+    public int SpotManager_Eager_Registration()
+    {
+        var random = new Random(123);
+        int registered = 0;
+
+        // Clear and re-register a subset of spots (simulates loading a chunk)
+        for (int i = 0; i < 500; i++)
+        {
+            int idx = random.Next(testSpots.Count);
+            var spot = testSpots[idx];
+
+            // Registration overhead is minimal since spot is already registered
+            // This measures the cost of the registration check
+            spotManager.RegisterSpot(spot, spot.Loc, spot.flags, dummyChunk);
+            registered++;
+        }
+
+        return registered;
+    }
+
+    /// <summary>
+    /// Benchmark: SpotManager flag operations (common in path evaluation)
+    /// Measures performance of bit flag checks on array data
+    /// </summary>
+    [Benchmark]
+    public int SpotManager_Flag_Operations()
+    {
+        int flaggedSpots = 0;
+
+        // Set water flag on random spots
+        var random = new Random(42);
+        for (int i = 0; i < 500; i++)
+        {
+            int idx = random.Next(testSpots.Count);
+            spotManager.SetFlag(testSpots[idx], Spot.FLAG_WATER, true);
+        }
+
+        // Count spots with water flag
+        foreach (var spot in testSpots)
+        {
+            if (spotManager.IsFlagSet(spot, Spot.FLAG_WATER))
+                flaggedSpots++;
+        }
+
+        return flaggedSpots;
+    }
+
+    /// <summary>
+    /// Benchmark: Path reconstruction (traceback following)
+    /// Simulates walking back through parent pointers to reconstruct path
+    /// </summary>
+    [Benchmark]
+    public int SpotManager_Path_Reconstruction()
+    {
+        int pathsReconstructed = 0;
+
+        // Create some parent relationships
+        spotManager.InitializeSearch(999, testSpots[0]);
+
+        var random = new Random(42);
+        for (int i = 1; i < 100; i++)
+        {
+            int childIdx = random.Next(1, Math.Min(i + 50, testSpots.Count));
+            int parentIdx = Math.Max(0, childIdx - 1);
+            spotManager.SetTraceBack(testSpots[childIdx], testSpots[parentIdx]);
+        }
+
+        // Trace back paths
+        for (int i = 50; i < 100; i++)
+        {
+            var spot = testSpots[i];
+            var current = spot;
+            int steps = 0;
+
+            while (current != null && steps < 100)
+            {
+                current = spotManager.GetTraceBack(current);
+                if (current == null) break;
+                steps++;
+            }
+
+            pathsReconstructed++;
+        }
+
+        spotManager.CompleteSearch();
+        return pathsReconstructed;
+    }
+
+    /// <summary>
+    /// Benchmark: Combined A* scoring operations
+    /// Simulates the tight loop in SpotManager's ScoreSpot method
+    /// </summary>
+    [Benchmark]
+    public float SpotManager_AStar_Scoring_Loop()
+    {
+        spotManager.InitializeSearch(888, testSpots[0]);
+
+        float totalScore = 0f;
+        var random = new Random(42);
+
+        for (int iteration = 0; iteration < 1000; iteration++)
+        {
+            int currentIdx = random.Next(testSpots.Count - 1);
+            int nextIdx = currentIdx + 1;
+
+            var current = testSpots[currentIdx];
+            var next = testSpots[nextIdx];
+
+            // Typical A* scoring operations
+            float gScore = spotManager.GetTraceBackDistance(current) +
+                          spotManager.GetDistance(current, next);
+            float hScore = spotManager.GetDistance2D(next, testSpots[0]);
+            float fScore = gScore + hScore;
+
+            if (!spotManager.SearchScoreIsSet(next) || fScore < spotManager.SearchScoreGet(next))
+            {
+                spotManager.SetTraceBack(next, current);
+                spotManager.SetTraceBackDistance(next, gScore);
+                spotManager.SearchScoreSet(next, fScore);
+                totalScore += fScore;
+            }
+        }
+
+        spotManager.CompleteSearch();
+        return totalScore;
+    }
+}

--- a/Core/GoalsComponent/Navigation.cs
+++ b/Core/GoalsComponent/Navigation.cs
@@ -47,7 +47,7 @@ public sealed partial class Navigation : IDisposable
     private float lastWorldDistance = float.MaxValue;
 
     private const float minAngleToTurn = PI / 35f;              // 5.14 degree
-    private const float minAngleToStopBeforeTurn = PI / 2f;     // 90 degree
+    private const float minAngleToStopBeforeTurn = PI / 3f;     // 60 degree
 
     private readonly Stack<Vector3> wayPoints = new();
     private readonly Stack<Vector3> routeToNextWaypoint = new();

--- a/PPather/Graph/GraphChunk.cs
+++ b/PPather/Graph/GraphChunk.cs
@@ -33,7 +33,10 @@ namespace PPather.Graph;
 
 public sealed class GraphChunk
 {
-    public const int CHUNK_SIZE = 256;
+    // MCNK-aligned chunk size: 33.33 yards = WoW's native MCNK chunk size
+    // Old value was 256 (65,536 spots), new value is 34 (1,156 spots) = 56× reduction!
+    // This aligns with WoW's ADT/MCNK structure for optimal memory usage
+    public const int CHUNK_SIZE = 34; // Rounded from 33.33 to nearest int
     public const int SIZE = CHUNK_SIZE * CHUNK_SIZE;
     private const bool saveEnabled = true;
 
@@ -45,6 +48,7 @@ public sealed class GraphChunk
     private readonly float base_x, base_y;
     private readonly string filePath;
     private readonly Spot[] spots = new Spot[SIZE];
+    private readonly SpotManager spotManager;
 
     public readonly int ix, iy;
     public bool modified;
@@ -65,7 +69,7 @@ public sealed class GraphChunk
     //     float y;
     //     float z;
 
-    public GraphChunk(float base_x, float base_y, int ix, int iy, ILogger logger, string baseDir)
+    public GraphChunk(float base_x, float base_y, int ix, int iy, ILogger logger, string baseDir, SpotManager spotManager = null)
     {
         this.logger = logger;
         this.base_x = base_x;
@@ -73,6 +77,8 @@ public sealed class GraphChunk
 
         this.ix = ix;
         this.iy = iy;
+
+        this.spotManager = spotManager;
 
         filePath = System.IO.Path.Join(baseDir, string.Format("c_{0,3:000}_{1,3:000}.bin", ix, iy));
     }
@@ -128,6 +134,11 @@ public sealed class GraphChunk
         spots[i] = s;
         modified = true;
         count++;
+
+        // Eagerly register spot with SpotManager to avoid lazy registration overhead during pathfinding
+        if (spotManager != null)
+            spotManager.RegisterSpot(s, s.Loc, s.flags, this);
+
         return s;
     }
 
@@ -192,15 +203,21 @@ public sealed class GraphChunk
                     continue;
                 }
 
-                Spot s = new(pos)
-                {
-                    flags = flags,
-                    n_paths = (int)n_paths,
-                    paths = new float[(int)n_paths * 3]
-                };
-                br.Read(MemoryMarshal.Cast<float, byte>(s.paths.AsSpan()));
-
+                Spot s = new(pos) { flags = flags };
                 _ = AddSpot(s);
+
+                // Load paths into SpotManager
+                if (n_paths > 0)
+                {
+                    float[] pathBuffer = new float[(int)n_paths * 3];
+                    br.Read(MemoryMarshal.Cast<float, byte>(pathBuffer.AsSpan()));
+
+                    for (int p = 0; p < n_paths; p++)
+                    {
+                        int offset = p * 3;
+                        spotManager.AddPathTo(s, pathBuffer[offset], pathBuffer[offset + 1], pathBuffer[offset + 2]);
+                    }
+                }
 
                 // After loading a Chunk mark it unmodified
                 modified = false;
@@ -243,14 +260,18 @@ public sealed class GraphChunk
                 bw.Write(s.Loc.X);
                 bw.Write(s.Loc.Y);
                 bw.Write(s.Loc.Z);
-                uint n_paths = (uint)s.n_paths;
+
+                // Read paths from SpotManager
+                uint n_paths = (uint)spotManager.GetPathCount(s);
                 bw.Write(n_paths);
                 for (uint i = 0; i < n_paths; i++)
                 {
-                    uint off = i * 3;
-                    bw.Write(s.paths[off]);
-                    bw.Write(s.paths[off + 1]);
-                    bw.Write(s.paths[off + 2]);
+                    if (spotManager.GetPath(s, (int)i, out float x, out float y, out float z))
+                    {
+                        bw.Write(x);
+                        bw.Write(y);
+                        bw.Write(z);
+                    }
                 }
                 n_spots++;
             }

--- a/PPather/Graph/PathGraph.cs
+++ b/PPather/Graph/PathGraph.cs
@@ -66,9 +66,13 @@ public sealed class PathGraph
     public const float StepPercent = 0.75f;
     public const float STEP_D = toonSize / 4f;
 
+    public const float WallAvoidanceDistance = 3.0f;
+
     public const float IsCloseToModelRange = toonSize * 2f;
 
-    public const float IsCloseToObjectRange = MinStepLength;
+    public const float IsCloseToObjectRange = MaxStepLength;
+
+    public const float CeilingCheckHeight = 20f;
 
     private const int COST_MOVE_THRU_WATER = 128 * 6;
 
@@ -87,35 +91,40 @@ public sealed class PathGraph
     private readonly SparseMatrix2D<GraphChunk> chunks;
     public readonly ChunkedTriangleCollection triangleWorld;
 
+    // Grid density for spot placement (configurable)
+    // Lower values = denser grid, more spots, better precision
+    // Higher values = sparser grid, fewer spots, faster pathfinding
+    // Default: WantedStepLength (1.2 units)
+    public const float SpotGridSize = WantedStepLength;
+
     private readonly HashSet<int> generatedChunks;
 
     private const int maxCache = 512;
     private long LRU;
 
+    // ==================== NEW: SpotManager for contiguous array storage ====================
+    // Manages all spot data in Structure-of-Arrays layout for cache efficiency
+    private readonly SpotManager spotManager;
+    public SpotManager SpotManager => spotManager;
+
     public int GetTriangleClosenessScore(Vector3 loc)
     {
         const TriangleType mask = TriangleType.Model | TriangleType.Object;
-
         const float ignoreStep = toonHeightHalf - stepDistance;
 
-        return !triangleWorld.IsCloseToType(loc.X, loc.Y, loc.Z + ignoreStep, 4 * WantedStepLength, mask)
-            ? 0
-            : !triangleWorld.IsCloseToType(loc.X, loc.Y, loc.Z + ignoreStep, 2 * WantedStepLength, mask)
-            ? 32
-            : !triangleWorld.IsCloseToType(loc.X, loc.Y, loc.Z + ignoreStep, 1 * WantedStepLength, mask)
-            ? 64
-            : 128;
+        float dist = triangleWorld.ClosestDistanceToType(
+            loc.X, loc.Y, loc.Z + ignoreStep, 7 * WantedStepLength, mask);
+
+        return dist >= 5 * WantedStepLength ? 0
+            : dist >= 4 * WantedStepLength ? 16
+            : dist >= 3 * WantedStepLength ? 64
+            : dist >= 2 * WantedStepLength ? 192
+            : 384;
     }
 
     public int GetTriangleGradiantScore(Vector3 loc, int gradiantMax)
     {
-        return triangleWorld.GradiantScore(loc.X, loc.Y, 1) > gradiantMax
-            ? 128
-            : triangleWorld.GradiantScore(loc.X, loc.Y, 2) > gradiantMax
-            ? 64
-            : triangleWorld.GradiantScore(loc.X, loc.Y, 3) > gradiantMax
-            ? 32
-            : 0;
+        return triangleWorld.GradiantScoreTiered(loc.X, loc.Y, gradiantMax);
     }
 
     public PathGraph(float mapId,
@@ -131,6 +140,7 @@ public sealed class PathGraph
             Directory.CreateDirectory(chunkDir);
 
         chunks = new SparseMatrix2D<GraphChunk>(8);
+        spotManager = new SpotManager(capacity: 50000);  // Estimated max spots
 
         //filePath = System.IO.Path.Join(baseDir, string.Format("c_{0,3:000}_{1,3:000}.bin", ix, iy));
         var files = Directory.GetFiles(chunkDir, "*.bin");
@@ -176,6 +186,17 @@ public sealed class PathGraph
     {
         bx = (float)ix * GraphChunk.CHUNK_SIZE - CHUNK_BASE;
         by = (float)iy * GraphChunk.CHUNK_SIZE - CHUNK_BASE;
+    }
+
+    /// <summary>
+    /// Snap coordinates to the configured grid for uniform spot placement.
+    /// This ensures spots are placed at predictable, evenly-spaced positions.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void SnapToGrid(float x, float y, out float snappedX, out float snappedY)
+    {
+        snappedX = Round(x / SpotGridSize) * SpotGridSize;
+        snappedY = Round(y / SpotGridSize) * SpotGridSize;
     }
 
     private bool GetChunkAt(float x, float y, [MaybeNullWhen(false)] out GraphChunk c)
@@ -233,7 +254,7 @@ public sealed class PathGraph
         GetChunkCoord(x, y, out int ix, out int iy);
         GetChunkBase(ix, iy, out float base_x, out float base_y);
 
-        gc = new GraphChunk(base_x, base_y, ix, iy, logger, chunkDir);
+        gc = new GraphChunk(base_x, base_y, ix, iy, logger, chunkDir, spotManager);
 
         int key = chunks.GetKey(ix, iy);
 
@@ -250,8 +271,14 @@ public sealed class PathGraph
 
     public Spot AddSpot(Spot s)
     {
+        // Snap spot coordinates to grid for uniform placement
+        SnapToGrid(s.Loc.X, s.Loc.Y, out float snappedX, out float snappedY);
+        s.Loc = new Vector3(snappedX, snappedY, s.Loc.Z);
+
         GraphChunk gc = LoadChunk(s.Loc.X, s.Loc.Y);
-        return gc.AddSpot(s);
+        var result = gc.AddSpot(s);
+
+        return result;
     }
 
     // Connect according to MPQ data
@@ -265,22 +292,38 @@ public sealed class PathGraph
 
         Vector3 avoidSmallBumps = new(0, 0, toonHeightHalf);
 
-        ReadOnlySpan<Spot> close = FindAllSpots(s, MaxStepLength);
-        for (int i = 0; i < close.Length; i++)
+        // Grid-based connectivity: only connect to the 8 immediate grid neighbors
+        // This prevents long-distance shortcuts and maintains uniform pathfinding
+        ReadOnlySpan<(int dx, int dy)> neighborOffsets =
+        [
+            (-1, 0), (1, 0), (0, -1), (0, 1),      // Cardinal: W, E, S, N
+            (-1, -1), (-1, 1), (1, -1), (1, 1)     // Diagonal: SW, NW, SE, NE
+        ];
+
+        foreach (var (dx, dy) in neighborOffsets)
         {
-            Spot cs = close[i];
-            if (s == cs)
+            // Calculate grid neighbor position
+            float nx = s.Loc.X + (dx * SpotGridSize);
+            float ny = s.Loc.Y + (dy * SpotGridSize);
+
+            // Try to find spot at this grid position (with Z tolerance for terrain following)
+            Spot neighbor = GetSpot2D(nx, ny);
+
+            if (neighbor == null || neighbor == s)
                 continue;
 
-            if (cs.IsBlocked() || s.IsBlocked() || (cs.HasPathTo(this, s) && s.HasPathTo(this, cs)))
+            // Skip if either spot is blocked or already connected
+            if (neighbor.IsBlocked() || s.IsBlocked() ||
+                (spotManager.HasPathTo(s, neighbor) && spotManager.HasPathTo(neighbor, s)))
             {
                 continue;
             }
 
-            if (triangleWorld.LineOfSightExists(s.Loc + avoidSmallBumps, cs.Loc + avoidSmallBumps))
+            // Verify line-of-sight before connecting
+            if (triangleWorld.LineOfSightExists(s.Loc + avoidSmallBumps, neighbor.Loc + avoidSmallBumps))
             {
-                s.AddPathTo(cs);
-                cs.AddPathTo(s);
+                spotManager.AddPathTo(s, neighbor);
+                spotManager.AddPathTo(neighbor, s);
             }
         }
         return s;
@@ -424,21 +467,39 @@ public sealed class PathGraph
             }
             if (wasAt != null)
             {
-                wasAt.AddPathTo(isAtSpot);
-                isAtSpot.AddPathTo(wasAt);
+                // Only connect if wasAt is a grid neighbor (not a long-distance movement)
+                float distance = Vector3.Distance(wasAt.Loc, isAtSpot.Loc);
+                if (distance <= SpotGridSize * 1.5f) // Allow up to 1.5x for diagonal
+                {
+                    spotManager.AddPathTo(wasAt, isAtSpot);
+                    spotManager.AddPathTo(isAtSpot, wasAt);
+                }
             }
 
-            ReadOnlySpan<Spot> sl = FindAllSpots(isAtSpot, MaxStepLength);
+            // Grid-based connectivity: connect to 8 grid neighbors only
+            ReadOnlySpan<(int dx, int dy)> neighborOffsets =
+            [
+                (-1, 0), (1, 0), (0, -1), (0, 1),
+                (-1, -1), (-1, 1), (1, -1), (1, 1)
+            ];
+
             int connected = 0;
-            for (int i = 0; i < sl.Length; i++)
+            foreach (var (dx, dy) in neighborOffsets)
             {
-                Spot other = sl[i];
-                if (other != isAtSpot)
+                float nx = isAtSpot.Loc.X + (dx * SpotGridSize);
+                float ny = isAtSpot.Loc.Y + (dy * SpotGridSize);
+
+                Spot neighbor = GetSpot2D(nx, ny);
+                if (neighbor != null && neighbor != isAtSpot && !neighbor.IsBlocked())
                 {
-                    other.AddPathTo(isAtSpot);
-                    isAtSpot.AddPathTo(other);
-                    connected++;
-                    // Log("  connect to " + other.location);
+                    // Check elevation difference
+                    float elevationDiff = MathF.Abs(isAtSpot.Loc.Z - neighbor.Loc.Z);
+                    if (elevationDiff <= MaxStepLength)
+                    {
+                        spotManager.AddPathTo(neighbor, isAtSpot);
+                        spotManager.AddPathTo(isAtSpot, neighbor);
+                        connected++;
+                    }
                 }
             }
             if (logger.IsEnabled(LogLevel.Debug))
@@ -450,8 +511,13 @@ public sealed class PathGraph
             if (wasAt != null && wasAt != isAtSpot)
             {
                 // moved to an old spot, make sure they are connected
-                wasAt.AddPathTo(isAtSpot);
-                isAtSpot.AddPathTo(wasAt);
+                // Only connect if it's a grid neighbor (not a long-distance movement)
+                float distance = Vector3.Distance(wasAt.Loc, isAtSpot.Loc);
+                if (distance <= SpotGridSize * 1.5f) // Allow up to 1.5x for diagonal
+                {
+                    spotManager.AddPathTo(wasAt, isAtSpot);
+                    spotManager.AddPathTo(isAtSpot, wasAt);
+                }
             }
             wasAt = isAtSpot;
         }
@@ -490,13 +556,14 @@ public sealed class PathGraph
     public Spot currentSearchStartSpot;
     public Spot currentSearchSpot;
 
-    private static float TurnCost(Spot from, Spot to)
+    // NEW: Updated to use SpotManager for traceback queries
+    private float TurnCost(Spot from, Spot to)
     {
-        if (from.traceBack == null)
+        Spot prev = spotManager.GetTraceBack(from);
+        if (prev == null)
             return 0.0f;
 
-        Spot prev = from.traceBack;
-        return TurnCost(prev.Loc, from.Loc, to.Loc);
+        return TurnCost(spotManager.GetLocation(prev), spotManager.GetLocation(from), spotManager.GetLocation(to));
     }
 
     private static float TurnCost(Vector3 p0, Vector3 p1, Vector3 p2)
@@ -540,13 +607,14 @@ public sealed class PathGraph
         int currentSearchID = searchID;
         //searchProgress = new SearchProgress(fromSpot, destinationSpot, searchID);
 
+        // Initialize SpotManager search (allocates SearchBuffer from pool)
+        // NOTE: Caller (CreatePath) is responsible for calling CompleteSearch() after path reconstruction
+        spotManager.InitializeSearch(currentSearchID, fromSpot);
+
         // lowest first queue
         PriorityQueue<Spot, float> prioritySpotQueue = new();
-        prioritySpotQueue.Enqueue(fromSpot, fromSpot.GetDistanceTo(destinationSpot) * heuristicsFactor);
-
-        fromSpot.SearchScoreSet(currentSearchID, 0.0f);
-        fromSpot.traceBack = null;
-        fromSpot.traceBackDistance = 0;
+        // Use SpotManager for distance calculation
+        prioritySpotQueue.Enqueue(fromSpot, spotManager.GetDistance(fromSpot, destinationSpot) * heuristicsFactor);
 
         // A* -ish algorithm
         while (prioritySpotQueue.TryDequeue(out currentSearchSpot, out _))
@@ -554,22 +622,25 @@ public sealed class PathGraph
             //if (sleepMSBetweenSpots > 0) { Thread.Sleep(sleepMSBetweenSpots); } // slow down the pathing
 
             // force the world to be loaded
-            _ = triangleWorld.GetChunkAt(currentSearchSpot.Loc.X, currentSearchSpot.Loc.Y);
+            // Use SpotManager to get location
+            Vector3 currentLoc = spotManager.GetLocation(currentSearchSpot);
+            _ = triangleWorld.GetChunkAt(currentLoc.X, currentLoc.Y);
 
-            if (currentSearchSpot.SearchIsClosed(currentSearchID))
+            // Use SpotManager for search state checks
+            if (spotManager.SearchIsClosed(currentSearchSpot))
             {
                 continue;
             }
-            currentSearchSpot.SearchClose(currentSearchID);
+            spotManager.SearchClose(currentSearchSpot);
 
             //update status
             //if (!searchProgress.CheckProgress(currentSearchSpot)) { break; }
 
             // are we there?
 
-            //float distance = currentSearchSpot.location.GetDistanceTo(destinationSpot.location);
-            float distance = Vector3.Distance(currentSearchSpot.Loc, destinationSpot.Loc);
-            float distance2D = Vector2.Distance(currentSearchSpot.Loc.AsVector2(), destinationSpot.Loc.AsVector2());
+            // Use SpotManager for distance calculations
+            float distance = spotManager.GetDistance(currentSearchSpot, destinationSpot);
+            float distance2D = spotManager.GetDistance2D(currentSearchSpot, destinationSpot);
 
             if (distance <= minHowClose || (distance2D <= minHowClose / 2f))
             {
@@ -594,17 +665,21 @@ public sealed class PathGraph
             }
 
             //Find spots to link to
+            long buildStart = GetTimestamp();
             CreateSpotsAroundSpot(currentSearchSpot, destinationSpot);
+            spotManager.AddBuildTicks(GetTimestamp() - buildStart);
 
             //score each spot around the current search spot and add them to the queue
-            ReadOnlySpan<Spot> spots = currentSearchSpot.GetPathsToSpots(this);
+            ReadOnlySpan<Spot> spots = spotManager.GetPathsToSpots(currentSearchSpot, this);
 
             for (int i = 0; i < spots.Length; i++)
             {
                 Spot linked = spots[i];
-                if (linked != null && !linked.IsBlocked() && !linked.SearchIsClosed(currentSearchID))
+                // Use SpotManager for flag and search state checks
+                if (linked != null && !spotManager.IsFlagSet(linked, Spot.FLAG_BLOCKED) && !spotManager.SearchIsClosed(linked))
                 {
-                    TestPoints.Add(linked.Loc);
+                    // Use SpotManager to get location
+                    TestPoints.Add(spotManager.GetLocation(linked));
 
                     ScoreSpot(linked, destinationSpot, searchScoreSpot, currentSearchID, prioritySpotQueue);
                 }
@@ -645,53 +720,79 @@ public sealed class PathGraph
     public void ScoreSpot_A_Star(Spot spotLinkedToCurrent, Spot destinationSpot, int currentSearchID, PriorityQueue<Spot, float> prioritySpotQueue)
     {
         //score spot
-        float G_Score = currentSearchSpot.traceBackDistance + currentSearchSpot.GetDistanceTo(spotLinkedToCurrent);//  the movement cost to move from the starting point A to a given square on the grid, following the path generated to get there.
-        float H_Score = spotLinkedToCurrent.GetDistanceTo2D(destinationSpot) * heuristicsFactor;// the estimated movement cost to move from that given square on the grid to the final destination, point B. This is often referred to as the heuristic, which can be a bit confusing. The reason why it is called that is because it is a guess. We really don�t know the actual distance until we find the path, because all sorts of things can be in the way (walls, water, etc.). You are given one way to calculate H in this tutorial, but there are many others that you can find in other articles on the web.
+        // NEW: Use SpotManager for distance and state queries
+        float G_Score = spotManager.GetTraceBackDistance(currentSearchSpot) + spotManager.GetDistance(currentSearchSpot, spotLinkedToCurrent);//  the movement cost to move from the starting point A to a given square on the grid, following the path generated to get there.
+        float H_Score = spotManager.GetDistance2D(spotLinkedToCurrent, destinationSpot) * heuristicsFactor;// the estimated movement cost to move from that given square on the grid to the final destination, point B. This is often referred to as the heuristic, which can be a bit confusing. The reason why it is called that is because it is a guess. We really don't know the actual distance until we find the path, because all sorts of things can be in the way (walls, water, etc.). You are given one way to calculate H in this tutorial, but there are many others that you can find in other articles on the web.
         float F_Score = G_Score + H_Score;
 
-        if (spotLinkedToCurrent.IsFlagSet(Spot.FLAG_WATER)) { F_Score += COST_MOVE_THRU_WATER; }
+        if (spotManager.IsFlagSet(spotLinkedToCurrent, Spot.FLAG_WATER)) { F_Score += COST_MOVE_THRU_WATER; }
 
-        if (!spotLinkedToCurrent.SearchScoreIsSet(currentSearchID) || F_Score < spotLinkedToCurrent.SearchScoreGet(currentSearchID))
+        // NEW: Use SpotManager for search state management
+        if (!spotManager.SearchScoreIsSet(spotLinkedToCurrent) || F_Score < spotManager.SearchScoreGet(spotLinkedToCurrent))
         {
             // shorter path to here found
-            spotLinkedToCurrent.traceBack = currentSearchSpot;
-            spotLinkedToCurrent.traceBackDistance = G_Score;
-            spotLinkedToCurrent.SearchScoreSet(currentSearchID, F_Score);
+            spotManager.SetTraceBack(spotLinkedToCurrent, currentSearchSpot);
+            spotManager.SetTraceBackDistance(spotLinkedToCurrent, G_Score);
+            spotManager.SearchScoreSet(spotLinkedToCurrent, F_Score);
             prioritySpotQueue.Enqueue(spotLinkedToCurrent, F_Score);
         }
     }
 
     public void ScoreSpot_A_Star_With_Model_And_Gradient_Avoidance(Spot spotLinkedToCurrent, Spot destinationSpot, int currentSearchID, PriorityQueue<Spot, float> prioritySpotQueue)
     {
-        //score spot
         //  the movement cost to move from the starting point A to a given square on the grid, following the path generated to get there.
-        float G_Score = currentSearchSpot.traceBackDistance + currentSearchSpot.GetDistanceTo(spotLinkedToCurrent);
+        float G_Score = spotManager.GetTraceBackDistance(currentSearchSpot) + spotManager.GetDistance(currentSearchSpot, spotLinkedToCurrent);
         // the estimated movement cost to move from that given square on the grid to the final destination, point B.
-        // This is often referred to as the heuristic, which can be a bit confusing.
-        // The reason why it is called that is because it is a guess.
-        // We really dont know the actual distance until we find the path,
-        // because all sorts of things can be in the way (walls, water, etc.).
-        // You are given one way to calculate H in this tutorial, but there are many others that you can find in other articles on the web.
-        float H_Score = spotLinkedToCurrent.GetDistanceTo2D(destinationSpot) * heuristicsFactor;
+        float H_Score = spotManager.GetDistance2D(spotLinkedToCurrent, destinationSpot) * heuristicsFactor;
         float F_Score = G_Score + H_Score;
 
-        if (spotLinkedToCurrent.IsFlagSet(Spot.FLAG_WATER)) { F_Score += COST_MOVE_THRU_WATER; }
+        if (spotManager.IsFlagSet(spotLinkedToCurrent, Spot.FLAG_WATER)) { F_Score += COST_MOVE_THRU_WATER; }
 
-        int score = GetTriangleClosenessScore(spotLinkedToCurrent.Loc);
+        if (!spotManager.TryGetCachedTriangleScore(spotLinkedToCurrent, out int score))
+        {
+            bool skipCloseness = spotManager.IsFlagSet(spotLinkedToCurrent, Spot.FLAG_ON_OBJECT)
+                && !spotManager.IsFlagSet(spotLinkedToCurrent, Spot.FLAG_INDOORS);
 
-        // Edges have less neighbours
-        //int neighbourCount = GetNeighborCount(spotLinkedToCurrent);
-        //F_Score += Min(0, 50 * (8 - neighbourCount));
+            if (skipCloseness)
+            {
+                // Skip closeness penalty for outdoor object surfaces (bridges, ramps)
+                // Indoor corridors (FLAG_ON_OBJECT + FLAG_INDOORS) still get scored
+                // Still need gradient score
+                Vector3 loc = spotManager.GetLocation(spotLinkedToCurrent);
+                score = triangleWorld.GradiantScoreTiered(loc.X, loc.Y, gradiantMax);
+            }
+            else
+            {
+                // Combined single-pass: closeness + gradient scoring
+                Vector3 loc = spotManager.GetLocation(spotLinkedToCurrent);
+                const float ignoreStep = toonHeightHalf - stepDistance;
+                const float closenessRange = 7 * WantedStepLength;
+                const TriangleType closenessMask = TriangleType.Model | TriangleType.Object;
 
-        score += GetTriangleGradiantScore(spotLinkedToCurrent.Loc, gradiantMax);
+                (float dist, int gradientScore) = triangleWorld.CombinedScoring(
+                    loc.X, loc.Y, loc.Z + ignoreStep,
+                    closenessRange, closenessMask, gradiantMax);
+
+                const float closenessMax = 384;
+                const float scoringRange = 5 * WantedStepLength;
+                int closenessScore = dist >= scoringRange
+                    ? 0
+                    : (int)(closenessMax * (1f - dist / scoringRange));
+
+                score = closenessScore + gradientScore;
+            }
+
+            spotManager.SetCachedTriangleScore(spotLinkedToCurrent, score);
+        }
+
         F_Score += score * 2;
 
-        if (!spotLinkedToCurrent.SearchScoreIsSet(currentSearchID) || F_Score < spotLinkedToCurrent.SearchScoreGet(currentSearchID))
+        if (!spotManager.SearchScoreIsSet(spotLinkedToCurrent) || F_Score < spotManager.SearchScoreGet(spotLinkedToCurrent))
         {
             // shorter path to here found
-            spotLinkedToCurrent.traceBack = currentSearchSpot;
-            spotLinkedToCurrent.traceBackDistance = G_Score;
-            spotLinkedToCurrent.SearchScoreSet(currentSearchID, F_Score);
+            spotManager.SetTraceBack(spotLinkedToCurrent, currentSearchSpot);
+            spotManager.SetTraceBackDistance(spotLinkedToCurrent, G_Score);
+            spotManager.SearchScoreSet(spotLinkedToCurrent, F_Score);
             prioritySpotQueue.Enqueue(spotLinkedToCurrent, F_Score);
         }
     }
@@ -699,23 +800,25 @@ public sealed class PathGraph
     public void ScoreSpot_Pather(Spot spotLinkedToCurrent, Spot destinationSpot, int currentSearchID, PriorityQueue<Spot, float> prioritySpotQueue)
     {
         //score spots
-        float currentSearchSpotScore = currentSearchSpot.SearchScoreGet(currentSearchID);
+        // NEW: Use SpotManager for state queries
+        float currentSearchSpotScore = spotManager.SearchScoreGet(currentSearchSpot);
         float linkedSpotScore = 1E30f;
-        float new_score = currentSearchSpotScore + currentSearchSpot.GetDistanceTo(spotLinkedToCurrent) + TurnCost(currentSearchSpot, spotLinkedToCurrent);
+        float new_score = currentSearchSpotScore + spotManager.GetDistance(currentSearchSpot, spotLinkedToCurrent) + TurnCost(currentSearchSpot, spotLinkedToCurrent);
 
-        if (spotLinkedToCurrent.IsFlagSet(Spot.FLAG_WATER)) { new_score += COST_MOVE_THRU_WATER; }
+        if (spotManager.IsFlagSet(spotLinkedToCurrent, Spot.FLAG_WATER)) { new_score += COST_MOVE_THRU_WATER; }
 
-        if (spotLinkedToCurrent.SearchScoreIsSet(currentSearchID))
+        if (spotManager.SearchScoreIsSet(spotLinkedToCurrent))
         {
-            linkedSpotScore = spotLinkedToCurrent.SearchScoreGet(currentSearchID);
+            linkedSpotScore = spotManager.SearchScoreGet(spotLinkedToCurrent);
         }
 
         if (new_score < linkedSpotScore)
         {
             // shorter path to here found
-            spotLinkedToCurrent.traceBack = currentSearchSpot;
-            spotLinkedToCurrent.SearchScoreSet(currentSearchID, new_score);
-            prioritySpotQueue.Enqueue(spotLinkedToCurrent, (new_score + spotLinkedToCurrent.GetDistanceTo(destinationSpot) * heuristicsFactor));
+            // NEW: Use SpotManager for state management
+            spotManager.SetTraceBack(spotLinkedToCurrent, currentSearchSpot);
+            spotManager.SearchScoreSet(spotLinkedToCurrent, new_score);
+            prioritySpotQueue.Enqueue(spotLinkedToCurrent, (new_score + spotManager.GetDistance(spotLinkedToCurrent, destinationSpot) * heuristicsFactor));
         }
     }
 
@@ -736,31 +839,28 @@ public sealed class PathGraph
 
         Vector3 loc = current.Loc;
 
-        //Vector3 target = destination.Loc;
+        // Snap current location to grid for uniform sampling
+        SnapToGrid(loc.X, loc.Y, out float gridX, out float gridY);
 
-        // Calculate the initial angle based on the facing direction
-        //float initialAngle = Atan2(target.Y - loc.Y, target.X - loc.X);
+        // Grid-based neighbor offsets: 8 directions (cardinal + diagonal)
+        // Using grid spacing for uniform, predictable spot placement
+        ReadOnlySpan<(int dx, int dy)> neighborOffsets =
+        [
+            (-1, 0), (1, 0), (0, -1), (0, 1),      // Cardinal: West, East, South, North
+            (-1, -1), (-1, 1), (1, -1), (1, 1)     // Diagonal: SW, NW, SE, NE
+        ];
 
-        // Loop through the spots in a circle around the current search spot, starting from the facing direction
-        //for (float radianAngle = initialAngle; radianAngle < initialAngle + Tau; radianAngle += PI / 8) // 4
-        for (float radianAngle = 0; radianAngle < Tau; radianAngle += PI / 8) // 4
+        bool currentOnObject = current.IsFlagSet(Spot.FLAG_ON_OBJECT);
+        bool currentOnWater = current.IsFlagSet(Spot.FLAG_WATER);
+
+        foreach (var (dx, dy) in neighborOffsets)
         {
-            //calculate the location of the spot at the angle
-            float nx = loc.X + (Sin(radianAngle) * WantedStepLength);
-            float ny = loc.Y + (Cos(radianAngle) * WantedStepLength);
+            // Calculate grid-aligned neighbor position
+            float nx = gridX + (dx * SpotGridSize);
+            float ny = gridY + (dy * SpotGridSize);
 
-            PeekSpot = new Spot(nx, ny, loc.Z);
-            if (DelayMs > 0)
-                Thread.Sleep(DelayMs / 2);
-
-            //find the spot at this location, stop if there is one already
+            // Quick check: spot already exists at this exact grid position (cheap hash lookup)
             if (GetSpot(nx, ny, loc.Z) != null)
-            {
-                continue;
-            }
-
-            //see if there is a close spot, stop if there is
-            if (FindClosestSpot(PeekSpot.Loc, WantedStepLength) != null) //MinStepLength
             {
                 continue;
             }
@@ -771,32 +871,46 @@ public sealed class PathGraph
                 loc.Z + MaxStepLength,
                 out float new_Z, out TriangleType flags, toonHeight, toonSize))
             {
-                loc.Z = new_Z;
-                Spot blockedSpot = new(loc);
+                Vector3 blockedLoc = new(nx, ny, new_Z);
+                Spot blockedSpot = new(blockedLoc);
                 blockedSpot.SetFlag(Spot.FLAG_BLOCKED, true);
                 AddSpot(blockedSpot);
 
-                BlockedPoints.Add(loc);
+                BlockedPoints.Add(blockedLoc);
                 continue;
             }
 
-            loc.Z = new_Z;
+            // LoS check against Object/Model geometry only (not Terrain/Water)
+            // Prevents paths through walls, tree trunks, and under bridges
+            // while still allowing normal terrain slopes.
+            // Skip when stepping onto an Object/Model surface (bridge, ramp) —
+            // the walkable surface's own triangles would falsely block the ray.
+            Vector3 neighborLoc = new(nx, ny, new_Z);
+            Vector3 avoidSmallBumps = new(0, 0, toonHeightHalf);
+
+            if (!currentOnObject && !currentOnWater &&
+                !flags.Has(TriangleType.Object | TriangleType.Model) &&
+                !triangleWorld.LineOfSightExists(loc + avoidSmallBumps, neighborLoc + avoidSmallBumps,
+                TriangleType.Object | TriangleType.Model))
+            {
+                continue;
+            }
+
+            PeekSpot = new Spot(nx, ny, new_Z);
+            if (DelayMs > 0)
+                Thread.Sleep(DelayMs / 2);
 
             const float ignoreStep = toonHeightHalf - stepDistance; //toonHeightQuad;
 
-            if (IsCloseToObjectRange > 0 &&
-                triangleWorld.IsCloseToType(nx, ny, loc.Z + ignoreStep, WantedStepLength, TriangleType.Object | TriangleType.Model))
+            if (!currentOnObject && !currentOnWater &&
+                !flags.Has(TriangleType.Object | TriangleType.Model) &&
+                IsCloseToObjectRange > 0 &&
+                triangleWorld.IsCloseToType(nx, ny, new_Z + ignoreStep, IsCloseToObjectRange, TriangleType.Object | TriangleType.Model))
             {
-                //loc.Z += toonHeightQuad;
-                Spot blockedSpot = new(loc);
-                blockedSpot.SetFlag(Spot.FLAG_BLOCKED, true);
-                AddSpot(blockedSpot);
-
-                BlockedPoints.Add(loc);
                 continue;
             }
 
-            var tempSpot = new Spot(nx, ny, loc.Z);
+            var tempSpot = new Spot(nx, ny, new_Z);
             if (flags.Has(TriangleType.Water))
             {
                 tempSpot.SetFlag(Spot.FLAG_WATER, true);
@@ -804,7 +918,16 @@ public sealed class PathGraph
 
             if (flags.Has(TriangleType.Object))
             {
-                tempSpot.SetFlag(Spot.FLAG_INDOORS, true);
+                tempSpot.SetFlag(Spot.FLAG_ON_OBJECT, true);
+
+                // Standing on Object geometry — raycast up to distinguish
+                // bridge (open sky) from building interior (ceiling above)
+                Vector3 head = new(nx, ny, new_Z + toonHeight);
+                Vector3 sky = new(nx, ny, new_Z + CeilingCheckHeight);
+                if (!triangleWorld.LineOfSightExists(head, sky, TriangleType.Object | TriangleType.Model))
+                {
+                    tempSpot.SetFlag(Spot.FLAG_INDOORS, true);
+                }
             }
 
             Spot newSpot = AddAndConnectSpot(tempSpot);
@@ -826,24 +949,37 @@ public sealed class PathGraph
         return FollowTraceBackLocations(currentSearchStartSpot, currentSearchSpot);
     }
 
-    private static List<Spot> FollowTraceBack(Spot from, Spot to)
+    // NEW: Updated to use SpotManager for traceback
+    private List<Spot> FollowTraceBack(Spot from, Spot to)
     {
         List<Spot> path = [];
-        for (Spot backtrack = to; backtrack != null; backtrack = backtrack.traceBack)
+        Spot prev = null;
+        for (Spot backtrack = to; backtrack != null; backtrack = spotManager.GetTraceBack(backtrack))
         {
+            if (prev != null)
+            {
+                float dist = spotManager.GetDistance(prev, backtrack);
+                if (dist > MaxStepLength * 3)
+                {
+                    logger.LogWarning("Traceback gap detected: {Distance:F1} units between spots at {PrevLoc} and {BacktrackLoc}",
+                        dist, spotManager.GetLocation(prev), spotManager.GetLocation(backtrack));
+                }
+            }
             path.Insert(0, backtrack);
+            prev = backtrack;
             if (backtrack == from)
                 break;
         }
         return path;
     }
 
-    private static List<Vector3> FollowTraceBackLocations(Spot from, Spot to)
+    // NEW: Updated to use SpotManager for traceback and location queries
+    private List<Vector3> FollowTraceBackLocations(Spot from, Spot to)
     {
         List<Vector3> path = [];
-        for (Spot backtrack = to; backtrack != null; backtrack = backtrack.traceBack)
+        for (Spot backtrack = to; backtrack != null; backtrack = spotManager.GetTraceBack(backtrack))
         {
-            path.Insert(0, backtrack.Loc);
+            path.Insert(0, spotManager.GetLocation(backtrack));
             if (backtrack == from)
                 break;
         }
@@ -853,18 +989,26 @@ public sealed class PathGraph
     private Path CreatePath(Spot from, Spot to, SearchStrategy searchScoreSpot, float minHowClose)
     {
         Spot newTo = Search(from, to, searchScoreSpot, minHowClose);
-        if (newTo == null)
-            return null;
-
-        float distance = newTo.GetDistanceTo(to);
-        if (distance <= MaximumAllowedRangeFromTarget)
+        try
         {
-            List<Spot> path = FollowTraceBack(from, newTo);
-            return new Path(path);
-        }
+            if (newTo == null)
+                return null;
 
-        logger.LogWarning("Closest spot is too far from target. {Distance}>{MaxAllowedRange}", distance, MaximumAllowedRangeFromTarget);
-        return null;
+            // Use SpotManager for distance calculation
+            float distance = spotManager.GetDistance(newTo, to);
+            if (distance <= MaximumAllowedRangeFromTarget)
+            {
+                List<Spot> path = FollowTraceBack(from, newTo);
+                return new Path(path);
+            }
+
+            logger.LogWarning("Closest spot is too far from target. {Distance}>{MaxAllowedRange}", distance, MaximumAllowedRangeFromTarget);
+            return null;
+        }
+        finally
+        {
+            spotManager.CompleteSearch();
+        }
     }
 
     private Vector3 GetBestLocations(Vector3 location)
@@ -905,6 +1049,113 @@ public sealed class PathGraph
         return new(location.X, location.Y, newZ);
     }
 
+    private void ApplyWallRepulsion(List<Vector3> locations)
+    {
+        const TriangleType wallMask = TriangleType.Model | TriangleType.Object;
+        const float ignoreStep = toonHeightHalf - stepDistance;
+
+        // Two passes: second pass catches waypoints whose neighbors weren't yet repelled
+        for (int pass = 0; pass < 2; pass++)
+        {
+            // Skip first and last waypoints to preserve endpoints
+            for (int i = 1; i < locations.Count - 1; i++)
+            {
+                Vector3 wp = locations[i];
+
+                // Outdoor Object surfaces (bridges, ramps): no walls to repel from,
+                // but edges can be dangerous drop-offs. Probe 8 directions for drops
+                // and push waypoint toward center of the walkable surface.
+                // Indoor corridors (ceiling blocks sky raycast) use normal wall repulsion.
+                if (triangleWorld.FindStandableAt(wp.X, wp.Y,
+                    wp.Z - toonHeight, wp.Z + toonHeight,
+                    out _, out TriangleType standFlags, toonHeight, toonSize) &&
+                    standFlags.Has(TriangleType.Object))
+                {
+                    Vector3 head = new(wp.X, wp.Y, wp.Z + toonHeight);
+                    Vector3 sky = new(wp.X, wp.Y, wp.Z + CeilingCheckHeight);
+                    if (triangleWorld.LineOfSightExists(head, sky, TriangleType.Object | TriangleType.Model))
+                    {
+                        // Edge repulsion: probe 8 directions for drop-offs
+                        const float probeDistance = 1.5f;
+                        const float dropThreshold = MinStepLength;
+                        const float edgePushDistance = 1.0f;
+
+                        float repX = 0, repY = 0;
+                        int edgeCount = 0;
+
+                        for (int d = 0; d < 8; d++)
+                        {
+                            float angle = d * (MathF.PI / 4f);
+                            float probeX = wp.X + MathF.Cos(angle) * probeDistance;
+                            float probeY = wp.Y + MathF.Sin(angle) * probeDistance;
+
+                            bool hasGround = triangleWorld.FindStandableAt(
+                                probeX, probeY,
+                                wp.Z - MaxStepLength, wp.Z + MaxStepLength,
+                                out float probeZ, out _, toonHeight, toonSize);
+
+                            if (!hasGround || (wp.Z - probeZ) > dropThreshold)
+                            {
+                                repX -= MathF.Cos(angle);
+                                repY -= MathF.Sin(angle);
+                                edgeCount++;
+                            }
+                        }
+
+                        if (edgeCount > 0)
+                        {
+                            float len = MathF.Sqrt(repX * repX + repY * repY);
+                            if (len > 0.001f)
+                            {
+                                repX /= len;
+                                repY /= len;
+
+                                float edgeX = wp.X + repX * edgePushDistance;
+                                float edgeY = wp.Y + repY * edgePushDistance;
+
+                                if (triangleWorld.FindStandableAt(
+                                    edgeX, edgeY,
+                                    wp.Z - MaxStepLength, wp.Z + MaxStepLength,
+                                    out float edgeZ, out _, toonHeight, toonSize))
+                                {
+                                    locations[i] = new(edgeX, edgeY, edgeZ);
+                                }
+                            }
+                        }
+
+                        continue;
+                    }
+                }
+
+                if (!triangleWorld.TryGetWallRepulsion(
+                    wp.X, wp.Y, wp.Z + ignoreStep,
+                    WallAvoidanceDistance, wallMask,
+                    out Vector3 repulsionDir, out float wallDistance))
+                {
+                    continue;
+                }
+
+                // Push away from wall: offset = direction * (desired - actual)
+                float pushAmount = WallAvoidanceDistance - wallDistance;
+                if (pushAmount <= 0)
+                    continue;
+
+                float newX = wp.X + repulsionDir.X * pushAmount;
+                float newY = wp.Y + repulsionDir.Y * pushAmount;
+
+                // Validate: must be walkable
+                if (!triangleWorld.FindStandableAt(newX, newY,
+                    wp.Z - MaxStepLength, wp.Z + MaxStepLength,
+                    out float newZ, out _, toonHeight, toonSize))
+                {
+                    continue;
+                }
+
+                locations[i] = new(newX, newY, newZ);
+            }
+        }
+    }
+
     public Path CreatePath(Vector3 fromLoc, Vector3 toLoc, SearchStrategy searchScoreSpot, float howClose)
     {
         if (logger.IsEnabled(LogLevel.Trace))
@@ -918,8 +1169,20 @@ public sealed class PathGraph
         Spot from = FindClosestSpot(fromLoc, MinStepLength);
         Spot to = FindClosestSpot(toLoc, MinStepLength);
 
-        from ??= AddAndConnectSpot(new Spot(fromLoc));
-        to ??= AddAndConnectSpot(new Spot(toLoc));
+        // If spots don't exist, create them and ensure grid connectivity
+        if (from == null)
+        {
+            from = AddAndConnectSpot(new Spot(fromLoc));
+            // Create neighbors to integrate into grid (respects FLAG_MPQ_MAPPED)
+            CreateSpotsAroundSpot(from, to ?? new Spot(toLoc));
+        }
+
+        if (to == null)
+        {
+            to = AddAndConnectSpot(new Spot(toLoc));
+            // Create neighbors to integrate into grid (respects FLAG_MPQ_MAPPED)
+            CreateSpotsAroundSpot(to, from);
+        }
 
         Path rawPath = CreatePath(from, to, searchScoreSpot, howClose);
 
@@ -938,6 +1201,12 @@ public sealed class PathGraph
                 rawPath.Add(toLoc);
             }
         }
+
+        if (searchScoreSpot == SearchStrategy.A_Star_With_Model_Avoidance)
+        {
+            ApplyWallRepulsion(rawPath.locations);
+        }
+
         return rawPath;
     }
 }

--- a/PPather/Graph/SearchBuffer.cs
+++ b/PPather/Graph/SearchBuffer.cs
@@ -1,0 +1,287 @@
+/*
+  This file is part of ppather.
+
+    PPather is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    PPather is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with ppather.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace PPather.Graph;
+
+/// <summary>
+/// Pooled search state buffer for A* pathfinding.
+///
+/// Design:
+/// - Allocated once per search, then returned to pool for reuse
+/// - Organized as arrays for cache-friendly sequential access
+/// - Each array element corresponds to a spot index
+///
+/// This avoids:
+/// - Allocating search state on each spot (70+ bytes × 10k spots)
+/// - Scattering search data across memory
+/// - Object allocation overhead per search
+///
+/// Instead provides:
+/// - One contiguous buffer per active search (~180 KB for 10k spots)
+/// - Reused buffer pool (same buffer used for multiple searches)
+/// - Tight memory layout for L1/L2 cache efficiency
+/// </summary>
+public class SearchBuffer
+{
+    // ==================== POOLING ====================
+
+    private static readonly ConcurrentStack<SearchBuffer> Pool = new();
+
+    /// <summary>
+    /// Get or create a search buffer from the pool
+    /// </summary>
+    public static SearchBuffer Get(int searchID, int capacity)
+    {
+        if (Pool.TryPop(out var buffer))
+        {
+            buffer.Reset(searchID, capacity);
+            return buffer;
+        }
+        return new SearchBuffer(searchID, capacity);
+    }
+
+    /// <summary>
+    /// Return buffer to pool for reuse
+    /// </summary>
+    public void Return()
+    {
+        Pool.Push(this);
+    }
+
+    // ==================== SEARCH STATE ====================
+    // All arrays indexed by spot.Index for O(1) access
+
+    private int searchID;
+
+    // Core search state - accessed in tight A* loops
+    private int[] searchIDs;              // Which search visited this spot? (validation)
+    private int[] traceBackIndices;       // Parent spot index for path reconstruction
+    private float[] traceBackDistances;   // G_Score (cost from start)
+    private float[] scores;               // F_Score (estimated total cost)
+    private BitArray closed;              // Visited/in closed set?
+    private BitArray scoreSet;            // Has score been computed?
+
+    private int capacity;
+
+    // ==================== STATISTICS ====================
+    private long startTimestamp;          // When this search started (Stopwatch ticks)
+    private int closedCount;              // Number of spots visited/closed
+    private int scoredCount;              // Number of spots scored
+
+    // ==================== INITIALIZATION ====================
+
+    public SearchBuffer(int id, int capacity)
+    {
+        searchID = id;
+        this.capacity = capacity;
+
+        searchIDs = new int[capacity];
+        traceBackIndices = new int[capacity];
+        traceBackDistances = new float[capacity];
+        scores = new float[capacity];
+        closed = new BitArray(capacity);
+        scoreSet = new BitArray(capacity);
+
+        Reset(id, capacity);
+    }
+
+    /// <summary>
+    /// Reset buffer for a new search, growing arrays if needed
+    /// </summary>
+    public void Reset(int newSearchID, int newCapacity)
+    {
+        searchID = newSearchID;
+
+        // Initialize statistics
+        startTimestamp = Stopwatch.GetTimestamp();
+        closedCount = 0;
+        scoredCount = 0;
+
+        // Grow arrays if needed
+        if (newCapacity > capacity)
+        {
+            Array.Resize(ref searchIDs, newCapacity);
+            Array.Resize(ref traceBackIndices, newCapacity);
+            Array.Resize(ref traceBackDistances, newCapacity);
+            Array.Resize(ref scores, newCapacity);
+            closed.Length = newCapacity;
+            scoreSet.Length = newCapacity;
+            capacity = newCapacity;
+        }
+
+        // Clear arrays - only clear the used range for efficiency
+        Array.Clear(searchIDs, 0, newCapacity);
+        Array.Clear(traceBackIndices, 0, newCapacity);
+        Array.Clear(traceBackDistances, 0, newCapacity);
+        Array.Clear(scores, 0, newCapacity);
+        closed.SetAll(false);
+        scoreSet.SetAll(false);
+    }
+
+    /// <summary>
+    /// Ensure buffer has at least the specified capacity, growing if needed.
+    /// Called by SpotManager when it grows during a search.
+    /// </summary>
+    public void EnsureCapacity(int requiredCapacity)
+    {
+        if (requiredCapacity <= capacity)
+            return;
+
+        Array.Resize(ref searchIDs, requiredCapacity);
+        Array.Resize(ref traceBackIndices, requiredCapacity);
+        Array.Resize(ref traceBackDistances, requiredCapacity);
+        Array.Resize(ref scores, requiredCapacity);
+        closed.Length = requiredCapacity;
+        scoreSet.Length = requiredCapacity;
+        capacity = requiredCapacity;
+    }
+
+    public int SearchID => searchID;
+    public int Capacity => capacity;
+
+    // ==================== SEARCH OPERATIONS ====================
+    // All methods are aggressively inlined - they're called in tight A* loops
+
+    /// <summary>
+    /// Set or validate search ID for a spot.
+    /// Returns true if this is a new visit in this search.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool SetSearchID(int spotIdx, int id)
+    {
+        if (searchIDs[spotIdx] == id)
+            return false;
+
+        closed.Set(spotIdx, false);
+        scoreSet.Set(spotIdx, false);
+        searchIDs[spotIdx] = id;
+        return true;
+    }
+
+    /// <summary>
+    /// Check if spot is in the closed set (visited in current search)
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool SearchIsClosed(int spotIdx)
+    {
+        return searchIDs[spotIdx] == searchID && closed.Get(spotIdx);
+    }
+
+    /// <summary>
+    /// Mark spot as closed (visited) in current search
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SearchClose(int spotIdx)
+    {
+        SetSearchID(spotIdx, searchID);
+        if (!closed.Get(spotIdx))
+        {
+            closed.Set(spotIdx, true);
+            closedCount++;
+        }
+    }
+
+    /// <summary>
+    /// Check if score has been set for this spot
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool SearchScoreIsSet(int spotIdx)
+    {
+        return searchIDs[spotIdx] == searchID && scoreSet.Get(spotIdx);
+    }
+
+    /// <summary>
+    /// Get F-Score (estimated total cost) for spot.
+    /// Returns float.MaxValue if not in current search or not scored.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public float SearchScoreGet(int spotIdx)
+    {
+        return searchIDs[spotIdx] == searchID ? scores[spotIdx] : float.MaxValue;
+    }
+
+    /// <summary>
+    /// Set F-Score for a spot in current search
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SetSearchScore(int spotIdx, float score)
+    {
+        SetSearchID(spotIdx, searchID);
+        scores[spotIdx] = score;
+        if (!scoreSet.Get(spotIdx))
+        {
+            scoreSet.Set(spotIdx, true);
+            scoredCount++;
+        }
+    }
+
+    /// <summary>
+    /// Get parent spot index for path reconstruction
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int GetTraceBack(int spotIdx) => traceBackIndices[spotIdx];
+
+    /// <summary>
+    /// Set parent spot index for path reconstruction
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SetTraceBack(int spotIdx, int parentIdx)
+        => traceBackIndices[spotIdx] = parentIdx;
+
+    /// <summary>
+    /// Get G-Score (cost from start) for spot
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public float GetTraceBackDistance(int spotIdx)
+        => traceBackDistances[spotIdx];
+
+    /// <summary>
+    /// Set G-Score (cost from start) for spot
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SetTraceBackDistance(int spotIdx, float distance)
+        => traceBackDistances[spotIdx] = distance;
+
+    // ==================== STATISTICS ACCESSORS ====================
+
+    /// <summary>
+    /// Number of spots closed/visited during this search
+    /// </summary>
+    public int ClosedCount => closedCount;
+
+    /// <summary>
+    /// Number of spots scored during this search
+    /// </summary>
+    public int ScoredCount => scoredCount;
+
+    /// <summary>
+    /// Elapsed time since search started
+    /// </summary>
+    public TimeSpan Elapsed => Stopwatch.GetElapsedTime(startTimestamp);
+
+    /// <summary>
+    /// Elapsed time in milliseconds since search started
+    /// </summary>
+    public double ElapsedMs => Elapsed.TotalMilliseconds;
+}

--- a/PPather/Graph/Spot.cs
+++ b/PPather/Graph/Spot.cs
@@ -19,12 +19,22 @@
 using SharedLib.Extensions;
 
 using System;
-using System.Buffers;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 
 namespace PPather.Graph;
 
+/// <summary>
+/// Minimal navigation graph node identifier.
+///
+/// Spot is now a lightweight reference type used for type safety and backwards compatibility.
+/// All data is managed by SpotManager in Structure-of-Arrays layout:
+/// - Location and flags: Stored in SpotManager arrays
+/// - Path connectivity: Stored in flattened edge arrays in SpotManager
+/// - Search state: Pooled in SearchBuffer, not stored in Spot
+///
+/// This class only holds references needed for spatial indexing (chunk, next).
+/// </summary>
 public sealed class Spot
 {
     public const float Z_RESOLUTION = PathGraph.MinStepLength / 2f; // Z spots max this close
@@ -35,22 +45,20 @@ public sealed class Spot
     public const uint FLAG_WATER = 0x0008;
     public const uint FLAG_INDOORS = 0x0010;
     public const uint FLAG_CLOSETOMODEL = 0x0020;
+    public const uint FLAG_ON_OBJECT = 0x0040;
 
     public Vector3 Loc;
 
     public uint flags;
 
-    public int n_paths;
-    public float[] paths = []; // 3 floats per outgoing path
-
     public GraphChunk chunk;
     public Spot next;  // list on same x,y, used by chunk
 
-    public int searchID;
-    public Spot traceBack; // Used by search
-    public float traceBackDistance; // Used by search
-    public float score; // Used by search
-    public bool closed, scoreSet;
+    /// <summary>
+    /// Cached index into SpotManager arrays. Set during RegisterSpot.
+    /// Avoids Dictionary&lt;Spot,int&gt; lookups on every SpotManager method call.
+    /// </summary>
+    internal int ManagerIndex = -1;
 
     public Spot(float x, float y, float z) : this(new(x, y, z)) { }
 
@@ -63,7 +71,7 @@ public sealed class Spot
     {
         next = null;
         chunk = null;
-        traceBack = null;
+        ManagerIndex = -1;
     }
 
     public bool IsCloseToModel()
@@ -118,175 +126,5 @@ public sealed class Spot
     public bool IsFlagSet(uint flag)
     {
         return (flags & flag) != 0;
-    }
-
-    public bool GetPath(int i, out float x, out float y, out float z)
-    {
-        if (i > n_paths)
-        {
-            x = y = z = 0;
-            return false;
-        }
-
-        int off = i * 3;
-        x = paths[off + 0];
-        y = paths[off + 1];
-        z = paths[off + 2];
-        return true;
-    }
-
-    public Spot GetToSpot(PathGraph pg, int i)
-    {
-        GetPath(i, out float x, out float y, out float z);
-        return pg.GetSpot(x, y, z);
-    }
-
-    public ReadOnlySpan<Spot> GetPathsToSpots(PathGraph pg)
-    {
-        var pooler = ArrayPool<Spot>.Shared;
-        Spot[] array = pooler.Rent(n_paths);
-
-        int j = 0;
-        for (int i = 0; i < n_paths; i++)
-        {
-            Spot spot = GetToSpot(pg, i);
-            if (spot != null)
-                array[j++] = spot;
-        }
-
-        pooler.Return(array);
-        return new(array, 0, j);
-    }
-
-    public bool HasPathTo(PathGraph pg, Spot s)
-    {
-        for (int i = 0; i < n_paths; i++)
-        {
-            Spot to = GetToSpot(pg, i);
-            if (to == s)
-                return true;
-        }
-        return false;
-    }
-
-    public bool HasPathTo(float x, float y, float z)
-    {
-        ReadOnlySpan<float> pos = [x, y, z];
-        return paths.AsSpan().IndexOf(pos) != -1;
-    }
-
-    public void AddPathTo(Spot s)
-    {
-        AddPathTo(s.Loc);
-    }
-
-    public void AddPathTo(Vector3 l)
-    {
-        AddPathTo(l.X, l.Y, l.Z);
-    }
-
-    public void AddPathTo(float x, float y, float z)
-    {
-        if (HasPathTo(x, y, z))
-            return;
-
-        Span<float> span = paths.AsSpan();
-        int old_size = span.Length / 3;
-        if (n_paths + 1 > old_size)
-        {
-            int new_size = old_size * 2;
-            if (new_size < 4)
-                new_size = 4;
-            Array.Resize(ref paths, new_size * 3);
-            span = paths.AsSpan();
-        }
-
-        int off = n_paths * 3;
-        span[off + 0] = x;
-        span[off + 1] = y;
-        span[off + 2] = z;
-        n_paths++;
-        if (chunk != null)
-            chunk.modified = true;
-    }
-
-    public void RemovePathTo(Vector3 l)
-    {
-        RemovePathTo(l.X, l.Y, l.Z);
-    }
-
-    public void RemovePathTo(float x, float y, float z)
-    {
-        // look for it
-        int found_index = -1;
-        for (int i = 0; i < n_paths && found_index == -1; i++)
-        {
-            int off = i * 3;
-            if (paths[off + 0] == x &&
-                paths[off + 1] == y &&
-                paths[off + 2] == z)
-            {
-                found_index = i;
-            }
-        }
-
-        if (found_index == -1)
-        {
-            return;
-        }
-
-        for (int i = found_index; i < n_paths - 1; i++)
-        {
-            int off = i * 3;
-            paths[off + 0] = paths[off + 3];
-            paths[off + 1] = paths[off + 4];
-            paths[off + 2] = paths[off + 5];
-        }
-        n_paths--;
-        if (chunk != null)
-            chunk.modified = true;
-    }
-
-    // search stuff
-
-    public bool SetSearchID(int id)
-    {
-        if (searchID == id)
-        {
-            return false;
-        }
-
-        closed = false;
-        scoreSet = false;
-        searchID = id;
-        return true;
-    }
-
-    public bool SearchIsClosed(int id)
-    {
-        return id == searchID && closed;
-    }
-
-    public void SearchClose(int id)
-    {
-        SetSearchID(id);
-        closed = true;
-    }
-
-    public bool SearchScoreIsSet(int id)
-    {
-        return id == searchID && scoreSet;
-    }
-
-    public float SearchScoreGet(int id)
-    {
-        return id == searchID ? score : float.MaxValue;
-    }
-
-    public void SearchScoreSet(int id, float score)
-    {
-        SetSearchID(id);
-        this.score = score;
-        scoreSet = true;
     }
 }

--- a/PPather/Graph/SpotManager.cs
+++ b/PPather/Graph/SpotManager.cs
@@ -1,0 +1,704 @@
+/*
+  This file is part of ppather.
+
+    PPather is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    PPather is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with ppather.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+namespace PPather.Graph;
+
+/// <summary>
+/// Manages spot data in Structure-of-Arrays (SoA) layout for cache efficiency.
+///
+/// MIGRATION DESIGN:
+/// - Old Spot objects (reference types) are used as the interface
+/// - Each Spot is assigned an internal array index when registered
+/// - Data is stored in parallel contiguous arrays (SoA pattern)
+/// - Search state is pooled in SearchBuffer (allocated per search)
+///
+/// This allows:
+/// - Cache-friendly sequential access in pathfinding
+/// - Gradual migration from object-oriented to data-oriented design
+/// - Backwards compatibility with existing GraphChunk/Spot code
+///
+/// The mapping from Spot object → array index is maintained via Spot.ManagerIndex.
+/// The reverse mapping (index → Spot) uses a flat Spot[] array for O(1) access.
+/// </summary>
+public class SpotManager
+{
+    // ==================== CONFIGURATION ====================
+    private const int DefaultCapacity = 10000;
+    private const float CapacityGrowthFactor = 1.5f;
+    private const int AveragePathsPerSpot = 32;
+    private const int InitialEdgeCapacity = 8; // Matches 8-neighbor grid connectivity
+
+    // ==================== CORE STATE ====================
+    private int count;  // Current number of registered spots
+
+    // ==================== SPOT MAPPING ====================
+
+    // Reverse mapping (index → Spot) for efficient traceback lookups
+    // Flat array indexed by spot index — O(1) access without hash computation
+    private Spot[] indexToSpot;
+
+    // ==================== HOT DATA (accessed in A* loops) ====================
+    // Parallel arrays indexed by internal index (from Spot.ManagerIndex)
+
+    private Vector3[] locations;        // Spot location in 3D space
+    private uint[] flags;               // Environmental flags (water, blocked, etc.)
+
+    // ==================== WARM DATA (path connectivity) ====================
+
+    private int[] pathCounts;           // Number of outgoing paths per spot
+    private float[] allEdges;           // Flattened edges: [x0,y0,z0, x1,y1,z1, ...]
+    private int[] edgeOffsets;          // Where this spot's edges start in allEdges
+    private int nextFreeEdgeOffset;     // Next available position in allEdges (O(1) allocation)
+    private int[] edgeCapacities;       // Pre-allocated edge slot count per spot
+    private int[] nextIndices;          // Linked list: next spot at same x,y
+    private Spot[] edgeSpotCache;       // Cached resolved Spot for each edge target (parallel to allEdges/3)
+
+    // ==================== REUSABLE BUFFERS ====================
+
+    private Spot[] neighborBuffer = new Spot[16]; // Reusable buffer for GetPathsToSpots (single-threaded A*)
+
+    // ==================== CACHED SCORING ====================
+
+    private const short TriangleScoreNotComputed = -1;
+    private short[] cachedTriangleScores;  // Cached combined triangle score per spot (-1 = not computed)
+
+    // ==================== COLD DATA (metadata, infrequent access) ====================
+
+    private GraphChunk[] chunks;        // Chunk ownership references
+
+    // ==================== SEARCH STATE (POOLED) ====================
+    // Allocated per search, returned to pool when search completes
+
+    private SearchBuffer currentSearch;
+
+    // ==================== INITIALIZATION ====================
+
+    public SpotManager(int capacity = DefaultCapacity)
+    {
+        count = 0;
+        indexToSpot = new Spot[capacity];
+
+        // Allocate hot data arrays
+        locations = new Vector3[capacity];
+        flags = new uint[capacity];
+
+        // Allocate warm data arrays
+        pathCounts = new int[capacity];
+        allEdges = new float[capacity * AveragePathsPerSpot * 3];
+        edgeOffsets = new int[capacity];
+        edgeCapacities = new int[capacity];
+        nextIndices = new int[capacity];
+        edgeSpotCache = new Spot[capacity * AveragePathsPerSpot];
+
+        // Allocate cold data arrays
+        chunks = new GraphChunk[capacity];
+
+        // Allocate cached scoring
+        cachedTriangleScores = new short[capacity];
+
+        // Initialize to sentinel values
+        Array.Fill(edgeOffsets, -1);
+        Array.Fill(nextIndices, -1);
+        Array.Fill(cachedTriangleScores, TriangleScoreNotComputed);
+    }
+
+    public int Count => count;
+    public int Capacity => locations.Length;
+
+    // ==================== SPOT REGISTRATION ====================
+
+    /// <summary>
+    /// Register an existing Spot object with the manager.
+    /// This assigns it an internal array index and stores its data.
+    /// </summary>
+    public void RegisterSpot(Spot spot, Vector3 location, uint spotFlags, GraphChunk chunk)
+    {
+        // Check if already registered via cached index
+        if (spot.ManagerIndex >= 0)
+            return;
+
+        // Grow arrays if needed
+        if (count >= Capacity)
+            Grow();
+
+        int index = count++;
+
+        // Store cached index on spot for O(1) future lookups
+        spot.ManagerIndex = index;
+
+        // Store reverse mapping (index → Spot)
+        indexToSpot[index] = spot;
+
+        // Store data in arrays
+        locations[index] = location;
+        flags[index] = spotFlags;
+        pathCounts[index] = 0;
+        edgeOffsets[index] = -1;
+        edgeCapacities[index] = 0;
+        nextIndices[index] = -1;
+        cachedTriangleScores[index] = TriangleScoreNotComputed;
+        chunks[index] = chunk;
+    }
+
+    private void Grow()
+    {
+        int newCapacity = (int)(Capacity * CapacityGrowthFactor);
+
+        Array.Resize(ref locations, newCapacity);
+        Array.Resize(ref flags, newCapacity);
+        Array.Resize(ref pathCounts, newCapacity);
+        int newEdgeSize = newCapacity * AveragePathsPerSpot * 3;
+        Array.Resize(ref allEdges, newEdgeSize);
+        Array.Resize(ref edgeSpotCache, newEdgeSize / 3);
+        Array.Resize(ref edgeOffsets, newCapacity);
+        Array.Resize(ref edgeCapacities, newCapacity);
+        Array.Resize(ref nextIndices, newCapacity);
+        Array.Resize(ref chunks, newCapacity);
+        Array.Resize(ref cachedTriangleScores, newCapacity);
+        Array.Resize(ref indexToSpot, newCapacity);
+
+        // Initialize new slots
+        for (int i = count; i < newCapacity; i++)
+        {
+            edgeOffsets[i] = -1;
+            nextIndices[i] = -1;
+            cachedTriangleScores[i] = TriangleScoreNotComputed;
+        }
+
+        // If a search is active, grow SearchBuffer to match
+        if (currentSearch != null)
+            currentSearch.EnsureCapacity(newCapacity);
+    }
+
+    // ==================== INTERNAL HELPERS ====================
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int GetIndex(Spot spot)
+    {
+        int idx = spot.ManagerIndex;
+        if (idx >= 0)
+            return idx;
+
+        // Auto-register spot on first access (lazy registration)
+        // This handles spots that were created/loaded without explicit registration
+        // Capture index BEFORE RegisterSpot (which will increment count)
+        idx = count;
+        RegisterSpot(spot, spot.Loc, spot.flags, spot.chunk);
+        return idx;
+    }
+
+    // ==================== DATA ACCESS ====================
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Vector3 GetLocation(Spot spot) => locations[GetIndex(spot)];
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SetLocation(Spot spot, Vector3 location)
+        => locations[GetIndex(spot)] = location;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public uint GetFlags(Spot spot) => flags[GetIndex(spot)];
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SetFlags(Spot spot, uint value)
+        => flags[GetIndex(spot)] = value;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsFlagSet(Spot spot, uint flag)
+        => (flags[GetIndex(spot)] & flag) != 0;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SetFlag(Spot spot, uint flag, bool value)
+    {
+        int idx = GetIndex(spot);
+        uint old = flags[idx];
+        if (value)
+            flags[idx] = old | flag;
+        else
+            flags[idx] = old & ~flag;
+    }
+
+    // ==================== CACHED TRIANGLE SCORE ACCESS ====================
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryGetCachedTriangleScore(Spot spot, out int score)
+    {
+        short cached = cachedTriangleScores[GetIndex(spot)];
+        score = cached;
+        return cached != TriangleScoreNotComputed;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SetCachedTriangleScore(Spot spot, int score)
+        => cachedTriangleScores[GetIndex(spot)] = (short)score;
+
+    // ==================== DISTANCE CALCULATIONS ====================
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public float GetDistance(Spot a, Spot b)
+        => Vector3.Distance(locations[GetIndex(a)], locations[GetIndex(b)]);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public float GetDistance2D(Spot a, Spot b)
+    {
+        var aIdx = GetIndex(a);
+        var bIdx = GetIndex(b);
+        return MathF.Sqrt(
+            (locations[aIdx].X - locations[bIdx].X) * (locations[aIdx].X - locations[bIdx].X) +
+            (locations[aIdx].Y - locations[bIdx].Y) * (locations[aIdx].Y - locations[bIdx].Y)
+        );
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public float GetDistanceTo(Spot spot, Vector3 target)
+        => Vector3.Distance(locations[GetIndex(spot)], target);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsCloseZ(Spot spot, float z)
+    {
+        float dz = z - locations[GetIndex(spot)].Z;
+        return dz >= -Spot.Z_RESOLUTION && dz <= Spot.Z_RESOLUTION;
+    }
+
+    // ==================== CHUNK MANAGEMENT ====================
+
+    public GraphChunk GetChunk(Spot spot)
+        => chunks[GetIndex(spot)];
+
+    public void SetChunk(Spot spot, GraphChunk chunk)
+        => chunks[GetIndex(spot)] = chunk;
+
+    // ==================== PATH MANAGEMENT (connectivity edges) ====================
+
+    /// <summary>
+    /// Get the number of outgoing paths from a spot
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int GetPathCount(Spot spot)
+        => pathCounts[GetIndex(spot)];
+
+    /// <summary>
+    /// Get a specific path destination as Vector3
+    /// </summary>
+    public bool GetPath(Spot spot, int pathIndex, out float x, out float y, out float z)
+    {
+        int idx = GetIndex(spot);
+        if (pathIndex >= pathCounts[idx])
+        {
+            x = y = z = 0;
+            return false;
+        }
+
+        int offset = edgeOffsets[idx] + pathIndex * 3;
+        x = allEdges[offset + 0];
+        y = allEdges[offset + 1];
+        z = allEdges[offset + 2];
+        return true;
+    }
+
+    /// <summary>
+    /// Add a path to a destination (as coordinates, target Spot unknown).
+    /// Delegates to AddPathToCore with null target — the Spot will be
+    /// resolved lazily on first GetPathsToSpots access.
+    /// </summary>
+    public void AddPathTo(Spot spot, float x, float y, float z)
+        => AddPathToCore(spot, x, y, z, null);
+
+    /// <summary>
+    /// Add a path to a known target Spot.
+    /// Populates the edge spot cache at creation time, eliminating
+    /// the costly GetSpot coordinate round-trip in GetPathsToSpots.
+    /// </summary>
+    public void AddPathTo(Spot source, Spot target)
+        => AddPathToCore(source, target.Loc.X, target.Loc.Y, target.Loc.Z, target);
+
+    /// <summary>
+    /// Add a path to another spot (Vector3 overload)
+    /// </summary>
+    public void AddPathTo(Spot spot, Vector3 destination)
+        => AddPathTo(spot, destination.X, destination.Y, destination.Z);
+
+    /// <summary>
+    /// Core implementation for adding a path edge.
+    /// If this spot's edge block is not at the tail of allEdges,
+    /// the edges are relocated to the tail first to prevent overwriting
+    /// adjacent spot data.
+    /// </summary>
+    private void AddPathToCore(Spot spot, float x, float y, float z, Spot targetSpot)
+    {
+        int idx = GetIndex(spot);
+
+        // Check if path already exists (use index-based overload to avoid redundant GetIndex)
+        if (HasPathTo(idx, x, y, z))
+            return;
+
+        int pathCount = pathCounts[idx];
+        int capacity = edgeCapacities[idx];
+
+        if (pathCount == 0 && capacity == 0)
+        {
+            // Case 1: First edge — reserve InitialEdgeCapacity slots upfront
+            int slotsNeeded = InitialEdgeCapacity * 3;
+            int requiredTotal = nextFreeEdgeOffset + slotsNeeded;
+            EnsureEdgeCapacity(requiredTotal);
+
+            edgeOffsets[idx] = nextFreeEdgeOffset;
+            edgeCapacities[idx] = InitialEdgeCapacity;
+            nextFreeEdgeOffset += slotsNeeded;
+        }
+        else if (pathCount >= capacity)
+        {
+            // Case 2: Overflow — relocate with doubled capacity (rare path)
+            int newCapacity = capacity * 2;
+            int newOffset = nextFreeEdgeOffset;
+            int newSlotsNeeded = newCapacity * 3;
+            int requiredTotal = newOffset + newSlotsNeeded;
+            EnsureEdgeCapacity(requiredTotal);
+
+            int oldOffset = edgeOffsets[idx];
+            int oldCacheBase = oldOffset / 3;
+            int newCacheBase = newOffset / 3;
+
+            // Copy existing edges to new location
+            Array.Copy(allEdges, oldOffset, allEdges, newOffset, pathCount * 3);
+            // Copy existing edge spot cache entries to new location
+            Array.Copy(edgeSpotCache, oldCacheBase, edgeSpotCache, newCacheBase, pathCount);
+
+            edgeOffsets[idx] = newOffset;
+            edgeCapacities[idx] = newCapacity;
+            nextFreeEdgeOffset = newOffset + newSlotsNeeded;
+        }
+        // Case 3: Fast path — pathCount < capacity, write directly in-place
+
+        // Write path coordinates
+        int offset = edgeOffsets[idx] + pathCount * 3;
+        allEdges[offset + 0] = x;
+        allEdges[offset + 1] = y;
+        allEdges[offset + 2] = z;
+
+        // Cache the target Spot (null if unknown — resolved lazily)
+        edgeSpotCache[offset / 3] = targetSpot;
+
+        pathCounts[idx]++;
+
+        // Mark chunk as modified
+        if (chunks[idx] != null)
+            chunks[idx].modified = true;
+    }
+
+    /// <summary>
+    /// Ensure allEdges and edgeSpotCache have room for at least requiredTotal float entries.
+    /// </summary>
+    private void EnsureEdgeCapacity(int requiredTotal)
+    {
+        if (requiredTotal <= allEdges.Length)
+            return;
+
+        int newSize = Math.Max((int)(allEdges.Length * CapacityGrowthFactor), requiredTotal + 1024);
+        Array.Resize(ref allEdges, newSize);
+        Array.Resize(ref edgeSpotCache, newSize / 3);
+    }
+
+    /// <summary>
+    /// Check if a path to coordinates exists (index-based, avoids redundant GetIndex)
+    /// </summary>
+    private bool HasPathTo(int idx, float x, float y, float z)
+    {
+        int pathCount = pathCounts[idx];
+        int baseOffset = edgeOffsets[idx];
+
+        for (int i = 0; i < pathCount; i++)
+        {
+            int offset = baseOffset + i * 3;
+            if (allEdges[offset + 0] == x &&
+                allEdges[offset + 1] == y &&
+                allEdges[offset + 2] == z)
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Check if a path to coordinates exists
+    /// </summary>
+    public bool HasPathTo(Spot spot, float x, float y, float z)
+        => HasPathTo(GetIndex(spot), x, y, z);
+
+    /// <summary>
+    /// Check if a path to destination spot exists
+    /// </summary>
+    public bool HasPathTo(Spot spot, Spot destination)
+        => HasPathTo(spot, destination.Loc.X, destination.Loc.Y, destination.Loc.Z);
+
+    /// <summary>
+    /// Remove a path to coordinates
+    /// </summary>
+    public void RemovePathTo(Spot spot, float x, float y, float z)
+    {
+        int idx = GetIndex(spot);
+        int pathCount = pathCounts[idx];
+
+        // Find the path to remove
+        int foundIndex = -1;
+        for (int i = 0; i < pathCount; i++)
+        {
+            if (GetPath(spot, i, out float px, out float py, out float pz))
+            {
+                if (px == x && py == y && pz == z)
+                {
+                    foundIndex = i;
+                    break;
+                }
+            }
+        }
+
+        if (foundIndex < 0)
+            return;
+
+        // Shift remaining paths down (swap with last)
+        if (foundIndex < pathCount - 1)
+        {
+            int offset = edgeOffsets[idx];
+            int lastOffset = offset + (pathCount - 1) * 3;
+            int removeOffset = offset + foundIndex * 3;
+
+            // Copy last path to removed position
+            allEdges[removeOffset + 0] = allEdges[lastOffset + 0];
+            allEdges[removeOffset + 1] = allEdges[lastOffset + 1];
+            allEdges[removeOffset + 2] = allEdges[lastOffset + 2];
+
+            // Also swap the edge spot cache entry
+            edgeSpotCache[removeOffset / 3] = edgeSpotCache[lastOffset / 3];
+        }
+
+        // Clear the removed (now-last) cache entry
+        int clearedOffset = edgeOffsets[idx] + (pathCount - 1) * 3;
+        edgeSpotCache[clearedOffset / 3] = null;
+
+        pathCounts[idx]--;
+
+        // Mark chunk as modified
+        if (chunks[idx] != null)
+            chunks[idx].modified = true;
+    }
+
+    /// <summary>
+    /// Remove a path to destination spot
+    /// </summary>
+    public void RemovePathTo(Spot spot, Vector3 destination)
+        => RemovePathTo(spot, destination.X, destination.Y, destination.Z);
+
+    /// <summary>
+    /// Get all connected spots for a given spot (for pathfinding).
+    /// </summary>
+    /// <remarks>
+    /// Returns a span over a reusable internal buffer (neighborBuffer).
+    /// Safe because A* is single-threaded and the returned span is consumed
+    /// before the next call to this method.
+    /// Uses edgeSpotCache to avoid costly GetSpot coordinate round-trips.
+    /// Cache misses (null entries from disk-loaded edges) are resolved lazily
+    /// and cached for subsequent searches.
+    /// </remarks>
+    public ReadOnlySpan<Spot> GetPathsToSpots(Spot spot, PathGraph pathGraph)
+    {
+        int idx = GetIndex(spot);
+        int pathCount = pathCounts[idx];
+
+        if (pathCount == 0)
+            return ReadOnlySpan<Spot>.Empty;
+
+        // Grow reusable buffer if needed (extremely rare — typically max 8 neighbors)
+        if (pathCount > neighborBuffer.Length)
+            neighborBuffer = new Spot[pathCount];
+
+        int baseOffset = edgeOffsets[idx];
+        int resultCount = 0;
+        for (int i = 0; i < pathCount; i++)
+        {
+            int cacheIdx = baseOffset / 3 + i;
+            Spot connectedSpot = edgeSpotCache[cacheIdx];
+
+            if (connectedSpot == null)
+            {
+                // Cache miss — resolve from coordinates and cache for future calls
+                int offset = baseOffset + i * 3;
+                connectedSpot = pathGraph.GetSpot(allEdges[offset], allEdges[offset + 1], allEdges[offset + 2]);
+                if (connectedSpot != null)
+                    edgeSpotCache[cacheIdx] = connectedSpot;
+            }
+
+            if (connectedSpot != null)
+                neighborBuffer[resultCount++] = connectedSpot;
+        }
+
+        return new(neighborBuffer, 0, resultCount);
+    }
+
+    // ==================== SEARCH BUFFER MANAGEMENT ====================
+
+    /// <summary>
+    /// Initialize search with SpotManager.
+    /// Allocates SearchBuffer from pool and initializes starting spot.
+    /// </summary>
+    public void InitializeSearch(int searchID, Spot startSpot)
+    {
+        // Reset build timing accumulator
+        buildTicks = 0;
+
+        // Get or create search buffer from pool
+        currentSearch = SearchBuffer.Get(searchID, Capacity);
+
+        // Initialize starting spot
+        int startIdx = GetIndex(startSpot);
+        currentSearch.SetSearchScore(startIdx, 0f);
+        currentSearch.SetTraceBack(startIdx, -1);
+        currentSearch.SetTraceBackDistance(startIdx, 0f);
+    }
+
+    // ==================== BUILD TIMING ====================
+    // Accumulated ticks spent in CreateSpotsAroundSpot during the current search
+    private long buildTicks;
+
+    /// <summary>
+    /// Record build ticks (time spent in CreateSpotsAroundSpot).
+    /// Called from PathGraph.Search() around each CreateSpotsAroundSpot call.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void AddBuildTicks(long ticks) => buildTicks += ticks;
+
+    /// <summary>
+    /// Complete search and return SearchBuffer to pool.
+    /// Returns search statistics (elapsed time, build time, spots visited, spots scored).
+    /// </summary>
+    public (double elapsedMs, double buildMs, int closedCount, int scoredCount) CompleteSearch()
+    {
+        if (currentSearch != null)
+        {
+            double buildMs = Stopwatch.GetElapsedTime(0, buildTicks).TotalMilliseconds;
+            var stats = (currentSearch.ElapsedMs, buildMs, currentSearch.ClosedCount, currentSearch.ScoredCount);
+            currentSearch.Return();
+            currentSearch = null;
+            return stats;
+        }
+        return (0, 0, 0, 0);
+    }
+
+    /// <summary>
+    /// Get current search statistics (if search is active).
+    /// </summary>
+    public (double elapsedMs, double buildMs, int closedCount, int scoredCount) GetSearchStats()
+    {
+        if (currentSearch != null)
+        {
+            double buildMs = Stopwatch.GetElapsedTime(0, buildTicks).TotalMilliseconds;
+            return (currentSearch.ElapsedMs, buildMs, currentSearch.ClosedCount, currentSearch.ScoredCount);
+        }
+        return (0, 0, 0, 0);
+    }
+
+    // ==================== SEARCH STATE DELEGATION ====================
+    // These methods forward to current SearchBuffer
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool SearchIsClosed(Spot spot)
+        => currentSearch?.SearchIsClosed(GetIndex(spot)) ?? false;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SearchClose(Spot spot)
+        => currentSearch?.SearchClose(GetIndex(spot));
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool SearchScoreIsSet(Spot spot)
+        => currentSearch?.SearchScoreIsSet(GetIndex(spot)) ?? false;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public float SearchScoreGet(Spot spot)
+        => currentSearch?.SearchScoreGet(GetIndex(spot)) ?? float.MaxValue;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SearchScoreSet(Spot spot, float score)
+        => currentSearch?.SetSearchScore(GetIndex(spot), score);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Spot GetTraceBack(Spot spot)
+    {
+        if (currentSearch == null)
+            return null;
+
+        int traceBackIdx = currentSearch.GetTraceBack(GetIndex(spot));
+        if (traceBackIdx < 0)
+            return null;
+
+        // Direct array index for O(1) lookup without hash computation
+        return indexToSpot[traceBackIdx];
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SetTraceBack(Spot spot, Spot parent)
+    {
+        if (currentSearch == null)
+            return;
+
+        int idx = GetIndex(spot);
+        int parentIdx = parent != null ? GetIndex(parent) : -1;
+        currentSearch.SetTraceBack(idx, parentIdx);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public float GetTraceBackDistance(Spot spot)
+        => currentSearch?.GetTraceBackDistance(GetIndex(spot)) ?? 0f;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SetTraceBackDistance(Spot spot, float distance)
+        => currentSearch?.SetTraceBackDistance(GetIndex(spot), distance);
+
+    // ==================== UTILITY METHODS ====================
+
+    /// <summary>
+    /// Check if a spot is registered with this manager
+    /// </summary>
+    public static bool IsRegistered(Spot spot)
+        => spot.ManagerIndex >= 0;
+
+    /// <summary>
+    /// Enumerate all registered spots
+    /// </summary>
+    public IEnumerable<Spot> AllSpots()
+    {
+        for (int i = 0; i < count; i++)
+            yield return indexToSpot[i];
+    }
+
+    /// <summary>
+    /// Clear all data
+    /// </summary>
+    public void Clear()
+    {
+        count = 0;
+        nextFreeEdgeOffset = 0;
+        Array.Clear(indexToSpot, 0, indexToSpot.Length);
+        Array.Clear(edgeSpotCache);
+        currentSearch = null;
+    }
+}

--- a/PPather/Search/MeshFactory.cs
+++ b/PPather/Search/MeshFactory.cs
@@ -1,5 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
+
+using PPather.Graph;
 
 using WowTriangles;
 
@@ -30,5 +34,286 @@ public static class MeshFactory
         }
 
         return c;
+    }
+
+    // ==================== NEW: Sparse Vertex Loading ====================
+
+    /// <summary>
+    /// VARIANT 1: Create mesh from actual discovered spots (most precise).
+    /// Only includes vertices from triangles that spots are standing on.
+    /// Perfect for visualizing the "explored" mesh.
+    /// </summary>
+    public static (List<Vector3> vertices, List<int> indices) CreateSparseFromSpots(
+        TriangleCollection tc,
+        IEnumerable<Spot> spots,
+        float toonHeight,
+        float toonSize)
+    {
+        HashSet<int> usedVertices = new();
+        List<int> triangleIndices = new();
+
+        var tSpan = tc.TrianglesSpan;
+        var vSpan = tc.VerteciesSpan;
+
+        // For each spot, find the triangle(s) it's standing on
+        foreach (Spot spot in spots)
+        {
+            if (spot.IsBlocked())
+                continue;
+
+            Vector3 spotLoc = spot.Loc;
+            Vector3 searchStart = new(spotLoc.X, spotLoc.Y, spotLoc.Z - 0.1f);
+            Vector3 searchEnd = new(spotLoc.X, spotLoc.Y, spotLoc.Z + toonHeight);
+
+            // Find triangles this spot is on
+            for (int i = 0; i < tSpan.Length; i++)
+            {
+                TriangleCollection.GetTriangleVertices(tSpan, vSpan, i,
+                    out Vector3 v0, out Vector3 v1, out Vector3 v2, out TriangleType flags);
+
+                if (flags != TriangleType.Terrain && flags != TriangleType.Object)
+                    continue;
+
+                // Check if spot is on this triangle
+                if (WowTriangles.Utils.SegmentTriangleIntersect(searchStart, searchEnd, v0, v1, v2, out _))
+                {
+                    TriangleCollection.GetTriangle(tSpan, i, out int idx0, out int idx1, out int idx2, out _);
+
+                    usedVertices.Add(idx0);
+                    usedVertices.Add(idx1);
+                    usedVertices.Add(idx2);
+
+                    triangleIndices.Add(idx0);
+                    triangleIndices.Add(idx1);
+                    triangleIndices.Add(idx2);
+                }
+            }
+        }
+
+        // Build compact vertex list (only used vertices)
+        var sortedIndices = usedVertices.OrderBy(x => x).ToList();
+        Dictionary<int, int> oldToNew = new();
+        List<Vector3> compactVertices = new(sortedIndices.Count);
+
+        for (int i = 0; i < sortedIndices.Count; i++)
+        {
+            int oldIndex = sortedIndices[i];
+            oldToNew[oldIndex] = i;
+            compactVertices.Add(vSpan[oldIndex]);
+        }
+
+        // Remap triangle indices to compact vertex list
+        for (int i = 0; i < triangleIndices.Count; i++)
+        {
+            triangleIndices[i] = oldToNew[triangleIndices[i]];
+        }
+
+        return (compactVertices, triangleIndices);
+    }
+
+    /// <summary>
+    /// VARIANT 2: Create mesh filtered by walkability test.
+    /// Pre-filters vertices by testing if they're standable.
+    /// Good for visualizing "walkable" areas without pathfinding.
+    ///
+    /// OPTIMIZED: Only tests vertices near explored spots (if spots provided).
+    /// </summary>
+    public static (List<Vector3> vertices, List<int> indices) CreateWalkableOnly(
+        TriangleCollection tc,
+        ChunkedTriangleCollection triangleWorld,
+        float toonHeight,
+        float toonSize,
+        IEnumerable<Spot> nearbySpots = null,
+        float searchRadius = 20.0f)
+    {
+        HashSet<int> walkableVertices = new();
+        List<int> triangleIndices = new();
+
+        var tSpan = tc.TrianglesSpan;
+        var vSpan = tc.VerteciesSpan;
+
+        // OPTIMIZATION: If spots provided, only test vertices near them
+        bool hasSpots = nearbySpots != null && nearbySpots.Any();
+        HashSet<Vector3> spotLocations = hasSpots
+            ? new HashSet<Vector3>(nearbySpots.Select(s => s.Loc))
+            : null;
+
+        // Test each vertex for walkability
+        for (int i = 0; i < vSpan.Length; i++)
+        {
+            Vector3 vertex = vSpan[i];
+
+            // OPTIMIZATION: Skip vertices far from explored spots
+            if (hasSpots && !IsNearAnySpot(vertex, spotLocations, searchRadius))
+            {
+                continue; // Skip this vertex - too far from explored areas
+            }
+
+            // Test if this vertex position is standable
+            if (triangleWorld.FindStandableAt(
+                vertex.X, vertex.Y,
+                vertex.Z - 2.0f, vertex.Z + 2.0f,
+                out float standZ, out TriangleType flags,
+                toonHeight, toonSize))
+            {
+                // Only include if close to actual vertex height (not far above/below)
+                if (Math.Abs(standZ - vertex.Z) < 5.0f)
+                {
+                    walkableVertices.Add(i);
+                }
+            }
+        }
+
+        // Build triangles using only walkable vertices
+        for (int i = 0; i < tSpan.Length; i++)
+        {
+            TriangleCollection.GetTriangle(tSpan, i, out int v0, out int v1, out int v2, out TriangleType flags);
+
+            if (flags != TriangleType.Terrain && flags != TriangleType.Object)
+                continue;
+
+            // Only include triangle if ALL vertices are walkable
+            if (walkableVertices.Contains(v0) && walkableVertices.Contains(v1) && walkableVertices.Contains(v2))
+            {
+                triangleIndices.Add(v0);
+                triangleIndices.Add(v1);
+                triangleIndices.Add(v2);
+            }
+        }
+
+        // Build compact vertex list
+        var sortedIndices = walkableVertices.OrderBy(x => x).ToList();
+        Dictionary<int, int> oldToNew = new();
+        List<Vector3> compactVertices = new(sortedIndices.Count);
+
+        for (int i = 0; i < sortedIndices.Count; i++)
+        {
+            int oldIndex = sortedIndices[i];
+            oldToNew[oldIndex] = i;
+            compactVertices.Add(vSpan[oldIndex]);
+        }
+
+        // Remap triangle indices
+        for (int i = 0; i < triangleIndices.Count; i++)
+        {
+            triangleIndices[i] = oldToNew[triangleIndices[i]];
+        }
+
+        return (compactVertices, triangleIndices);
+    }
+
+    /// <summary>
+    /// VARIANT 3: Create mesh from explored area (spot-based bounds).
+    /// Only includes triangles within bounding box of discovered spots.
+    /// Fast approximation of explored mesh.
+    /// </summary>
+    public static (List<Vector3> vertices, List<int> indices) CreateExploredArea(
+        TriangleCollection tc,
+        IEnumerable<Spot> spots,
+        float expandRadius = 10.0f)
+    {
+        if (!spots.Any())
+            return (new List<Vector3>(), new List<int>());
+
+        // Calculate bounding box of explored area
+        float minX = float.MaxValue, minY = float.MaxValue, minZ = float.MaxValue;
+        float maxX = float.MinValue, maxY = float.MinValue, maxZ = float.MinValue;
+
+        foreach (Spot spot in spots)
+        {
+            if (spot.IsBlocked())
+                continue;
+
+            Vector3 loc = spot.Loc;
+            minX = Math.Min(minX, loc.X);
+            minY = Math.Min(minY, loc.Y);
+            minZ = Math.Min(minZ, loc.Z);
+            maxX = Math.Max(maxX, loc.X);
+            maxY = Math.Max(maxY, loc.Y);
+            maxZ = Math.Max(maxZ, loc.Z);
+        }
+
+        // Expand bounds slightly
+        minX -= expandRadius;
+        minY -= expandRadius;
+        minZ -= expandRadius;
+        maxX += expandRadius;
+        maxY += expandRadius;
+        maxZ += expandRadius;
+
+        HashSet<int> usedVertices = new();
+        List<int> triangleIndices = new();
+
+        var tSpan = tc.TrianglesSpan;
+        var vSpan = tc.VerteciesSpan;
+
+        // Include triangles within explored bounds
+        for (int i = 0; i < tSpan.Length; i++)
+        {
+            TriangleCollection.GetTriangleVertices(tSpan, vSpan, i,
+                out Vector3 v0, out Vector3 v1, out Vector3 v2, out TriangleType flags);
+
+            if (flags != TriangleType.Terrain && flags != TriangleType.Object)
+                continue;
+
+            // Check if triangle is within bounds (test all 3 vertices)
+            bool inBounds = IsVertexInBounds(v0, minX, minY, minZ, maxX, maxY, maxZ) ||
+                           IsVertexInBounds(v1, minX, minY, minZ, maxX, maxY, maxZ) ||
+                           IsVertexInBounds(v2, minX, minY, minZ, maxX, maxY, maxZ);
+
+            if (inBounds)
+            {
+                TriangleCollection.GetTriangle(tSpan, i, out int idx0, out int idx1, out int idx2, out _);
+
+                usedVertices.Add(idx0);
+                usedVertices.Add(idx1);
+                usedVertices.Add(idx2);
+
+                triangleIndices.Add(idx0);
+                triangleIndices.Add(idx1);
+                triangleIndices.Add(idx2);
+            }
+        }
+
+        // Build compact vertex list
+        var sortedIndices = usedVertices.OrderBy(x => x).ToList();
+        Dictionary<int, int> oldToNew = new();
+        List<Vector3> compactVertices = new(sortedIndices.Count);
+
+        for (int i = 0; i < sortedIndices.Count; i++)
+        {
+            int oldIndex = sortedIndices[i];
+            oldToNew[oldIndex] = i;
+            compactVertices.Add(vSpan[oldIndex]);
+        }
+
+        // Remap triangle indices
+        for (int i = 0; i < triangleIndices.Count; i++)
+        {
+            triangleIndices[i] = oldToNew[triangleIndices[i]];
+        }
+
+        return (compactVertices, triangleIndices);
+    }
+
+    private static bool IsVertexInBounds(Vector3 v, float minX, float minY, float minZ, float maxX, float maxY, float maxZ)
+    {
+        return v.X >= minX && v.X <= maxX &&
+               v.Y >= minY && v.Y <= maxY &&
+               v.Z >= minZ && v.Z <= maxZ;
+    }
+
+    private static bool IsNearAnySpot(Vector3 vertex, HashSet<Vector3> spotLocations, float searchRadius)
+    {
+        float radiusSquared = searchRadius * searchRadius;
+        foreach (var spotLoc in spotLocations)
+        {
+            float dx = vertex.X - spotLoc.X;
+            float dy = vertex.Y - spotLoc.Y;
+            float distSquared = (dx * dx) + (dy * dy);
+            if (distSquared <= radiusSquared)
+                return true;
+        }
+        return false;
     }
 }

--- a/PPather/Search/PPatherService.cs
+++ b/PPather/Search/PPatherService.cs
@@ -98,6 +98,13 @@ public sealed class PPatherService
         return search.PathGraph.triangleWorld.GetChunkAt(grid_x, grid_y);
     }
 
+    public ChunkedTriangleCollection TriangleWorld => search.PathGraph.triangleWorld;
+
+    public IEnumerable<Spot> GetSpots()
+    {
+        return search.PathGraph.SpotManager.AllSpots();
+    }
+
     public void ChunkAdded(ChunkEventArgs e)
     {
         OnChunkAdded?.Invoke(e);

--- a/PPather/Triangles/ChunkedTriangleCollection.cs
+++ b/PPather/Triangles/ChunkedTriangleCollection.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 
 using PPather;
 using PPather.Graph;
+using PPather.Triangles;
 using PPather.Triangles.Data;
 
 using System;
@@ -78,6 +79,16 @@ public sealed class ChunkedTriangleCollection
         grid_y = (int)(y / ChunkReader.TILESIZE);
     }
 
+    /// <summary>
+    /// Get MCNK-level grid coordinates (256x finer granularity than ADT)
+    /// Key format: (adt_x << 24) | (adt_y << 16) | (mcnk_x << 8) | mcnk_y
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void GetMCNKGridCoord(float x, float y, out int grid_x, out int grid_y, out int mcnk_x, out int mcnk_y)
+    {
+        MCNKHelper.GetMCNKCoord(x, y, out grid_x, out grid_y, out mcnk_x, out mcnk_y);
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void GetGridLimits(int grid_x, int grid_y,
                                 out float min_x, out float min_y,
@@ -122,6 +133,58 @@ public sealed class ChunkedTriangleCollection
     public TriangleCollection GetChunkAt(float x, float y)
     {
         return LoadChunkAt(x, y);
+    }
+
+    /// <summary>
+    /// Load triangles for a specific MCNK chunk (33.33 yards)
+    /// This loads only:
+    /// - 145 MCVT terrain vertices for this MCNK
+    /// - Models/WMOs that intersect this MCNK's bounds
+    /// Memory: ~97% reduction compared to loading full ADT
+    /// </summary>
+    private TriangleCollection LoadMCNKAt(float x, float y)
+    {
+        GetMCNKGridCoord(x, y, out int adt_x, out int adt_y, out int mcnk_x, out int mcnk_y);
+
+        // Use combined grid coordinate that includes MCNK offsets
+        // grid_x_combined = (adt_x * 16) + mcnk_x
+        // grid_y_combined = (adt_y * 16) + mcnk_y
+        int grid_x_combined = (adt_x * MapTile.SIZE) + mcnk_x;
+        int grid_y_combined = (adt_y * MapTile.SIZE) + mcnk_y;
+
+        if (chunks.TryGetValue(grid_x_combined, grid_y_combined, out TriangleCollection cached))
+        {
+            return cached;
+        }
+
+        MCNKHelper.GetMCNKBounds(adt_x, adt_y, mcnk_x, mcnk_y,
+            out float min_x, out float min_y, out float max_x, out float max_y);
+
+        long startTime = Stopwatch.GetTimestamp();
+        TriangleCollection tc = new(logger);
+        tc.SetLimits(min_x - 1, min_y - 1, -1E30f, max_x + 1, max_y + 1, 1E30f);
+
+        // Load only this specific MCNK's geometry
+        supplier.GetMCNKTriangles(tc, adt_x, adt_y, mcnk_x, mcnk_y);
+        var endTime = Stopwatch.GetElapsedTime(startTime);
+
+        chunks.Add(grid_x_combined, grid_y_combined, tc);
+
+        if (logger.IsEnabled(LogLevel.Trace))
+        {
+            logger.LogTrace($"MCNK [{adt_x},{adt_y}:{mcnk_x},{mcnk_y}] Bounds: [{min_x:F4}, {min_y:F4}] [{max_x:F4}, {max_y:F4}] - Count: {chunks.Count} - Loaded {endTime.TotalMilliseconds}ms");
+        }
+        NotifyChunkAdded?.Invoke(new ChunkEventArgs(adt_x, adt_y));
+
+        return tc;
+    }
+
+    /// <summary>
+    /// Get MCNK-level chunk at world position (new optimized path)
+    /// </summary>
+    public TriangleCollection GetMCNKAt(float x, float y)
+    {
+        return LoadMCNKAt(x, y);
     }
 
     public TriangleCollection GetChunkAt(int grid_x, int grid_y)
@@ -400,6 +463,62 @@ public sealed class ChunkedTriangleCollection
     }
 
     [SkipLocalsInit]
+    public int GradiantScoreTiered(float x, float y, int gradiantMax)
+    {
+        TriangleCollection tc = GetChunkAt(x, y);
+        TriangleMatrix tm = tc.GetTriangleMatrix();
+
+        var tSpan = tc.TrianglesSpan;
+        var vSpan = tc.VerteciesSpan;
+
+        ReadOnlySpan<int> ts = tm.GetAllCloseTo(x, y, 3);
+
+        float maxZ1 = float.MinValue, minZ1 = float.MaxValue;
+        float maxZ2 = float.MinValue, minZ2 = float.MaxValue;
+        float maxZ3 = float.MinValue, minZ3 = float.MaxValue;
+
+        foreach (int index in ts)
+        {
+            TriangleCollection.GetTriangleVertices(tSpan, vSpan, index,
+                out Vector3 v0,
+                out Vector3 v1,
+                out Vector3 v2,
+                out TriangleType flags);
+
+            if (flags != TriangleType.Terrain)
+                continue;
+
+            float triMinX = Min3(v0.X, v1.X, v2.X);
+            float triMaxX = Max3(v0.X, v1.X, v2.X);
+            float triMinY = Min3(v0.Y, v1.Y, v2.Y);
+            float triMaxY = Max3(v0.Y, v1.Y, v2.Y);
+
+            // Tier 3 (range=3) — all triangles qualify (already filtered by GetAllCloseTo)
+            maxZ3 = Max4(maxZ3, v0.Z, v1.Z, v2.Z);
+            minZ3 = Min4(minZ3, v0.Z, v1.Z, v2.Z);
+
+            // Tier 2 (range=2)
+            if (triMaxX >= x - 2 && triMinX <= x + 2 && triMaxY >= y - 2 && triMinY <= y + 2)
+            {
+                maxZ2 = Max4(maxZ2, v0.Z, v1.Z, v2.Z);
+                minZ2 = Min4(minZ2, v0.Z, v1.Z, v2.Z);
+            }
+
+            // Tier 1 (range=1)
+            if (triMaxX >= x - 1 && triMinX <= x + 1 && triMaxY >= y - 1 && triMinY <= y + 1)
+            {
+                maxZ1 = Max4(maxZ1, v0.Z, v1.Z, v2.Z);
+                minZ1 = Min4(minZ1, v0.Z, v1.Z, v2.Z);
+            }
+        }
+
+        if ((int)(maxZ1 - minZ1) > gradiantMax) return 128;
+        if ((int)(maxZ2 - minZ2) > gradiantMax) return 64;
+        if ((int)(maxZ3 - minZ3) > gradiantMax) return 32;
+        return 0;
+    }
+
+    [SkipLocalsInit]
     public bool IsCloseToType(float x, float y, float z, float range, TriangleType type)
     {
         TriangleCollection tc = GetChunkAt(x, y);
@@ -422,9 +541,9 @@ public sealed class ChunkedTriangleCollection
 
             if (flags.Has(type))
             {
-                // ignore the triangle if it is below the toon
-                float minZ = Min3(v0.Z, v1.Z, v2.Z);
-                if (minZ < z)
+                // ignore the triangle if it is entirely below the toon
+                float maxZ = Max3(v0.Z, v1.Z, v2.Z);
+                if (maxZ < z)
                     continue;
 
                 float d = PointDistanceToTriangle(toon, v0, v1, v2);
@@ -435,6 +554,133 @@ public sealed class ChunkedTriangleCollection
             }
         }
         return false;
+    }
+
+    [SkipLocalsInit]
+    public float ClosestDistanceToType(float x, float y, float z, float range, TriangleType type)
+    {
+        TriangleCollection tc = GetChunkAt(x, y);
+        TriangleMatrix tm = tc.GetTriangleMatrix();
+
+        Vector3 toon = new(x, y, z);
+
+        var tSpan = tc.TrianglesSpan;
+        var vSpan = tc.VerteciesSpan;
+
+        float minDist = float.MaxValue;
+
+        ReadOnlySpan<int> ts = tm.GetAllCloseTo(x, y, range);
+        foreach (int index in ts)
+        {
+            TriangleCollection.GetTriangleVertices(tSpan, vSpan, index,
+                out Vector3 v0,
+                out Vector3 v1,
+                out Vector3 v2,
+                out TriangleType flags);
+
+            if (!flags.Has(type))
+                continue;
+
+            float maxZ = Max3(v0.Z, v1.Z, v2.Z);
+            if (maxZ < z)
+                continue;
+
+            float d = PointDistanceToTriangle(toon, v0, v1, v2);
+            if (d < minDist)
+                minDist = d;
+        }
+
+        return minDist;
+    }
+
+    /// <summary>
+    /// Combined closeness distance + gradient scoring in a single triangle query.
+    /// Eliminates duplicate GetChunkAt/GetTriangleMatrix/GetAllCloseTo calls
+    /// that occur when calling ClosestDistanceToType and GradiantScoreTiered separately.
+    /// </summary>
+    [SkipLocalsInit]
+    public (float closestDist, int gradientScore) CombinedScoring(
+        float x, float y, float z,
+        float closenessRange, TriangleType closenessMask,
+        int gradiantMax)
+    {
+        TriangleCollection tc = GetChunkAt(x, y);
+        TriangleMatrix tm = tc.GetTriangleMatrix();
+
+        var tSpan = tc.TrianglesSpan;
+        var vSpan = tc.VerteciesSpan;
+
+        // Query once with the larger range (closenessRange >= 3)
+        ReadOnlySpan<int> ts = tm.GetAllCloseTo(x, y, closenessRange);
+
+        Vector3 toon = new(x, y, z);
+        float minDist = float.MaxValue;
+
+        float maxZ1 = float.MinValue, minZ1 = float.MaxValue;
+        float maxZ2 = float.MinValue, minZ2 = float.MaxValue;
+        float maxZ3 = float.MinValue, minZ3 = float.MaxValue;
+
+        foreach (int index in ts)
+        {
+            TriangleCollection.GetTriangleVertices(tSpan, vSpan, index,
+                out Vector3 v0,
+                out Vector3 v1,
+                out Vector3 v2,
+                out TriangleType flags);
+
+            // Closeness scoring (Model|Object triangles)
+            if (flags.Has(closenessMask))
+            {
+                float maxVertZ = Max3(v0.Z, v1.Z, v2.Z);
+                if (maxVertZ >= z)
+                {
+                    // Skip floors/ceilings — only wall-like (mostly vertical) triangles
+                    GetTriangleNormal(v0, v1, v2, out Vector3 normal);
+                    if (Abs(normal.Z) > 0.7f)
+                        continue;
+
+                    float d = PointDistanceToTriangle(toon, v0, v1, v2);
+                    if (d < minDist)
+                        minDist = d;
+                }
+            }
+
+            // Gradient scoring (Terrain triangles only, within range 3)
+            if (flags == TriangleType.Terrain)
+            {
+                float triMinX = Min3(v0.X, v1.X, v2.X);
+                float triMaxX = Max3(v0.X, v1.X, v2.X);
+                float triMinY = Min3(v0.Y, v1.Y, v2.Y);
+                float triMaxY = Max3(v0.Y, v1.Y, v2.Y);
+
+                // Only consider triangles within gradient range (3)
+                if (triMaxX >= x - 3 && triMinX <= x + 3 && triMaxY >= y - 3 && triMinY <= y + 3)
+                {
+                    maxZ3 = Max4(maxZ3, v0.Z, v1.Z, v2.Z);
+                    minZ3 = Min4(minZ3, v0.Z, v1.Z, v2.Z);
+
+                    if (triMaxX >= x - 2 && triMinX <= x + 2 && triMaxY >= y - 2 && triMinY <= y + 2)
+                    {
+                        maxZ2 = Max4(maxZ2, v0.Z, v1.Z, v2.Z);
+                        minZ2 = Min4(minZ2, v0.Z, v1.Z, v2.Z);
+                    }
+
+                    if (triMaxX >= x - 1 && triMinX <= x + 1 && triMaxY >= y - 1 && triMinY <= y + 1)
+                    {
+                        maxZ1 = Max4(maxZ1, v0.Z, v1.Z, v2.Z);
+                        minZ1 = Min4(minZ1, v0.Z, v1.Z, v2.Z);
+                    }
+                }
+            }
+        }
+
+        int gradientScore;
+        if ((int)(maxZ1 - minZ1) > gradiantMax) gradientScore = 128;
+        else if ((int)(maxZ2 - minZ2) > gradiantMax) gradientScore = 64;
+        else if ((int)(maxZ3 - minZ3) > gradiantMax) gradientScore = 32;
+        else gradientScore = 0;
+
+        return (minDist, gradientScore);
     }
 
     [SkipLocalsInit]
@@ -456,6 +702,42 @@ public sealed class ChunkedTriangleCollection
                 out Vector3 v0,
                 out Vector3 v1,
                 out Vector3 v2, out _);
+
+            if (SegmentTriangleIntersect(s0, s1, v0, v1, v2, out _))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Check line of sight considering only triangles matching the blocking mask.
+    /// Triangles not matching the mask are ignored (transparent to this check).
+    /// </summary>
+    [SkipLocalsInit]
+    public bool LineOfSightExists(Vector3 a, Vector3 b, TriangleType blockingMask)
+    {
+        TriangleCollection tc = GetChunkAt(a.X, a.Y);
+        TriangleMatrix tm = tc.GetTriangleMatrix();
+        ReadOnlySpan<int> ts = tm.GetAllCloseTo(a.X, a.Y, Vector3.Distance(a, b) + 1);
+
+        var tSpan = tc.TrianglesSpan;
+        var vSpan = tc.VerteciesSpan;
+
+        Vector3 s0 = a;
+        Vector3 s1 = b;
+
+        foreach (int index in ts)
+        {
+            TriangleCollection.GetTriangleVertices(tSpan, vSpan, index,
+                out Vector3 v0,
+                out Vector3 v1,
+                out Vector3 v2,
+                out TriangleType flags);
+
+            if (!flags.Has(blockingMask))
+                continue;
 
             if (SegmentTriangleIntersect(s0, s1, v0, v1, v2, out _))
             {
@@ -591,6 +873,73 @@ public sealed class ChunkedTriangleCollection
         }
 
         return best_flags != TriangleType.None;
+    }
+
+    [SkipLocalsInit]
+    public bool TryGetWallRepulsion(float x, float y, float z, float range, TriangleType type, out Vector3 repulsionDir, out float wallDistance)
+    {
+        TriangleCollection tc = GetChunkAt(x, y);
+        TriangleMatrix tm = tc.GetTriangleMatrix();
+
+        Vector3 toon = new(x, y, z);
+
+        var tSpan = tc.TrianglesSpan;
+        var vSpan = tc.VerteciesSpan;
+
+        float minDist = float.MaxValue;
+        Vector3 closestPoint = default;
+
+        ReadOnlySpan<int> ts = tm.GetAllCloseTo(x, y, range);
+        foreach (int index in ts)
+        {
+            TriangleCollection.GetTriangleVertices(tSpan, vSpan, index,
+                out Vector3 v0,
+                out Vector3 v1,
+                out Vector3 v2,
+                out TriangleType flags);
+
+            if (!flags.Has(type))
+                continue;
+
+            float maxZ = Max3(v0.Z, v1.Z, v2.Z);
+            if (maxZ < z)
+                continue;
+
+            // Skip floors/ceilings — only wall-like (mostly vertical) triangles
+            GetTriangleNormal(v0, v1, v2, out Vector3 normal);
+            if (Abs(normal.Z) > 0.7f)
+                continue;
+
+            Vector3 cp = ClosestPointOnTriangle(toon, v0, v1, v2);
+            float d = Vector3.Distance(toon, cp);
+            if (d < minDist)
+            {
+                minDist = d;
+                closestPoint = cp;
+            }
+        }
+
+        if (minDist < range)
+        {
+            // XY-only repulsion direction (away from wall)
+            float dx = x - closestPoint.X;
+            float dy = y - closestPoint.Y;
+            float len = Sqrt(dx * dx + dy * dy);
+            if (len > 1e-6f)
+            {
+                repulsionDir = new Vector3(dx / len, dy / len, 0);
+            }
+            else
+            {
+                repulsionDir = Vector3.UnitX;
+            }
+            wallDistance = minDist;
+            return true;
+        }
+
+        repulsionDir = default;
+        wallDistance = float.MaxValue;
+        return false;
     }
 
     public (int, float) GetAreaIdAndZ(Vector3 location)

--- a/PPather/Triangles/MCNKHelper.cs
+++ b/PPather/Triangles/MCNKHelper.cs
@@ -1,0 +1,206 @@
+/*
+  This file is part of ppather.
+
+    PPather is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    PPather is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with ppather.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+using Wmo;
+
+namespace WowTriangles;
+
+/// <summary>
+/// Helper utilities for MCNK-aligned coordinate conversions and spatial queries.
+///
+/// WoW's terrain hierarchy:
+/// - ADT: 533.33 yards (64×64 world grid)
+/// - MCNK: 33.33 yards (16×16 grid per ADT = 256 chunks)
+/// - MCVT: 145 vertices per MCNK (9×9 outer + 8×8 inner)
+/// </summary>
+internal static class MCNKHelper
+{
+    /// <summary>
+    /// Get ADT tile coordinates from world position
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void GetADTCoord(float x, float y, out int adt_x, out int adt_y)
+    {
+        float xOffset = ChunkReader.ZEROPOINT - y;
+        float yOffset = ChunkReader.ZEROPOINT - x;
+
+        adt_x = (int)(xOffset / ChunkReader.TILESIZE);
+        adt_y = (int)(yOffset / ChunkReader.TILESIZE);
+    }
+
+    /// <summary>
+    /// Get MCNK chunk coordinates within an ADT from world position
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void GetMCNKCoord(float x, float y, out int adt_x, out int adt_y, out int mcnk_x, out int mcnk_y)
+    {
+        // First get ADT coordinates
+        GetADTCoord(x, y, out adt_x, out adt_y);
+
+        // Then get MCNK coordinates within the ADT
+        float localX = (ChunkReader.ZEROPOINT - y) % ChunkReader.TILESIZE;
+        float localY = (ChunkReader.ZEROPOINT - x) % ChunkReader.TILESIZE;
+
+        mcnk_x = (int)(localX / ChunkReader.CHUNKSIZE);
+        mcnk_y = (int)(localY / ChunkReader.CHUNKSIZE);
+
+        // Clamp to valid range [0, 15]
+        mcnk_x = System.Math.Clamp(mcnk_x, 0, 15);
+        mcnk_y = System.Math.Clamp(mcnk_y, 0, 15);
+    }
+
+    /// <summary>
+    /// Get MCNK index within MapTile (0-255)
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int GetMCNKIndex(int mcnk_x, int mcnk_y)
+    {
+        return mcnk_y * MapTile.SIZE + mcnk_x;
+    }
+
+    /// <summary>
+    /// Get world bounds for a specific MCNK chunk
+    /// </summary>
+    public static void GetMCNKBounds(int adt_x, int adt_y, int mcnk_x, int mcnk_y,
+                                     out float minX, out float minY, out float maxX, out float maxY)
+    {
+        // Get ADT base position
+        float adt_base_x = ChunkReader.ZEROPOINT - (adt_x * ChunkReader.TILESIZE);
+        float adt_base_y = ChunkReader.ZEROPOINT - (adt_y * ChunkReader.TILESIZE);
+
+        // Calculate MCNK bounds within ADT
+        minX = adt_base_x - (mcnk_x * ChunkReader.CHUNKSIZE);
+        minY = adt_base_y - (mcnk_y * ChunkReader.CHUNKSIZE);
+        maxX = minX - ChunkReader.CHUNKSIZE;
+        maxY = minY - ChunkReader.CHUNKSIZE;
+
+        // Ensure min < max
+        if (minX > maxX) (minX, maxX) = (maxX, minX);
+        if (minY > maxY) (minY, maxY) = (maxY, minY);
+    }
+
+    /// <summary>
+    /// Get MCNK bounds from MapChunk
+    /// </summary>
+    public static void GetMCNKBoundsFromChunk(in MapChunk chunk, out float minX, out float minY, out float maxX, out float maxY)
+    {
+        // MapChunk stores base position
+        minX = chunk.xbase;
+        minY = chunk.ybase;
+        maxX = minX + ChunkReader.CHUNKSIZE;
+        maxY = minY + ChunkReader.CHUNKSIZE;
+    }
+
+    /// <summary>
+    /// Check if a 2D point is within MCNK bounds (ignoring Z)
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsPointInMCNK(float x, float y, float minX, float minY, float maxX, float maxY)
+    {
+        return x >= minX && x <= maxX && y >= minY && y <= maxY;
+    }
+
+    /// <summary>
+    /// Check if an AABB (Axis-Aligned Bounding Box) intersects with MCNK bounds
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool AABBIntersectsMCNK(
+        float aabb_minX, float aabb_minY, float aabb_maxX, float aabb_maxY,
+        float mcnk_minX, float mcnk_minY, float mcnk_maxX, float mcnk_maxY)
+    {
+        // AABB intersection test (2D)
+        return !(aabb_maxX < mcnk_minX || aabb_minX > mcnk_maxX ||
+                 aabb_maxY < mcnk_minY || aabb_minY > mcnk_maxY);
+    }
+
+    /// <summary>
+    /// Calculate AABB for a ModelInstance
+    /// </summary>
+    public static void GetModelBounds(in ModelInstance mi, out float minX, out float minY, out float maxX, out float maxY)
+    {
+        if (mi.model.boundingVertices == null || mi.model.boundingVertices.Length == 0)
+        {
+            // Fallback: use position with small radius
+            const float DEFAULT_RADIUS = 5.0f;
+            minX = mi.pos.X - DEFAULT_RADIUS;
+            minY = mi.pos.Y - DEFAULT_RADIUS;
+            maxX = mi.pos.X + DEFAULT_RADIUS;
+            maxY = mi.pos.Y + DEFAULT_RADIUS;
+            return;
+        }
+
+        // Calculate actual bounding box from vertices
+        minX = float.MaxValue;
+        minY = float.MaxValue;
+        maxX = float.MinValue;
+        maxY = float.MinValue;
+
+        for (int i = 0; i < mi.model.boundingVertices.Length / 3; i++)
+        {
+            int off = i * 3;
+            float x = mi.model.boundingVertices[off] * mi.scale + mi.pos.X;
+            float y = mi.model.boundingVertices[off + 2] * mi.scale + mi.pos.Y;
+
+            if (x < minX) minX = x;
+            if (y < minY) minY = y;
+            if (x > maxX) maxX = x;
+            if (y > maxY) maxY = y;
+        }
+    }
+
+    /// <summary>
+    /// Calculate AABB for a WMOInstance using bounding box from WMORoot
+    /// </summary>
+    public static void GetWMOBounds(in WMOInstance wi, out float minX, out float minY, out float maxX, out float maxY)
+    {
+        // WMOInstance stores pos2 and pos3 which appear to be bounding box corners
+        // Use these directly for a conservative AABB
+        minX = System.Math.Min(wi.pos2.X, wi.pos3.X);
+        minY = System.Math.Min(wi.pos2.Y, wi.pos3.Y);
+        maxX = System.Math.Max(wi.pos2.X, wi.pos3.X);
+        maxY = System.Math.Max(wi.pos2.Y, wi.pos3.Y);
+
+        // Ensure we have valid bounds
+        if (minX > maxX) (minX, maxX) = (maxX, minX);
+        if (minY > maxY) (minY, maxY) = (maxY, minY);
+    }
+
+    /// <summary>
+    /// Check if a ModelInstance intersects with MCNK chunk
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool ModelIntersectsMCNK(in ModelInstance mi, float mcnk_minX, float mcnk_minY, float mcnk_maxX, float mcnk_maxY)
+    {
+        GetModelBounds(mi, out float model_minX, out float model_minY, out float model_maxX, out float model_maxY);
+        return AABBIntersectsMCNK(model_minX, model_minY, model_maxX, model_maxY,
+                                  mcnk_minX, mcnk_minY, mcnk_maxX, mcnk_maxY);
+    }
+
+    /// <summary>
+    /// Check if a WMOInstance intersects with MCNK chunk
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool WMOIntersectsMCNK(in WMOInstance wi, float mcnk_minX, float mcnk_minY, float mcnk_maxX, float mcnk_maxY)
+    {
+        GetWMOBounds(wi, out float wmo_minX, out float wmo_minY, out float wmo_maxX, out float wmo_maxY);
+        return AABBIntersectsMCNK(wmo_minX, wmo_minY, wmo_maxX, wmo_maxY,
+                                  mcnk_minX, mcnk_minY, mcnk_maxX, mcnk_maxY);
+    }
+}

--- a/PPather/Triangles/MPQTriangleSupplier.cs
+++ b/PPather/Triangles/MPQTriangleSupplier.cs
@@ -176,6 +176,72 @@ public sealed class MPQTriangleSupplier
         }
     }
 
+    /// <summary>
+    /// Load triangles for a specific MCNK chunk with spatial model culling.
+    /// Only loads:
+    /// - 145 MCVT vertices for this MCNK's terrain
+    /// - Models/WMOs whose bounding boxes intersect this MCNK
+    /// </summary>
+    [SkipLocalsInit]
+    public void GetMCNKTriangles(TriangleCollection tc, int adt_x, int adt_y, int mcnk_x, int mcnk_y)
+    {
+        if (tc == null || wdtf == null || wdt == null)
+            return;
+        if (adt_x < 0 || adt_y < 0 || adt_x > 63 || adt_y > 63)
+            return;
+        if (mcnk_x < 0 || mcnk_y < 0 || mcnk_x > 15 || mcnk_y > 15)
+            return;
+
+        int index = adt_y * WDT.SIZE + adt_x;
+
+        // Load ADT if not already loaded
+        if (!wdt.loaded[index])
+        {
+            wdtf.LoadMapTile(adt_x, adt_y, index);
+        }
+
+        MapTile mapTile = wdt.maptiles[index];
+        if (!wdt.loaded[index])
+            return;
+
+        // Get MCNK bounds for spatial filtering
+        MCNKHelper.GetMCNKBounds(adt_x, adt_y, mcnk_x, mcnk_y,
+            out float mcnk_minX, out float mcnk_minY, out float mcnk_maxX, out float mcnk_maxY);
+
+        // 1. Load ONLY this specific MCNK's terrain
+        int mcnk_index = MCNKHelper.GetMCNKIndex(mcnk_x, mcnk_y);
+        if (mapTile.hasChunk[mcnk_index])
+        {
+            AddTriangles(tc, mapTile.chunks[mcnk_index]);
+        }
+
+        // 2. Load ONLY WMOs that intersect this MCNK's bounds
+        for (int i = 0; i < mapTile.wmois.Length; i++)
+        {
+            WMOInstance wi = mapTile.wmois[i];
+            if (MCNKHelper.WMOIntersectsMCNK(wi, mcnk_minX, mcnk_minY, mcnk_maxX, mcnk_maxY))
+            {
+                AddTriangles(tc, wi);
+            }
+        }
+
+        // 3. Load ONLY M2 models that intersect this MCNK's bounds
+        for (int i = 0; i < mapTile.modelis.Length; i++)
+        {
+            ModelInstance mi = mapTile.modelis[i];
+            if (MCNKHelper.ModelIntersectsMCNK(mi, mcnk_minX, mcnk_minY, mcnk_maxX, mcnk_maxY))
+            {
+                AddDetailedTriangles(tc, mi);
+            }
+        }
+
+        // Note: Global WMOs are handled at a higher level if needed
+        // They span multiple MCNKs so we don't include them here
+
+        // Mark as not loaded to allow garbage collection
+        wdt.loaded[index] = false;
+    }
+
     [SkipLocalsInit]
     private static void AddTriangles(TriangleCollection tc, MapChunk c)
     {

--- a/PPather/Triangles/TriangleMatrix.cs
+++ b/PPather/Triangles/TriangleMatrix.cs
@@ -17,6 +17,8 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
+using static System.Math;
+
 using static WowTriangles.Utils;
 
 namespace WowTriangles;
@@ -28,6 +30,9 @@ public sealed class TriangleMatrix
 
     private const int CellCapacity = 4096;
     private const int ACount = 128;
+    private const int MinElementBufferSize = 256;
+
+    [ThreadStatic] private static int[]? t_elementBuffer;
 
     private readonly SparseFloatMatrix2D<List<int>> matrix = new(resolution, CellCapacity);
 
@@ -151,8 +156,10 @@ public sealed class TriangleMatrix
 
         (int collectionCount, int totalSize) = matrix.GetAllInSquare(collectionMem, x - range, y - range, x + range, y + range);
 
-        int[] elements = ArrayPool<int>.Shared.Rent(totalSize);
-        Span<int> outputSpan = elements.AsSpan();
+        if (t_elementBuffer == null || t_elementBuffer.Length < totalSize)
+            t_elementBuffer = new int[Max(totalSize, MinElementBufferSize)];
+
+        Span<int> outputSpan = t_elementBuffer.AsSpan();
 
         int c = 0;
         for (int i = 0; i < collectionCount; i++)
@@ -179,8 +186,10 @@ public sealed class TriangleMatrix
 
         (int collectionCount, int totalSize) = matrix.GetAllInSquare(collectionMem, x0, y0, x1, y1);
 
-        int[] elements = ArrayPool<int>.Shared.Rent(totalSize);
-        Span<int> outputSpan = elements.AsSpan();
+        if (t_elementBuffer == null || t_elementBuffer.Length < totalSize)
+            t_elementBuffer = new int[Max(totalSize, MinElementBufferSize)];
+
+        Span<int> outputSpan = t_elementBuffer.AsSpan();
 
         int c = 0;
         for (int i = 0; i < collectionCount; i++)

--- a/PPather/Triangles/Utils.cs
+++ b/PPather/Triangles/Utils.cs
@@ -367,4 +367,51 @@ public static class Utils
     {
         return Max(Max(a, b), Max(c, d));
     }
+
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Vector3 ClosestPointOnSegment(in Vector3 p0, in Vector3 x1, in Vector3 x2)
+    {
+        Vector3 L = x2 - x1;
+        float l2 = Dot(L, L);
+        if (l2 < 1e-12f)
+            return x1;
+
+        float t = Math.Clamp(Dot(p0 - x1, L) / l2, 0.0f, 1.0f);
+        return x1 + (L * t);
+    }
+
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Vector3 ClosestPointOnTriangle(in Vector3 p0, in Vector3 t0, in Vector3 t1, in Vector3 t2)
+    {
+        Vector3 u = Subtract(t1, t0);
+        Vector3 v = Subtract(t2, t0);
+        Vector3 n = Cross(u, v);
+
+        float normalLenSq = Dot(n, n);
+        if (normalLenSq >= 1e-12f)
+        {
+            Vector3 normalDir = n * (1.0f / Sqrt(normalLenSq));
+            Vector3 above = p0 + normalDir * 1E6f;
+            Vector3 below = p0 - normalDir * 1E6f;
+
+            if (SegmentTriangleIntersect(above, below, t0, t1, t2, out Vector3 intersect))
+            {
+                return intersect;
+            }
+        }
+
+        Vector3 c0 = ClosestPointOnSegment(p0, t0, t1);
+        Vector3 c1 = ClosestPointOnSegment(p0, t1, t2);
+        Vector3 c2 = ClosestPointOnSegment(p0, t2, t0);
+
+        float d0 = Subtract(c0, p0).LengthSquared();
+        float d1 = Subtract(c1, p0).LengthSquared();
+        float d2 = Subtract(c2, p0).LengthSquared();
+
+        if (d0 <= d1 && d0 <= d2) return c0;
+        if (d1 <= d2) return c1;
+        return c2;
+    }
 }

--- a/PathingAPI/Pages/Watch.razor
+++ b/PathingAPI/Pages/Watch.razor
@@ -55,8 +55,10 @@
             <button @onclick="ToggleWireFrame">
                 <span style="@(WireFrameEnabled ? "color: green;" : "")">Wire</span>
             </button>
-            <button @onclick="() => LoadGeometry = !LoadGeometry">
-                <span style="@(LoadGeometry ? "color: green;" : "")">Show3D</span>
+            <button @onclick="CycleGeometryMode">
+                <span style="@(CurrentGeometryMode != GeometryMode.Off ? "color: " + GetGeometryModeColor() + ";" : "")">
+                    @GetGeometryModeText()
+                </span>
             </button>
         }
         <button @onclick="async () => await Reset()">
@@ -86,7 +88,17 @@
         Magenta
     }
 
+    public enum GeometryMode
+    {
+        Off = 0,              // No geometry
+        SparseFromSpots,      // Only explored triangles (70-90% reduction)
+        WalkableOnly,         // Pre-filtered walkable areas (50-80% reduction)
+        ExploredArea,         // Bounding box of explored spots (30-70% reduction)
+        All                   // Full mesh (current behavior)
+    }
+
     private const int RefreshTimeMs = 50;
+    private const float WalkableSearchRadius = 20.0f;
 
     [Parameter]
     public int PathColour { get; set; } = (int)Color.Red;
@@ -107,7 +119,7 @@
 
     private ConcurrentQueue<ChunkEventArgs> chunkEventArgs = new();
 
-    private bool LoadGeometry { get; set; } = true;
+    private GeometryMode CurrentGeometryMode { get; set; } = GeometryMode.All;
 
     private bool DrawTestPoints { get; set; } = false;
 
@@ -193,6 +205,46 @@
     {
         SceneExplorerEnabled = !SceneExplorerEnabled;
         await jsRuntime.InvokeVoidAsync("toggleSceneExplorer", Token, SceneExplorerEnabled);
+    }
+
+    private void CycleGeometryMode()
+    {
+        // Cycle through modes: Off -> SparseFromSpots -> WalkableOnly -> ExploredArea -> All -> Off
+        CurrentGeometryMode = CurrentGeometryMode switch
+        {
+            GeometryMode.Off => GeometryMode.SparseFromSpots,
+            GeometryMode.SparseFromSpots => GeometryMode.WalkableOnly,
+            GeometryMode.WalkableOnly => GeometryMode.ExploredArea,
+            GeometryMode.ExploredArea => GeometryMode.All,
+            GeometryMode.All => GeometryMode.Off,
+            _ => GeometryMode.All
+        };
+    }
+
+    private string GetGeometryModeText()
+    {
+        return CurrentGeometryMode switch
+        {
+            GeometryMode.Off => "3D:Off",
+            GeometryMode.SparseFromSpots => "3D:Sparse",
+            GeometryMode.WalkableOnly => "3D:Walk",
+            GeometryMode.ExploredArea => "3D:Area",
+            GeometryMode.All => "3D:All",
+            _ => "3D"
+        };
+    }
+
+    private string GetGeometryModeColor()
+    {
+        return CurrentGeometryMode switch
+        {
+            GeometryMode.Off => "gray",
+            GeometryMode.SparseFromSpots => "cyan",      // Most precise - cyan
+            GeometryMode.WalkableOnly => "yellow",       // Pre-filtered - yellow
+            GeometryMode.ExploredArea => "orange",       // Bounding box - orange
+            GeometryMode.All => "green",                 // Full mesh - green
+            _ => "white"
+        };
     }
 
     private async ValueTask Reset()
@@ -296,7 +348,7 @@
     {
         if (!BabylonJs) { return; }
 
-        while (LoadGeometry &&
+        while (CurrentGeometryMode != GeometryMode.Off &&
             !token.IsCancellationRequested &&
             chunkEventArgs.TryDequeue(out var e))
         {
@@ -365,40 +417,15 @@
         {
             TriangleCollection chunks = pPatherService.GetChunkAt(e.GridX, e.GridY);
 
-            var pooler = ArrayPool<int>.Shared;
-
-            int count = chunks.TriangleCount * 3;
-
-            var array1 = pooler.Rent(count);
-            var array2 = pooler.Rent(count);
-            var array3 = pooler.Rent(count);
-            var array4 = pooler.Rent(count);
-
-            try
+            if (CurrentGeometryMode == GeometryMode.All)
             {
-                var c1 = MeshFactory.CreateTriangles(TriangleType.Terrain, chunks, array1);
-                var c2 = MeshFactory.CreateTriangles(TriangleType.Water, chunks, array2);
-                var c3 = MeshFactory.CreateTriangles(TriangleType.Object, chunks, array3);
-                var c4 = MeshFactory.CreateTriangles(TriangleType.Model, chunks, array4);
-
-                int i = 0;
-                Memory<int>[] models = new Memory<int>[4];
-                models[i++] = array1.AsMemory(0, c1);
-                models[i++] = array2.AsMemory(0, c2);
-                models[i++] = array3.AsMemory(0, c3);
-                models[i++] = array4.AsMemory(0, c4);
-
-                var positions = MeshFactory.CreatePoints(chunks);
-
-                await hubContext.Clients.All.SendAsync("addModels", models, positions, token);
-                //await SendDrawBoundBox(chunks.Min, chunks.Max, Color.Magenta, $"boundbox_{e.GridX}_{e.GridY}", token);
+                // Original behavior: Load full mesh
+                await LoadFullMesh(chunks, token);
             }
-            finally
+            else
             {
-                pooler.Return(array1);
-                pooler.Return(array2);
-                pooler.Return(array3);
-                pooler.Return(array4);
+                // Sparse mesh variants: Load only used vertices
+                await LoadSparseMesh(chunks, token);
             }
         }
         catch (OperationCanceledException)
@@ -410,6 +437,142 @@
             // Log the exception or handle it as needed
             await SendLog($"Error in DequeueChunkEvent: {ex.Message}", token);
         }
+    }
+
+    private async ValueTask LoadFullMesh(TriangleCollection chunks, CancellationToken token)
+    {
+        var pooler = ArrayPool<int>.Shared;
+        int count = chunks.TriangleCount * 3;
+
+        var array1 = pooler.Rent(count);
+        var array2 = pooler.Rent(count);
+        var array3 = pooler.Rent(count);
+        var array4 = pooler.Rent(count);
+
+        try
+        {
+            var c1 = MeshFactory.CreateTriangles(TriangleType.Terrain, chunks, array1);
+            var c2 = MeshFactory.CreateTriangles(TriangleType.Water, chunks, array2);
+            var c3 = MeshFactory.CreateTriangles(TriangleType.Object, chunks, array3);
+            var c4 = MeshFactory.CreateTriangles(TriangleType.Model, chunks, array4);
+
+            int i = 0;
+            Memory<int>[] models = new Memory<int>[4];
+            models[i++] = array1.AsMemory(0, c1);
+            models[i++] = array2.AsMemory(0, c2);
+            models[i++] = array3.AsMemory(0, c3);
+            models[i++] = array4.AsMemory(0, c4);
+
+            var positions = MeshFactory.CreatePoints(chunks);
+
+            await hubContext.Clients.All.SendAsync("addModels", models, positions, token);
+        }
+        finally
+        {
+            pooler.Return(array1);
+            pooler.Return(array2);
+            pooler.Return(array3);
+            pooler.Return(array4);
+        }
+    }
+
+    private async ValueTask LoadSparseMesh(TriangleCollection chunks, CancellationToken token)
+    {
+        List<Vector3> vertices;
+        List<int> indices;
+
+        // OPTIMIZATION: Filter spots to only those within chunk bounds
+        // This reduces O(all_spots × triangles) to O(chunk_spots × triangles)
+        var allSpots = pPatherService.GetSpots();
+        var spotsInChunk = FilterSpotsInChunkBounds(allSpots, chunks);
+
+        // Early exit: If no spots in chunk for spot-based modes
+        if (spotsInChunk.Count == 0 &&
+            (CurrentGeometryMode == GeometryMode.SparseFromSpots ||
+             CurrentGeometryMode == GeometryMode.ExploredArea))
+        {
+            // Send empty mesh
+            await SendEmptyMesh(token);
+            return;
+        }
+
+        switch (CurrentGeometryMode)
+        {
+            case GeometryMode.SparseFromSpots:
+                // Most precise: Only triangles with spots
+                (vertices, indices) = MeshFactory.CreateSparseFromSpots(
+                    chunks, spotsInChunk,
+                    toonHeight: 2.0f, toonSize: 0.5f);
+                break;
+
+            case GeometryMode.WalkableOnly:
+                // Pre-filtered: Only walkable areas near explored spots
+                // OPTIMIZED: Only tests vertices within searchRadius of discovered spots
+                (vertices, indices) = MeshFactory.CreateWalkableOnly(
+                    chunks, pPatherService.TriangleWorld,
+                    toonHeight: 2.0f, toonSize: 0.5f,
+                    nearbySpots: spotsInChunk,
+                    searchRadius: WalkableSearchRadius);
+                break;
+
+            case GeometryMode.ExploredArea:
+                // Bounding box: Explored region
+                (vertices, indices) = MeshFactory.CreateExploredArea(
+                    chunks, spotsInChunk,
+                    expandRadius: 10.0f);
+                break;
+
+            default:
+                return; // Off mode - do nothing
+        }
+
+        // Send sparse mesh to client
+        // We'll send all as terrain type for simplicity
+        Memory<int>[] models = new Memory<int>[4];
+        models[0] = indices.ToArray().AsMemory();  // Terrain
+        models[1] = Array.Empty<int>().AsMemory(); // Water
+        models[2] = Array.Empty<int>().AsMemory(); // Object
+        models[3] = Array.Empty<int>().AsMemory(); // Model
+
+        await hubContext.Clients.All.SendAsync("addModels", models, vertices, token);
+    }
+
+    private List<Spot> FilterSpotsInChunkBounds(IEnumerable<Spot> spots, TriangleCollection chunks)
+    {
+        // Get chunk bounds with some padding
+        const float PADDING = 5.0f; // Include spots slightly outside chunk
+        float minX = chunks.Min.X - PADDING;
+        float minY = chunks.Min.Y - PADDING;
+        float maxX = chunks.Max.X + PADDING;
+        float maxY = chunks.Max.Y + PADDING;
+
+        List<Spot> filtered = new();
+        foreach (var spot in spots)
+        {
+            if (spot.IsBlocked())
+                continue;
+
+            Vector3 loc = spot.Loc;
+            if (loc.X >= minX && loc.X <= maxX &&
+                loc.Y >= minY && loc.Y <= maxY)
+            {
+                filtered.Add(spot);
+            }
+        }
+
+        return filtered;
+    }
+
+    private async Task SendEmptyMesh(CancellationToken token)
+    {
+        Memory<int>[] models = new Memory<int>[4];
+        models[0] = Array.Empty<int>().AsMemory();
+        models[1] = Array.Empty<int>().AsMemory();
+        models[2] = Array.Empty<int>().AsMemory();
+        models[3] = Array.Empty<int>().AsMemory();
+
+        List<Vector3> emptyVertices = new();
+        await hubContext.Clients.All.SendAsync("addModels", models, emptyVertices, token);
     }
 
     // SignalR methods to babylonjs.js


### PR DESCRIPTION
TLDR: 
* Less likely to hug walls
* More likely to reach the destination via the navigation
* Respects the current player movement limitation and accounts for them

---

Introduce Structure-of-Arrays (SoA) data layout for pathfinding graph nodes via a new SpotManager, replacing the previous object-scattered Spot storage. Add grid-aligned spot placement, wall/edge repulsion post-processing, and improved triangle scoring -- all validated by iterative benchmarking.

=== Architecture: SpotManager (SoA data layout) ===

- NEW PPather/Graph/SpotManager.cs: Central manager storing all spot data in contiguous parallel arrays (locations, flags, path edges, chunks) indexed by a cached Spot.ManagerIndex for O(1) access.
  - Flattened edge storage in a single float[] with per-spot offset/capacity tracking, eliminating per-Spot float[] path allocations.
  - Edge spot cache (edgeSpotCache[]) avoids costly coordinate->Spot round-trips in GetPathsToSpots; cache misses resolved lazily.
  - Reusable neighborBuffer for single-threaded A* neighbor enumeration.
  - Cached triangle scores (short[]) per spot to avoid redundant closeness+gradient recomputation during a single search.

- NEW PPather/Graph/SearchBuffer.cs: Pooled per-search state buffer (traceBack indices, G/F scores, closed/scoreSet BitArrays) allocated from a ConcurrentStack<SearchBuffer> pool and returned after each search. Replaces search state fields that were previously scattered across individual Spot objects (searchID, traceBack, score, closed, scoreSet). ~180 KB per search, reused across searches via pool.

- CHANGED PPather/Graph/Spot.cs: Stripped down to a lightweight identifier. Removed ~170 lines of path management, search state, and scoring methods. All data now lives in SpotManager arrays. Only Loc, flags, chunk, next (for spatial hash chaining), and ManagerIndex remain. Added FLAG_ON_OBJECT (0x0040) to distinguish bridge/ramp surfaces from indoor corridors.

=== Pathfinding: Grid-based connectivity ===

- CHANGED PPather/Graph/PathGraph.cs:
  - Replaced radial spot scanning (FindAllSpots + angle-based loop) with grid-aligned 8-neighbor connectivity using SpotGridSize (= WantedStepLength).
  - SnapToGrid() ensures spots land on predictable, evenly-spaced positions.
  - AddAndConnectSpot() now connects only to 8 cardinal+diagonal grid neighbors instead of all spots within MaxStepLength radius, preventing long-distance shortcut edges.
  - CreateSpotsAroundSpot() uses grid offsets instead of radial angle sweep, producing uniform coverage with no overlap or gaps.
  - Line-of-sight checks now filter by TriangleType (Object|Model only), preventing terrain slopes from falsely blocking neighbor connections while still blocking paths through walls and tree trunks.
  - Spots standing on Object geometry (bridges, ramps) skip the LoS block check to avoid the walkable surface's own triangles blocking the ray.
  - Ceiling raycast (head->sky at CeilingCheckHeight=20) distinguishes indoor corridors (FLAG_INDOORS) from open bridges (FLAG_ON_OBJECT only).

- All A* scoring methods (ScoreSpot_A_Star, ScoreSpot_A_Star_With_Model_ And_Gradient_Avoidance, ScoreSpot_Pather) updated to use SpotManager for distance calculations, flag checks, and search state management.

- CreatePath() now wraps Search() in try/finally to guarantee SpotManager.CompleteSearch() returns the SearchBuffer to the pool.

- Search start/end spots are now integrated into the grid by calling CreateSpotsAroundSpot() at path creation time.

=== Wall and edge avoidance ===

- NEW: ApplyWallRepulsion() post-processes path waypoints (2 passes):
  - For ground-level waypoints near Model|Object walls: computes XY repulsion direction from closest wall triangle (filtering floors/ ceilings via normal.Z > 0.7 threshold), pushes waypoint away by WallAvoidanceDistance (3.0 yards) minus actual wall distance.
  - For waypoints on Object surfaces (bridges): probes 8 directions for drop-off edges, pushes toward center of walkable surface.
  - Validates all pushed positions are standable before applying.
  - Only applied when SearchStrategy is A_Star_With_Model_Avoidance.

- CHANGED: IsCloseToObjectRange increased from MinStepLength to MaxStepLength for broader object proximity detection.

- CHANGED Core/GoalsComponent/Navigation.cs: minAngleToStopBeforeTurn reduced from PI/2 (90 degrees) to PI/3 (60 degrees) for smoother turning behavior.

=== Triangle geometry improvements ===

- CHANGED PPather/Triangles/ChunkedTriangleCollection.cs:
  - NEW: GradiantScoreTiered() -- single-pass tiered gradient scoring at ranges 1/2/3 instead of 3 separate GradiantScore() calls.
  - NEW: ClosestDistanceToType() -- returns continuous float distance to nearest triangle of given type (replaces boolean IsCloseToType for closeness scoring, enabling smooth cost gradients).
  - NEW: CombinedScoring() -- fused closeness+gradient scoring in one triangle query pass, eliminating duplicate GetChunkAt/GetTriangleMatrix/ GetAllCloseTo lookups. Filters wall-like triangles (|normal.Z| <= 0.7) for closeness, ignoring floors and ceilings.
  - NEW: LineOfSightExists(a, b, blockingMask) overload -- LoS check considering only triangles matching a TriangleType mask.
  - NEW: TryGetWallRepulsion() -- finds closest wall triangle within range and returns XY repulsion direction + distance for path smoothing.
  - FIX: IsCloseToType() now checks maxZ (not minZ) against toon height, fixing false negatives for triangles partially above the toon.

- NEW PPather/Triangles/MCNKHelper.cs: MCNK-aligned coordinate conversion utilities (ADT->MCNK coord mapping, bounds calculation, AABB intersection tests for Model/WMO instances). Enables MCNK-granularity chunk loading.

- CHANGED PPather/Triangles/MPQTriangleSupplier.cs: NEW GetMCNKTriangles() loads only a single MCNK's terrain (145 vertices) plus spatially-culled models/WMOs, ~97% memory reduction vs full ADT loading.

- NEW PPather/Triangles/Utils.cs: Added ClosestPointOnSegment() and ClosestPointOnTriangle() for wall repulsion distance calculations.

- CHANGED PPather/Triangles/TriangleMatrix.cs: Replaced ArrayPool<int>
  rentals with ThreadStatic reusable buffer (t_elementBuffer) to eliminate per-query pool overhead in hot triangle lookup paths.

=== GraphChunk alignment ===

- CHANGED PPather/Graph/GraphChunk.cs:
  - CHUNK_SIZE reduced from 256 to 34 (MCNK-aligned: 33.33 yards), reducing per-chunk spot array from 65,536 to 1,156 entries (56x smaller).
  - Constructor accepts optional SpotManager for eager spot registration.
  - Load/Save updated to use SpotManager for path storage instead of per-Spot float[] paths.

=== Visualization enhancements ===

- CHANGED PathingAPI/Pages/Watch.razor:
  - Replaced binary Show3D toggle with 5-mode geometry cycle: Off -> SparseFromSpots -> WalkableOnly -> ExploredArea -> All
  - Each mode has distinct color indicator (cyan/yellow/orange/green).
  - Spots are filtered to chunk bounds before mesh generation.

- NEW PPather/Search/MeshFactory.cs: Three sparse mesh creation variants:
  - CreateSparseFromSpots: Only triangles intersecting discovered spots.
  - CreateWalkableOnly: Pre-filtered walkable vertices near explored spots.
  - CreateExploredArea: All triangles within explored bounding box.

- CHANGED PPather/Search/PPatherService.cs: Exposed TriangleWorld property and GetSpots() method for visualization access.

=== Benchmarks ===

- NEW Benchmarks/PPather/PPather_PathGraph_Performance.cs: BenchmarkDotNet suite measuring SpotManager operations (location lookups, distance calcs, flag ops, path reconstruction, A* scoring loop, SearchBuffer alloc/reset).

=== Performance progression (30-route PathingAPI benchmark suite) ===

  Before refactor:    297ms avg, 171ms median, 17.86s total
  After initial SoA:  357ms avg, 142ms median, 21.45s total (regression)
  Manager index opt:  199ms avg,  10ms median, 11.97s total (breakthrough)
  Final stabilized:   243ms avg,  74ms median, 14.65s total
  Third warm run:     201ms avg,  62ms median, 12.05s total

  Median improved 64% (171ms -> 62ms). Key route improvements:
  - "Coldridge->gnome": 950ms -> 187ms (80% faster)
  - "Redridge Grave->North": 570ms -> 248ms (56% faster)
  
---
  
## Few issues which had been addressed
 
**Before**: Too close to corridor walls often hugging them
<img width="1181" height="857" alt="hugs_close_to_wall" src="https://github.com/user-attachments/assets/4a13aae7-eae7-4de9-a72a-68763eb80ed0" />

**After**
<img width="1554" height="823" alt="image" src="https://github.com/user-attachments/assets/b56c06c5-9bd5-45b0-a16f-c682198a6ec9" />

---

**Before**
<img width="1519" height="975" alt="hugging_wall" src="https://github.com/user-attachments/assets/5ab575b1-f95f-41a4-9d5a-f579565bc0b2" />

**After**
<img width="1173" height="789" alt="image" src="https://github.com/user-attachments/assets/eb68e754-a498-4d6d-8298-6ee84f2d86ea" />

---

**After**
<img width="1021" height="863" alt="image" src="https://github.com/user-attachments/assets/46483b96-74d4-44ac-a619-78806646874b" />


---

**Before**: Unable to step on ramps during the terran type transition
<img width="878" height="615" alt="unable_to_step_on_the_ramp_stairs" src="https://github.com/user-attachments/assets/1fdaa2e4-1a73-4e87-8a01-d524bb770655" />

**After**
<img width="1325" height="941" alt="image" src="https://github.com/user-attachments/assets/d548eccf-7e75-4fbb-8715-46a81f2978df" />

---

**Before**: Crossing bridges dangerously close to the edge
<img width="1690" height="842" alt="bridges_objects_dangerously_close_to_edge" src="https://github.com/user-attachments/assets/bb0fe99b-b408-4fdc-b24e-d01102427ba1" />

**After**
<img width="1627" height="726" alt="made_difference" src="https://github.com/user-attachments/assets/b1220e58-fb5e-4b1e-802c-7977b4fe9caa" />
