### PR TITLE
Addon: [1.9.11] Event-driven caching and frame-loop throttling

### DIFF
--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -504,6 +504,12 @@ function DataToColor:Reset()
 
     DataToColor.actionBarCooldownQueue = DataToColor.struct:new(ACTION_BAR_ITERATION_FRAME_CHANGE_RATE)
 
+    DataToColor:InvalidateCurrentActionCache()
+    DataToColor:InvalidateActionUseableCache()
+    DataToColor:InvalidateDurabilityCache()
+    DataToColor:InvalidatePetNameCache()
+    DataToColor:InvalidateShapeshiftCache()
+
     DataToColor.playerBuffTime = DataToColor.struct:new(AURA_DURATION_ITERATION_FRAME_CHANGE_RATE)
     DataToColor.playerDebuffTime = DataToColor.struct:new(AURA_DURATION_ITERATION_FRAME_CHANGE_RATE)
     DataToColor.targetBuffTime = DataToColor.struct:new(AURA_DURATION_ITERATION_FRAME_CHANGE_RATE)
@@ -727,6 +733,8 @@ function DataToColor:PopulateSpellBookInfo()
     end
 
     --DataToColor:Print(("Loaded %d spells"):format(numLoaded))
+
+    DataToColor:PopulateSpellInRangeNames()
 end
 
 function DataToColor:InitSpellBookQueue()
@@ -801,6 +809,24 @@ function DataToColor:CreateFrames()
         return 0
     end
 
+    -- Precomputed static value for cell 46 (race/class/version never change)
+    local raceClassVersionCell = DataToColor.C.CHARACTER_RACE_ID * 10000
+        + DataToColor.C.CHARACTER_CLASS_ID * 100
+        + DataToColor.ClientVersion
+
+    -- MiniMap settings cache (cells 16-17), recomputed every ~200 ticks
+    local miniMapCache1 = 0
+    local miniMapCache2 = 0
+    local miniMapCacheTick = -999
+
+    -- areSpellsInRange throttle (cell 40)
+    local spellsInRangeCache = 0
+    local spellsInRangeTick = -999
+
+    -- UnitsTargetAsNumber throttle (cell 59)
+    local unitsTargetCache = 0
+    local unitsTargetTick = -999
+
     local function updateFrames()
         if not SETUP_SEQUENCE and globalTick >= initPhase then
             -- Ensure globalTime is past the C# FullReset threshold (Value <= 3)
@@ -873,8 +899,13 @@ function DataToColor:CreateFrames()
                 Pixel(int, UnitPower(DataToColor.C.unitPlayer, PowerType.Mana), 15)
             end
 
-            Pixel(int, DataToColor:MiniMapSettings1(), 16)
-            Pixel(int, DataToColor:MiniMapSettings2(), 17)
+            if globalTick - miniMapCacheTick >= 200 then
+                miniMapCache1 = DataToColor:MiniMapSettings1()
+                miniMapCache2 = DataToColor:MiniMapSettings2()
+                miniMapCacheTick = globalTick
+            end
+            Pixel(int, miniMapCache1, 16)
+            Pixel(int, miniMapCache2, 17)
 
             if DataToColor.targetChanged then
                 DataToColor.targetBuffTime:forcedReset()
@@ -931,17 +962,21 @@ function DataToColor:CreateFrames()
             Pixel(int, itemId, 24)
             --DataToColor:Print("equipmentQueue ", equipmentSlot, " slot -> ", slot, " -> ", itemId)
 
-            Pixel(int, DataToColor:isCurrentAction(1, 24), 25)
-            Pixel(int, DataToColor:isCurrentAction(25, 48), 26)
-            Pixel(int, DataToColor:isCurrentAction(49, 72), 27)
-            Pixel(int, DataToColor:isCurrentAction(73, 96), 28)
-            Pixel(int, DataToColor:isCurrentAction(97, 120), 29)
+            Pixel(int, DataToColor:isCurrentActionCached(1), 25)
+            Pixel(int, DataToColor:isCurrentActionCached(2), 26)
+            Pixel(int, DataToColor:isCurrentActionCached(3), 27)
+            Pixel(int, DataToColor:isCurrentActionCached(4), 28)
+            Pixel(int, DataToColor:isCurrentActionCached(5), 29)
 
-            Pixel(int, DataToColor:isActionUseable(1, 24), 30)
-            Pixel(int, DataToColor:isActionUseable(25, 48), 31)
-            Pixel(int, DataToColor:isActionUseable(49, 72), 32)
-            Pixel(int, DataToColor:isActionUseable(73, 96), 33)
-            Pixel(int, DataToColor:isActionUseable(97, 120), 34)
+            -- Safety: periodic forced invalidation every ~1 second
+            if globalTick % 60 == 0 then
+                DataToColor:InvalidateActionUseableCache()
+            end
+            Pixel(int, DataToColor:isActionUseableCached(1), 30)
+            Pixel(int, DataToColor:isActionUseableCached(2), 31)
+            Pixel(int, DataToColor:isActionUseableCached(3), 32)
+            Pixel(int, DataToColor:isActionUseableCached(4), 33)
+            Pixel(int, DataToColor:isActionUseableCached(5), 34)
 
             local costMeta, costValue = DataToColor.actionBarCostQueue:getTimed(globalTick)
             if costMeta and costValue then
@@ -973,18 +1008,19 @@ function DataToColor:CreateFrames()
             Pixel(int, UnitHealthMax(DataToColor.C.unitPet), 38)
             Pixel(int, UnitHealth(DataToColor.C.unitPet), 39)
 
-            Pixel(int, DataToColor:areSpellsInRange(), 40)
+            if globalTick - spellsInRangeTick >= 5 then
+                spellsInRangeCache = DataToColor:areSpellsInRange()
+                spellsInRangeTick = globalTick
+            end
+            Pixel(int, spellsInRangeCache, 40)
             Pixel(int, DataToColor:getAuraMaskForClass(UnitBuff, DataToColor.C.unitPlayer, DataToColor.S.playerBuffs), 41)
             Pixel(int, DataToColor:getAuraMaskForClass(UnitDebuff, DataToColor.C.unitTarget, DataToColor.S.targetDebuffs), 42)
-
-            local targetLevel = UnitLevelSafe(DataToColor.C.unitTarget, playerLevel)
-            Pixel(int, targetLevel * 100 + DataToColor.C.unitClassification[UnitClassification(DataToColor.C.unitTarget)], 43)
 
             -- Amount of money in coppers
             Pixel(int, GetMoney() % 1000000, 44) -- Represents amount of money held (in copper)
             Pixel(int, floor(GetMoney() / 1000000), 45) -- Represents amount of money held (in gold) 
 
-            Pixel(int, DataToColor.C.CHARACTER_RACE_ID * 10000 + DataToColor.C.CHARACTER_CLASS_ID * 100 + DataToColor.ClientVersion, 46)
+            Pixel(int, raceClassVersionCell, 46)
             Pixel(int, DataToColor.uiErrorMessageTime, 47)
             Pixel(int, DataToColor:shapeshiftForm(), 48) -- Shapeshift id https://wowwiki.fandom.com/wiki/API_GetShapeshiftForm
             Pixel(int, DataToColor:getRange(), 49) -- Represents minRange-maxRange ex. 0-5 5-15
@@ -995,7 +1031,7 @@ function DataToColor:CreateFrames()
             DataToColor.uiErrorMessage = 0
 
             Pixel(int, DataToColor:CastingInfoSpellId(DataToColor.C.unitPlayer), 53)                                                                                                                                                                               -- SpellId being cast
-            Pixel(int, DataToColor:getAvgEquipmentDurability() * 100 + ((DataToColor.C.CHARACTER_CLASS_ID == 2 and UnitPower(DataToColor.C.unitPlayer, PowerType.HolyPower) or GetComboPoints(DataToColor.C.unitPlayer, DataToColor.C.unitTarget)) or 0), 54)                                                                                                                                                                                                                                                -- for paladin holy power or combo points
+            Pixel(int, DataToColor:getAvgEquipmentDurabilityCached() * 100 + ((DataToColor.C.CHARACTER_CLASS_ID == 2 and UnitPower(DataToColor.C.unitPlayer, PowerType.HolyPower) or GetComboPoints(DataToColor.C.unitPlayer, DataToColor.C.unitTarget)) or 0), 54)                                                                                                                                                                                                                                                -- for paladin holy power or combo points
 
             local playerBuffCount = DataToColor:populateAuraTimer(UnitBuff, DataToColor.C.unitPlayer, DataToColor.playerBuffTime)
             local playerDebuffCount = DataToColor:populateAuraTimer(UnitDebuff, DataToColor.C.unitPlayer, DataToColor.playerDebuffTime)
@@ -1009,16 +1045,21 @@ function DataToColor:CreateFrames()
             Pixel(int, min(16, playerDebuffCount) * 1000000 + playerBuffCount * 10000 + targetDebuffCount * 100 + targetBuffCount, 55)
 
             if DataToColor.targetChanged then
+                local targetLevel = UnitLevelSafe(DataToColor.C.unitTarget, playerLevel)
+                Pixel(int, targetLevel * 100 + DataToColor.C.unitClassification[UnitClassification(DataToColor.C.unitTarget)], 43)
                 Pixel(int, DataToColor:NpcId(DataToColor.C.unitTarget), 56) -- target id
                 Pixel(int, DataToColor:getGuidFromUnit(DataToColor.C.unitTarget), 57)
             end
 
             Pixel(int, DataToColor:CastingInfoSpellId(DataToColor.C.unitTarget), 58) -- SpellId being cast by target
 
-            Pixel(int,
-                10 * DataToColor:UnitsTargetAsNumber(DataToColor.C.unitmouseover, DataToColor.C.unitmouseovertarget) +
-                DataToColor:UnitsTargetAsNumber(DataToColor.C.unitTarget, DataToColor.C.unitTargetTarget),
-                59)
+            if globalTick - unitsTargetTick >= 5 then
+                unitsTargetCache =
+                    10 * DataToColor:UnitsTargetAsNumber(DataToColor.C.unitmouseover, DataToColor.C.unitmouseovertarget) +
+                    DataToColor:UnitsTargetAsNumber(DataToColor.C.unitTarget, DataToColor.C.unitTargetTarget)
+                unitsTargetTick = globalTick
+            end
+            Pixel(int, unitsTargetCache, 59)
 
             Pixel(int, DataToColor.lastAutoShot, 60)
             Pixel(int, DataToColor.lastMainHandMeleeSwing, 61)

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Legacy Cataclysm 4.3.0)
-## Version: 1.9.10
+## Version: 1.9.11
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, cTimerBackport
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor_Classic.toc
+++ b/Addons/DataToColor/DataToColor_Classic.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic)
-## Version: 1.9.10
+## Version: 1.9.11
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor_TBC.toc
+++ b/Addons/DataToColor/DataToColor_TBC.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic TBC)
-## Version: 1.9.10
+## Version: 1.9.11
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/EventHandlers.lua
+++ b/Addons/DataToColor/EventHandlers.lua
@@ -150,6 +150,10 @@ function DataToColor:RegisterEvents()
         DataToColor:RegisterEvent('UNIT_SPELLCAST_FAILED', 'SoM_OnCastFailed')
     end
 
+    -- Shapeshift form cache invalidation
+    DataToColor:SafeRegisterEvent('UPDATE_SHAPESHIFT_FORM', 'OnShapeshiftChanged')
+    DataToColor:SafeRegisterEvent('UPDATE_SHAPESHIFT_FORMS', 'OnShapeshiftChanged')
+
     ---------------------------------------------------------------------------
     -- BitCache events (centralized here to avoid AceEvent overwrites)
     ---------------------------------------------------------------------------
@@ -180,6 +184,14 @@ function DataToColor:RegisterEvents()
     DataToColor:RegisterEvent('MAIL_SHOW', 'OnMailShow_BitCache')
     DataToColor:RegisterEvent('MAIL_CLOSED', 'OnMailClosed_BitCache')
     DataToColor:RegisterEvent('BAG_OPEN', 'OnBagOpen_BitCache')
+
+    ---------------------------------------------------------------------------
+    -- Action cache events (invalidate isActionUseable / isCurrentAction)
+    ---------------------------------------------------------------------------
+    DataToColor:RegisterEvent('ACTIONBAR_UPDATE_USABLE', 'OnActionbarUsabilityChanged')
+    DataToColor:RegisterEvent('ACTIONBAR_UPDATE_COOLDOWN', 'OnActionbarUsabilityChanged')
+    DataToColor:RegisterEvent('SPELL_UPDATE_USABLE', 'OnActionbarUsabilityChanged')
+    DataToColor:RegisterEvent('UNIT_POWER_UPDATE', 'OnUnitPowerUpdate_ActionCache')
 
     -- Classic-only events
     if DataToColor:IsClassicPreCata() then
@@ -578,6 +590,7 @@ function DataToColor:OnUnitSpellCastSucceeded(...)
     DataToColor.lastCastEvent = CAST_SUCCESS
     DataToColor.uiErrorMessageTime = DataToColor.globalTime
     DataToColor.lastCastSpellId = spellId
+    DataToColor:InvalidateActionUseableCache()
 end
 
 function DataToColor:OnUnitSpellCastFailed(...)
@@ -711,6 +724,9 @@ function DataToColor:OnSpellsChanged(event)
     DataToColor:InitTalentQueue()
     DataToColor:InitSpellBookQueue()
     DataToColor:InitActionBarCostQueue()
+    DataToColor:PopulateSpellInRangeNames()
+    DataToColor:InvalidateCurrentActionCache()
+    DataToColor:InvalidateActionUseableCache()
 end
 
 function DataToColor:ActionbarSlotChanged(event, slot)
@@ -721,6 +737,8 @@ function DataToColor:ActionbarSlotChanged(event, slot)
         -- Check for texture change (works for both add and remove)
         DataToColor:CheckActionBarTextureChange(slot)
     end
+    DataToColor:InvalidateCurrentActionCache()
+    DataToColor:InvalidateActionUseableCache()
 end
 
 function DataToColor:CorpseInRangeEvent(event)
@@ -747,6 +765,7 @@ end
 function DataToColor:OnPetChanged(event, unit)
     if unit == DataToColor.C.unitPlayer then
         DataToColor.petGUID = UnitGUID(DataToColor.C.unitPet)
+        DataToColor:InvalidatePetNameCache()
     end
 
     -- Update BitCache pet state
@@ -771,6 +790,7 @@ function DataToColor:OnLeftCombat()
     if DataToColor.BitCache and DataToColor.BitCache.bits1 then
         DataToColor.BitCache.bits1.playerInCombat = false
     end
+    DataToColor:InvalidateActionUseableCache()
 end
 
 function DataToColor:AutoFollowBegin()
@@ -812,6 +832,10 @@ end
 
 function DataToColor:OnMessageParty(event, msg, author)
     DataToColor:PushChatMessage(DataToColor.TextCommand.ChatParty, author, msg)
+end
+
+function DataToColor:OnShapeshiftChanged(event)
+    DataToColor:InvalidateShapeshiftCache()
 end
 
 function DataToColor:OnPlayerSoftInteractChanged(event, old, new)
@@ -943,6 +967,7 @@ function DataToColor:OnEnteredCombat(event)
     if DataToColor.BitCache and DataToColor.BitCache.bits1 then
         DataToColor.BitCache.bits1.playerInCombat = true
     end
+    DataToColor:InvalidateActionUseableCache()
 end
 
 function DataToColor:OnUnitFlags_BitCache(event, unit)
@@ -1022,6 +1047,7 @@ function DataToColor:OnDurabilityChanged_BitCache(event)
     if DataToColor.BitCache and DataToColor.BitCache.updateEquipment then
         DataToColor.BitCache.updateEquipment()
     end
+    DataToColor:InvalidateDurabilityCache()
 end
 
 function DataToColor:OnTalentChanged_BitCache(event)
@@ -1034,6 +1060,7 @@ function DataToColor:OnSpellStateChanged_BitCache(event)
     if DataToColor.BitCache and DataToColor.BitCache.updateSpellState then
         DataToColor.BitCache.updateSpellState()
     end
+    DataToColor:InvalidateCurrentActionCache()
 end
 
 function DataToColor:OnMirrorTimer_BitCache(event)
@@ -1069,5 +1096,19 @@ end
 function DataToColor:OnBagOpen_BitCache(event, containerID)
     if DataToColor.BitCache and DataToColor.BitCache.bits3 then
         DataToColor.BitCache.bits3.anyBagOpen = true
+    end
+end
+
+-------------------------------------------------------------------------------
+-- Action Cache Event Handlers
+-------------------------------------------------------------------------------
+
+function DataToColor:OnActionbarUsabilityChanged(event)
+    DataToColor:InvalidateActionUseableCache()
+end
+
+function DataToColor:OnUnitPowerUpdate_ActionCache(event, unit)
+    if unit == DataToColor.C.unitPlayer then
+        DataToColor:InvalidateActionUseableCache()
     end
 end

--- a/Addons/DataToColor/Query.lua
+++ b/Addons/DataToColor/Query.lua
@@ -107,6 +107,15 @@ local GetPetHappiness = GetPetHappiness
 
 local ammoSlot = GetInventorySlotInfo("AmmoSlot")
 
+local spellRangeNameCache = {}
+local spellRangeUnitNameCache = {}
+
+local cachedPetName = nil
+local petNameDirty = true
+
+local cachedShapeshiftForm = 0
+local shapeshiftDirty = true
+
 -- Use Astrolabe function to get current player position
 function DataToColor:GetPosition()
     if not DataToColor.map then
@@ -405,27 +414,43 @@ end
 -- -- Function to tell if a spell is on cooldown and if the specified slot has a spell assigned to it
 -- -- Slot ID information can be found on WoW Wiki. Slots we are using: 1-12 (main action bar), Bottom Right Action Bar maybe(49-60), and  Bottom Left (61-72)
 
+function DataToColor:PopulateSpellInRangeNames()
+    local S = DataToColor.S
+    for i = 1, #S.spellInRangeTarget do
+        local spellIconId = S.spellInRangeTarget[i]
+        local spellId = S.playerSpellBookIconToId[spellIconId] or spellIconId
+        spellRangeNameCache[i] = GetSpellInfo(spellId)
+    end
+    for i = 1, #S.spellInRangeUnit do
+        local data = S.spellInRangeUnit[i]
+        local spellId = S.playerSpellBookIconToId[data[1]]
+        if spellId then
+            spellRangeUnitNameCache[i] = GetSpellInfo(spellId)
+        end
+    end
+end
+
+function DataToColor:InvalidatePetNameCache()
+    petNameDirty = true
+end
+
 function DataToColor:areSpellsInRange()
     local inRange = 0
     local targetCount = #DataToColor.S.spellInRangeTarget
     for i = 1, targetCount do
-        local spellIconId = DataToColor.S.spellInRangeTarget[i]
-        local spellId = DataToColor.S.playerSpellBookIconToId[spellIconId] or spellIconId -- fallback to spellId
-        local spellName = GetSpellInfo(spellId)
+        local spellName = spellRangeNameCache[i]
         if spellName then
             if IsSpellInRange(spellName, DataToColor.C.unitTarget) == 1 then
                 inRange = inRange + (2 ^ (i - 1))
             end
-        else
-            --print(spellId .. " is null")
         end
     end
 
     for i = 1, #DataToColor.S.spellInRangeUnit do
         local data = DataToColor.S.spellInRangeUnit[i]
-        local spellId = DataToColor.S.playerSpellBookIconToId[data[1]]
+        local spellName = spellRangeUnitNameCache[i]
         local unit = data[2]
-        if spellId and IsSpellInRange(GetSpellInfo(spellId), unit) == 1 then
+        if spellName and IsSpellInRange(spellName, unit) == 1 then
             inRange = inRange + (2 ^ (targetCount + i - 1))
         end
     end
@@ -525,6 +550,30 @@ function DataToColor:isActionUseable(min, max)
   return isUsableBits
 end
 
+-- isActionUseable cache (cells 30-34)
+local actionUseableCache = { 0, 0, 0, 0, 0 }
+local actionUseableDirty = true
+
+local function RebuildActionUseableCache()
+    actionUseableCache[1] = DataToColor:isActionUseable(1, 24)
+    actionUseableCache[2] = DataToColor:isActionUseable(25, 48)
+    actionUseableCache[3] = DataToColor:isActionUseable(49, 72)
+    actionUseableCache[4] = DataToColor:isActionUseable(73, 96)
+    actionUseableCache[5] = DataToColor:isActionUseable(97, 120)
+    actionUseableDirty = false
+end
+
+function DataToColor:isActionUseableCached(chunk)
+    if actionUseableDirty then
+        RebuildActionUseableCache()
+    end
+    return actionUseableCache[chunk]
+end
+
+function DataToColor:InvalidateActionUseableCache()
+    actionUseableDirty = true
+end
+
 function DataToColor:isCurrentAction(min, max)
     local isUsableBits = 0
     for i = min, max do
@@ -533,6 +582,30 @@ function DataToColor:isCurrentAction(min, max)
         end
     end
     return isUsableBits
+end
+
+-- isCurrentAction cache (cells 25-29)
+local currentActionCache = { 0, 0, 0, 0, 0 }
+local currentActionDirty = true
+
+local function RebuildCurrentActionCache()
+    currentActionCache[1] = DataToColor:isCurrentAction(1, 24)
+    currentActionCache[2] = DataToColor:isCurrentAction(25, 48)
+    currentActionCache[3] = DataToColor:isCurrentAction(49, 72)
+    currentActionCache[4] = DataToColor:isCurrentAction(73, 96)
+    currentActionCache[5] = DataToColor:isCurrentAction(97, 120)
+    currentActionDirty = false
+end
+
+function DataToColor:isCurrentActionCached(chunk)
+    if currentActionDirty then
+        RebuildCurrentActionCache()
+    end
+    return currentActionCache[chunk]
+end
+
+function DataToColor:InvalidateCurrentActionCache()
+    currentActionDirty = true
 end
 
 -- Finds passed in string to return profession level
@@ -580,6 +653,22 @@ function DataToColor:getAvgEquipmentDurability()
     return math.max(0, floor((current + 1) * 100 / (max + 1)) - 1) -- 0-99
 end
 
+-- Equipment durability cache (cell 54)
+local cachedDurability = 0
+local durabilityDirty = true
+
+function DataToColor:getAvgEquipmentDurabilityCached()
+    if durabilityDirty then
+        cachedDurability = DataToColor:getAvgEquipmentDurability()
+        durabilityDirty = false
+    end
+    return cachedDurability
+end
+
+function DataToColor:InvalidateDurabilityCache()
+    durabilityDirty = true
+end
+
 -----------------------------------------------------------------
 -- Boolean functions --------------------------------------------
 -- Only put functions here that are part of a boolean sequence --
@@ -587,17 +676,21 @@ end
 -----------------------------------------------------------------
 
 function DataToColor:shapeshiftForm()
-    local index = GetShapeshiftForm(false)
-    if not index or index == 0 then
-        return 0
+    if shapeshiftDirty then
+        local index = GetShapeshiftForm(false)
+        if not index or index == 0 then
+            cachedShapeshiftForm = 0
+        else
+            local _, _, _, spellId = GetShapeshiftFormInfo(index)
+            cachedShapeshiftForm = DataToColor.S.playerAuraMap[spellId] or index
+        end
+        shapeshiftDirty = false
     end
+    return cachedShapeshiftForm
+end
 
-    local _, _, _, spellId = GetShapeshiftFormInfo(index)
-    local form = DataToColor.S.playerAuraMap[spellId]
-    if form then
-        return form
-    end
-    return index
+function DataToColor:InvalidateShapeshiftCache()
+    shapeshiftDirty = true
 end
 
 function DataToColor:GetInventoryBroken()
@@ -610,20 +703,26 @@ function DataToColor:GetInventoryBroken()
 end
 
 function DataToColor:UnitsTargetAsNumber(unit, unittarget)
-    if not (UnitName(unittarget)) then return 2 end                              -- target has no target
-    if DataToColor.C.CHARACTER_NAME == UnitName(unit) then return 0 end          -- targeting self
-    if UnitName(DataToColor.C.unitPet) == UnitName(unittarget) then return 4 end -- targetting my pet
-    if DataToColor.playerPetSummons[UnitGUID(unittarget)] then return 4 end
-    if DataToColor.C.CHARACTER_NAME == UnitName(unittarget) then return 1 end    -- targetting me
-    if UnitName(DataToColor.C.unitPet) == UnitName(unit) and UnitName(unittarget) then
-        return 5
+    local targetName = UnitName(unittarget)
+    if not targetName then return 2 end                                             -- target has no target
+
+    local unitName = UnitName(unit)
+    if DataToColor.C.CHARACTER_NAME == unitName then return 0 end                   -- targeting self
+
+    if petNameDirty then
+        cachedPetName = UnitName(DataToColor.C.unitPet)
+        petNameDirty = false
     end
-    if IsInGroup() and DataToColor:UnitTargetsPartyOrPet(unittarget) then return 6 end
+
+    if cachedPetName and cachedPetName == targetName then return 4 end              -- targetting my pet
+    if DataToColor.playerPetSummons[UnitGUID(unittarget)] then return 4 end
+    if DataToColor.C.CHARACTER_NAME == targetName then return 1 end                 -- targetting me
+    if cachedPetName and unitName == cachedPetName and targetName then return 5 end
+    if IsInGroup() and DataToColor:UnitTargetsPartyOrPet(targetName) then return 6 end
     return 3
 end
 
-function DataToColor:UnitTargetsPartyOrPet(unittarget)
-    local targetName = UnitName(unittarget)
+function DataToColor:UnitTargetsPartyOrPet(targetName)
     if not targetName then return false end
 
     for i = 1, 4 do


### PR DESCRIPTION
## Summary
- Replace per-frame polling with dirty-flag caches invalidated by WoW events for `isCurrentAction`, `isActionUseable`, equipment durability, pet name, and shapeshift form
- Throttle expensive computations: minimap settings (~200 ticks), `areSpellsInRange` and `UnitsTargetAsNumber` (~5 ticks)
- Precompute static race/class/version cell value and cache spell names for range checks
- Move target level/classification computation into `targetChanged` block to avoid redundant per-frame calls

## Test plan
- [x] Verify action bar highlights update correctly when activating/deactivating abilities
- [x] Verify action bar usability updates on cooldown, mana change, and combat state transitions
- [x] Verify shapeshift form detection works for druid forms and other shapeshifts
- [x] Verify spell range detection still works for all configured spells
- [x] Verify equipment durability updates after taking damage
- [x] Verify pet name detection works after summoning/dismissing pet
- [x] Verify target info (level, classification, NPC ID) updates on target change
- [x] Verify minimap settings still refresh periodically

🤖 Generated with [Claude Code](https://claude.com/claude-code)