### PR TITLE
Addon: [1.10.0] - Per-slot cast time and HasCastBar/Item inference

### DIFF
--- a/Addons/DataToColor/Constants.lua
+++ b/Addons/DataToColor/Constants.lua
@@ -69,19 +69,26 @@ DataToColor.C.CHARACTER_RACE_MAP = {
     ["Worgen"] = 22
 }
 
--- Character's name
-DataToColor.C.CHARACTER_NAME = UnitName(DataToColor.C.unitPlayer)
-DataToColor.C.CHARACTER_GUID = UnitGUID(DataToColor.C.unitPlayer)
-DataToColor.C.CHARACTER_CLASS_LOWER, DataToColor.C.CHARACTER_CLASS, DataToColor.C.CHARACTER_CLASS_ID = UnitClass(DataToColor.C.unitPlayer)
-DataToColor.C.CHARACTER_RACE, _, DataToColor.C.CHARACTER_RACE_ID = UnitRace(DataToColor.C.unitPlayer)
+-- Character info — wrapped so it can be re-detected from OnEnteringWorld.
+-- On cold-start (addon loaded before PLAYER_ENTERING_WORLD) UnitClass("player")
+-- returns nil and any class-conditional table built from these constants ends
+-- up empty (e.g. S.spellInRangeTarget is empty -> Pull/Combat range always false).
+function DataToColor:DetectPlayerCharacter()
+    DataToColor.C.CHARACTER_NAME = UnitName(DataToColor.C.unitPlayer)
+    DataToColor.C.CHARACTER_GUID = UnitGUID(DataToColor.C.unitPlayer)
+    DataToColor.C.CHARACTER_CLASS_LOWER, DataToColor.C.CHARACTER_CLASS, DataToColor.C.CHARACTER_CLASS_ID = UnitClass(DataToColor.C.unitPlayer)
+    DataToColor.C.CHARACTER_RACE, _, DataToColor.C.CHARACTER_RACE_ID = UnitRace(DataToColor.C.unitPlayer)
 
-if DataToColor.C.CHARACTER_RACE_ID == nil then
-    DataToColor.C.CHARACTER_RACE_ID = DataToColor.C.CHARACTER_RACE_MAP[DataToColor.C.CHARACTER_RACE]
+    if DataToColor.C.CHARACTER_RACE_ID == nil then
+        DataToColor.C.CHARACTER_RACE_ID = DataToColor.C.CHARACTER_RACE_MAP[DataToColor.C.CHARACTER_RACE]
+    end
+
+    if DataToColor.C.CHARACTER_CLASS_ID == nil then
+        DataToColor.C.CHARACTER_CLASS_ID = DataToColor.C.CHARACTER_CLASS_MAP[DataToColor.C.CHARACTER_CLASS_LOWER]
+    end
 end
 
-if DataToColor.C.CHARACTER_CLASS_ID == nil then
-    DataToColor.C.CHARACTER_CLASS_ID = DataToColor.C.CHARACTER_CLASS_MAP[DataToColor.C.CHARACTER_CLASS_LOWER]
-end
+DataToColor:DetectPlayerCharacter()
 
 -- Spells
 DataToColor.C.Spell.AutoShotId = 75

--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -5,7 +5,7 @@
 -- Trigger between emitting game data and frame location data
 local SETUP_SEQUENCE = false
 -- Total number of data frames generated
-local NUMBER_OF_FRAMES = 114
+local NUMBER_OF_FRAMES = 117
 -- Set number of pixel rows
 local FRAME_ROWS = 1
 -- Size of data squares in px. Varies based on rounding errors as well as dimension size. Use as a guideline, but not 100% accurate.
@@ -253,6 +253,14 @@ DataToColor.talentQueue = DataToColor.TimedQueue:new(TALENT_ITERATION_FRAME_CHAN
 
 DataToColor.actionBarCostQueue = DataToColor.struct:new(ACTION_BAR_ITERATION_FRAME_CHANGE_RATE)
 DataToColor.actionBarCooldownQueue = DataToColor.struct:new(ACTION_BAR_ITERATION_FRAME_CHANGE_RATE)
+DataToColor.actionBarCastTimeQueue = DataToColor.struct:new(ACTION_BAR_ITERATION_FRAME_CHANGE_RATE)
+
+-- Per-spell cast event log: FIFO of encoded (spellId, eventCode) pairs.
+-- Drained one per tick into cell 113 (encoded) + cell 114 (monotonic seq).
+-- Lets the bot read cast events keyed by spellId instead of the global
+-- lastCastEvent cell which is overwrite-prone when events fire close together.
+DataToColor.castEventQueue = DataToColor.TimedQueue:new(FRAME_CHANGE_RATE, 0)
+DataToColor.castEventSeq = 0
 
 DataToColor.eligibleKillCredit = {}
 
@@ -422,6 +430,13 @@ function DataToColor:OnEnteringWorld()
     DataToColor:Print("Welcome. Using " .. version)
     DataToColor:InitializeErrorLists()
 
+    -- Re-detect the player's class/race now that PLAYER_ENTERING_WORLD has fired.
+    -- The addon-load-time read in Constants.lua may have happened before
+    -- UnitClass("player") returned valid data on a cold start, leaving every
+    -- class-conditional table (e.g. S.spellInRangeTarget) empty until /reload.
+    DataToColor:DetectPlayerCharacter()
+    DataToColor:InitStorage()
+
     DataToColor:PopulateSpellBookInfo()
 
     DataToColor:InitUpdateQueues()
@@ -510,6 +525,10 @@ function DataToColor:Reset()
     bagCache = {}
 
     DataToColor.actionBarCooldownQueue = DataToColor.struct:new(ACTION_BAR_ITERATION_FRAME_CHANGE_RATE)
+    DataToColor.actionBarCastTimeQueue = DataToColor.struct:new(ACTION_BAR_ITERATION_FRAME_CHANGE_RATE)
+
+    DataToColor.castEventQueue = DataToColor.TimedQueue:new(FRAME_CHANGE_RATE, 0)
+    DataToColor.castEventSeq = 0
 
     DataToColor:InvalidateCurrentActionCache()
     DataToColor:InvalidateActionUseableCache()
@@ -569,6 +588,8 @@ function DataToColor:FushState()
     DataToColor:Reset()
     DataToColor:ClearAllQueues()
 
+    DataToColor:InitStorage()
+
     DataToColor:PopulateSpellBookInfo()
     DataToColor:InitUpdateQueues()
 
@@ -592,6 +613,7 @@ function DataToColor:InitUpdateQueues()
     DataToColor:InitInventoryQueue(0)
 
     DataToColor:InitActionBarCostQueue()
+    DataToColor:InitActionBarCastTimeQueue()
     DataToColor:InitSpellBookQueue()
     DataToColor:InitTalentQueue()
     DataToColor:InitBindingQueue()
@@ -658,6 +680,14 @@ function DataToColor:InitActionBarCostQueue()
     for slot = 1, DataToColor.C.MAX_ACTIONBAR_SLOT do
         if HasAction(slot) then
             DataToColor:populateActionbarCost(slot)
+        end
+    end
+end
+
+function DataToColor:InitActionBarCastTimeQueue()
+    for slot = 1, DataToColor.C.MAX_ACTIONBAR_SLOT do
+        if HasAction(slot) then
+            DataToColor:populateActionbarCastTime(slot)
         end
     end
 end
@@ -1020,6 +1050,30 @@ function DataToColor:CreateFrames()
             else
                 Pixel(int, 0, 37)
             end
+
+            local castSlot, castTimeMs = DataToColor.actionBarCastTimeQueue:getTimed(globalTick)
+            if castSlot then
+                DataToColor.actionBarCastTimeQueue:removeWhenExpired(castSlot, globalTick)
+                Pixel(int, castSlot * 100000 + (castTimeMs or 0), 112)
+                --DataToColor:Print("castTime: ", castSlot, " ", castTimeMs)
+            else
+                Pixel(int, 0, 112)
+            end
+
+            -- Per-spell cast event log: drain one entry per tick.
+            -- The seq counter ticks up every time a NEW item is shifted, so
+            -- the bot can detect repeats (same encoded value pushed twice)
+            -- by watching the seq cell instead of just the value cell.
+            local beforeShiftTick = DataToColor.castEventQueue.lastChangedTick
+            local nextEvent = DataToColor.castEventQueue:shift(globalTick)
+            if nextEvent and nextEvent ~= 0 and DataToColor.castEventQueue.lastChangedTick ~= beforeShiftTick then
+                DataToColor.castEventSeq = DataToColor.castEventSeq + 1
+                if DataToColor.castEventSeq > 16777215 then
+                    DataToColor.castEventSeq = 1
+                end
+            end
+            Pixel(int, nextEvent or 0, 113)
+            Pixel(int, DataToColor.castEventSeq, 114)
 
             Pixel(int, UnitHealthMax(DataToColor.C.unitPet), 38)
             Pixel(int, UnitHealth(DataToColor.C.unitPet), 39)

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Legacy Cataclysm 4.3.0)
-## Version: 1.9.17
+## Version: 1.10.0
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, cTimerBackport
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor_TBC.toc
+++ b/Addons/DataToColor/DataToColor_TBC.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic TBC)
-## Version: 1.9.17
+## Version: 1.10.0
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor_Wrath.toc
+++ b/Addons/DataToColor/DataToColor_Wrath.toc
@@ -1,7 +1,7 @@
-## Interface: 11300, 11400, 11500, 20500, 30400, 40400, 50500
+## Interface: 34300
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
-## Notes: Displays data as colors (Classic)
+## Notes: Displays data as colors (Classic Wrath)
 ## Version: 1.10.0
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino

--- a/Addons/DataToColor/EventHandlers.lua
+++ b/Addons/DataToColor/EventHandlers.lua
@@ -37,6 +37,22 @@ local CAST_SENT = 999997
 local CAST_START = 999998
 local CAST_SUCCESS = 999999
 
+-- Short codes for the per-spell cast event queue (cell 113).
+-- Errors 1..18 from errorList map directly to the same UI_ERROR.* values
+-- on the bot side; sentinels above 250 are remapped by the bot back to the
+-- 999997/8/9 constants. Layout: encoded = spellId + eventCode * 65536.
+local EVENT_CODE_CAST_SENT = 251
+local EVENT_CODE_CAST_START = 252
+local EVENT_CODE_CAST_SUCCESS = 253
+
+local function PushCastEvent(spellId, eventCode)
+    if not DataToColor.castEventQueue then return end
+    spellId = (spellId or 0) % 65536
+    eventCode = (eventCode or 0) % 256
+    if eventCode == 0 then return end
+    DataToColor.castEventQueue:push(spellId + eventCode * 65536)
+end
+
 local MERCHANT_SHOW_V = 9999999
 local MERCHANT_CLOSED_V = 9999998
 
@@ -372,7 +388,7 @@ function DataToColor:OnCombatEvent(...)
     local _, subEvent, _, sourceGUID, sourceName, sourceFlags, _, destGUID, destName, destFlags, _, spellId, spellName, _ = ...
     --print(...)
 
-    if playerDamageTakenEvents[subEvent] and
+    if (playerDamageTakenEvents[subEvent] or playerDamageMiss[subEvent]) and
         band(destFlags, COMBATLOG_OBJECT_TYPE_PLAYER_OR_PET) and
         strlen(sourceGUID) > 0 and
         (destGUID == DataToColor.playerGUID or
@@ -438,6 +454,7 @@ function DataToColor:OnCombatEvent(...)
                 DataToColor.lastCastEvent = errorListMessages[failedMessage] or 0
                 DataToColor.uiErrorMessage = DataToColor.lastCastEvent
                 DataToColor.uiErrorMessageTime = DataToColor.globalTime
+                PushCastEvent(spellId, DataToColor.lastCastEvent)
                 --DataToColor:Print(subEvent, " ", lastCastEvent, " -> ", DataToColor.lastCastEvent, " ", failedMessage, " ", spellId)
             else
                 DataToColor.lastCastEvent = CAST_SUCCESS
@@ -557,6 +574,7 @@ function DataToColor:OnCombatEvent(...)
             DataToColor.lastLoot = DataToColor.C.Loot.Corpse
             DataToColor.sessionKillCount = DataToColor.sessionKillCount + 1
             --DataToColor:Print(subEvent, " ", destGUID, " ", DataToColor:getGuidFromUUID(destGUID))
+            DataToColor.eligibleKillCredit[destGUID] = nil
         elseif destGUID == DataToColor.playerGUID then
             DataToColor.CombatCreatureDiedQueue:push(16777215)
             --DataToColor:Print(subEvent, " player Death ", destGUID, " 16777215")
@@ -580,6 +598,7 @@ function DataToColor:OnUnitSpellCastSent(...)
     DataToColor.lastCastEvent = CAST_SENT
     DataToColor.uiErrorMessageTime = DataToColor.globalTime
     DataToColor.lastCastSpellId = spellId
+    PushCastEvent(spellId, EVENT_CODE_CAST_SENT)
 end
 
 function DataToColor:OnUnitSpellCastSucceeded(...)
@@ -591,6 +610,7 @@ function DataToColor:OnUnitSpellCastSucceeded(...)
     DataToColor.lastCastEvent = CAST_SUCCESS
     DataToColor.uiErrorMessageTime = DataToColor.globalTime
     DataToColor.lastCastSpellId = spellId
+    PushCastEvent(spellId, EVENT_CODE_CAST_SUCCESS)
     DataToColor:InvalidateActionUseableCache()
 end
 
@@ -603,6 +623,7 @@ function DataToColor:OnUnitSpellCastFailed(...)
     DataToColor.lastCastEvent = DataToColor.uiErrorMessage
     DataToColor.uiErrorMessageTime = DataToColor.globalTime
     DataToColor.lastCastSpellId = spellId
+    PushCastEvent(spellId, DataToColor.uiErrorMessage)
 end
 
 function DataToColor:OnUnitSpellCastChannelStart(event, unit, castGUID, spellID)
@@ -623,6 +644,7 @@ end
 function DataToColor:SoM_OnCastStart(event, unitTarget, castGuid, spellId)
     if unitTarget ~= DataToColor.C.unitPlayer then return end
     som_spellId = spellId or 0
+    PushCastEvent(spellId, EVENT_CODE_CAST_START)
 end
 
 function DataToColor:SoM_OnCastFailed(event, unitTarget, castGuid, spellId)
@@ -722,10 +744,17 @@ end
 ]]--
 
 function DataToColor:OnSpellsChanged(event)
+    -- Rebuild the spellbook map first so anything below (range cache,
+    -- cast-time queue) resolves spell IDs/textures against fresh data.
+    -- Without this the icon->id map can be stale if the addon loaded
+    -- before SPELLS_CHANGED has fully synced — symptom: Warlock spell
+    -- range bit never sets, both Pull and Combat goals fail until /reload.
+    -- PopulateSpellBookInfo also calls PopulateSpellInRangeNames at the end.
+    DataToColor:PopulateSpellBookInfo()
     DataToColor:InitTalentQueue()
     DataToColor:InitSpellBookQueue()
     DataToColor:InitActionBarCostQueue()
-    DataToColor:PopulateSpellInRangeNames()
+    DataToColor:InitActionBarCastTimeQueue()
     DataToColor:InvalidateCurrentActionCache()
     DataToColor:InvalidateActionUseableCache()
 end
@@ -735,6 +764,8 @@ function DataToColor:ActionbarSlotChanged(event, slot)
         if HasAction(slot) then
             DataToColor:populateActionbarCost(slot)
         end
+        -- Always publish cast time (0 when slot is empty) so the bot clears stale state on removal.
+        DataToColor:populateActionbarCastTime(slot)
         -- Check for texture change (works for both add and remove)
         DataToColor:CheckActionBarTextureChange(slot)
     end
@@ -785,8 +816,6 @@ function DataToColor:OnZoneChanged(event)
 end
 
 function DataToColor:OnLeftCombat()
-    DataToColor.eligibleKillCredit = {}
-
     -- Update BitCache combat state (player left combat)
     if DataToColor.BitCache and DataToColor.BitCache.bits1 then
         DataToColor.BitCache.bits1.playerInCombat = false

--- a/Addons/DataToColor/Query.lua
+++ b/Addons/DataToColor/Query.lua
@@ -396,6 +396,71 @@ function DataToColor:populateActionbarCost(slot)
     end
 end
 
+-- Item-flag offset added to the cast-time component when the slot represents
+-- an item-like action (true items, macros wrapping items, auto-repeat
+-- shoot/wand/auto-shot). Lets the bot derive KeyAction.Item from the addon
+-- without a manual JSON setting. Cast time is clamped to 49999ms so the
+-- offset bit stays unambiguous.
+local CASTTIME_MAX = 49999
+local ITEM_FLAG_OFFSET = 50000
+
+function DataToColor:populateActionbarCastTime(slot)
+    local actionType, id = GetActionInfo(slot)
+    local castTime = 0
+    local isItem = false
+
+    if actionType == "spell" then
+        if id then
+            local _, _, _, ct = GetSpellInfo(id)
+            castTime = ct or 0
+        end
+
+    elseif actionType == "item" then
+        -- Hearthstone (10s), Bandage (8s channeled), trinkets etc.
+        -- GetItemSpell(itemId) -> spellName, spellId of the item's Use: effect
+        isItem = true
+        if id then
+            local _, spellId = GetItemSpell(id)
+            if spellId then
+                local _, _, _, ct = GetSpellInfo(spellId)
+                castTime = ct or 0
+            end
+        end
+
+    elseif actionType == "macro" then
+        local macroSpell = GetMacroSpell(id)
+        if macroSpell then
+            local _, _, _, ct = GetSpellInfo(macroSpell)
+            castTime = ct or 0
+        else
+            local macroItemName = GetMacroItem(id)
+            if macroItemName then
+                isItem = true
+                local _, spellId = GetItemSpell(macroItemName)
+                if spellId then
+                    local _, _, _, ct = GetSpellInfo(spellId)
+                    castTime = ct or 0
+                end
+            end
+        end
+    end
+
+    -- Auto-repeat actions (Auto Shot for Hunter, Shoot for Wand) behave like
+    -- items in the bot's casting flow even though they're technically spells.
+    if not isItem and IsAutoRepeatAction and IsAutoRepeatAction(slot) then
+        isItem = true
+    end
+
+    if castTime > CASTTIME_MAX then
+        castTime = CASTTIME_MAX
+    end
+    if isItem then
+        castTime = castTime + ITEM_FLAG_OFFSET
+    end
+
+    DataToColor.actionBarCastTimeQueue:set(slot, castTime)
+end
+
 function DataToColor:equipSlotItemId(slot)
     return GetInventoryItemID(DataToColor.C.unitPlayer, slot) or 0
 end

--- a/Core/Actionbar/ActionBarCastTimeReader.cs
+++ b/Core/Actionbar/ActionBarCastTimeReader.cs
@@ -1,0 +1,71 @@
+using System;
+
+using static Core.ActionBar;
+
+namespace Core;
+
+public sealed class ActionBarCastTimeReader : IReader
+{
+    private const int cActionbarNum = 112;
+
+    // Cast-time portion is < 50000; the +50000 offset added by the addon
+    // marks the slot as item-like (true items, macros wrapping items, or
+    // auto-repeat actions like Shoot / Auto Shot). Lets KeyAction.Item be
+    // derived without a manual JSON setting.
+    private const int ITEM_FLAG_OFFSET = 50000;
+
+    private readonly int[] castTimeData;
+    private readonly bool[] isItemData;
+
+    public ActionBarCastTimeReader()
+    {
+        int n = CELL_COUNT * BIT_PER_CELL;
+        castTimeData = new int[n];
+        isItemData = new bool[n];
+    }
+
+    public void Update(IAddonDataProvider reader)
+    {
+        // Guard against the bot's Data array being shorter than our cell —
+        // happens when frame_config.json is stale relative to the addon
+        // (e.g. addon bumped frame count but the bot still uses a cached
+        // smaller layout). Without this the indexer at line 29 throws
+        // IndexOutOfRangeException and crashes the addon thread.
+        if ((uint)cActionbarNum >= (uint)reader.Data.Length)
+            return;
+
+        int value = reader.GetInt(cActionbarNum);
+        if (value is 0 or < ACTION_SLOT_MUL)
+            return;
+
+        int slotIdx = (value / ACTION_SLOT_MUL) - 1;
+
+        // Guard against a corrupt / mis-aligned read producing a slot index
+        // outside the 120-slot action bar range.
+        if ((uint)slotIdx >= (uint)castTimeData.Length)
+            return;
+
+        int rem = value % ACTION_SLOT_MUL;
+
+        bool isItem = rem >= ITEM_FLAG_OFFSET;
+        int castTimeMs = isItem ? rem - ITEM_FLAG_OFFSET : rem;
+
+        castTimeData[slotIdx] = castTimeMs;
+        isItemData[slotIdx] = isItem;
+    }
+
+    public void Reset()
+    {
+        castTimeData.AsSpan().Clear();
+        isItemData.AsSpan().Clear();
+    }
+
+    public int Get(KeyAction keyAction) => castTimeData[keyAction.SlotIndex];
+
+    public bool HasCastBar(KeyAction keyAction) => castTimeData[keyAction.SlotIndex] > 0;
+
+    public bool IsItem(KeyAction keyAction) => isItemData[keyAction.SlotIndex];
+
+    public int GetBySlotIndex(int slotIndex) =>
+        (uint)slotIndex < (uint)castTimeData.Length ? castTimeData[slotIndex] : 0;
+}

--- a/Core/Actionbar/CastEventReader.cs
+++ b/Core/Actionbar/CastEventReader.cs
@@ -1,0 +1,112 @@
+using System.Collections.Generic;
+
+namespace Core;
+
+/// <summary>
+/// Per-spell cast event log.
+/// <para>
+/// The addon's global <c>lastCastEvent</c> cell only ever holds the most
+/// recent event; if two events for two different spells fire between bot
+/// polls, the second overwrites the first and the bot misses important
+/// failure codes (e.g. ERR_BADATTACKFACING right before a successful
+/// retry). This reader drains the addon's per-tick event queue (cell 113
+/// encoded value + cell 114 monotonic seq) and keeps the latest event
+/// keyed by spell ID, so consumers can ask "what was the last event for
+/// spell X" without contamination from other spells.
+/// </para>
+/// </summary>
+public sealed class CastEventReader : IReader
+{
+    private const int cEncoded = 113;
+    private const int cSeq = 114;
+
+    // Short codes the addon publishes for the cast-event sentinels — must
+    // match EVENT_CODE_CAST_SENT/START/SUCCESS in EventHandlers.lua.
+    private const int CODE_CAST_SENT = 251;
+    private const int CODE_CAST_START = 252;
+    private const int CODE_CAST_SUCCESS = 253;
+
+    private readonly Dictionary<int, UI_ERROR> latestBySpellId = [];
+
+    private int lastSeq;
+
+    public void Update(IAddonDataProvider reader)
+    {
+        // Guard against a stale/short Data array — same bounds-safety pattern
+        // as ActionBarCastTimeReader. Without this a cached frame_config that
+        // doesn't include cells 113/114 yet would crash the addon thread.
+        if ((uint)cSeq >= (uint)reader.Data.Length)
+            return;
+
+        int seq = reader.GetInt(cSeq);
+        if (seq == lastSeq)
+            return;
+
+        lastSeq = seq;
+
+        int encoded = reader.GetInt(cEncoded);
+        if (encoded == 0)
+            return;
+
+        int spellId = encoded % 65536;
+        int rawCode = encoded / 65536;
+        if (spellId == 0 || rawCode == 0)
+            return;
+
+        UI_ERROR ev = MapEventCode(rawCode);
+        latestBySpellId[spellId] = ev;
+    }
+
+    public void Reset()
+    {
+        latestBySpellId.Clear();
+        lastSeq = 0;
+    }
+
+    /// <summary>
+    /// Returns the most recently published event for the given spell, or
+    /// <see cref="UI_ERROR.NONE"/> if the bot has never seen one.
+    /// </summary>
+    public UI_ERROR Latest(int spellId)
+    {
+        if (spellId == 0)
+            return UI_ERROR.NONE;
+
+        return latestBySpellId.TryGetValue(spellId, out UI_ERROR ev)
+            ? ev
+            : UI_ERROR.NONE;
+    }
+
+    /// <summary>
+    /// Reads the latest event AND clears it, so each call observes a
+    /// distinct event. Useful inside a per-cast verification loop where we
+    /// want to react exactly once to BADATTACKFACING / OUT_OF_RANGE etc.
+    /// </summary>
+    public bool TryConsume(int spellId, out UI_ERROR ev)
+    {
+        if (spellId == 0)
+        {
+            ev = UI_ERROR.NONE;
+            return false;
+        }
+
+        if (latestBySpellId.TryGetValue(spellId, out ev) && ev != UI_ERROR.NONE)
+        {
+            latestBySpellId[spellId] = UI_ERROR.NONE;
+            return true;
+        }
+
+        ev = UI_ERROR.NONE;
+        return false;
+    }
+
+    private static UI_ERROR MapEventCode(int rawCode) => rawCode switch
+    {
+        CODE_CAST_SENT => UI_ERROR.CAST_SENT,
+        CODE_CAST_START => UI_ERROR.CAST_START,
+        CODE_CAST_SUCCESS => UI_ERROR.CAST_SUCCESS,
+        // Errors 1..18 in the addon's errorList line up 1:1 with the
+        // small UI_ERROR enum values on this side (UI_ERROR.cs).
+        _ => (UI_ERROR)rawCode
+    };
+}

--- a/Core/DependencyInjection.cs
+++ b/Core/DependencyInjection.cs
@@ -60,6 +60,8 @@ public static class DependencyInjection
 
         s.ForwardSingleton<ActionBarCostReader, IReader>();
         s.ForwardSingleton<ActionBarCooldownReader, IReader>();
+        s.ForwardSingleton<ActionBarCastTimeReader, IReader>();
+        s.ForwardSingleton<CastEventReader, IReader>();
 
         s.ForwardSingleton<ActionBarBits<ICurrentAction>, IReader>(
             x => new(25, 26, 27, 28, 29));
@@ -186,6 +188,8 @@ public static class DependencyInjection
 
         s.ForwardSingleton<ActionBarCostReader>(sp);
         s.ForwardSingleton<ActionBarCooldownReader>(sp);
+        s.ForwardSingleton<ActionBarCastTimeReader>(sp);
+        s.ForwardSingleton<CastEventReader>(sp);
 
         s.ForwardSingleton<ActionBarBits<ICurrentAction>>(sp);
         s.ForwardSingleton<ActionBarBits<IUsableAction>>(sp);

--- a/Core/Goals/CombatGoal.cs
+++ b/Core/Goals/CombatGoal.cs
@@ -25,6 +25,7 @@ public sealed class CombatGoal : GoapGoal, IGoapEventListener
     private readonly CastingHandler castingHandler;
     private readonly IMountHandler mountHandler;
     private readonly CombatLog combatLog;
+    private readonly ActionBarCastTimeReader castTimeReader;
 
     private float lastDirection;
     private float lastMinDistance;
@@ -34,7 +35,8 @@ public sealed class CombatGoal : GoapGoal, IGoapEventListener
         Wait wait, PlayerReader playerReader, StopMoving stopMoving, AddonBits bits,
         ClassConfiguration classConfiguration, ClassConfiguration classConfig,
         CastingHandler castingHandler, CombatLog combatLog,
-        IMountHandler mountHandler)
+        IMountHandler mountHandler,
+        ActionBarCastTimeReader castTimeReader)
         : base(nameof(CombatGoal))
     {
         this.logger = logger;
@@ -49,6 +51,7 @@ public sealed class CombatGoal : GoapGoal, IGoapEventListener
         this.castingHandler = castingHandler;
         this.mountHandler = mountHandler;
         this.classConfig = classConfig;
+        this.castTimeReader = castTimeReader;
 
         AddPrecondition(GoapKey.incombat, true);
         AddPrecondition(GoapKey.hastarget, true);
@@ -148,6 +151,17 @@ public sealed class CombatGoal : GoapGoal, IGoapEventListener
             KeyAction keyAction = span[i];
 
             if (castingHandler.SpellInQueue() && !keyAction.BaseAction)
+            {
+                continue;
+            }
+
+            // Items / auto-repeat actions (Shoot, Auto Shot, trinkets,
+            // on-use items) cannot be queued against an in-progress spell
+            // cast — pressing them now triggers ERR_SPELL_FAILED_ANOTHER_IN_PROGRESS.
+            // Cast-time spells DO benefit from SQW so they are not gated here.
+            if (playerReader.IsCasting() &&
+                !keyAction.BaseAction &&
+                castTimeReader.IsItem(keyAction))
             {
                 continue;
             }

--- a/Core/GoalsComponent/CastingHandler.cs
+++ b/Core/GoalsComponent/CastingHandler.cs
@@ -41,6 +41,8 @@ public sealed partial class CastingHandler
 
     private readonly ActionBarBits<IUsableAction> usableAction;
     private readonly ActionBarBits<ICurrentAction> currentAction;
+    private readonly ActionBarCastTimeReader castTimeReader;
+    private readonly CastEventReader castEventReader;
 
     private readonly ClassConfiguration classConfig;
     private readonly FormKeyActions forms;
@@ -52,17 +54,24 @@ public sealed partial class CastingHandler
 
     public bool SpellInQueue()
     {
+        // Returns true while a non-base press would be wasted; CombatGoal
+        // uses this to skip non-base actions during the wait.
+        //
+        // Semantics line up with WoW's spell-queue window:
+        //   - During cast: skip while RemainCast > SQW; inside the last SQW
+        //     ms of the cast, return false so the next press queues.
+        //   - During GCD: skip while GCD > SQW; inside the last SQW ms of
+        //     the GCD, return false so the next press queues against the
+        //     end-of-GCD boundary (the SpellQueueWindow CVar window).
+        // The GCD branch used to gate on HalfSQW which both wasted press
+        // attempts before SQW opened and skipped the SQW window itself —
+        // the inversion here enables actual GCD-tail queueing.
         if (playerReader.IsCasting())
         {
             return playerReader.RemainCastMs > playerReader.SpellQueueTimeMs;
         }
-        else if (playerReader.GCD.Value != 0 &&
-            playerReader.GCD.Value < playerReader.HalfSpellQueueTimeMs)
-        {
-            return true;
-        }
 
-        return false;
+        return playerReader.GCD.Value > playerReader.SpellQueueTimeMs;
     }
 
     public static int _GCD() => GCD;
@@ -74,6 +83,8 @@ public sealed partial class CastingHandler
         AddonBits bits,
         ActionBarBits<IUsableAction> usableAction,
         ActionBarBits<ICurrentAction> currentAction,
+        ActionBarCastTimeReader castTimeReader,
+        CastEventReader castEventReader,
         Wait wait,
         AddonReader addonReader,
         PlayerReader playerReader,
@@ -96,6 +107,8 @@ public sealed partial class CastingHandler
 
         this.usableAction = usableAction;
         this.currentAction = currentAction;
+        this.castTimeReader = castTimeReader;
+        this.castEventReader = castEventReader;
 
         this.classConfig = classConfig;
         Log = classConfig.Log;
@@ -145,6 +158,21 @@ public sealed partial class CastingHandler
         bool Interrupt() =>
             currentAction.Is(item) ||
             playerReader.CastState == UI_ERROR.CAST_SENT ||
+            token.IsCancellationRequested;
+    }
+
+    private static void WaitForItemCastResolution(Wait wait,
+        AddonBits bits, PlayerReader playerReader,
+        CancellationToken token)
+    {
+        bool wasAnyAuto = bits.Any_AutoAttack();
+        int afterSentUIErrorTime = playerReader.UIErrorTime.Value;
+
+        wait.Until(playerReader.DoubleNetworkLatency, Resolved);
+
+        bool Resolved() =>
+            bits.Any_AutoAttack() != wasAnyAuto ||
+            afterSentUIErrorTime != playerReader.UIErrorTime.Value ||
             token.IsCancellationRequested;
     }
 
@@ -294,8 +322,55 @@ public sealed partial class CastingHandler
             item.SpellId = playerReader.CastSpellId.Value;
         }
 
+        bool isItem = castTimeReader.IsItem(item);
+
+        // For items (especially auto-repeat actions like Shoot / Auto Shot),
+        // CAST_SENT confirms the keypress was registered but the action may
+        // still fail at the server (e.g. ERR_BADATTACKFACING, OUT_OF_RANGE).
+        // Wait a short follow-up window for either the auto-attack bit to
+        // toggle (success) or a UNIT_SPELLCAST_FAILED to overwrite CastEvent
+        // with the error code (failure -> outer retry path runs react.Do).
+        if (isItem)
+        {
+            WaitForItemCastResolution(wait, bits, playerReader, token);
+
+            // Per-spell event lookup — the global CastEvent cell would leak
+            // events from other spells (pet cast, auto-shoot tick, etc.) and
+            // either cause false-positive failures or hide real ones (a
+            // BADATTACKFACING immediately overwritten by a later success).
+            // CastEventReader maintains a per-spellId log so we read exactly
+            // this item's most recent event. TryConsume clears the entry so
+            // a stale event from a previous attempt can't fire twice.
+            //
+            // Fallback: when item.SpellId is 0 (never cast yet, or item
+            // without a known spell ID), fall back to the global cell with
+            // the cross-spell guard.
+            if (item.SpellId != 0)
+            {
+                if (castEventReader.TryConsume(item.SpellId, out UI_ERROR ev) &&
+                    !CastInstantSuccessful((int)ev))
+                {
+                    LogInstantInputFailed(logger, item.Name, pressMs, ev, 0);
+                    return CastResult.UIError;
+                }
+            }
+            else
+            {
+                UI_ERROR latest = (UI_ERROR)playerReader.CastEvent.Value;
+                int latestSpellId = playerReader.CastSpellId.Value;
+                bool eventIsOursOrUnknown =
+                    latestSpellId == 0 || latestSpellId == item.SpellId;
+
+                if (eventIsOursOrUnknown && !CastInstantSuccessful((int)latest))
+                {
+                    LogInstantInputFailed(logger, item.Name, pressMs, latest, 0);
+                    return CastResult.UIError;
+                }
+            }
+        }
+
         item.SetClicked();
-        if (item.Item)
+        if (isItem)
         {
             playerReader.ResetLastCastGCD();
             wait.Update(token);
@@ -391,7 +466,8 @@ public sealed partial class CastingHandler
         {
             if (playerReader.IsCasting() || bits.Channeling())
             {
-                int remainMs = playerReader.RemainCastMs - playerReader.SpellQueueTimeMs;
+                int expected = castTimeReader.Get(item);
+                int remainMs = Max(0, Max(playerReader.RemainCastMs, expected) - playerReader.SpellQueueTimeMs);
                 if (Log && item.Log)
                     LogVisibleAfterCastWaitCastbar(logger, item.Name, remainMs);
 
@@ -408,7 +484,8 @@ public sealed partial class CastingHandler
             {
                 beforeCastEventValue = playerReader.CastState;
 
-                int remainMs = playerReader.RemainCastMs - playerReader.SpellQueueTimeMs;
+                int expected = castTimeReader.Get(item);
+                int remainMs = Max(0, Max(playerReader.RemainCastMs, expected) - playerReader.SpellQueueTimeMs);
                 if (Log && item.Log)
                     LogHiddenAfterCastWaitCastbar(logger, item.Name, remainMs);
 
@@ -532,7 +609,7 @@ public sealed partial class CastingHandler
 
         if (item.BeforeCastDelay > 0)
         {
-            if (!playerReader.IsCasting() && bits.Moving() && (item.BeforeCastStop || item.HasCastBar))
+            if (!playerReader.IsCasting() && bits.Moving() && (item.BeforeCastStop || castTimeReader.HasCastBar(item)))
             {
                 stopMoving.Stop();
                 wait.Until(SPELL_QUEUE_HALF,
@@ -586,7 +663,7 @@ public sealed partial class CastingHandler
         {
             int delay = playerReader.SpellQueueTimeMs +
                 Max(playerReader.RemainCastMs,
-                item.Item ? 0 : playerReader.LastCastGCD);
+                castTimeReader.IsItem(item) ? 0 : playerReader.LastCastGCD);
 
             if (Log && item.Log)
                 LogAfterCastAuraExpected(logger, item.Name,
@@ -703,8 +780,10 @@ public sealed partial class CastingHandler
     {
         CancellationToken token = CancellationToken.None;
 
+        bool hasCastBar = castTimeReader.HasCastBar(item);
+
         if (item.PressDuration > InputDuration.DefaultPress ||
-            item.HasCastBar)
+            hasCastBar)
             token = interruptWatchdog.Set(interrupt);
 
         if (!PreparedForCast(item, token))
@@ -713,7 +792,7 @@ public sealed partial class CastingHandler
         int auraHash = playerReader.AuraCount.Hash;
 
         Func<KeyAction, CancellationToken, CastResult> castStrategy =
-            item.HasCastBar
+            hasCastBar
             ? CastCastbar
             : CastInstant;
 

--- a/Frontend/Pages/GoapGoalView.razor
+++ b/Frontend/Pages/GoapGoalView.razor
@@ -11,9 +11,16 @@
 
 @inject ActionBarCooldownReader ActionBarCooldownReader
 
+@inject ActionBarCastTimeReader castTimeReader
+
 @inject KeyBindingsReader keyBindingsReader
 
-<tr class="@ActionClass(IsSelected, 0)">
+@inject PlayerReader playerReader
+
+@{
+    bool singleKeyCasting = goal.Keys.Length == 1 && IsCastingThis(goal.Keys[0]);
+}
+<tr class="@RowClass(IsSelected, 0, singleKeyCasting)" style="@CastBarStyle(singleKeyCasting ? goal.Keys[0] : null)">
     <td>
         <b style="color:@DisplayCanRun(goal.CanRun())">@goal.Cost: @GoalName(goal)</b>
     </td>
@@ -54,7 +61,10 @@
         if (key.Slot > 0)
             cooldown = ActionBarCooldownReader.Get(key);
 
-        <tr class="@ActionClass(goal == botController.GoapAgent!.CurrentGoal && lastKey == key.ConsoleKeyFormHash, cooldown) goal-child-row">
+        bool casting = IsCastingThis(key);
+
+        <tr class="@RowClass(goal == botController.GoapAgent!.CurrentGoal && lastKey == key.ConsoleKeyFormHash, cooldown, casting) goal-child-row"
+            style="@CastBarStyle(casting ? key : null)">
             <td class="goal-child-cell">
                 @if (key.HasForm)
                 {
@@ -83,6 +93,19 @@
         </tr>
     }
 }
+
+@* Cast progress visualised as the row's own background gradient — *@
+@* the yellow "selected" highlight grows left → right as the cast progresses. *@
+<style>
+    /* Casting rows: cells must be transparent so the row-level
+       gradient (set via inline style) is visible.
+       !important overrides Bootstrap's per-cell --bs-table-bg. */
+    tr.cast-bar-row,
+    tr.cast-bar-row > td {
+        background-color: transparent !important;
+        transition: background-image 80ms linear;
+    }
+</style>
 
 @code {
 
@@ -140,6 +163,45 @@
             return "table-danger animate__animated animate__fadeIn";
 
         return item ? "table-warning animate__animated animate__fadeIn" : "";
+    }
+
+    private bool IsCastingThis(KeyAction key)
+    {
+        // SpellId is set after the first successful cast — until then we can't
+        // match by id. Once known, it covers both regular casts and channels
+        // because the addon's CastingInfoSpellId falls back to UnitChannelInfo.
+        if (!playerReader.IsCasting() || key.SpellId == 0)
+            return false;
+
+        return key.SpellId == playerReader.SpellBeingCast;
+    }
+
+    private static string RowClass(bool current, int cooldown, bool casting)
+    {
+        // While casting, suppress the table-warning/table-info background so
+        // the inline cast-bar gradient (CastBarStyle) is the only paint on the row.
+        // The cast-bar-row class makes cells transparent so the gradient shows through.
+        if (casting)
+            return "cast-bar-row animate__animated animate__fadeIn";
+
+        return ActionClass(current, cooldown);
+    }
+
+    private string CastBarStyle(KeyAction? key)
+    {
+        if (key is null)
+            return string.Empty;
+
+        int total = castTimeReader.Get(key);
+        int remain = playerReader.RemainCastMs;
+        int pct = total > 0 ? Math.Clamp(100 * (total - remain) / total, 0, 100) : 100;
+
+        // Filled (#ffc107 — Bootstrap warning solid) grows left → right.
+        // Empty (#fff3cd — Bootstrap warning subtle) matches the original
+        // table-warning row colour so the rest of the row still looks "selected".
+        return $"background-image: linear-gradient(to right, " +
+               $"#ffc107 0%, #ffc107 {pct}%, " +
+               $"#fff3cd {pct}%, #fff3cd 100%);";
     }
 
     private static string DisplayCanRun(bool item)

--- a/Frontend/Pages/SpellBookComponent.razor
+++ b/Frontend/Pages/SpellBookComponent.razor
@@ -3,16 +3,104 @@
 @using SharedLib
 
 @inject SpellBookReader spellBookReader
+@inject ActionBarCastTimeReader castTimeReader
+@inject ActionBarTextureReader textureReader
 @inject IconDB iconDB
 @inject WApi api
 @inject IAddonReader addonReader
 
 @implements IDisposable
 
+@* ===================== Action Bar (per-slot, includes items) ===================== *@
 <div class="card mt-1">
     <div class="card-header d-flex justify-content-between align-items-center">
+        <span>Action Bar (@populatedCount populated of @totalSlots slots)</span>
+        <div>
+            <span class="badge bg-secondary me-1">@instantCount Instant</span>
+            <span class="badge bg-info me-1">@castbarCount Cast Bar</span>
+            <InitButton />
+        </div>
+    </div>
+    <div class="card-body p-0">
+        @if (populatedCount == 0)
+        {
+            <div class="p-3 text-muted">
+                No action bar slots populated yet. Make sure the addon is running and a class profile is loaded.
+                <br />
+                <small>Cast times come from the addon via <code>GetSpellInfo</code>/<code>GetItemSpell</code> and reflect talents
+                (e.g. 5/5 Improved Corruption flips Corruption to instant).</small>
+            </div>
+        }
+        else
+        {
+            <div class="table-responsive">
+                <table class="table table-sm table-striped table-hover mb-0">
+                    <thead class="sticky-top bg-dark">
+                        <tr>
+                            <th style="width: 60px;">Slot</th>
+                            <th style="width: 40px;"></th>
+                            <th>Spell / Item / Macro</th>
+                            <th style="width: 120px;">Cast Time</th>
+                            <th style="width: 100px;">Routing</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (SlotEntry entry in slotEntries)
+                        {
+                            <tr>
+                                <td class="align-middle text-muted">@entry.Slot</td>
+                                <td class="align-middle">
+                                    @if (!string.IsNullOrEmpty(entry.IconUrl))
+                                    {
+                                        <img src="@entry.IconUrl" alt=""
+                                             style="width: 24px; height: 24px; border-radius: 4px;" />
+                                    }
+                                    else
+                                    {
+                                        <div style="width: 24px; height: 24px; background: #333; border-radius: 4px;"></div>
+                                    }
+                                </td>
+                                <td class="align-middle">
+                                    @entry.Name
+                                    @if (entry.TextureId > 0)
+                                    {
+                                        <span class="text-muted ms-2" style="font-size: 0.75rem;">tex:@entry.TextureId</span>
+                                    }
+                                </td>
+                                <td class="align-middle">
+                                    @if (entry.CastTimeMs == 0)
+                                    {
+                                        <span class="text-muted">— instant</span>
+                                    }
+                                    else
+                                    {
+                                        <span>@(entry.CastTimeMs)ms</span>
+                                        <span class="text-muted ms-1">(@((entry.CastTimeMs / 1000f).ToString("0.0"))s)</span>
+                                    }
+                                </td>
+                                <td class="align-middle">
+                                    @if (entry.CastTimeMs > 0)
+                                    {
+                                        <span class="badge bg-info">CastCastbar</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="badge bg-secondary">CastInstant</span>
+                                    }
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        }
+    </div>
+</div>
+
+@* ===================== Spell Book (all known spells) ===================== *@
+<div class="card mt-3">
+    <div class="card-header d-flex justify-content-between align-items-center">
         <span>Spellbook (@spellBookReader.Count spells)</span>
-        <InitButton />
     </div>
     <div class="card-body p-0">
         @if (spellBookReader.Count == 0)
@@ -29,12 +117,13 @@
                         <tr>
                             <th style="width: 40px;"></th>
                             <th>Spell Name</th>
+                            <th style="width: 120px;">Cast Time</th>
                             <th style="width: 80px;">Level</th>
                             <th style="width: 80px;">Spell ID</th>
                         </tr>
                     </thead>
                     <tbody>
-                        @foreach (var spellEntry in GetSortedSpells())
+                        @foreach (var spellEntry in cachedSpells)
                         {
                             <tr>
                                 <td class="align-middle">
@@ -57,6 +146,21 @@
                                         @spellEntry.Spell.Name
                                     </a>
                                 </td>
+                                <td class="align-middle">
+                                    @if (spellEntry.CastTimeMs is int ct && ct > 0)
+                                    {
+                                        <span>@(ct)ms</span>
+                                        <span class="text-muted ms-1">(@((ct / 1000f).ToString("0.0"))s)</span>
+                                    }
+                                    else if (spellEntry.CastTimeMs == 0)
+                                    {
+                                        <span class="text-muted">— instant</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="text-muted" title="Spell is not bound to an action bar slot — cast time unknown">—</span>
+                                    }
+                                </td>
                                 <td class="align-middle text-muted">@spellEntry.Spell.Level</td>
                                 <td class="align-middle text-muted">@spellEntry.Spell.Id</td>
                             </tr>
@@ -69,59 +173,184 @@
 </div>
 
 @code {
-    private record SpellDisplayEntry(Spell Spell, string? IconUrl);
+    private const int totalSlots = ActionBar.CELL_COUNT * ActionBar.BIT_PER_CELL;
+
+    // ---------- Action bar ----------
+    private record SlotEntry(int Slot, int TextureId, int CastTimeMs, string Name, string? IconUrl);
+
+    private List<SlotEntry> slotEntries = [];
+    private int populatedCount;
+    private int instantCount;
+    private int castbarCount;
+
+    // ---------- Spellbook ----------
+    private record SpellDisplayEntry(Spell Spell, string? IconUrl, int? CastTimeMs);
 
     private List<SpellDisplayEntry> cachedSpells = [];
-    private int lastHash;
+    private int lastSpellbookHash;
 
     protected override void OnInitialized()
     {
         addonReader.AddonDataChanged += OnAddonDataChanged;
+        textureReader.TextureChanged += OnTextureChanged;
+
+        RebuildActionBar();
+        RebuildSpellbook();
     }
 
     public void Dispose()
     {
         addonReader.AddonDataChanged -= OnAddonDataChanged;
+        textureReader.TextureChanged -= OnTextureChanged;
     }
 
     private void OnAddonDataChanged()
     {
-        // Only update UI if spellbook hash changed
-        if (lastHash != spellBookReader.Hash)
+        InvokeAsync(() =>
         {
-            base.InvokeAsync(StateHasChanged);
-        }
+            int beforePopulated = populatedCount;
+            int beforeCastbar = castbarCount;
+            int beforeSpellHash = lastSpellbookHash;
+
+            RebuildActionBar();
+            RebuildSpellbook();
+
+            if (beforePopulated != populatedCount
+                || beforeCastbar != castbarCount
+                || beforeSpellHash != lastSpellbookHash)
+            {
+                StateHasChanged();
+            }
+        });
     }
 
-    private List<SpellDisplayEntry> GetSortedSpells()
+    private void OnTextureChanged(int slot, int textureId)
     {
-        // Return cached list if hash hasn't changed
-        if (lastHash == spellBookReader.Hash && cachedSpells.Count > 0)
+        InvokeAsync(() =>
         {
-            return cachedSpells;
+            RebuildActionBar();
+            // Spellbook cast-time enrichment depends on texture mapping too.
+            RebuildSpellbook();
+            StateHasChanged();
+        });
+    }
+
+    // -------------------------------------------------------------
+    //  Action bar: one row per populated slot. Items work because
+    //  the addon already publishes per-slot cast time regardless of
+    //  whether the slot is a spell, item, or macro.
+    // -------------------------------------------------------------
+    private void RebuildActionBar()
+    {
+        var entries = new List<SlotEntry>(totalSlots);
+        int populated = 0;
+        int instant = 0;
+        int castbar = 0;
+
+        for (int slot = 1; slot <= totalSlots; slot++)
+        {
+            textureReader.TryGetTexture(slot, out int textureId);
+            int castTimeMs = castTimeReader.GetBySlotIndex(slot - 1);
+
+            if (textureId == 0 && castTimeMs == 0)
+                continue;
+
+            populated++;
+            if (castTimeMs > 0) castbar++;
+            else instant++;
+
+            string name = ResolveSlotName(textureId);
+            string? iconUrl = textureId > 0 ? iconDB.GetIconUrl(textureId, 18) : null;
+
+            entries.Add(new SlotEntry(slot, textureId, castTimeMs, name, iconUrl));
         }
 
-        lastHash = spellBookReader.Hash;
+        slotEntries = entries;
+        populatedCount = populated;
+        instantCount = instant;
+        castbarCount = castbar;
+    }
 
-        // Iterate over stable snapshot array
+    private string ResolveSlotName(int textureId)
+    {
+        if (textureId == 0)
+            return "(empty)";
+
+        string[] names = iconDB.GetSpellNamesForDisplay(textureId);
+        if (names.Length == 0)
+            return "(unknown texture — likely an item)";
+
+        return names.Length switch
+        {
+            1 => names[0],
+            _ => string.Join(" / ", names.Take(3))
+        };
+    }
+
+    // -------------------------------------------------------------
+    //  Spellbook: enrich each spell with cast time when it can be
+    //  located on the action bar. Spells unbound to any action slot
+    //  show "—" (cast time unknown).
+    // -------------------------------------------------------------
+    private void RebuildSpellbook()
+    {
+        // Skip rebuild if spellbook hasn't changed AND action bar hasn't changed
+        // either — cast time enrichment would yield same values. But action bar
+        // changes are rare relative to addonDataChanged ticks, so just rebuild.
+        lastSpellbookHash = spellBookReader.Hash;
+
+        // Build a spell-id → cast-time lookup by scanning action bar slots once.
+        Dictionary<int, int>? spellCastTimeBySpellId = BuildSpellCastTimeLookup();
+
         int[] spellIds = spellBookReader.SpellIds;
         var entries = new List<SpellDisplayEntry>(spellIds.Length);
         foreach (int spellId in spellIds)
         {
-            if (spellBookReader.TryGetValue(spellId, out Spell spell))
-            {
-                string? iconUrl = iconDB.GetIconUrlForSpell(spellId, 36);
-                entries.Add(new SpellDisplayEntry(spell, iconUrl));
-            }
+            if (!spellBookReader.TryGetValue(spellId, out Spell spell))
+                continue;
+
+            string? iconUrl = iconDB.GetIconUrlForSpell(spellId, 18);
+            int? castTime = spellCastTimeBySpellId is not null
+                && spellCastTimeBySpellId.TryGetValue(spellId, out int ct)
+                ? ct
+                : null;
+
+            entries.Add(new SpellDisplayEntry(spell, iconUrl, castTime));
         }
 
-        // Sort by name, then by level (for ranked spells)
         cachedSpells = entries
             .OrderBy(e => GetBaseSpellName(e.Spell.Name))
             .ThenBy(e => e.Spell.Level)
             .ToList();
+    }
 
-        return cachedSpells;
+    // For each populated slot with a known texture, find spellbook spells that
+    // share that texture and attribute the slot's cast time to them. Multiple
+    // ranks share one texture, so all ranks get the same cast time — which is
+    // correct for ranked spells in vanilla.
+    private Dictionary<int, int>? BuildSpellCastTimeLookup()
+    {
+        Dictionary<int, int>? lookup = null;
+
+        for (int slot = 1; slot <= totalSlots; slot++)
+        {
+            if (!textureReader.TryGetTexture(slot, out int textureId) || textureId == 0)
+                continue;
+
+            int castTimeMs = castTimeReader.GetBySlotIndex(slot - 1);
+
+            ReadOnlySpan<int> sharedSpellIds = iconDB.GetSpellIds(textureId);
+            if (sharedSpellIds.Length == 0)
+                continue;
+
+            lookup ??= [];
+            foreach (int sid in sharedSpellIds)
+            {
+                lookup[sid] = castTimeMs;
+            }
+        }
+
+        return lookup;
     }
 
     private static string GetBaseSpellName(string name)

--- a/Json/class/Warlock_1.json
+++ b/Json/class/Warlock_1.json
@@ -4,6 +4,10 @@
   "PathFilename": "1_Gnome.json",
   "PathThereAndBack": true,
   "PathReduceSteps": false,
+  "IntVariables": {
+    "MIN_WATER%": 20,
+    "MIN_MANA_SHADOWBOLT%": 40
+  },
   "Wait": {
     "Sequence": [
       {
@@ -18,7 +22,8 @@
       {
         "Name": "Shadow Bolt",
         "Key": "2",
-        "HasCastBar": true
+        "HasCastBar": true,
+        "Requirement": "Mana% > MIN_MANA_SHADOWBOLT%"
       }
     ]
   },
@@ -27,11 +32,16 @@
       {
         "Name": "Shadow Bolt",
         "HasCastBar": true,
-        "Key": "2"
+        "Key": "2",
+        "Requirements": [
+          "TargetHealth% > 20",
+          "Mana% > MIN_MANA_SHADOWBOLT%"
+        ]
       },
       {
         "Name": "AutoAttack",
         "Requirements": [
+          "InMeleeRange",
           "!Casting"
         ]
       },
@@ -39,7 +49,8 @@
         "Name": "Approach",
         "Requirements": [
           "!Casting",
-          "AutoAttacking"
+          "AutoAttacking && !MeleeSwinging",
+          "!SoftTargetDead"
         ]
       }
     ]
@@ -54,12 +65,12 @@
       {
         "Name": "Food",
         "Key": "=",
-        "Requirement": "Health% < 50"
+        "Requirement": "Health% < MIN_WATER%"
       },
       {
         "Name": "Drink",
         "Key": "-",
-        "Requirement": "Mana% < 50"
+        "Requirement": "Mana% < MIN_WATER%"
       }
     ]
   },
@@ -69,7 +80,7 @@
         "Name": "Repair",
         "Key": "C",
         "Requirement": "Durability% < 35",
-        "PathFilename": "1_Gnome_Vendor.json",
+        //"PathFilename": "1_Gnome_Vendor.json",
         "Cost": 6
       },
       {
@@ -79,7 +90,7 @@
           "BagFull",
           "BagGreyItem"
         ],
-        "PathFilename": "1_Gnome_Vendor.json",
+        //"PathFilename": "1_Gnome_Vendor.json",
         "Cost": 6
       }
     ]

--- a/Json/class/Warlock_1_10.json
+++ b/Json/class/Warlock_1_10.json
@@ -1,0 +1,174 @@
+{
+  //"Mode": "AttendedGrind",
+  "Loot": true,
+  "PathFilename": "1_Gnome.json",
+  "PathThereAndBack": true,
+  "PathReduceSteps": false,
+  "IntVariables": {
+    "MIN_WATER%": 20,
+    "MIN_MANA_SHADOWBOLT%": 40,
+    "MIN_MANA_IMMOLATE%": 40,
+    "MIN_MANA_CORRUPTION%": 30,
+    "MIN_HEALTH_CAST%": 40,
+    "DOT_MIN_HEALTH": 50,
+
+    "SPELL_IMMOLATE": [348, 707, 1094, 2941, 11665, 11667, 11668, 25309],
+    "SPELL_CORRUPTION": [172, 6222, 6223, 7648, 11671, 11672, 25311],
+    "SPELL_SUMMON_IMP": [688]
+  },
+  "Wait": {
+    "Sequence": [
+      {
+        "Cost": 0.9,
+        "Name": "User",
+        "Requirement": "MenuOpen || ChatInputVisible"
+      }
+    ]
+  },
+  "Pull": {
+    "Sequence": [
+      {
+        // let the pet pull
+        "Name": "Approach",
+        "Requirements": [
+          "Has Pet",
+          "MinRange > 20"
+        ]
+      },
+      {
+        "Name": "Immolate",
+        "Key": "4",
+        "AfterCastAuraExpected": true,
+        "Requirements": [
+          "!Has Pet",
+          "!Immolate",
+          "Spell:SPELL_IMMOLATE",
+          "Mana% > MIN_MANA_IMMOLATE%"
+        ]
+      },
+      {
+        "Name": "Shadow Bolt",
+        "Key": "2",
+        "Requirements": [
+          "!Has Pet",
+          "!Spell:SPELL_IMMOLATE",
+          "Mana% > MIN_MANA_SHADOWBOLT%"
+        ]
+      }
+    ]
+  },
+  "Combat": {
+    "Sequence": [
+      {
+        "Name": "Immolate",
+        "Key": "4",
+        "Requirements": [
+          "Has Pet",
+          "!Immolate",
+          "Spell:SPELL_IMMOLATE",
+          "TargetHealth% > DOT_MIN_HEALTH",
+          "Mana% > MIN_MANA_IMMOLATE%"
+        ],
+        "AfterCastWaitCastbar": true,
+        "Interrupt": "TargetHealth% < DOT_MIN_HEALTH",
+        "CancelOnInterrupt": true
+      },
+      {
+        "Name": "Corruption",
+        "Key": "5",
+        "Requirements": [
+          "!Corruption",
+          "Spell:SPELL_CORRUPTION",
+          "TargetHealth% > DOT_MIN_HEALTH",
+          "Mana% > MIN_MANA_CORRUPTION%"
+        ],
+        "AfterCastWaitCastbar": true,
+        "Interrupt": "TargetHealth% < DOT_MIN_HEALTH",
+        "CancelOnInterrupt": true
+      },
+      {
+        "Name": "Shadow Bolt",
+        "Key": "2",
+        "Requirements": [
+          "!HasRangedWeapon",
+          "TargetHealth% > MIN_HEALTH_CAST%",
+          "Mana% > MIN_MANA_SHADOWBOLT%"
+        ],
+        "AfterCastWaitCastbar": true,
+        "Interrupt": "TargetHealth% < MIN_HEALTH_CAST%",
+        "CancelOnInterrupt": true
+      },
+      {
+        "Name": "Shoot",
+        "Key": "0",
+        "Item": true,
+        "Requirements": [
+          "HasRangedWeapon",
+          "!Shooting",
+          "SpellInRange:1"
+        ]
+      },
+      {
+        "Name": "AutoAttack",
+        "Requirements": [
+          //"InMeleeRange",
+          "!HasRangedWeapon",
+          "!Casting && !Shooting"
+        ]
+      },
+      {
+        "Name": "Approach",
+        "Requirements": [
+          "!Casting",
+          "AutoAttacking && !MeleeSwinging",
+          "!SoftTargetDead"
+        ]
+      }
+    ]
+  },
+  "Adhoc": {
+    "Sequence": [
+      {
+        "Name": "Summon Imp",
+        "Key": "6",
+        "Requirements": [
+          "!Has Pet",
+          "Spell:SPELL_SUMMON_IMP"
+        ],
+        "AfterCastWaitCastbar": true
+      },
+      {
+        "Name": "Demon Skin",
+        "Key": "3",
+        "Requirement": "!Demon Skin"
+      },
+      {
+        "Name": "Food",
+        "Key": "=",
+        "Requirement": "Health% < MIN_WATER%"
+      },
+      {
+        "Name": "Drink",
+        "Key": "-",
+        "Requirement": "Mana% < MIN_WATER%"
+      }
+    ]
+  },
+  "NPC": {
+    "Sequence": [
+      {
+        "Cost": 6,
+        "Name": "Repair",
+        "Requirement": "Durability% < 35"
+      },
+      {
+        "Cost": 6,
+        "Name": "Sell",
+        "Requirements": [
+          "BagFull",
+          "BagGreyItem"
+        ]
+      }
+    ]
+  }
+}

--- a/Json/class/Warlock_66_Demo_pet_pull.json
+++ b/Json/class/Warlock_66_Demo_pet_pull.json
@@ -11,14 +11,25 @@
   "PathFilename": "_pack\\60-70\\Terokkar Forest\\62-64.json",
   "IntVariables": {
     "Item_Soul_Shard": 6265,
-    "Item_Healthstone": 22103, //22105
+    "Items_Healthstone": [19005, 19004, 5512, 19006, 19007, 5511, 19009, 5509, 19008, 5510, 19011, 19010, 19012, 9421, 19013],
     "DOT_MIN_HEALTH%": 35,
     "DRAIN_MIN_HP%": 70,
+    "DRAIN_STOP_HP%": 90,
+    "FUNNEL_STOP_PET_HP%": 90,
     "TAP_MIN_MANA%": 65,
     "MIN_TARGET_HP_CD%": 75,
     "MIN_FOOD_DRINK%": 30,
     "USE_TRINKET_1": 0,
     "USE_TRINKET_2": 0
+  },
+  "Wait": {
+    "Sequence": [
+      {
+        "Cost": 0.9,
+        "Name": "User",
+        "Requirement": "MenuOpen || ChatInputVisible"
+      }
+    ]
   },
   "Pull": {
     "Sequence": [
@@ -38,7 +49,7 @@
         "Key": "7",
         "Requirements": [
           "Health% < 35",
-          "BagItem:Item_Healthstone"
+          "BagItem:Items_Healthstone"
         ],
         "Cooldown": 120000,
         "InCombat": "true"
@@ -76,7 +87,7 @@
       {
         "Name": "Drain Soul",
         "Key": "F2",
-        "HasCastBar": true,
+        "AfterCastWaitCastbar": true,
         "Requirements": [
           "TargetHealth% < 25",
           "!BagItem:Item_Soul_Shard:3",
@@ -96,14 +107,16 @@
       {
         "Name": "Immolate",
         "Key": "1",
-        "HasCastBar": true,
         "WhenUsable": true,
+        "AfterCastWaitCastbar": true,
         "AfterCastAuraExpected": true,
         "Requirements": [
           "TargetHealth% > DOT_MIN_HEALTH%",
           "!Immolate",
           "!TargetsMe || Sacrifice"
-        ]
+        ],
+        "Interrupt": "TargetHealth% < DOT_MIN_HEALTH% || !TargetAlive",
+        "CancelOnInterrupt": true
       },
       {
         "Name": "Amplify Curse",
@@ -138,19 +151,20 @@
       {
         "Name": "Incinerate",
         "Key": "F4",
-        "HasCastBar": true,
-        //"Cooldown": 6000,
+        "AfterCastWaitCastbar": true,
         "Requirements": [
           "!TargetsMe || Sacrifice",
           "Immolate",
           "Health% > DRAIN_MIN_HP%",
           "TargetHealth% > 40"
-        ]
+        ],
+        "Interrupt": "TargetHealth% < DOT_MIN_HEALTH% || !TargetAlive || !Immolate",
+        "CancelOnInterrupt": true
       },
       {
         "Name": "Shadow Bolt",
         "Key": "2",
-        "HasCastBar": true,
+        "AfterCastWaitCastbar": true,
         "Cooldown": 6000,
         "WhenUsable": true,
         "Requirements": [
@@ -158,33 +172,39 @@
           "!Immolate",
           "Health% > DRAIN_MIN_HP%",
           "TargetHealth% > 40"
-        ]
+        ],
+        "Interrupt": "TargetHealth% < DOT_MIN_HEALTH% || !TargetAlive || Shadow Trance",
+        "CancelOnInterrupt": true
       },
       {
         "Name": "Health Funnel",
         "Key": "F1",
-        "HasCastBar": true,
+        "AfterCastWaitCastbar": true,
         //"WhenUsable": true,
         "Requirements": [
           "Has Pet",
           "Health% > MIN_FOOD_DRINK%",
           "PetHealth% <= DOT_MIN_HEALTH%",
           "CD_Fel Domination > 0"
-        ]
+        ],
+        "Interrupt": "PetHealth% > FUNNEL_STOP_PET_HP% || Health% < MIN_FOOD_DRINK% || !Has Pet",
+        "CancelOnInterrupt": true
       },
       {
         "Name": "Drain Life",
         "Key": "N3",
-        "HasCastBar": true,
+        "AfterCastWaitCastbar": true,
         "Requirements": [
           "Health% < DRAIN_MIN_HP%"
-        ]
+        ],
+        "Interrupt": "Health% > DRAIN_STOP_HP% || !TargetAlive",
+        "CancelOnInterrupt": true
       },
       {
         "Name": "Shoot",
         "Key": "3",
-        "Item": true,
-        "PressDuration": 51,
+        //"Item": true,
+        //"PressDuration": 51,
         "WhenUsable": true,
         "Requirements": [
           "HasRangedWeapon",
@@ -237,7 +257,7 @@
         "Name": "Summon Felguard",
         "Key": "6",
         "Cost": 3.2,
-        "HasCastBar": true,
+        "AfterCastWaitCastbar": true,
         "InCombat": "true",
         "Requirements": [
           "!Has Pet",
@@ -250,7 +270,6 @@
       {
         "Name": "Summon Felguard",
         "Key": "6",
-        "HasCastBar": true,
         "Requirements": [
           "!Has Pet",
           "!Mounted",
@@ -283,12 +302,11 @@
       {
         "Name": "heal",
         "Key": "7",
-        "HasCastBar": true,
         "AfterCastWaitCastbar": true,
         "AfterCastWaitBag": true,
         "Requirements": [
           "BagItem:Item_Soul_Shard",
-          "!BagItem:Item_Healthstone"
+          "!BagItem:Items_Healthstone"
         ]
       }
     ]

--- a/README.md
+++ b/README.md
@@ -1273,7 +1273,7 @@ Can specify conditions with [Requirement(s)](#requirement) in order to create a 
 | `"Modifier"` | Modifier key to hold while pressing the key. Values: `"None"`, `"Shift"`, `"Ctrl"`, `"Alt"`. Alternative to using prefix in `Key`. **Note**: Combined modifiers (e.g., `Shift-Alt`) are not supported - only single modifiers. | `"None"` |
 | `"Cost"` | [Adhoc Goals](#adhoc-goals) or [NPC Goal](#npc-goals) only, priority | `18` |
 | `"PathFilename"` | [NPC Goal](#npc-goals) only, this is a short path to get close to the NPC to avoid walls etc. | `""` |
-| `"HasCastBar"` | After key press cast bar is expected?<br>By default sets `BeforeCastStop`=`true` | `false` |
+| `"HasCastBar"` | **Auto-detected** from the spell's effective cast time (`GetSpellInfo`), so it reflects talents like 5/5 Improved Corruption that flip a cast to instant. JSON setting is accepted but ignored. | _derived_ |
 | `"InCombat"` | Should combat matter when attempt to cast?<br>Accepted values:<br>* `"any value for doesn't matter"`<br>* `"true"`<br>* `"false"` | `false` |
 | `"Item"` | Like on use Trinket, `Food`, `Drink`.<br>The following spells counts as Item, `Throw`, `Auto Shot`, `Shoot` | `false` |
 | `"PressDuration"` | How many minimum milliseconds to hold the key press down | `50` |
@@ -1326,7 +1326,7 @@ Important, the `AfterCast` prefixed conditions are ordered as shown in the table
 
 | Property Group | Purpose |
 | --- | --- |
-| `HasCastBar` | Tells the bot to wait for the cast to complete before taking the next action. Without this, the bot might interrupt your cast by pressing another key. |
+| `HasCastBar` | _Auto-detected_ from the spell's effective cast time via `GetSpellInfo` — the bot waits for the cast bar without you needing to declare it in JSON. Talent-aware: a spell that becomes instant via talents (e.g., 5/5 Improved Corruption) is automatically routed through the instant path. The JSON field is accepted for back-compat but ignored. |
 | `WhenUsable` | Only attempts to cast when the game reports the ability is usable (enough mana/rage/energy, not on cooldown). Prevents wasting key presses. |
 | `Cooldown` | Prevents the bot from spamming the same ability. This is the bot's internal cooldown, not the game's. Set to match GCD (~400ms) for most abilities. |
 | `Form` | For Druids/Warriors - ensures you're in the correct shapeshift/stance before casting. Prevents "Can only use in Cat Form" errors. |
@@ -1340,12 +1340,11 @@ Important, the `AfterCast` prefixed conditions are ordered as shown in the table
 | [`Requirement(s)`](#requirement) | Conditions that must be true to use this ability. Core of the combat rotation logic. |
 | [`Interrupt(s)`](#interrupt-requirement) | Conditions that will interrupt a channeled spell or cancel casting. Useful for react to incoming damage. |
 
-e.g. - bare minimum for a spell which has castbar.
+e.g. - bare minimum for a spell which has castbar. `HasCastBar` is auto-detected from the spell's cast time, so you no longer need to set it explicitly. The JSON field is accepted for back-compat:
 ```json
 {
     "Name": "Frostbolt",
     "Key": "1",
-    "HasCastBar": true,   //<-- Must be indicated the spell has a castbar
 }
 ```
 


### PR DESCRIPTION
## Summary

- **Auto-detect HasCastBar/Item routing from the addon.** New per-slot cast time queue (cell 112) driven by `GetSpellInfo` / `GetItemSpell` — so cast routing tracks talents (e.g. 5/5 Improved Corruption flips Corruption to instant without a JSON edit). Item flag is derived from `IsAutoRepeatAction` + macro-wraps-item detection, which also picks up Shoot/Auto Shot without `Item:true` in JSON. JSON `HasCastBar`/`Item` fields are still parsed for back-compat but ignored by the routing.
- **Per-spell cast event queue (cells 113/114).** Replaces the global `lastCastEvent` cell as the source of truth for item / auto-repeat retries. Closes the gap where an `ERR_BADATTACKFACING` was overwritten by a later pet-cast / auto-shoot success on the global cell and masked the failure. `CastEventReader.TryConsume(spellId)` reads + clears so a stale event from a previous attempt can't fire twice.
- **Supporting fixes.** Cold-start init race that left class-conditional tables empty until `/reload`; kill-credit cleared per `UNIT_DIED` instead of on combat exit; miss/parry/dodge damage now sources the attacker; `SpellInQueue` rewritten for actual GCD-tail queueing (was gating on `HalfSpellQueueTimeMs` which both wasted presses and skipped the SQW window).
- **Frontend visualization.** `GoapGoalView` paints the casting row as a left→right yellow gradient that fills with `RemainCastMs`. `SpellBookComponent` gains an Action Bar panel listing every populated slot with cast time and routing badge (CastInstant / CastCastbar), and the spellbook table shows cast time per spell.
- **New Wrath Classic build target** (`DataToColor_Wrath.toc`, interface 34300). Addon version bumped to 1.10.0 across all toc files (frame count 114 → 117 for the three new cells).
- **Profiles.** Warlock_66_Demo_pet_pull migrated to `AfterCastWaitCastbar` + Interrupt/CancelOnInterrupt rules, switched to `Items_Healthstone` array. Warlock_1 introduces IntVariables for thresholds. New Warlock_1_10 profile added.

## Test plan

- [x] Run with `Warlock_66_Demo_pet_pull` and confirm cast-time spells (Shadow Bolt, Incinerate, Drain Life, Health Funnel) route through CastCastbar with the new visualization filling the row.
- [x] With 5/5 Improved Corruption talented, confirm Corruption routes through CastInstant (not CastCastbar) — visible as the "Instant" badge in the SpellBook Action Bar panel.
- [x] Hunter / Warlock with wand: fire Auto Shot / Shoot from out-of-range and confirm `ERR_BADATTACKFACING` / `OUT_OF_RANGE` retries fire (no false success masking even when a pet cast or auto-shoot tick lands between polls).
- [x] SpellBook view: confirm Action Bar panel populates on login, updates on slot rebind, and badges match game state. Cast Time column on the spellbook table populates for slot-bound spells.
- [x] GoapGoalView: confirm the casting row paints a left→right gradient that completes with the cast bar; no double-paint with table-warning highlight.
- [x] Cold-start: load addon before `PLAYER_ENTERING_WORLD` finishes (e.g. quick relog) and confirm Pull/Combat range bits set correctly without `/reload`.
- [x] Wrath Classic 3.4.3 client: verify `DataToColor_Wrath.toc` loads and the addon emits frames.
- [x] CombatGoal: while a cast is in progress, confirm items / auto-repeat actions are skipped (no `ERR_SPELL_FAILED_ANOTHER_IN_PROGRESS` spam) but cast-time spells still queue via the SQW window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)