### PR TITLE
refactor(Core): PathsAreSmoothed capability + PathingEngine config seam

### DIFF
--- a/Core/GoalsComponent/Navigation.cs
+++ b/Core/GoalsComponent/Navigation.cs
@@ -248,7 +248,7 @@ public sealed partial class Navigation : IDisposable
     {
         ResetStuckParameters();
 
-        if (pather.GetType() != typeof(RemotePathingAPIV3) && routeToNextWaypoint.Count > 0)
+        if (!pather.PathsAreSmoothed && routeToNextWaypoint.Count > 0)
         {
             V1_AttemptToKeepRouteToWaypoint();
         }
@@ -268,7 +268,7 @@ public sealed partial class Navigation : IDisposable
     {
         active = false;
 
-        if (pather.GetType() == typeof(RemotePathingAPIV3))
+        if (pather.PathsAreSmoothed)
             routeToNextWaypoint.Clear();
 
         ResetStuckParameters();

--- a/Core/PPather/IPPather.cs
+++ b/Core/PPather/IPPather.cs
@@ -8,6 +8,14 @@ namespace Core;
 
 public interface IPPather
 {
+    /// <summary>
+    /// True when returned paths are already smoothed and validated by the
+    /// pathfinder (server-side spline + re-projection) and cheap to re-request,
+    /// so consumers should drop partial routes and re-query instead of
+    /// patching them up client-side.
+    /// </summary>
+    bool PathsAreSmoothed => false;
+
     Vector3[] FindMapRoute(int uiMap, Vector3 mapFrom, Vector3 mapTo);
     Vector3[] FindWorldRoute(int uiMap, bool startIndoors, Vector3 worldFrom, Vector3 worldTo);
     ValueTask DrawLines(List<LineArgs> lineArgs);

--- a/Core/PPather/RemotePathingAPIV3.cs
+++ b/Core/PPather/RemotePathingAPIV3.cs
@@ -22,6 +22,8 @@ namespace Core;
 
 public sealed class RemotePathingAPIV3 : IPPather, IDisposable
 {
+    public bool PathsAreSmoothed => true;
+
     private const bool debug = false;
     private const int watchdogPollMs = 500;
 

--- a/PathingAPI/Controllers/PPatherController.cs
+++ b/PathingAPI/Controllers/PPatherController.cs
@@ -280,6 +280,21 @@ public sealed class PPatherController : ControllerBase
         return new JsonResult(service.MPQSelfTest());
     }
 
+    /// <summary>
+    /// Describes this server's pathfinding capabilities so remote clients can
+    /// adapt (e.g. smoothed paths are cheap to re-request instead of patching
+    /// partial routes client-side). Absent on older servers - treat 404 as
+    /// all-capabilities-false.
+    /// </summary>
+    [HttpGet("Capabilities")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public JsonResult Capabilities()
+    {
+        return new JsonResult(new CapabilitiesResponse(false));
+    }
+
+    public sealed record CapabilitiesResponse(bool PathsAreSmoothed);
+
     [HttpPost("DrawPathTest")]
     [ProducesResponseType(StatusCodes.Status202Accepted)]
     [RateLimit]

--- a/PathingAPI/PathingAPI.xml
+++ b/PathingAPI/PathingAPI.xml
@@ -133,6 +133,14 @@
             </summary>
             <returns></returns>
         </member>
+        <member name="M:PathingAPI.Controllers.PPatherController.Capabilities">
+            <summary>
+            Describes this server's pathfinding capabilities so remote clients can
+            adapt (e.g. smoothed paths are cheap to re-request instead of patching
+            partial routes client-side). Absent on older servers - treat 404 as
+            all-capabilities-false.
+            </summary>
+        </member>
         <member name="M:PathingAPI.Controllers.PPatherController.DrawPath(PPather.DrawWorldPathRequest)">
             <summary>
             Draws a path based on continentID and world coordinates.

--- a/SharedLib/PathingEngine.cs
+++ b/SharedLib/PathingEngine.cs
@@ -1,0 +1,13 @@
+namespace SharedLib;
+
+/// <summary>
+/// Which in-process pathfinding engine PPatherService uses.
+/// </summary>
+public enum PathingEngine
+{
+    /// <summary>Legacy on-demand spot-grid A* (PathGraph).</summary>
+    SpotAStar,
+
+    /// <summary>DotRecast navmesh: runtime-baked tiles + Detour query.</summary>
+    Navmesh
+}

--- a/SharedLib/StartupConfig/StartupConfigPathing.cs
+++ b/SharedLib/StartupConfig/StartupConfigPathing.cs
@@ -35,6 +35,15 @@ public sealed class StartupConfigPathing
 
     public string Mode { get; set; } = string.Empty;
 
+    /// <summary>
+    /// In-process engine for Local mode (and the PathingAPI server).
+    /// Parsed into <see cref="PathingEngine"/>; defaults to SpotAStar.
+    /// </summary>
+    public string Engine { get; set; } = nameof(PathingEngine.SpotAStar);
+
+    public PathingEngine EngineType =>
+        System.Enum.TryParse(Engine, out PathingEngine e) ? e : PathingEngine.SpotAStar;
+
     public string hostv1 { get; set; } = string.Empty;
     public int portv1 { get; set; }
 


### PR DESCRIPTION
## Summary
Pre-refactor seams for the in-process DotRecast navmesh engine (zero behavior change):

- `IPPather.PathsAreSmoothed` default interface member (`false`) replaces both `typeof(RemotePathingAPIV3)` checks in `Navigation.Resume/Stop` — expresses the actual contract (smoothed, server-validated paths are cheap to re-request → drop partial routes instead of patching client-side). V3 opts in; all other pathers unchanged.
- `PathingEngine` enum (`SpotAStar | Navmesh`) + `StartupConfigPathing.Engine` bound from `Pathing:Engine` (same parse pattern as `Mode`/`Type`). Unconsumed until the navmesh engine PR — documented then.
- `GET api/PPather/Capabilities` — remote clients probe server capabilities; 404 on older servers = all-false.

## Verification
- `dotnet build MasterOfPuppets.sln` green, 0 errors, no new warnings.
- Semantics: V3 → `true`, Local/V1 → default `false` — identical branch outcomes to the removed typeof checks.

Part of the pathfinding re-engineering plan (follows #806).

🤖 Generated with [Claude Code](https://claude.com/claude-code)