### PR TITLE
Addon: [1.9.14] Fix AuraCache focus alias on Vanilla/SoM

### DIFF
--- a/Addons/DataToColor/AuraCache.lua
+++ b/Addons/DataToColor/AuraCache.lua
@@ -33,7 +33,7 @@ local unitCache = {}
 local trackedUnits = {
     "player",
     "target",
-    "focus",
+    DataToColor.C.unitFocus,
     "pet",
     "mouseover",
     "softenemy",
@@ -270,7 +270,7 @@ local function OnTargetChanged()
 end
 
 local function OnFocusChanged()
-    RefreshUnitAuras("focus")
+    RefreshUnitAuras(DataToColor.C.unitFocus)
 end
 
 local function OnMouseoverChanged()
@@ -309,7 +309,7 @@ function DataToColor:RegisterAuraCacheEvents()
     -- Register unit change events
     -- NOTE: These events are registered in EventHandlers.lua to avoid AceEvent overwrites:
     -- - PLAYER_TARGET_CHANGED -> OnPlayerTargetChanged -> AuraCache.refresh("target")
-    -- - PLAYER_FOCUS_CHANGED -> OnFocusChanged_BitCache -> AuraCache.refresh("focus")
+    -- - PLAYER_FOCUS_CHANGED -> OnFocusChanged_BitCache -> AuraCache.refresh(DataToColor.C.unitFocus)
     -- - UPDATE_MOUSEOVER_UNIT -> OnMouseoverChanged_BitCache -> AuraCache.refresh("mouseover")
     -- - UNIT_PET -> OnPetChanged -> AuraCache.refresh("pet")
     -- - PLAYER_SOFT_INTERACT_CHANGED -> OnPlayerSoftInteractChanged -> AuraCache.refresh("softinteract")

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Legacy Cataclysm 4.3.0)
-## Version: 1.9.13
+## Version: 1.9.14
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, cTimerBackport
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor_Classic.toc
+++ b/Addons/DataToColor/DataToColor_Classic.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic)
-## Version: 1.9.13
+## Version: 1.9.14
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor_TBC.toc
+++ b/Addons/DataToColor/DataToColor_TBC.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic TBC)
-## Version: 1.9.13
+## Version: 1.9.14
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/EventHandlers.lua
+++ b/Addons/DataToColor/EventHandlers.lua
@@ -960,7 +960,7 @@ function DataToColor:OnFocusChanged_BitCache(event)
         DataToColor.BitCache.updateFocus()
     end
     if DataToColor.AuraCache and DataToColor.AuraCache.refresh then
-        DataToColor.AuraCache.refresh("focus")
+        DataToColor.AuraCache.refresh(DataToColor.C.unitFocus)
     end
 end
 


### PR DESCRIPTION
## Summary

Fixes #791 — On Vanilla/SoM (1.14.x), assist focus mode enters combat correctly but **never detects buffs/debuffs on the focus target**. `BuffStatus<IFocus>.*` always returns `false`.

## Root Cause

`AuraCache.lua` hardcoded `"focus"` as the unit token in three places:

1. **`trackedUnits` table** — creates `unitCache["focus"]`, but on Vanilla there is no native `"focus"` unit token. `UnitBuff("focus", i)` returns nothing, so the cache is always empty.
2. **`OnFocusChanged()`** — refreshes `"focus"` instead of the aliased token.
3. **`OnFocusChanged_BitCache()` in `EventHandlers.lua`** — calls `AuraCache.refresh("focus")` instead of the aliased token.

Meanwhile, `Query.lua` correctly uses `DataToColor.C.unitFocus` (which resolves to `"party1"` on Vanilla) when querying auras. Since `unitCache["party1"]` never existed, every buff/debuff query returned `nil`.

**Why combat detection worked:** `BitCache.lua` already correctly uses `DataToColor.C.unitFocus` (line 216), and `EventHandlers.lua` checks both tokens for flag events (lines 941, 978). Only `AuraCache.lua` was broken.

## Changes

- **`AuraCache.lua` line 36:** `"focus"` → `DataToColor.C.unitFocus` in `trackedUnits` — cache is now keyed by the correct unit token per WoW version
- **`AuraCache.lua` line 273:** `RefreshUnitAuras("focus")` → `RefreshUnitAuras(DataToColor.C.unitFocus)` in `OnFocusChanged()`
- **`AuraCache.lua` line 312:** Updated internal comment to reflect the alias
- **`EventHandlers.lua` line 963:** `AuraCache.refresh("focus")` → `AuraCache.refresh(DataToColor.C.unitFocus)` in `OnFocusChanged_BitCache()`
- **Version bump:** 1.9.13 → 1.9.14 in all three `.toc` files

## Impact

- **Vanilla/SoM (1.14.x):** Focus target buffs/debuffs now detected correctly — `DataToColor.C.unitFocus` resolves to `"party1"`, cache is keyed as `"party1"`, `UnitBuff("party1", i)` returns valid data
- **TBC/Wrath/Cata/Retail:** No behavior change — `DataToColor.C.unitFocus` is `"focus"` on these clients

## Test Plan

- [x] On Vanilla (1.14.x): Set focus on a party member with Mark of the Wild → `BuffStatus<IFocus>.Mark_of_the_Wild` should return `true`
- [x] On Vanilla: Verify `UNIT_AURA` events for `"party1"` correctly refresh the aura cache
- [x] On non-Vanilla client: Verify no regression — focus target buffs still detected as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)