### PR TITLE
Addon: [1.9.8] - Add UI frame open state bits and make AnyBagOpen event-driven

### DIFF
--- a/Addons/DataToColor/BitCache.lua
+++ b/Addons/DataToColor/BitCache.lua
@@ -37,6 +37,9 @@ local HasPetUI = HasPetUI
 local GetPetHappiness = GetPetHappiness
 local GetPetActionInfo = GetPetActionInfo
 local UnitIsTrivial = UnitIsTrivial
+local CharacterFrame = CharacterFrame
+local SpellBookFrame = SpellBookFrame
+local FriendsFrame = FriendsFrame
 
 --------------------------------------------------------------------------------
 -- Bit Cache Storage
@@ -110,6 +113,10 @@ local bits3Cache = {
     chatInputActive = false,        -- bit 9 (polled)
     softTargetEnabled = false,      -- bit 10
     mailFrameShown = false,         -- bit 11
+    anyBagOpen = false,             -- bit 12 (event-driven: BAG_OPEN/BAG_CLOSED)
+    characterFrameOpen = false,     -- bit 13 (hooked)
+    spellBookFrameOpen = false,     -- bit 14 (hooked)
+    friendsFrameOpen = false,       -- bit 15 (hooked)
 }
 
 -- Track if cache has been initialized
@@ -409,6 +416,11 @@ local function InitializeCache()
     UpdateLootFrameCache()
     UpdateMailFrameCache()
 
+    bits3Cache.anyBagOpen = DataToColor:AnyBagOpen()
+    bits3Cache.characterFrameOpen = DataToColor:CharacterFrameOpen()
+    bits3Cache.spellBookFrameOpen = DataToColor:SpellBookFrameOpen()
+    bits3Cache.friendsFrameOpen = DataToColor:FriendsFrameOpen()
+
     -- Initialize polled values (includes UpdateSpellStateCache)
     UpdatePolledValues()
 
@@ -503,7 +515,11 @@ function DataToColor:Bits3Cached()
         (bits3Cache.lootFrameShown and 2 or 0) ^ 8 +
         (bits3Cache.chatInputActive and 2 or 0) ^ 9 +
         (bits3Cache.softTargetEnabled and 2 or 0) ^ 10 +
-        (bits3Cache.mailFrameShown and 2 or 0) ^ 11
+        (bits3Cache.mailFrameShown and 2 or 0) ^ 11 +
+        (bits3Cache.anyBagOpen and 2 or 0) ^ 12 +
+        (bits3Cache.characterFrameOpen and 2 or 0) ^ 13 +
+        (bits3Cache.spellBookFrameOpen and 2 or 0) ^ 14 +
+        (bits3Cache.friendsFrameOpen and 2 or 0) ^ 15
 end
 
 --------------------------------------------------------------------------------
@@ -514,13 +530,42 @@ end
 
 local cacheInitializedOnce = false
 
+local function HookFrameVisibility()
+    if CharacterFrame then
+        CharacterFrame:HookScript("OnShow", function()
+            bits3Cache.characterFrameOpen = true
+        end)
+        CharacterFrame:HookScript("OnHide", function()
+            bits3Cache.characterFrameOpen = false
+        end)
+    end
+
+    if SpellBookFrame then
+        SpellBookFrame:HookScript("OnShow", function()
+            bits3Cache.spellBookFrameOpen = true
+        end)
+        SpellBookFrame:HookScript("OnHide", function()
+            bits3Cache.spellBookFrameOpen = false
+        end)
+    end
+
+    if FriendsFrame then
+        FriendsFrame:HookScript("OnShow", function()
+            bits3Cache.friendsFrameOpen = true
+        end)
+        FriendsFrame:HookScript("OnHide", function()
+            bits3Cache.friendsFrameOpen = false
+        end)
+    end
+end
+
 function DataToColor:RegisterBitCacheEvents()
     -- Initialize cache (events are registered in EventHandlers.lua)
     InitializeCache()
 
     if not cacheInitializedOnce then
         cacheInitializedOnce = true
-        --DataToColor:Print("BitCache initialized - event-driven caching enabled")
+        HookFrameVisibility()
     end
 end
 

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Legacy Cataclysm 4.3.0)
-## Version: 1.9.7
+## Version: 1.9.8
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, cTimerBackport
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor_Classic.toc
+++ b/Addons/DataToColor/DataToColor_Classic.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic)
-## Version: 1.9.7
+## Version: 1.9.8
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor_TBC.toc
+++ b/Addons/DataToColor/DataToColor_TBC.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic TBC)
-## Version: 1.9.7
+## Version: 1.9.8
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/EventHandlers.lua
+++ b/Addons/DataToColor/EventHandlers.lua
@@ -179,6 +179,7 @@ function DataToColor:RegisterEvents()
     DataToColor:RegisterEvent('LOOT_OPENED', 'OnLootOpened_BitCache')
     DataToColor:RegisterEvent('MAIL_SHOW', 'OnMailShow_BitCache')
     DataToColor:RegisterEvent('MAIL_CLOSED', 'OnMailClosed_BitCache')
+    DataToColor:RegisterEvent('BAG_OPEN', 'OnBagOpen_BitCache')
 
     -- Classic-only events
     if DataToColor:IsClassicPreCata() then
@@ -642,6 +643,11 @@ function DataToColor:OnBagUpdate(event, containerID)
             DataToColor.equipmentQueue:push(invID)
         end
     end
+
+    -- Update BitCache on bag close (recheck since other bags may still be open)
+    if event == "BAG_CLOSED" and DataToColor.BitCache and DataToColor.BitCache.bits3 then
+        DataToColor.BitCache.bits3.anyBagOpen = DataToColor:AnyBagOpen()
+    end
     --DataToColor:Print("OnBagUpdate "..containerID)
 end
 
@@ -1057,5 +1063,11 @@ end
 function DataToColor:OnMailClosed_BitCache(event)
     if DataToColor.BitCache and DataToColor.BitCache.bits3 then
         DataToColor.BitCache.bits3.mailFrameShown = false
+    end
+end
+
+function DataToColor:OnBagOpen_BitCache(event, containerID)
+    if DataToColor.BitCache and DataToColor.BitCache.bits3 then
+        DataToColor.BitCache.bits3.anyBagOpen = true
     end
 end

--- a/Addons/DataToColor/Query.lua
+++ b/Addons/DataToColor/Query.lua
@@ -57,6 +57,10 @@ local GameMenuFrame = GameMenuFrame
 local LootFrame = LootFrame
 local ChatEdit_GetActiveWindow = ChatEdit_GetActiveWindow
 local MailFrame = MailFrame
+local IsBagOpen = IsBagOpen
+local CharacterFrame = CharacterFrame
+local SpellBookFrame = SpellBookFrame
+local FriendsFrame = FriendsFrame
 
 local HasPetUI = HasPetUI
 
@@ -195,7 +199,11 @@ function DataToColor:Bits3()
         (LootFrame:IsShown() and 2 or 0) ^ 8 +
         (DataToColor:IsChatInputActive() and 2 or 0) ^ 9 +
         (DataToColor:SoftTargetInteractEnabled() and 2 or 0) ^ 10 +
-        (MailFrame:IsShown() and 2 or 0) ^ 11
+        (MailFrame:IsShown() and 2 or 0) ^ 11 +
+        (DataToColor:AnyBagOpen() and 2 or 0) ^ 12 +
+        (DataToColor:CharacterFrameOpen() and 2 or 0) ^ 13 +
+        (DataToColor:SpellBookFrameOpen() and 2 or 0) ^ 14 +
+        (DataToColor:FriendsFrameOpen() and 2 or 0) ^ 15
 end
 
 function DataToColor:CustomTrigger(t)
@@ -654,6 +662,27 @@ end
 function DataToColor:SoftTargetInteractEnabled()
     local success, value = pcall(GetCVar, DataToColor.C.CVarSoftTargetInteract)
     return success and tonumber(value) == 3
+end
+
+function DataToColor:AnyBagOpen()
+    for i = 0, NUM_BAG_SLOTS do
+        if IsBagOpen(i) then
+            return true
+        end
+    end
+    return false
+end
+
+function DataToColor:CharacterFrameOpen()
+    return CharacterFrame and CharacterFrame:IsShown() or false
+end
+
+function DataToColor:SpellBookFrameOpen()
+    return SpellBookFrame and SpellBookFrame:IsShown() or false
+end
+
+function DataToColor:FriendsFrameOpen()
+    return FriendsFrame and FriendsFrame:IsShown() or false
 end
 
 -- Returns true if target of our target is us

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,9 @@ dotnet run --project Benchmarks -c Release
   - Replace magic strings/numbers with `public const` fields for cross-file discoverability
   - Place constants in the owning class to enable Find All References and compile-time safety
 
+## User facing API changes
+- When the `Core\Requirement\RequirementFactory.cs` is changed, a user facing API is added, removed, renamed make sure to update the `README.md` file
+
 ## Performance Guidelines
 Follow .NET performance best practices from:
 - https://devblogs.microsoft.com/dotnet/performance-improvements-in-net-10/
@@ -85,6 +88,15 @@ Central package management via `Directory.Packages.props`:
 ## DataToColor WoW Addon (Lua 5.1)
 
 **Location:** `Addons/DataToColor/`
+
+### Addon version tracking
+
+In order to provide easy way for the user to receive addon changes we keep track of each addon change in a Pull Request. The pull request title starts with "Addon: [x.y.z] - TITLE"
+
+When a change happens in the *.lua files make sure to bump the patch version (if not changed already) in the following files
+* `Addons\DataToColor\DataToColor_TBC.toc`
+* `Addons\DataToColor\DataToColor.toc`
+* `Addons\DataToColor\DataToColor_Classic.toc`
 
 World of Warcraft uses **Lua 5.1** (all versions including Classic). The addon encodes game state as pixel colors for external reading.
 
@@ -221,6 +233,7 @@ Addons/DataToColor/
 ├── DataToColor.lua       - Main frame update loop (performance critical)
 ├── Constants.lua         - Static data tables
 ├── Query.lua             - Game state queries
+├── BitCache.lua          - Cache for Query.lua avoid excessive amount of wow lua api calls.
 ├── Storage.lua           - Data storage structures
 ├── EventHandlers.lua     - WoW event handling
 ├── Collections.lua       - Data structure implementations
@@ -228,3 +241,7 @@ Addons/DataToColor/
 ├── ActionBarMacros.lua   - Macro detection
 └── libs/                 - Ace3 libraries (external, don't modify)
 ```
+
+### Use event driven change tracking
+Use Event driven change tracking in the addon instead of polling the state each time.
+The lua Events should be handled in `EventHandlers.lua`.

--- a/Core/AddonComponent/AddonBits.cs
+++ b/Core/AddonComponent/AddonBits.cs
@@ -116,4 +116,12 @@ public sealed class AddonBits : IReader, IGameMenuWindowShown
     public bool MailFrameShown() => v3[Mask._11];
 
     public bool NotMailFrameShown() => !MailFrameShown();
+
+    public bool AnyBagOpen() => v3[Mask._12];
+
+    public bool CharacterFrameOpen() => v3[Mask._13];
+
+    public bool SpellBookFrameOpen() => v3[Mask._14];
+
+    public bool FriendsFrameOpen() => v3[Mask._15];
 }

--- a/Core/Requirement/RequirementFactory.cs
+++ b/Core/Requirement/RequirementFactory.cs
@@ -199,6 +199,10 @@ public sealed partial class RequirementFactory
 
             { "MenuOpen", bits.GameMenuWindowShown },
             { "ChatInputVisible", bits.ChatInputIsVisible },
+            { "AnyBagOpen", bits.AnyBagOpen },
+            { "CharacterFrameOpen", bits.CharacterFrameOpen },
+            { "SpellBookFrameOpen", bits.SpellBookFrameOpen },
+            { "FriendsFrameOpen", bits.FriendsFrameOpen },
 
             // Corpse-based abilities
             { "CannibalizeCorpse", CannibalizeCorpseNearby },

--- a/README.md
+++ b/README.md
@@ -2456,6 +2456,10 @@ Allow requirements about what buffs/debuffs you have or the target has or in gen
 | `"Flying"` | The player is currently flying, not touching the ground. |
 | `"MenuOpen"` | Returns true if the Game Menu window is open (ESC) |
 | `"ChatInputVisible"` | Returns true if the Chat inputbox is open (ENTER) |
+| `"AnyBagOpen"` | Returns true if any bag frame is visible on screen |
+| `"CharacterFrameOpen"` | Returns true if the Character Info window is open (C) |
+| `"SpellBookFrameOpen"` | Returns true if the Spellbook window is open (P) |
+| `"FriendsFrameOpen"` | Returns true if the Social/Friends window is open (O) |
 | `"Dead"` | The player is currently dead. |
 | `"CannibalizeCorpse"` | A Humanoid or Undead corpse is within 5 yards of the player. |
 | `"DamageTakenFromTotem"` | The player has taken damage from a Totem creature type. Useful to detect nearby totems. |


### PR DESCRIPTION
## Summary

- Add **AnyBagOpen** (bit 12), **CharacterFrameOpen** (bit 13), **SpellBookFrameOpen** (bit 14), **FriendsFrameOpen** (bit 15) to `Bits3`/`v3` addon data
- Make **AnyBagOpen** event-driven via `BAG_OPEN`/`BAG_CLOSED` events instead of polling
- Use `HookScript("OnShow"/"OnHide")` for CharacterFrame, SpellBookFrame, FriendsFrame visibility tracking
- Expose all four as `RequirementFactory` keys for use in profile requirements (e.g. manual pause when a UI window is open)
- Bump addon version to **1.9.8**

Closes #768

## Test plan

- [x] Verify AnyBagOpen requirement triggers when opening/closing any bag
- [x] Verify CharacterFrameOpen triggers when pressing C to open/close character info
- [x] Verify SpellBookFrameOpen triggers when pressing P to open/close spellbook
- [x] Verify FriendsFrameOpen triggers when pressing O to open/close social window
- [x] Confirm bits reset correctly when frames are closed
- [x] Test that existing bits (0-11) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)