### PR TITLE
fix(AssistFocus): check target GUID before targeting/clearing focus

### DIFF
--- a/Core/Goals/AssistFocusGoal.cs
+++ b/Core/Goals/AssistFocusGoal.cs
@@ -63,15 +63,21 @@ public sealed class AssistFocusGoal : GoapGoal
     public override void OnEnter()
     {
         wait.Update();
-        input.PressTargetFocus();
-        wait.Update();
+        if (playerReader.TargetGuid != playerReader.FocusGuid)
+        {
+            input.PressTargetFocus();
+            wait.Update();
+        }
     }
 
     public override void OnExit()
     {
         wait.Update();
-        input.PressClearTarget();
-        wait.Update();
+        if (playerReader.TargetGuid == playerReader.FocusGuid)
+        {
+            input.PressClearTarget();
+            wait.Update();
+        }
     }
 
     public override void Update()


### PR DESCRIPTION
## Summary
Fixes #788 - Assist Focus doesn't work properly when the player is following a party leader.

## Problem
The `AssistFocusGoal` had issues in both `OnEnter()` and `OnExit()` methods:
- `OnEnter()` always called `PressTargetFocus()` without checking if the player was already targeting the focus
- `OnExit()` always called `PressClearTarget()` without checking if the current target was the focus

This caused the mage to either not properly target the party leader or incorrectly clear the target, preventing proper assist behavior and combat detection.

## Solution
Modified both methods to check the target GUID before performing operations:
- `OnEnter()`: Only press TargetFocus if `TargetGuid != FocusGuid`
- `OnExit()`: Only clear target if `TargetGuid == FocusGuid`

This aligns `AssistFocusGoal` with `FollowFocusGoal` which already correctly implements these checks.

## Changes
- `Core/Goals/AssistFocusGoal.cs`: Updated `OnEnter()` and `OnExit()` methods

## Testing
This fix follows the same pattern used in `FollowFocusGoal.cs`, which already handles party member targeting correctly in Assist Focus mode.