### PR TITLE
Addon: [1.9.16] - Fix combat lockdown, queue init, and array requirement support

### DIFF
--- a/Addons/DataToColor/ActionBarTextures.lua
+++ b/Addons/DataToColor/ActionBarTextures.lua
@@ -89,13 +89,21 @@ end
 
 -- Populates the texture queue with current action bar textures (initial load)
 function DataToColor:InitActionBarTextureQueue()
+    local count = 0
     for index, slot in pairs(IndexToSlot) do
         local encoded = EncodeTexture(slot)
         local textureId = encoded % TEXTURE_MULTIPLIER
         textureCache[slot] = textureId
-
         if textureId > 0 then
-            DataToColor.actionBarTextureQueue:push(encoded)
+            count = count + 1
+        end
+    end
+
+    DataToColor.actionBarTextureQueue:push(DataToColor.QUEUE_COUNT_MARKER + count)
+    for index, slot in pairs(IndexToSlot) do
+        local textureId = textureCache[slot] or 0
+        if textureId > 0 then
+            DataToColor.actionBarTextureQueue:push(EncodeTexture(slot))
         end
     end
 end

--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -179,6 +179,13 @@ DataToColor.DATA_CONFIG = {
 local FRAME_CHANGE_RATE = 5
 local initPhase = 2 * FRAME_CHANGE_RATE
 
+-- Queue count header marker (must match AddonTicks.QUEUE_COUNT_MARKER in C#)
+-- First item in a queue batch encodes QUEUE_COUNT_MARKER + expectedCount
+-- Must be above max possible queue data value (texture max = 16,149,999)
+-- Exposed on DataToColor table for access from other addon files
+local QUEUE_COUNT_MARKER = 16777000
+DataToColor.QUEUE_COUNT_MARKER = QUEUE_COUNT_MARKER
+
 -- How often item frames change
 local ITEM_ITERATION_FRAME_CHANGE_RATE = FRAME_CHANGE_RATE
 -- How often the actionbar frames change
@@ -738,6 +745,11 @@ function DataToColor:PopulateSpellBookInfo()
 end
 
 function DataToColor:InitSpellBookQueue()
+    local count = 0
+    for _ in pairs(DataToColor.S.playerSpellBookIdHighest) do
+        count = count + 1
+    end
+    DataToColor.spellBookQueue:push(QUEUE_COUNT_MARKER + count)
     for _, id in pairs(DataToColor.S.playerSpellBookIdHighest) do
         DataToColor.spellBookQueue:push(id)
     end

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Legacy Cataclysm 4.3.0)
-## Version: 1.9.15
+## Version: 1.9.16
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, cTimerBackport
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor_Classic.toc
+++ b/Addons/DataToColor/DataToColor_Classic.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic)
-## Version: 1.9.15
+## Version: 1.9.16
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor_TBC.toc
+++ b/Addons/DataToColor/DataToColor_TBC.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic TBC)
-## Version: 1.9.15
+## Version: 1.9.16
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/SetupDefaultBindings.lua
+++ b/Addons/DataToColor/SetupDefaultBindings.lua
@@ -502,8 +502,12 @@ end
 
 -- Auto-setup bindings if needed (called deferred after login)
 function DataToColor:AutoSetupBindingsIfNeeded()
-  -- Skip if in combat - user can run /dcactions manually later
+  -- Defer if in combat - retry automatically when combat ends
   if InCombatLockdown and InCombatLockdown() then
+    DataToColor:Print("Bindings deferred - in combat. Will retry after combat ends.")
+    BindPadCore.WaitForEvent("PLAYER_REGEN_ENABLED", function()
+      DataToColor:AutoSetupBindingsIfNeeded()
+    end)
     return
   end
 

--- a/Addons/DataToColor/SetupDefaultBindings.lua
+++ b/Addons/DataToColor/SetupDefaultBindings.lua
@@ -206,10 +206,18 @@ end
 
 -- Populates the binding queue with current in-game bindings (initial load)
 function DataToColor:InitBindingQueue()
+    local count = 0
     for bindingId, index in pairs(BindingIndex) do
         local encoded = EncodeBinding(bindingId)
         bindingCache[bindingId] = encoded
+        if encoded > 0 then
+            count = count + 1
+        end
+    end
 
+    DataToColor.bindingQueue:push(DataToColor.QUEUE_COUNT_MARKER + count)
+    for bindingId, _ in pairs(bindingCache) do
+        local encoded = bindingCache[bindingId]
         if encoded > 0 then
             DataToColor.bindingQueue:push(encoded)
         end

--- a/Core/Addon/ActionBarTextureReader.cs
+++ b/Core/Addon/ActionBarTextureReader.cs
@@ -12,10 +12,13 @@ public sealed partial class ActionBarTextureReader : IReader
     private readonly ILogger<ActionBarTextureReader> logger;
     private readonly Dictionary<int, int> slotTextures = [];
 
-    private bool initialized;
+    private int expectedCount = -1;
+    private int receivedCount;
 
     public int Count => slotTextures.Count;
-    public bool IsInitialized => initialized;
+    public int ExpectedCount => expectedCount;
+    public int ReceivedCount => receivedCount;
+    public bool IsInitialized => expectedCount >= 0 && receivedCount >= expectedCount;
 
     public IReadOnlyDictionary<int, int> SlotTextures => slotTextures;
 
@@ -37,50 +40,51 @@ public sealed partial class ActionBarTextureReader : IReader
     public void Update(IAddonDataProvider reader)
     {
         int encodedValue = reader.GetInt(TEXTURE_SLOT);
-        if (encodedValue == 0)
+        if (encodedValue == 0) return;
+
+        if (encodedValue >= AddonTicks.QUEUE_COUNT_MARKER)
         {
-            // Queue exhausted, mark as initialized if we received any textures
-            if (slotTextures.Count > 0 && !initialized)
-            {
-                initialized = true;
-                LogTexturesInitialized(logger, slotTextures.Count);
-            }
+            expectedCount = encodedValue - AddonTicks.QUEUE_COUNT_MARKER;
+            receivedCount = 0;
             return;
         }
 
+        receivedCount++;
+
         var decoded = DecodeTexture(encodedValue);
-        if (decoded.HasValue)
+        if (!decoded.HasValue)
+            return;
+
+        int slot = decoded.Value.slot;
+        int textureId = decoded.Value.textureId;
+
+        bool changed = false;
+        if (!slotTextures.TryGetValue(slot, out var existingTexture) || existingTexture != textureId)
         {
-            int slot = decoded.Value.slot;
-            int textureId = decoded.Value.textureId;
-
-            bool changed = false;
-            if (!slotTextures.TryGetValue(slot, out var existingTexture) || existingTexture != textureId)
+            changed = true;
+            if (textureId > 0)
             {
-                changed = true;
-                if (textureId > 0)
-                {
-                    slotTextures[slot] = textureId;
-                    LogTextureReceived(logger, slot, textureId);
-                }
-                else
-                {
-                    slotTextures.Remove(slot);
-                    LogTextureCleared(logger, slot);
-                }
+                slotTextures[slot] = textureId;
+                LogTextureReceived(logger, slot, textureId);
             }
-
-            if (changed)
+            else
             {
-                TextureChanged?.Invoke(slot, textureId);
+                slotTextures.Remove(slot);
+                LogTextureCleared(logger, slot);
             }
+        }
+
+        if (changed)
+        {
+            TextureChanged?.Invoke(slot, textureId);
         }
     }
 
     public void Reset()
     {
         slotTextures.Clear();
-        initialized = false;
+        expectedCount = -1;
+        receivedCount = 0;
     }
 
     /// <summary>

--- a/Core/Addon/AddonReader.cs
+++ b/Core/Addon/AddonReader.cs
@@ -1,6 +1,7 @@
 using Core.Database;
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 using SharedLib;
 
@@ -12,8 +13,9 @@ using static System.Diagnostics.Stopwatch;
 
 namespace Core;
 
-public sealed class AddonReader : IAddonReader
+public sealed partial class AddonReader : IAddonReader
 {
+    private readonly ILogger<AddonReader> logger;
     private readonly IAddonDataProvider reader;
 
     private readonly PlayerReader playerReader;
@@ -23,6 +25,13 @@ public sealed class AddonReader : IAddonReader
     private readonly TextReader textReader;
 
     private readonly ImmutableArray<IReader> readers;
+
+    private readonly SpellBookReader spellBookReader;
+    private readonly KeyBindingsReader keyBindingsReader;
+    private readonly ActionBarTextureReader textureReader;
+
+    private bool awaitingReinitialization;
+    private long reinitStartTime;
 
     public event Action? AddonDataChanged;
 
@@ -40,19 +49,27 @@ public sealed class AddonReader : IAddonReader
 
     public double AvgUpdateLatency { private set; get; }
 
-    public AddonReader(IAddonDataProvider reader,
+    public AddonReader(ILogger<AddonReader> logger,
+        IAddonDataProvider reader,
         PlayerReader playerReader, ManualResetEventSlim resetEvent,
         CreatureDB creatureDb,
         CombatLog combatLog,
         TextReader textReader,
+        SpellBookReader spellBookReader,
+        KeyBindingsReader keyBindingsReader,
+        ActionBarTextureReader textureReader,
         DataFrame[] frames,
         IServiceProvider sp)
     {
+        this.logger = logger;
         this.reader = reader;
         this.creatureDb = creatureDb;
         this.combatLog = combatLog;
         this.textReader = textReader;
         this.playerReader = playerReader;
+        this.spellBookReader = spellBookReader;
+        this.keyBindingsReader = keyBindingsReader;
+        this.textureReader = textureReader;
         DataReady = resetEvent;
 
         GlobalTime = new(frames.Length - 2);
@@ -106,6 +123,25 @@ public sealed class AddonReader : IAddonReader
                 : string.Empty;
         }
 
+        // After FullReset, wait for queue-based readers to reinitialize
+        // before signaling DataReady. This pauses the GOAP agent until
+        // spell book, bindings, and textures have been repopulated.
+        if (awaitingReinitialization)
+        {
+            if (spellBookReader.IsInitialized &&
+                keyBindingsReader.IsInitialized &&
+                textureReader.IsInitialized)
+            {
+                awaitingReinitialization = false;
+                float elapsed = (float)GetElapsedTime(reinitStartTime).TotalSeconds;
+                LogReinitComplete(logger, elapsed);
+            }
+            else
+            {
+                return;
+            }
+        }
+
         DataReady.Set();
     }
 
@@ -122,6 +158,10 @@ public sealed class AddonReader : IAddonReader
             span[i].Reset();
         }
 
+        awaitingReinitialization = true;
+        reinitStartTime = GetTimestamp();
+        LogFullReset(logger);
+
         SessionReset();
     }
 
@@ -129,4 +169,16 @@ public sealed class AddonReader : IAddonReader
     {
         AddonDataChanged?.Invoke();
     }
+
+    [LoggerMessage(
+        EventId = 100,
+        Level = LogLevel.Information,
+        Message = "FullReset: pausing bot until readers reinitialize")]
+    static partial void LogFullReset(ILogger logger);
+
+    [LoggerMessage(
+        EventId = 101,
+        Level = LogLevel.Information,
+        Message = "Readers reinitialized after {elapsedSec:F1}s, resuming bot")]
+    static partial void LogReinitComplete(ILogger logger, float elapsedSec);
 }

--- a/Core/Addon/AddonTicks.cs
+++ b/Core/Addon/AddonTicks.cs
@@ -7,4 +7,11 @@ public static class AddonTicks
     public const int INIT_PHASE = 2 * GLOBAL_QUEUE_UPDATE;
 
     public const int BAG_UPDATE = GLOBAL_QUEUE_UPDATE;
+
+    /// <summary>
+    /// Marker value for queue count headers.
+    /// First item in a queue batch encodes COUNT_MARKER + expectedCount.
+    /// Must be above max possible queue data value (texture max = 16,149,999).
+    /// </summary>
+    public const int QUEUE_COUNT_MARKER = 16_777_000;
 }

--- a/Core/Addon/KeyBindingsReader.cs
+++ b/Core/Addon/KeyBindingsReader.cs
@@ -15,10 +15,13 @@ public sealed partial class KeyBindingsReader : IReader
     private readonly Dictionary<BindingID, (ConsoleKey Key, ModifierKey Modifier)> bindings = [];
     private readonly Dictionary<BindingID, (ConsoleKey Key, ModifierKey Modifier)> secondaryBindings = [];
 
-    private bool initialized;
+    private int expectedCount = -1;
+    private int receivedCount;
 
     public int Count => bindings.Count;
-    public bool IsInitialized => initialized;
+    public int ExpectedCount => expectedCount;
+    public int ReceivedCount => receivedCount;
+    public bool IsInitialized => expectedCount >= 0 && receivedCount >= expectedCount;
 
     public IReadOnlyDictionary<BindingID, (ConsoleKey Key, ModifierKey Modifier)> Bindings => bindings;
     public IReadOnlyDictionary<BindingID, (ConsoleKey Key, ModifierKey Modifier)> SecondaryBindings => secondaryBindings;
@@ -36,78 +39,74 @@ public sealed partial class KeyBindingsReader : IReader
     public void Update(IAddonDataProvider reader)
     {
         int encodedValue = reader.GetInt(BINDING_SLOT);
-        if (encodedValue == 0)
+        if (encodedValue == 0) return;
+
+        if (encodedValue >= AddonTicks.QUEUE_COUNT_MARKER)
         {
-            // Queue exhausted, mark as initialized if we received any bindings
-            if (bindings.Count > 0 && !initialized)
-            {
-                initialized = true;
-                LogBindingsInitialized(logger, bindings.Count);
-            }
+            expectedCount = encodedValue - AddonTicks.QUEUE_COUNT_MARKER;
+            receivedCount = 0;
             return;
         }
 
+        receivedCount++;
+
         var decoded = KeyReader.DecodeBinding(encodedValue);
-        if (decoded.HasValue)
+        if (!decoded.HasValue)
+            return;
+
+        bool changed = false;
+        var bindingId = decoded.Value.bindingId;
+
+        if (decoded.Value.key1 != ConsoleKey.NoName)
         {
-            bool changed = false;
-            var bindingId = decoded.Value.bindingId;
-
-            if (decoded.Value.key1 != ConsoleKey.NoName)
+            var newBinding = (decoded.Value.key1, decoded.Value.mod1);
+            if (!bindings.TryGetValue(bindingId, out var existingBinding) ||
+                existingBinding.Key != newBinding.key1 ||
+                existingBinding.Modifier != newBinding.mod1)
             {
-                var newBinding = (decoded.Value.key1, decoded.Value.mod1);
-                // Check if this is a new or changed binding
-                if (!bindings.TryGetValue(bindingId, out var existingBinding) ||
-                    existingBinding.Key != newBinding.key1 ||
-                    existingBinding.Modifier != newBinding.mod1)
+                bindings[bindingId] = newBinding;
+                KeyReader.GameBindings[bindingId] = newBinding;
+                changed = true;
+                if (logger.IsEnabled(LogLevel.Trace))
                 {
-                    bindings[bindingId] = newBinding;
-                    // Sync to KeyReader.GameBindings for key resolution
-                    KeyReader.GameBindings[bindingId] = newBinding;
-                    changed = true;
-                    if (logger.IsEnabled(LogLevel.Trace))
-                    {
-                        string prefix = decoded.Value.mod1.ToPrefix();
-                        LogBindingReceived(logger, bindingId, prefix, decoded.Value.key1);
-                    }
+                    string prefix = decoded.Value.mod1.ToPrefix();
+                    LogBindingReceived(logger, bindingId, prefix, decoded.Value.key1);
                 }
             }
-            else if (bindings.Remove(bindingId))
-            {
-                // Key was unbound
-                KeyReader.GameBindings.Remove(bindingId);
-                changed = true;
-                LogBindingRemoved(logger, bindingId);
-            }
+        }
+        else if (bindings.Remove(bindingId))
+        {
+            KeyReader.GameBindings.Remove(bindingId);
+            changed = true;
+            LogBindingRemoved(logger, bindingId);
+        }
 
-            if (decoded.Value.key2 != ConsoleKey.NoName)
+        if (decoded.Value.key2 != ConsoleKey.NoName)
+        {
+            var newBinding = (decoded.Value.key2, decoded.Value.mod2);
+            if (!secondaryBindings.TryGetValue(bindingId, out var existingBinding) ||
+                existingBinding.Key != newBinding.key2 ||
+                existingBinding.Modifier != newBinding.mod2)
             {
-                var newBinding = (decoded.Value.key2, decoded.Value.mod2);
-                if (!secondaryBindings.TryGetValue(bindingId, out var existingBinding) ||
-                    existingBinding.Key != newBinding.key2 ||
-                    existingBinding.Modifier != newBinding.mod2)
+                secondaryBindings[bindingId] = newBinding;
+                KeyReader.GameBindingsSecondary[bindingId] = newBinding;
+                changed = true;
+                if (logger.IsEnabled(LogLevel.Trace))
                 {
-                    secondaryBindings[bindingId] = newBinding;
-                    // Sync to KeyReader.GameBindingsSecondary
-                    KeyReader.GameBindingsSecondary[bindingId] = newBinding;
-                    changed = true;
-                    if (logger.IsEnabled(LogLevel.Trace))
-                    {
-                        string prefix = decoded.Value.mod2.ToPrefix();
-                        LogSecondaryBindingReceived(logger, bindingId, prefix, decoded.Value.key2);
-                    }
+                    string prefix = decoded.Value.mod2.ToPrefix();
+                    LogSecondaryBindingReceived(logger, bindingId, prefix, decoded.Value.key2);
                 }
             }
-            else if (secondaryBindings.Remove(bindingId))
-            {
-                KeyReader.GameBindingsSecondary.Remove(bindingId);
-                changed = true;
-            }
+        }
+        else if (secondaryBindings.Remove(bindingId))
+        {
+            KeyReader.GameBindingsSecondary.Remove(bindingId);
+            changed = true;
+        }
 
-            if (changed)
-            {
-                BindingChanged?.Invoke(bindingId);
-            }
+        if (changed)
+        {
+            BindingChanged?.Invoke(bindingId);
         }
     }
 
@@ -117,7 +116,8 @@ public sealed partial class KeyBindingsReader : IReader
         secondaryBindings.Clear();
         KeyReader.GameBindings.Clear();
         KeyReader.GameBindingsSecondary.Clear();
-        initialized = false;
+        expectedCount = -1;
+        receivedCount = 0;
     }
 
     /// <summary>

--- a/Core/Addon/SpellBookReader.cs
+++ b/Core/Addon/SpellBookReader.cs
@@ -15,8 +15,14 @@ public sealed class SpellBookReader : IReader
     private readonly HashSet<string> spellNames = new(StringComparer.OrdinalIgnoreCase);
     private int[] spellIdsSnapshot = [];
 
+    private int expectedCount = -1;
+    private int receivedCount;
+
     public SpellDB SpellDB { get; }
     public int Count => spells.Count;
+    public int ExpectedCount => expectedCount;
+    public int ReceivedCount => receivedCount;
+    public bool IsInitialized => expectedCount >= 0 && receivedCount >= expectedCount;
     public int Hash { get; private set; }
     public int[] SpellIds => spellIdsSnapshot;
 
@@ -33,14 +39,23 @@ public sealed class SpellBookReader : IReader
         int spellId = reader.GetInt(cSpellId);
         if (spellId == 0) return;
 
-        if (spells.Add(spellId))
+        if (spellId >= AddonTicks.QUEUE_COUNT_MARKER)
         {
-            Hash++;
-            spellIdsSnapshot = [.. spells];
-            if (TryGetValue(spellId, out Spell spell))
-            {
-                spellNames.Add(spell.Name);
-            }
+            expectedCount = spellId - AddonTicks.QUEUE_COUNT_MARKER;
+            receivedCount = 0;
+            return;
+        }
+
+        receivedCount++;
+
+        if (!spells.Add(spellId))
+            return;
+
+        Hash++;
+        spellIdsSnapshot = [.. spells];
+        if (TryGetValue(spellId, out Spell spell))
+        {
+            spellNames.Add(spell.Name);
         }
     }
 
@@ -49,6 +64,8 @@ public sealed class SpellBookReader : IReader
         spells.Clear();
         spellNames.Clear();
         spellIdsSnapshot = [];
+        expectedCount = -1;
+        receivedCount = 0;
         Hash++;
     }
 

--- a/Core/GOAP/GoapAgent.cs
+++ b/Core/GOAP/GoapAgent.cs
@@ -284,10 +284,11 @@ public sealed partial class GoapAgent : IDisposable
             (B(dmgTaken || dmgDone) << (int)GoapKey.damagetakenordone) |
             (B(hasTarget && !b.Target_Dead()) << (int)GoapKey.targetisalive) |
 
-            (B((hasTarget &&
+            (B(((hasTarget &&
             playerReader.TargetHealthPercent() < 30) ||
             playerReader.TargetTarget is UnitsTarget.Me or
-                UnitsTarget.Pet or UnitsTarget.PartyOrPet) << (int)GoapKey.targettargetsus) |
+                UnitsTarget.Pet or UnitsTarget.PartyOrPet) &&
+                !combatLog.ToPull.Contains(playerReader.TargetGuid)) << (int)GoapKey.targettargetsus) |
 
             (B(playerCombat) << (int)GoapKey.incombat) |
             (B(playerReader.PetTarget() && !b.PetTarget_Dead()) << (int)GoapKey.pethastarget) |

--- a/Core/Goals/PullTargetGoal.cs
+++ b/Core/Goals/PullTargetGoal.cs
@@ -108,14 +108,12 @@ public sealed class PullTargetGoal : GoapGoal, IGoapEventListener
             mountHandler.Dismount();
         }
 
-        if (Keys.Length != 0 && !input.StopAttack.OnCooldown())
+        if (Keys.Length != 0 && !input.StopAttack.OnCooldown() && !playerReader.IsInMeleeRange())
         {
-            Log("Stop auto interact!");
             input.PressStopAttack();
-            wait.Update();
-            stopMoving.StopForward();
-            wait.Update(playerReader.DoubleNetworkLatency);
-            wait.Update();
+            stopMoving.Stop();
+            float stopElapsedMs = wait.Until(CastingHandler.SPELL_QUEUE_HALF, bits.NotMoving);
+            Log($"Stop auto interact {stopElapsedMs}ms!");
         }
 
         if (requiresNpcNameFinder)
@@ -239,7 +237,7 @@ public sealed class PullTargetGoal : GoapGoal, IGoapEventListener
             wait.Update();
         }
 
-        if (!stuckDetector.IsMoving())
+        if (!stuckDetector.IsMoving)
             stuckDetector.Update();
     }
 

--- a/Core/GoalsComponent/CursorScan.cs
+++ b/Core/GoalsComponent/CursorScan.cs
@@ -50,13 +50,10 @@ public sealed partial class CursorScan : IDisposable
     {
         classifier.Classify(out CursorType current, out _);
 
-        for (int i = 0; i < targetCursors.Length; i++)
+        if (targetCursors.Contains(current))
         {
-            if (current == targetCursors[i])
-            {
-                foundCursor = current;
-                return true;
-            }
+            foundCursor = current;
+            return true;
         }
 
         foundCursor = CursorType.None;

--- a/Core/GoalsComponent/StuckDetector.cs
+++ b/Core/GoalsComponent/StuckDetector.cs
@@ -1,4 +1,4 @@
-﻿using Core.Goals;
+using Core.Goals;
 
 using Microsoft.Extensions.Logging;
 
@@ -11,16 +11,11 @@ using System.Threading;
 
 using static System.Diagnostics.Stopwatch;
 
-#pragma warning disable 162
-
 namespace Core;
 
-public sealed class StuckDetector
+public sealed partial class StuckDetector
 {
-    private const bool debug = false;
-
-    private const float MIN_RANGE_DIFF = 2f;
-    private const float MIN_DISTANCE = 0.2f;
+    private const float MIN_RANGE_DIFF = 1f;
     private const float MAX_RANGE = 999999;
     private const double UNSTUCK_AFTER_MS = 2000;
     private const double ACTION_STUCK_TIME = 3000;
@@ -38,9 +33,12 @@ public sealed class StuckDetector
     private float prevDistance = MAX_RANGE;
     private long startTime;
     private long attemptTime;
+    private int attemptCount;
 
     public double ActionDurationMs => GetElapsedTime(startTime).TotalMilliseconds;
     private double UnstuckMs => GetElapsedTime(attemptTime).TotalMilliseconds;
+
+    public bool IsMoving => bits.Moving();
 
     public StuckDetector(ILogger<StuckDetector> logger, ConfigurableInput input,
         AddonBits bits, PlayerReader playerReader, PlayerDirection playerDirection,
@@ -72,6 +70,7 @@ public sealed class StuckDetector
         startTime = GetTimestamp();
 
         prevDistance = MAX_RANGE;
+        attemptCount = 0;
     }
 
     public void Update(CancellationToken token = default)
@@ -79,64 +78,94 @@ public sealed class StuckDetector
         if (bits.Falling())
             return;
 
-        if (debug && logger.IsEnabled(LogLevel.Debug))
-            logger.LogDebug("Stuck for {ActionDurationMs}ms, last tried to unstick {UnstuckMs}ms ago.", ActionDurationMs, UnstuckMs);
-
-        if (UnstuckMs > UNSTUCK_AFTER_MS)
-        {
-            stopMoving.Stop();
-
-            // Turn
-            int turnDuration = Random.Shared.Next(350);
-            if (logger.IsEnabled(LogLevel.Information))
-                logger.LogInformation("Unstuck by turning for {TurnDuration}ms", turnDuration);
-            input.TurnRandomDir(turnDuration, token);
-
-            // Move
-            ConsoleKey moveKey = Random.Shared.Next(100) >= 25 ? input.ForwardKey : input.BackwardKey;
-            int moveDuration = Random.Shared.Next(750) + 1000;
-            if (logger.IsEnabled(LogLevel.Information))
-                logger.LogInformation("Unstuck by moving for {MoveDuration}ms", moveDuration);
-            input.PressFixed(moveKey, moveDuration, token);
-
-            input.PressJump();
-
-            Vector3 targetM = WorldMapAreaDB.ToMap_FlipXY(worldTarget, playerReader.WorldMapArea);
-            float heading = DirectionCalculator.CalculateMapHeading(playerReader.MapPos, targetM);
-            playerDirection.SetDirection(heading, targetM, PlayerDirection.DefaultIgnoreDistance, token);
-
-            attemptTime = GetTimestamp();
-        }
-        else
+        if (UnstuckMs < UNSTUCK_AFTER_MS)
         {
             if (!bits.Flying())
-                input.PressJump();
+                input.PressJump(token);
+
+            return;
         }
+
+        attemptCount++;
+        attemptTime = GetTimestamp();
+
+        if (attemptCount == 1)
+        {
+            LogUnstuckJump(logger, attemptCount);
+
+            if (!bits.Flying())
+                input.PressJump(token);
+
+            return;
+        }
+
+        if (attemptCount == 2)
+        {
+            LogUnstuckNudge(logger, attemptCount);
+
+            if (!bits.Flying())
+                input.PressJump(token);
+
+            int nudgeDuration = Random.Shared.Next(200) + 200;
+            input.PressFixed(input.ForwardKey, nudgeDuration, token);
+
+            return;
+        }
+
+        // Aggressive: stop, turn, move forward, jump, reorient
+        stopMoving.Stop();
+
+        int turnDuration = Random.Shared.Next(150) + 100;
+        LogUnstuckTurn(logger, attemptCount, turnDuration);
+        input.TurnRandomDir(turnDuration, token);
+
+        int moveDuration = Random.Shared.Next(500) + 500;
+        input.PressFixed(input.ForwardKey, moveDuration, token);
+
+        if (!bits.Flying())
+            input.PressJump(token);
+
+        Vector3 targetM = WorldMapAreaDB.ToMap_FlipXY(worldTarget, playerReader.WorldMapArea);
+        float heading = DirectionCalculator.CalculateMapHeading(playerReader.MapPos, targetM);
+        playerDirection.SetDirection(heading, targetM, PlayerDirection.DefaultIgnoreDistance, token);
     }
 
     public bool IsGettingCloser()
     {
         float distance = playerReader.WorldPos.WorldDistanceXYTo(worldTarget);
-        if (distance <= prevDistance - MIN_RANGE_DIFF)
+        if (distance < prevDistance - MIN_RANGE_DIFF)
         {
             Reset();
             prevDistance = distance;
             return true;
         }
 
-        return ActionDurationMs < ACTION_STUCK_TIME;
-    }
-
-    public bool IsMoving()
-    {
-        float distance = playerReader.WorldPos.WorldDistanceXYTo(worldTarget);
-        if (MathF.Abs(distance - prevDistance) > MIN_DISTANCE)
-        {
-            Reset();
-            prevDistance = distance;
+        // Grace period only if client confirms movement
+        if (ActionDurationMs < ACTION_STUCK_TIME && bits.Moving())
             return true;
-        }
 
-        return ActionDurationMs < ACTION_STUCK_TIME;
+        return false;
     }
+
+    #region Logging
+
+    [LoggerMessage(
+        EventId = 0050,
+        Level = LogLevel.Information,
+        Message = "Unstuck attempt {Attempt}: jump")]
+    static partial void LogUnstuckJump(ILogger logger, int attempt);
+
+    [LoggerMessage(
+        EventId = 0051,
+        Level = LogLevel.Information,
+        Message = "Unstuck attempt {Attempt}: jump + nudge forward")]
+    static partial void LogUnstuckNudge(ILogger logger, int attempt);
+
+    [LoggerMessage(
+        EventId = 0052,
+        Level = LogLevel.Information,
+        Message = "Unstuck attempt {Attempt}: turning {TurnDuration}ms")]
+    static partial void LogUnstuckTurn(ILogger logger, int attempt, int turnDuration);
+
+    #endregion
 }

--- a/Core/Input/ConfigurableInput.cs
+++ b/Core/Input/ConfigurableInput.cs
@@ -74,17 +74,11 @@ public sealed partial class ConfigurableInput
 
     public int PressRandom(KeyAction keyAction, CancellationToken token = default)
     {
-        int elapsedMs;
+        int elapsedMs = keyAction.HasModifier
+            ? input.PressRandomWithModifier(keyAction.ConsoleKey, keyAction.Modifier, keyAction.PressDuration, token)
+            : input.PressRandom(keyAction.ConsoleKey, keyAction.PressDuration, token);
 
         // Use modifier-aware pressing if the keyAction has a modifier
-        if (keyAction.HasModifier)
-        {
-            elapsedMs = input.PressRandomWithModifier(keyAction.ConsoleKey, keyAction.Modifier, keyAction.PressDuration, token);
-        }
-        else
-        {
-            elapsedMs = input.PressRandom(keyAction.ConsoleKey, keyAction.PressDuration, token);
-        }
 
         keyAction.SetClicked();
 

--- a/Core/Requirement/RequirementFactory.cs
+++ b/Core/Requirement/RequirementFactory.cs
@@ -44,6 +44,7 @@ public sealed partial class RequirementFactory
     private readonly FrozenDictionary<int, SchoolMask> npcSchoolImmunity;
 
     private readonly Dictionary<string, Func<int>> intVariables;
+    private Dictionary<string, int[]> intArrayVariables = [];
 
     private readonly FrozenDictionary<string, Func<bool>> boolVariables;
 
@@ -421,6 +422,8 @@ public sealed partial class RequirementFactory
         AuraTimeReader<ITargetBuffTimeReader> targetBuffTimeReader,
         AuraTimeReader<IFocusBuffTimeReader> focusBuffTimeReader)
     {
+        intArrayVariables = intKeyValues;
+
         foreach ((string key, int[] values) in intKeyValues)
         {
             if (values.Length == 1)
@@ -1167,14 +1170,38 @@ public sealed partial class RequirementFactory
 
     private Requirement CreateSpell(ReadOnlySpan<char> requirement)
     {
-        return create(requirement, spellBookReader, intVariables);
-        static Requirement create(ReadOnlySpan<char> requirement, SpellBookReader spellBookReader, Dictionary<string, Func<int>> intVariables)
-        {
-            // 'Spell:_NAME_OR_ID_'
-            int sep = requirement.IndexOf(SEP1);
-            string name = requirement[(sep + 1)..].Trim().ToString();
+        // 'Spell:_NAME_OR_INTVARIABLE_OR_ID_'
+        int sep = requirement.IndexOf(SEP1);
+        string name = requirement[(sep + 1)..].Trim().ToString();
 
-            // variable
+        // Array variable: true if ANY spell in the array is known
+        if (intArrayVariables.TryGetValue(name, out int[]? ids) && ids.Length > 1)
+        {
+            int[] captured = ids;
+
+            bool f()
+            {
+                for (int i = 0; i < captured.Length; i++)
+                {
+                    if (spellBookReader.Has(captured[i]))
+                        return true;
+                }
+                return false;
+            }
+
+            string s() => $"Spell {name}[{captured.Length}]";
+
+            return new Requirement
+            {
+                HasRequirement = f,
+                LogMessage = s
+            };
+        }
+
+        // Single value: variable, literal ID, or spell name
+        return createSingle(name, spellBookReader, intVariables);
+        static Requirement createSingle(string name, SpellBookReader spellBookReader, Dictionary<string, Func<int>> intVariables)
+        {
             var spanLookup = intVariables.GetAlternateLookup<ReadOnlySpan<char>>();
             if (spanLookup.TryGetValue(name, out Func<int>? idFunc))
             {
@@ -1269,13 +1296,40 @@ public sealed partial class RequirementFactory
 
     private Requirement CreateNpcId(ReadOnlySpan<char> requirement)
     {
-        return create(requirement, playerReader, intVariables, creatureDb);
-        static Requirement create(ReadOnlySpan<char> requirement, PlayerReader playerReader,
+        // 'npcID:_ID_OR_INTVARIABLE_RANGE_'
+        int sep = requirement.IndexOf(SEP1);
+        string name_or_id = requirement[(sep + 1)..].Trim().ToString();
+
+        // Array variable: true if target matches ANY NPC ID in the array
+        if (intArrayVariables.TryGetValue(name_or_id, out int[]? ids) && ids.Length > 1)
+        {
+            int[] captured = ids;
+
+            bool f()
+            {
+                int targetId = playerReader.TargetId;
+                for (int i = 0; i < captured.Length; i++)
+                {
+                    if (targetId == captured[i])
+                        return true;
+                }
+                return false;
+            }
+
+            string s() => $"TargetID {name_or_id}[{captured.Length}]";
+
+            return new Requirement
+            {
+                HasRequirement = f,
+                LogMessage = s
+            };
+        }
+
+        // Single value case
+        return createSingle(name_or_id, playerReader, intVariables, creatureDb);
+        static Requirement createSingle(string name_or_id, PlayerReader playerReader,
             Dictionary<string, Func<int>> intVariables, CreatureDB creatureDb)
         {
-            // 'npcID:_ID_OR_INTVARIABLE_'
-            int sep = requirement.IndexOf(SEP1);
-            ReadOnlySpan<char> name_or_id = requirement[(sep + 1)..];
             int npcId = GetIntValueOrVariable(intVariables, name_or_id);
             string npcName = string.Empty;
 
@@ -1297,27 +1351,53 @@ public sealed partial class RequirementFactory
 
     private Requirement CreateBagItem(ReadOnlySpan<char> requirement)
     {
-        return create(requirement, bagReader, intVariables, itemDb);
-        static Requirement create(ReadOnlySpan<char> requirement, BagReader bagReader,
+        // 'BagItem:_ID_OR_INTVARIABLE_RANGE_?:_COUNT_OR_INTVARIABLE_'
+        int firstSep = requirement.IndexOf(SEP1);
+        int lastSep = requirement.LastIndexOf(SEP1);
+
+        int count = 1;
+        if (firstSep != lastSep)
+        {
+            var count_or_variable = requirement[(lastSep + 1)..];
+            count = GetIntValueOrVariable(intVariables, count_or_variable);
+        }
+        else
+        {
+            lastSep = requirement.Length;
+        }
+
+        string name_or_id = requirement[(firstSep + 1)..lastSep].Trim().ToString();
+
+        // Array variable: sum item counts across all IDs
+        if (intArrayVariables.TryGetValue(name_or_id, out int[]? ids) && ids.Length > 1)
+        {
+            int[] captured = ids;
+            int capturedCount = count;
+
+            bool f()
+            {
+                int total = 0;
+                for (int i = 0; i < captured.Length; i++)
+                    total += bagReader.ItemCount(captured[i]);
+                return total >= capturedCount;
+            }
+
+            string s() => capturedCount == 1
+                ? $"in bag {name_or_id}[{captured.Length}]"
+                : $"{name_or_id}[{captured.Length}] count >= {capturedCount}";
+
+            return new Requirement
+            {
+                HasRequirement = f,
+                LogMessage = s
+            };
+        }
+
+        // Single value case
+        return createSingle(name_or_id, count, bagReader, intVariables, itemDb);
+        static Requirement createSingle(string name_or_id, int count, BagReader bagReader,
             Dictionary<string, Func<int>> intVariables, ItemDB itemDb)
         {
-            // 'BagItem:_ID_OR_INTVARIABLE_?:_COUNT_OR_INTVARIABLE_'
-            int firstSep = requirement.IndexOf(SEP1);
-            int lastSep = requirement.LastIndexOf(SEP1);
-
-            int count = 1;
-            if (firstSep != lastSep)
-            {
-                var count_or_variable = requirement[(lastSep + 1)..];
-                count = GetIntValueOrVariable(intVariables, count_or_variable);
-            }
-            else
-            {
-                lastSep = requirement.Length;
-            }
-
-            ReadOnlySpan<char> name_or_id = requirement[(firstSep + 1)..lastSep];
-
             int itemId = GetIntValueOrVariable(intVariables, name_or_id);
 
             string itemName = string.Empty;

--- a/Frontend/Pages/BotHeader.razor
+++ b/Frontend/Pages/BotHeader.razor
@@ -9,6 +9,7 @@
 @inject TalentReader TalentReader
 @inject ActionBarCostReader ActionBarCostReader
 @inject KeyBindingsReader KeyBindingsReader
+@inject ActionBarTextureReader ActionBarTextureReader
 
 @inject AddonBits Bits
 
@@ -44,7 +45,7 @@
                     <th>Level @playerReader.Level.Value<br>(XP: @((int)playerReader.PlayerXpPercent)%)</th>
                     <th>Health / Resource:</th>
                     <th>Bag Items:</th>
-                    <th>AB / SB / Tal / Bind:</th>
+                    <th>Readers:</th>
                     <th>Target:</th>
                 </tr>
                 <tr>
@@ -55,7 +56,13 @@
                     <td>@playerReader.HealthCurrent() (@playerReader.HealthPercent() %)<br />@playerReader.PTCurrent() (@playerReader.PTPercentage() %)</td>
 
                     <td>@BagReader.BagItems.Count / @BagReader.SlotCount</td>
-                    <td>@ActionBarCostReader.Count / @SpellBookReader.Count / @TalentReader.Count / @KeyBindingsReader.Count</td>
+                    <td>
+                        ActionBar: @ActionBarCostReader.Count |
+                        Spells: @QueueStatus(SpellBookReader.ReceivedCount, SpellBookReader.ExpectedCount, SpellBookReader.Count) |
+                        Talents: @TalentReader.Count<br />
+                        Bindings: @QueueStatus(KeyBindingsReader.ReceivedCount, KeyBindingsReader.ExpectedCount, KeyBindingsReader.Count) |
+                        Textures: @QueueStatus(ActionBarTextureReader.ReceivedCount, ActionBarTextureReader.ExpectedCount, ActionBarTextureReader.Count)
+                    </td>
                     <td>
                         @if (Bits.Target())
                         {
@@ -132,6 +139,15 @@
     {
         return levelTracker.TimeToLevel == TimeSpan.Zero
             ? "∞"
-            : levelTracker.TimeToLevel.ToString();
+            : levelTracker.TimeToLevel.ToString(@"hh\:mm\:ss");
+    }
+
+    private static MarkupString QueueStatus(int received, int expected, int count)
+    {
+        if (expected < 0)
+            return new MarkupString("<span class='text-muted'>-</span>");
+        if (received < expected)
+            return new MarkupString($"<span class='text-warning'>{received}/{expected}</span>");
+        return new MarkupString($"<span class='text-success'>{count}</span>");
     }
 }

--- a/Json/class/Warlock_32.json
+++ b/Json/class/Warlock_32.json
@@ -1,0 +1,256 @@
+{
+  "ClassName": "Warlock",
+  "Loot": true,
+  "UseMount": false,
+  "Mount": {
+    "Key": "N1"
+  },
+  "NPCMaxLevels_Below": 7,
+  "NPCMaxLevels_Above": 3,
+  "Blacklist": [
+    "Mo'grosh Ogre",
+    "Mo'grosh Brute",
+    "Mo'grosh Enforcer",
+    "Mo'grosh Shaman",
+    "Mo'grosh Mystic",
+    "Gradok",
+    "Haren Swifthoof",
+    "Thragomm",
+    "Mosshide Gnoll",
+    "Mosshide Mongrel",
+    "Mosshide Fenrunner",
+    "Mosshide Brute",
+    "Mosshide Trapper",
+    "Mosshide Alpha"
+  ],
+  "PathFilename": "\\_pack\\30-40\\Arathi Highlands\\32-33 Quiet.json",
+  "PathThereAndBack": false,
+  "PathReduceSteps": true,
+  "AutoPetAttack": true,
+  "IntVariables": {
+    "Item_Soul_Shard": 6265,
+    "Items_Healthstone": [19005, 19004, 5512, 19006, 19007, 5511, 19009, 5509, 19008, 5510, 19011, 19010, 19012, 9421, 19013],
+    "MIN_SOUL_SHARDS": 2,
+    "DOT_MIN_HEALTH%": 40,
+    "LIFE_TAP_HP%": 70,
+    "LIFE_TAP_MANA%": 50,
+    "WAND_MANA%": 30,
+    "DRAIN_SOUL_HP%": 15,
+    "DRAIN_LIFE_HP%": 65,
+    "HEALTHSTONE_HP%": 40
+  },
+  "Pull": {
+    "Sequence": [
+      {
+        // let the pet pull
+        "Name": "Approach",
+        "Requirements": [
+          "Has Pet",
+          "MinRange > 15"
+        ]
+      }
+    ]
+  },
+  "Combat": {
+    "Sequence": [
+      {
+        "Name": "Use Healthstone",
+        "Key": "F7",
+        "Requirements": [
+          "Health% < HEALTHSTONE_HP%",
+          "BagItem:Items_Healthstone"
+        ],
+        "Cooldown": 120000,
+        "InCombat": "true"
+      },
+      {
+        "Name": "Drain Life",
+        "Key": "3",
+        "HasCastBar": true,
+        "InCombat": "true",
+        "Requirements": [
+          "Health% < DRAIN_LIFE_HP%",
+          "TargetHealth% > 65"
+        ]
+      },
+      {
+        "Name": "Drain Soul",
+        "Key": "8",
+        "HasCastBar": true,
+        "Requirements": [
+          "TargetHealth% < DRAIN_SOUL_HP%",
+          "!BagItem:Item_Soul_Shard:MIN_SOUL_SHARDS",
+          "TargetYieldXP"
+        ],
+        "AfterCastWaitCastbar": true
+      },
+      {
+        "Name": "Immolate",
+        "Key": "1",
+        "HasCastBar": true,
+        "AfterCastAuraExpected": true,
+        "ResetOnNewTarget": true,
+        "Cooldown": 2000,
+        "Requirements": [
+          "!Immolate",
+          "TargetHealth% > DOT_MIN_HEALTH%",
+          "Mana% > 30"
+        ]
+      },
+      {
+        "Name": "Curse of Agony",
+        "Key": "5",
+        "AfterCastAuraExpected": true,
+        "ResetOnNewTarget": true,
+        "Cooldown": 2000,
+        "Requirements": [
+          "!Curse of Agony",
+          "TargetHealth% > DOT_MIN_HEALTH%",
+          "Mana% > 30"
+        ]
+      },
+      {
+        "Name": "Corruption",
+        "Key": "4",
+        "AfterCastAuraExpected": true,
+        "ResetOnNewTarget": true,
+        "Cooldown": 2000,
+        "Requirements": [
+          "!Corruption",
+          "TargetHealth% > DOT_MIN_HEALTH%",
+          "Mana% > 30"
+        ]
+      },
+      {
+        "Name": "Siphon Life",
+        "Key": "F4",
+        "AfterCastAuraExpected": true,
+        "ResetOnNewTarget": true,
+        "Cooldown": 2000,
+        "Requirements": [
+          "!Siphon Life",
+          "TargetHealth% > DOT_MIN_HEALTH%",
+          "Mana% > 30"
+        ]
+      },
+      {
+        "Name": "Shadow Bolt",
+        "Key": "2",
+        "HasCastBar": true,
+        "ResetOnNewTarget": true,
+        "Requirements": [
+          "(Talent:Nightfall && Shadow Trance) || (!TargetsMe && Mana% > WAND_MANA% && TargetHealth% > 70)"
+        ]
+      },
+      {
+        "Name": "Shoot",
+        "Key": "0",
+        "Item": true,
+        "Requirements": [
+          "HasRangedWeapon",
+          "!Shooting",
+          "SpellInRange:1"
+        ]
+      },
+      {
+        "Name": "AutoAttack",
+        "Requirements": [
+          "!Casting",
+          "!HasRangedWeapon"
+        ]
+      },
+      {
+        "Name": "Approach",
+        "Requirements": [
+          "!Casting",
+          "!Shooting",
+          "AutoAttacking"
+        ]
+      }
+    ]
+  },
+  "Parallel": {
+    "Sequence": [
+      {
+        "Name": "Food",
+        "Key": "=",
+        "Requirement": "Health% < 50"
+      },
+      {
+        "Name": "Drink",
+        "Key": "-",
+        "Requirement": "Mana% < 40"
+      }
+    ]
+  },
+  "Adhoc": {
+    "Sequence": [
+      {
+        "Name": "Demon Skin",
+        "Key": "F2",
+        "Requirement": "!Demon Skin"
+      },
+      {
+        "Name": "Summon Succubus",
+        "Key": "7",
+        "HasCastBar": true,
+        "Requirements": [
+          "!Has Pet",
+          "BagItem:Item_Soul_Shard"
+        ],
+        "AfterCastWaitCastbar": true
+      },
+      {
+        "Name": "Health Funnel",
+        "Key": "F6",
+        "HasCastBar": true,
+        "Requirements": [
+          "PetHealth% < 35",
+          "Health% > 50",
+          "Has Pet"
+        ],
+        "AfterCastWaitCastbar": true
+      },
+      {
+        "Name": "Life Tap",
+        "Key": "6",
+        "Charge": 2,
+        "Requirements": [
+          "Health% > LIFE_TAP_HP%",
+          "Mana% < LIFE_TAP_MANA%"
+        ]
+      },
+      {
+        "Name": "Create Healthstone",
+        "Key": "9",
+        "HasCastBar": true,
+        "Requirements": [
+          "BagItem:Item_Soul_Shard",
+          "!BagItem:Items_Healthstone"
+        ],
+        "AfterCastWaitCastbar": true,
+        "AfterCastWaitBag": true
+      }
+    ]
+  },
+  "NPC": {
+    "Sequence": [
+      {
+        "Name": "Repair",
+        "Key": "C",
+        "Requirement": "Durability% < 35",
+        "UseMount": true
+      },
+      {
+        "Name": "Sell",
+        "Key": "C",
+        "Requirements": [
+          "BagFull",
+          "BagGreyItem"
+        ],
+        "UseMount": true,
+        "Cost": 6
+      }
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -2405,11 +2405,13 @@ If a particular npc is required then this requirement can be used.
 
 Formula: `npcID:[intVariableKey/Numeric integer value]`
 
+When the variable is an array (e.g. `[6195, 6196, 6197]`), returns true if the target matches ANY NPC ID in the array.
+
 e.g.
 
 * `"Requirement": "!npcID:6195"` - target is not [6195](https://tbc.wowhead.com/npc=6195)
 * `"Requirement": "npcID:6195"` - target is [6195](https://tbc.wowhead.com/npc=6195)
-* `"Requirement": "npcID:MyAwesomeIntVariable"`
+* `"Requirement": "npcID:MyAwesomeIntVariable"` - single or array IntVariable
 
 ---
 ### **Bag requirements**
@@ -2420,6 +2422,8 @@ Useful to determine when to create warlock Healthstone or soul shards.
 
 Formula: `BagItem:[intVariableKey/itemid]:[count/IntVariablesKey]`
 
+When the variable is an array (e.g. `[5512, 5511, 5509]`), the item counts across all IDs are summed and compared to the required count. This is useful for items with multiple ranks like Healthstones.
+
 e.g.
 
 * `"Requirement": "BagItem:5175"` - Must have a [Earth Totem](https://tbc.wowhead.com/item=5175) in bag
@@ -2427,6 +2431,7 @@ e.g.
 * `"Requirement": "!BagItem:19007:1"` - Must not have a [Lesser Healthstone](https://tbc.wowhead.com/item=19007) in bag
 * `"Requirement": "!BagItem:6265:3"` - Must not have [3x Soulshard](https://tbc.wowhead.com/item=6265) in bag
 * `"Requirement": "!BagItem:MyAwesomeIntVariable:69"`
+* `"Requirement": "BagItem:ITEM_HEALTHSTONE_ALL:1"` - Using array IntVariable, true if ANY item in the array is in bag
 
 ---
 ### **Form requirements**
@@ -2617,6 +2622,7 @@ It has the following formulas:
 
 * `Spell:[name]`. The `name` only works with the English client name.
 * `Spell:[id]`
+* `Spell:[IntVariablesKey]` - Resolves to a single spell ID or an array of IDs. When the variable is an array (e.g. `[100, 6178, 11578]`), returns true if ANY spell in the array is known.
 
 e.g.
 
@@ -2624,6 +2630,7 @@ e.g.
 * `"Requirement": "Spell:Demon Skin"` - Must have known the given `name`
 * `"Requirement": "!Spell:702"` - Must not have known the given [`id=702`](https://tbc.wowhead.com/item=702)
 * `"Requirement": "!Spell:Curse of Weakness"` - Must not have known the given `name`
+* `"Requirement": "Spell:SPELL_CHARGE"` - Using IntVariable (single or array)
 
 ---
 ### **Talent requirements**
@@ -2651,7 +2658,8 @@ It is important, the addon keeps track of the **icon_id**! Not **spell_id**
 e.g.
 ```json
 "IntVariables": {
-    "Buff_Horn of Winter": 134228
+    "Buff_Horn of Winter": 134228,
+    "Item_Healthstone_All": [19005, 19004, 5512, 19006, 19007, 5511, 19009, 5509, 19008, 5510, 19011, 19010, 19012, 9421, 19013],
 },
 ```
 


### PR DESCRIPTION
## Summary

This PR addresses two bugs discovered during testing and adds a new feature to the requirement DSL.

### Bug Fixes

**1. Keybinding setup silently fails when login enters combat**
- When a player logs in and immediately enters combat (e.g., logged out in a hostile area), `AutoSetupBindingsIfNeeded()` silently returned due to `InCombatLockdown()` with no retry
- Essential keybindings (targeting, interaction, pet control) were never configured, requiring `/reload`
- **Fix**: Uses BindPad's `WaitForEvent("PLAYER_REGEN_ENABLED", ...)` to automatically retry once combat ends

**2. Bot uses abilities with empty readers after /dcflush**
- When `/dcflush` is triggered during bot operation, `FullReset()` clears all reader data (spell book, bindings, textures). The GOAP agent continued running immediately with empty readers
- `Spell:SPELL_CHARGE` requirements returned false because `SpellBookReader` was empty — the bot never attempted Charge
- **Root cause**: No reliable mechanism to know when queue-based readers were fully repopulated
- **Fix**: Each queue now embeds an expected item count as the first data item using a count marker (`QUEUE_COUNT_MARKER = 16,777,000`). C# readers extract this count and track received items. `AddonReader` withholds `DataReady.Set()` until all three queue readers report `receivedCount >= expectedCount`, naturally pausing the GOAP agent

### Feature: IntVariable Array Support for Requirements

Expanded `Spell:`, `BagItem:`, and `npcID:` requirements to support IntVariable arrays (matching the existing aura array pattern):

- **`Spell:VARIABLE`** with array `[100, 6178, 11578]` → true if ANY spell ID is known
- **`BagItem:VARIABLE:COUNT`** with array `[5512, 5511, 5509]` → sums item counts across all IDs
- **`npcID:VARIABLE`** with array `[6195, 6196]` → true if target matches ANY NPC ID

Example (Warlock healthstones):
```json
"Item_Healthstone_All": [19005, 19004, 5512, 19006, 19007, 5511, 19009, 5509, 19008, 5510, 19011, 19010, 19012, 9421, 19013],
"Requirements": ["BagItem:Item_Healthstone_All"]
```

### Other Improvements

- **PullTargetGoal**: Add melee range guard to stop-attack, use `stopMoving.Stop()` with `wait.Until()` for reliable pre-pull stops
- **StuckDetector**: Refactor to escalating unstuck strategy (jump → nudge → aggressive turn+move), add `LoggerMessage` source generation
- **GoapAgent**: Exclude `ToPull` targets from `targettargetsus` check
- **CursorScan**: Simplify with `Array.Contains()`
- **BotHeader.razor**: Display reader initialization progress with color-coded status (gray=waiting, orange=loading, green=complete), fix `TimeSpan` format string crash
- **README.md**: Document array support for `Spell:`, `BagItem:`, and `npcID:` requirements

## Test plan

- [x] Start bot normally → verify green reader counts in BotHeader
- [x] Press Shift+PageDown during bot operation → observe orange progress, then green resume
- [x] Log in a character in a hostile area while in combat → verify "Bindings deferred" message and auto-retry
- [x] Test Warlock_32.json healthstone array config → verify `BagItem:Item_Healthstone_All` detects any healthstone variant
- [x] Verify Warrior Charge works after single `/dcflush` (no second flush needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)