### PR TITLE
Addon: [1.9.13] Fix FocusTarget bits stale on Vanilla/SoM

### DIFF
--- a/Addons/DataToColor/BitCache.lua
+++ b/Addons/DataToColor/BitCache.lua
@@ -387,6 +387,12 @@ local function UpdatePolledValues()
     bits3Cache.chatInputActive = DataToColor:IsChatInputActive() or false
     UpdateMailFrameCache()
 
+    -- Focus target combat state - UNIT_FLAGS doesn't fire for derived units
+    -- like "focustarget" / "party1target", so we must poll
+    if bits2Cache.focusTargetExists then
+        bits2Cache.focusTargetInCombat = UnitAffectingCombat(DataToColor.C.unitFocusTarget) or false
+    end
+
     -- Spell states - must be polled because bot checks these immediately after
     -- sending key presses, faster than START/STOP_AUTOREPEAT_SPELL events fire
     UpdateSpellStateCache()

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Legacy Cataclysm 4.3.0)
-## Version: 1.9.12
+## Version: 1.9.13
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, cTimerBackport
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor_Classic.toc
+++ b/Addons/DataToColor/DataToColor_Classic.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic)
-## Version: 1.9.12
+## Version: 1.9.13
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor_TBC.toc
+++ b/Addons/DataToColor/DataToColor_TBC.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic TBC)
-## Version: 1.9.12
+## Version: 1.9.13
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/EventHandlers.lua
+++ b/Addons/DataToColor/EventHandlers.lua
@@ -159,9 +159,10 @@ function DataToColor:RegisterEvents()
     ---------------------------------------------------------------------------
     DataToColor:RegisterEvent('UNIT_TARGET', 'OnUnitTarget_BitCache')
     DataToColor:RegisterEvent('UPDATE_MOUSEOVER_UNIT', 'OnMouseoverChanged_BitCache')
-    DataToColor:RegisterEvent('PLAYER_FOCUS_CHANGED', 'OnFocusChanged_BitCache')
+    DataToColor:SafeRegisterEvent('PLAYER_FOCUS_CHANGED', 'OnFocusChanged_BitCache')
     DataToColor:RegisterEvent('PLAYER_REGEN_DISABLED', 'OnEnteredCombat')
     DataToColor:RegisterEvent('UNIT_FLAGS', 'OnUnitFlags_BitCache')
+    DataToColor:RegisterEvent('GROUP_ROSTER_UPDATE', 'OnGroupRosterUpdate_BitCache')
     DataToColor:RegisterEvent('PLAYER_DEAD', 'OnPlayerDead_BitCache')
     DataToColor:RegisterEvent('PLAYER_ALIVE', 'OnPlayerAlive_BitCache')
     DataToColor:RegisterEvent('PLAYER_UNGHOST', 'OnPlayerUnghost_BitCache')
@@ -937,7 +938,7 @@ function DataToColor:OnUnitTarget_BitCache(event, unit)
     if DataToColor.BitCache and DataToColor.BitCache.updateTargetTarget then
         if unit == "target" then
             DataToColor.BitCache.updateTargetTarget()
-        elseif unit == "focus" then
+        elseif unit == "focus" or unit == DataToColor.C.unitFocus then
             DataToColor.BitCache.updateFocus()
         elseif unit == "pet" then
             DataToColor.BitCache.updatePet()
@@ -974,10 +975,16 @@ function DataToColor:OnUnitFlags_BitCache(event, unit)
     if not DataToColor.BitCache or not DataToColor.BitCache.bits1 then return end
     if unit == "target" then
         DataToColor.BitCache.bits1.targetInCombat = UnitAffectingCombat(unit) or false
-    elseif unit == "focus" then
+    elseif unit == "focus" or unit == DataToColor.C.unitFocus then
         DataToColor.BitCache.bits2.focusInCombat = UnitAffectingCombat(unit) or false
-    elseif unit == "focustarget" then
+    elseif unit == "focustarget" or unit == DataToColor.C.unitFocusTarget then
         DataToColor.BitCache.bits2.focusTargetInCombat = UnitAffectingCombat(unit) or false
+    end
+end
+
+function DataToColor:OnGroupRosterUpdate_BitCache(event)
+    if DataToColor.BitCache and DataToColor.BitCache.updateFocus then
+        DataToColor.BitCache.updateFocus()
     end
 end
 

--- a/Core/ClassConfig/ClassConfiguration.cs
+++ b/Core/ClassConfig/ClassConfiguration.cs
@@ -3,6 +3,8 @@ using Microsoft.Extensions.Logging;
 
 using Newtonsoft.Json;
 
+using SharedLib;
+
 using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
@@ -212,6 +214,12 @@ public sealed partial class ClassConfiguration
         }
 
         RequirementFactory factory = new(sp, this);
+
+        // Vanilla has no TARGETFOCUS binding — use TARGETPARTYMEMBER1 instead
+        if (playerReader.Version == ClientVersion.SoM)
+        {
+            TargetFocus.BindingID = BindingID.TARGETPARTYMEMBER1;
+        }
 
         var baseActionKeys = GetByType<KeyAction>();
         foreach ((string _, KeyAction keyAction) in baseActionKeys)


### PR DESCRIPTION
## Summary

Fixes #788

### Root Cause Analysis

The event-driven BitCache system introduced in #742 ("Add event-driven BitCache and AuraCache for major performance improvement") replaced per-frame polling of game state with WoW event listeners. This was a major win (~17x reduction in memory allocation rate), but it introduced a subtle regression for the **Assist Focus** workflow on **Vanilla Classic / Season of Mastery (SoM)**.

The symptom: `TargetFocusTargetGoal.CanRun()` always returns `false`, so the GOAP planner never selects "Target Focus Target" (cost 10) and instead falls through to "Follow Focus" (cost 19). The bot follows the party leader but never targets or attacks the leader's target.

Three independent issues compound to cause this:

#### 1. `UNIT_FLAGS` does not fire for derived unit tokens

The WoW `UNIT_FLAGS` event fires for primary unit tokens (`"player"`, `"target"`, `"party1"`, `"focus"`) but **never** for derived/compound tokens like `"focustarget"` or `"party1target"`. In the pre-#742 polling model, `focusTargetInCombat` was checked every frame via `UnitAffectingCombat()`. After #742, it was only updated when `UpdateFocusCache()` ran in response to `UNIT_TARGET` (i.e., when the focus unit changed its target). If the mob entered combat **after** being targeted, the combat flag stayed `false` forever — making `TargetFocusTargetGoal.CanRun()` evaluate `(true && false) || false || false = false`.

#### 2. Vanilla Classic has no `"focus"` unit token

On Vanilla/SoM, there is no `/focus` command or `"focus"` unit token. The addon maps focus to `"party1"` via `DataToColor.C.unitFocus`. However, the `OnUnitTarget_BitCache` and `OnUnitFlags_BitCache` event handlers only checked for the literal string `"focus"`, missing `"party1"` entirely. This meant focus-related cache updates never triggered on Vanilla.

#### 3. `PLAYER_FOCUS_CHANGED` may not exist on Vanilla

`PLAYER_FOCUS_CHANGED` is a TBC+ event. Using `RegisterEvent` (which errors on missing events) instead of `SafeRegisterEvent` (which silently skips) could abort all subsequent event registrations in the same initialization block, leaving the addon in a broken state.

### Changes

| File | Change |
|------|--------|
| `BitCache.lua` | Poll `focusTargetInCombat` every frame in `UpdatePolledValues()` — 1 cheap `UnitAffectingCombat()` call, only when `focusTargetExists` is true. This is necessary because `UNIT_FLAGS` never fires for derived tokens. |
| `EventHandlers.lua` | Add `DataToColor.C.unitFocus` / `DataToColor.C.unitFocusTarget` checks alongside literal `"focus"` / `"focustarget"` in `OnUnitTarget_BitCache` and `OnUnitFlags_BitCache` so Vanilla's `"party1"` / `"party1target"` tokens are handled |
| `EventHandlers.lua` | `RegisterEvent` → `SafeRegisterEvent` for `PLAYER_FOCUS_CHANGED` to prevent errors on Vanilla |
| `EventHandlers.lua` | Register `GROUP_ROSTER_UPDATE` → `OnGroupRosterUpdate_BitCache` to refresh focus cache when party composition changes |
| `ClassConfiguration.cs` | On SoM, override `TargetFocus.BindingID` from `TARGETFOCUS` to `TARGETPARTYMEMBER1` since Vanilla has no `/targetfocus` keybind |
| `*.toc` | Addon version bump 1.9.12 → 1.9.13 |

### Expected Behavior After Fix

When the focus unit (party leader) targets a hostile mob that then enters combat:
1. `FocusTarget_Combat()` flips to `true` within 1 frame (polled)
2. `TargetFocusTargetGoal.CanRun()` returns `true`
3. GOAP planner selects "Target Focus Target" (cost 10) over "Follow Focus" (cost 19)
4. Bot targets the focus's target and engages via `AssistFocusGoal`

## Test plan

- [x] `dotnet build MasterOfPuppets.sln` compiles without errors
- [x] Runtime on SoM: focus (party1) targets a hostile mob → mob enters combat → `FocusTarget_Combat()` flips to `true` within 1 frame
- [x] `TargetFocusTargetGoal.CanRun()` returns `true` when focus target is hostile and in combat
- [x] GOAP planner selects "Target Focus Target" (cost 10) over "Follow Focus" (cost 19)
- [x] Bot correctly targets focus's target and casts spells via AssistFocusGoal
- [x] Party roster changes (join/leave) correctly refresh the focus cache
- [x] No errors on Vanilla Classic from `PLAYER_FOCUS_CHANGED` registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)