### PR TITLE
Addon: [1.9.7] - Fix addon init/reset sync and pet targeting dead mobs (#751)

### DIFF
--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -166,7 +166,6 @@ end
 
 -- initialization
 local globalTick = 0
-local initPhase = 10
 
 DataToColor.DATA_CONFIG = {
     ACCEPT_PARTY_REQUESTS = false, -- O
@@ -177,6 +176,7 @@ DataToColor.DATA_CONFIG = {
 }
 
 local FRAME_CHANGE_RATE = 5
+local initPhase = 2 * FRAME_CHANGE_RATE
 
 -- How often item frames change
 local ITEM_ITERATION_FRAME_CHANGE_RATE = FRAME_CHANGE_RATE
@@ -804,6 +804,13 @@ function DataToColor:CreateFrames()
 
     local function updateFrames()
         if not SETUP_SEQUENCE and globalTick >= initPhase then
+            -- Ensure globalTime is past the C# FullReset threshold (Value <= 3)
+            -- so queue data is processed immediately when rendering starts.
+            -- Without this, the first queue items only get ~1 frame of C# visibility.
+            if DataToColor.globalTime < initPhase then
+                DataToColor.globalTime = initPhase
+            end
+
             Pixel(int, 0, 0)
             -- The final data square, reserved for additional metadata.
             Pixel(int, 2000001, NUMBER_OF_FRAMES - 1)

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Legacy Cataclysm 4.3.0)
-## Version: 1.9.6
+## Version: 1.9.7
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, cTimerBackport
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor_Classic.toc
+++ b/Addons/DataToColor/DataToColor_Classic.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic)
-## Version: 1.9.6
+## Version: 1.9.7
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor_TBC.toc
+++ b/Addons/DataToColor/DataToColor_TBC.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic TBC)
-## Version: 1.9.6
+## Version: 1.9.7
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Core/Addon/AddonReader.cs
+++ b/Core/Addon/AddonReader.cs
@@ -30,6 +30,8 @@ public sealed class AddonReader : IAddonReader
 
     public RecordInt GlobalTime { get; }
 
+    private int previousGlobalTime;
+
     private int lastTargetGuid = -1;
     public string TargetName { get; private set; } = string.Empty;
 
@@ -70,11 +72,14 @@ public sealed class AddonReader : IAddonReader
 
         AvgUpdateLatency = GetElapsedTime(lastUpdate).TotalMilliseconds;
 
-        if (GlobalTime.Value <= 3)
+        if (GlobalTime.Value < AddonTicks.INIT_PHASE || GlobalTime.Value < previousGlobalTime)
         {
+            previousGlobalTime = GlobalTime.Value;
             FullReset();
             return;
         }
+
+        previousGlobalTime = GlobalTime.Value;
 
         ReadOnlySpan<IReader> span = readers.AsSpan();
         for (int i = 0; i < span.Length; i++)

--- a/Core/Addon/AddonTicks.cs
+++ b/Core/Addon/AddonTicks.cs
@@ -4,5 +4,7 @@ public static class AddonTicks
 {
     public const int GLOBAL_QUEUE_UPDATE = 5;
 
+    public const int INIT_PHASE = 2 * GLOBAL_QUEUE_UPDATE;
+
     public const int BAG_UPDATE = GLOBAL_QUEUE_UPDATE;
 }

--- a/Core/Goals/TargetPetTargetGoal.cs
+++ b/Core/Goals/TargetPetTargetGoal.cs
@@ -39,7 +39,7 @@ public sealed class TargetPetTargetGoal : GoapGoal
 
     public override bool CanRun()
     {
-        return playerReader.PetAlive() && bits.Pet_Defensive();
+        return playerReader.PetAlive() && bits.Pet_Defensive() && bits.PetTarget_Alive();
     }
 
     public override void Update()


### PR DESCRIPTION
## Summary

- **Addon init/reset race condition**: The C# `FullReset` threshold was a hardcoded magic number (`<= 3`) that didn't align with the Lua `initPhase`. Queue data sent during early frames could be missed because `globalTime` wasn't past the reset threshold when rendering started. Now both sides derive the threshold from `FRAME_CHANGE_RATE` / `GLOBAL_QUEUE_UPDATE`, and `AddonReader` also detects time wraparound (addon reload) via `previousGlobalTime`.
- **Pet targeting dead mobs**: `TargetPetTargetGoal.CanRun()` didn't check `PetTarget_Alive()`, causing the Succubus (or any defensive pet) to loop on a corpse target. Added the alive guard.

Addon version bumped from 1.9.6 to 1.9.7.

## Test plan

- [x] Start bot fresh — verify `FullReset` fires once during init phase and addon frames render correctly after
- [x] `/reload` in-game — verify `FullReset` triggers on time wraparound (globalTime decreases)
- [x] With Warlock Succubus: kill a mob via pet — verify the bot does not re-target the corpse

🤖 Generated with [Claude Code](https://claude.com/claude-code)