### PR TITLE
Add Target: and MouseOver: creature type requirements

### DIFF
--- a/Core/AddonComponent/CorpseTracker.cs
+++ b/Core/AddonComponent/CorpseTracker.cs
@@ -76,7 +76,7 @@ public sealed class CorpseTracker
             if (!creatureDb.Entries.TryGetValue(npcId, out Creature creature))
                 continue;
 
-            if (!CreatureTypes.IsCannibalizable(creature.Type))
+            if (!creature.Type.IsCannibalizable())
                 continue;
 
             Vector3 corpseWorldPos = WorldMapAreaDB.ToWorld_FlipXY(corpse.MapLoc, worldMapArea);

--- a/Core/AddonComponent/TotemDetector.cs
+++ b/Core/AddonComponent/TotemDetector.cs
@@ -41,7 +41,7 @@ public sealed class TotemDetector
         {
             int npcId = GuidUtils.GetNpcId(packedGuid);
             if (creatureDb.Entries.TryGetValue(npcId, out Creature creature) &&
-                creature.Type == CreatureTypes.Totem)
+                creature.Type == CreatureType.Totem)
             {
                 totem = creature;
                 return true;
@@ -69,7 +69,7 @@ public sealed class TotemDetector
         {
             int npcId = GuidUtils.GetNpcId(packedGuid);
             if (creatureDb.Entries.TryGetValue(npcId, out Creature creature) &&
-                creature.Type == CreatureTypes.Totem)
+                creature.Type == CreatureType.Totem)
             {
                 totem = creature;
                 return true;

--- a/Core/Requirement/RequirementFactory.cs
+++ b/Core/Requirement/RequirementFactory.cs
@@ -136,7 +136,9 @@ public sealed partial class RequirementFactory
             { "Talent", CreateTalent },
             { "Trigger:", CreateTrigger },
             { "Usable:", CreateUsable },
-            { "CanRun:", CreateCanRun }
+            { "CanRun:", CreateCanRun },
+            { "Target:", CreateTargetType },
+            { "MouseOver:", CreateMouseOverType }
         };
         this.requirementMap = requirementMap.ToFrozenDictionary();
 
@@ -1056,7 +1058,7 @@ public sealed partial class RequirementFactory
         {
             // 'Form:_FORM_'
             int sep = requirement.IndexOf(SEP1);
-            Form form = Enum.Parse<Form>(requirement[(sep + 1)..]);
+            Form form = Enum.Parse<Form>(requirement[(sep + 1)..], true);
 
             bool f() => playerReader.Form == form;
             string s() => playerReader.Form.ToStringF();
@@ -1076,10 +1078,58 @@ public sealed partial class RequirementFactory
         {
             // 'Race:_RACE_'
             int sep = requirement.IndexOf(SEP1);
-            UnitRace race = Enum.Parse<UnitRace>(requirement[(sep + 1)..]);
+            UnitRace race = Enum.Parse<UnitRace>(requirement[(sep + 1)..], true);
 
             bool f() => playerReader.Race == race;
             string s() => playerReader.Race.ToStringF();
+
+            return new Requirement
+            {
+                HasRequirement = f,
+                LogMessage = s
+            };
+        }
+    }
+
+    private Requirement CreateTargetType(ReadOnlySpan<char> requirement)
+    {
+        return create(requirement, playerReader, creatureDb);
+        static Requirement create(ReadOnlySpan<char> requirement,
+            PlayerReader playerReader, CreatureDB creatureDb)
+        {
+            // 'Target:_TYPE_'
+            int sep = requirement.IndexOf(SEP1);
+            CreatureType type = Enum.Parse<CreatureType>(requirement[(sep + 1)..], true);
+
+            bool f() =>
+                creatureDb.Entries.TryGetValue(playerReader.TargetId, out Creature c)
+                && c.Type == type;
+
+            string s() => type.ToStringF();
+
+            return new Requirement
+            {
+                HasRequirement = f,
+                LogMessage = s
+            };
+        }
+    }
+
+    private Requirement CreateMouseOverType(ReadOnlySpan<char> requirement)
+    {
+        return create(requirement, playerReader, creatureDb);
+        static Requirement create(ReadOnlySpan<char> requirement,
+            PlayerReader playerReader, CreatureDB creatureDb)
+        {
+            // 'MouseOver:_TYPE_'
+            int sep = requirement.IndexOf(SEP1);
+            CreatureType type = Enum.Parse<CreatureType>(requirement[(sep + 1)..], true);
+
+            bool f() =>
+                creatureDb.Entries.TryGetValue(playerReader.MouseOverId, out Creature c)
+                && c.Type == type;
+
+            string s() => type.ToStringF();
 
             return new Requirement
             {

--- a/README.md
+++ b/README.md
@@ -2156,6 +2156,70 @@ e.g.
 ```
 
 ---
+### **Target requirements**
+
+If the current target must be a specific creature type use this requirement. Uses the DBC creature database to look up the target's type by NPC ID.
+
+Useful for abilities that only work on certain creature types (e.g. Paladin's Exorcism on Undead/Demon).
+
+Formula: `Target:[type]`
+
+| type |
+| --- |
+| Beast |
+| Dragonkin |
+| Demon |
+| Elemental |
+| Giant |
+| Undead |
+| Humanoid |
+| Critter |
+| Mechanical |
+| NotSpecified |
+| Totem |
+| NonCombatPet |
+| GasCloud |
+
+e.g.
+```json
+"Requirement": "Target:Undead"                          // Target must be Undead
+"Requirement": "Target:Demon"                             // Target must be Demon
+"Requirement": "!Target:Humanoid"                         // Target must not be Humanoid
+"Requirement": "Target:Undead || Target:Demon"            // Target is Undead or Demon
+```
+
+---
+### **MouseOver requirements**
+
+If the current mouseover must be a specific creature type use this requirement. Uses the DBC creature database to look up the mouseover's type by NPC ID.
+
+Formula: `MouseOver:[type]`
+
+| type |
+| --- |
+| Beast |
+| Dragonkin |
+| Demon |
+| Elemental |
+| Giant |
+| Undead |
+| Humanoid |
+| Critter |
+| Mechanical |
+| NotSpecified |
+| Totem |
+| NonCombatPet |
+| GasCloud |
+
+e.g.
+```json
+"Requirement": "MouseOver:Undead"                          // MouseOver must be Undead
+"Requirement": "MouseOver:Demon"                           // MouseOver must be Demon
+"Requirement": "!MouseOver:Humanoid"                       // MouseOver must not be Humanoid
+"Requirement": "MouseOver:Undead || MouseOver:Demon"       // MouseOver is Undead or Demon
+```
+
+---
 ### **Equipment requirements**
 
 Check if the player has an item equipped in the specified `slot`. Optionally check for a specific `itemId`.

--- a/SharedLib/Data/Creature.cs
+++ b/SharedLib/Data/Creature.cs
@@ -14,30 +14,54 @@ public readonly record struct Creature
     public NpcFlags NpcFlag { get; init; }
     public int SkinLoot { get; init; }
     public int Family { get; init; }
-    public int Type { get; init; }
+    public CreatureType Type { get; init; }
 }
 
 /// <summary>
-/// Creature type constants from WoW database.
+/// Creature type values from DB2 CreatureType table.
 /// </summary>
-public static class CreatureTypes
+public enum CreatureType
 {
-    public const int Beast = 1;
-    public const int Dragonkin = 2;
-    public const int Demon = 3;
-    public const int Elemental = 4;
-    public const int Giant = 5;
-    public const int Undead = 6;
-    public const int Humanoid = 7;
-    public const int Critter = 8;
-    public const int Mechanical = 9;
-    public const int NotSpecified = 10;
-    public const int Totem = 11;
-    public const int NonCombatPet = 12;
-    public const int GasCloud = 13;
+    None = 0,
+    Beast = 1,
+    Dragonkin = 2,
+    Demon = 3,
+    Elemental = 4,
+    Giant = 5,
+    Undead = 6,
+    Humanoid = 7,
+    Critter = 8,
+    Mechanical = 9,
+    NotSpecified = 10,
+    Totem = 11,
+    NonCombatPet = 12,
+    GasCloud = 13
+}
+
+public static class CreatureType_Extension
+{
+    public static string ToStringF(this CreatureType value) => value switch
+    {
+        CreatureType.None => nameof(CreatureType.None),
+        CreatureType.Beast => nameof(CreatureType.Beast),
+        CreatureType.Dragonkin => nameof(CreatureType.Dragonkin),
+        CreatureType.Demon => nameof(CreatureType.Demon),
+        CreatureType.Elemental => nameof(CreatureType.Elemental),
+        CreatureType.Giant => nameof(CreatureType.Giant),
+        CreatureType.Undead => nameof(CreatureType.Undead),
+        CreatureType.Humanoid => nameof(CreatureType.Humanoid),
+        CreatureType.Critter => nameof(CreatureType.Critter),
+        CreatureType.Mechanical => nameof(CreatureType.Mechanical),
+        CreatureType.NotSpecified => nameof(CreatureType.NotSpecified),
+        CreatureType.Totem => nameof(CreatureType.Totem),
+        CreatureType.NonCombatPet => nameof(CreatureType.NonCombatPet),
+        CreatureType.GasCloud => nameof(CreatureType.GasCloud),
+        _ => nameof(CreatureType.None)
+    };
 
     /// <summary>
     /// Check if creature type is valid for Cannibalize (Humanoid or Undead).
     /// </summary>
-    public static bool IsCannibalizable(int type) => type is Humanoid or Undead;
+    public static bool IsCannibalizable(this CreatureType type) =>
+        type is CreatureType.Humanoid or CreatureType.Undead;
 }


### PR DESCRIPTION
## Summary

Closes https://github.com/Xian55/WowClassicGrindBot/issues/775

This PR adds two new requirement types that allow class profiles to conditionally execute actions based on the **creature type** of the current target or mouseover unit. Creature types are resolved via the DBC creature database using the unit's NPC ID — no addon changes are needed.

### Changes

#### `SharedLib/Data/Creature.cs`
- **Refactored** `CreatureTypes` static class (magic `int` constants) into a strongly-typed `CreatureType` enum with values: `None`, `Beast`, `Dragonkin`, `Demon`, `Elemental`, `Giant`, `Undead`, `Humanoid`, `Critter`, `Mechanical`, `NotSpecified`, `Totem`, `NonCombatPet`, `GasCloud`
- **Added** `CreatureType_Extension` with:
  - `ToStringF()` — allocation-free `nameof`-based string conversion (consistent with other enums in the codebase)
  - `IsCannibalizable()` — migrated from `CreatureTypes.IsCannibalizable(int)` to an extension method on the enum
- **Changed** `Creature.Type` property from `int` to `CreatureType`

#### `Core/AddonComponent/CorpseTracker.cs`
- Updated `CreatureTypes.IsCannibalizable(creature.Type)` → `creature.Type.IsCannibalizable()` to match the new extension method API

#### `Core/AddonComponent/TotemDetector.cs`
- Updated `creature.Type == CreatureTypes.Totem` → `creature.Type == CreatureType.Totem` (2 occurrences) to use the new enum

#### `Core/Requirement/RequirementFactory.cs`
- **Added** `Target:` entry to `requirementMap` with `CreateTargetType` handler
  - Parses `Target:[CreatureType]` (case-insensitive)
  - Looks up `playerReader.TargetId` in `creatureDb.Entries` and checks `Creature.Type`
  - Supports negation (`!Target:Humanoid`) and boolean composition (`Target:Undead || Target:Demon`)
- **Added** `MouseOver:` entry to `requirementMap` with `CreateMouseOverType` handler
  - Same pattern as `Target:` but reads `playerReader.MouseOverId` (addon pixel slot 86)
- **Fixed** `CreateForm` and `CreateRace` to use case-insensitive `Enum.Parse` for consistency with the new requirement parsers

#### `README.md`
- **Added** `Target requirements` documentation section with formula, type table, and examples
- **Added** `MouseOver requirements` documentation section with formula, type table, and examples

### Example usage

```json
"Requirement": "Target:Undead"
"Requirement": "!Target:Humanoid"
"Requirement": "Target:Undead || Target:Demon"
"Requirement": "MouseOver:Beast"
"Requirement": "!MouseOver:Mechanical"
```

## Test plan

- [x] `dotnet build MasterOfPuppets.sln` — compiles with 0 errors
- [x] Manual in-game testing confirms `Target:Undead` requirement evaluates correctly against Undead NPCs
- [x] Verify `MouseOver:` requirement triggers correctly when hovering over matching creature types
- [x] Verify negation (`!MouseOver:Demon`) works as expected
- [x] Verify boolean composition (`MouseOver:Undead || MouseOver:Demon`) works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)