### PR TITLE
feat(PPather): DotRecast navmesh bake skeleton + BakeTile go/no-go probe

### DIFF
--- a/.github/workflows/dotnet_build.yml
+++ b/.github/workflows/dotnet_build.yml
@@ -23,6 +23,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: recursive
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/DotRecast"]
+	path = external/DotRecast
+	url = https://github.com/Xian55/DotRecast.git

--- a/PPather/Navmesh/NavmeshCoords.cs
+++ b/PPather/Navmesh/NavmeshCoords.cs
@@ -1,0 +1,61 @@
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+using Wmo;
+
+namespace PPather.Navmesh;
+
+/// <summary>
+/// Coordinate bridge between WoW world space and Recast/Detour space.
+///
+/// Detour axes: index 0 = wow Y, index 1 = wow Z (up), index 2 = wow X
+/// (the AmeisenNavigation/TrinityCore convention, so their query extents and
+/// filter parameters transfer verbatim).
+///
+/// Detour tile indices are ascending in rc-space from the world corner at
+/// -ZEROPOINT: dtTileX walks along wow Y, dtTileZ along wow X. This is
+/// deliberately NOT the PPather ADT grid convention ((ZEROPOINT - coord) /
+/// TILESIZE, descending); conversion between the two only ever happens through
+/// wow-space AABBs produced by <see cref="GetTileWowBounds"/>.
+/// </summary>
+public static class NavmeshCoords
+{
+    /// <summary>Rc-space grid origin (both horizontal axes): -32 ADT.</summary>
+    public const float Origin = -ChunkReader.ZEROPOINT;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Vector3 ToRc(in Vector3 wow)
+    {
+        return new(wow.Y, wow.Z, wow.X);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Vector3 ToWow(in Vector3 rc)
+    {
+        return new(rc.Z, rc.X, rc.Y);
+    }
+
+    /// <summary>Detour tile indices for a WoW position.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void GetTileIndex(float wowX, float wowY, out int dtTileX, out int dtTileZ)
+    {
+        dtTileX = (int)((wowY - Origin) / NavmeshSettings.TileWorldSize);
+        dtTileZ = (int)((wowX - Origin) / NavmeshSettings.TileWorldSize);
+    }
+
+    /// <summary>Unpadded WoW-space bounds of a Detour tile.</summary>
+    public static void GetTileWowBounds(int dtTileX, int dtTileZ,
+        out float minX, out float minY, out float maxX, out float maxY)
+    {
+        minY = Origin + (dtTileX * NavmeshSettings.TileWorldSize);
+        maxY = minY + NavmeshSettings.TileWorldSize;
+        minX = Origin + (dtTileZ * NavmeshSettings.TileWorldSize);
+        maxX = minX + NavmeshSettings.TileWorldSize;
+    }
+
+    public static bool IsValidTile(int dtTileX, int dtTileZ)
+    {
+        return dtTileX is >= 0 and < NavmeshSettings.TilesPerSide &&
+               dtTileZ is >= 0 and < NavmeshSettings.TilesPerSide;
+    }
+}

--- a/PPather/Navmesh/NavmeshSettings.cs
+++ b/PPather/Navmesh/NavmeshSettings.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace PPather.Navmesh;
+
+/// <summary>
+/// All recast bake parameters for the WoW navmesh engine.
+///
+/// Values mirror TrinityCore 3.3.5 mmaps_generator defaults (bigBaseUnit=false)
+/// so the runtime filter semantics proven by AmeisenNavigation transfer 1:1.
+/// Any change that alters produced mesh bytes must bump <see cref="FormatVersion"/>.
+/// </summary>
+public sealed class NavmeshSettings
+{
+    /// <summary>Bump when serialized tile bytes change (params, DotRecast fork, areas).</summary>
+    public const int FormatVersion = 1;
+
+    // --- Voxel grid -----------------------------------------------------
+
+    /// <summary>Cell size == cell height (isotropic voxels), yards.</summary>
+    public const float CellSize = 0.26666667f;
+    public const float CellHeight = 0.26666667f;
+
+    /// <summary>Detour tile edge, yards: 1/4 ADT => 16 tiles per ADT.</summary>
+    public const float TileWorldSize = 133.33333f;
+
+    /// <summary>Tile edge in cells (TileWorldSize / CellSize).</summary>
+    public const int TileSizeCells = 500;
+
+    // --- Agent (toon) ---------------------------------------------------
+
+    public const float AgentHeight = 1.6f;
+    public const float AgentRadius = 0.533f;
+    /// <summary>1.6yd: walks over fences/small steps like the WoW client.</summary>
+    public const float AgentMaxClimb = 1.6f;
+    public const float WalkableSlopeAngle = 55f;
+
+    // --- Region/contour/detail ------------------------------------------
+
+    /// <summary>3600 cells^2 (TC minRegionArea) in world units.</summary>
+    public const float MinRegionAreaWorld = 3600f * CellSize * CellSize;
+
+    /// <summary>2500 cells^2 (TC mergeRegionArea) in world units.</summary>
+    public const float MergeRegionAreaWorld = 2500f * CellSize * CellSize;
+
+    /// <summary>81 cells (TC maxEdgeLen) in world units.</summary>
+    public const float MaxEdgeLenWorld = 81f * CellSize;
+
+    public const float MaxSimplificationError = 1.8f;
+
+    /// <summary>Multiplier over CellSize (RcConfig semantics): cs*16 ~ 4.27yd.</summary>
+    public const float DetailSampleDistFactor = 16f;
+
+    /// <summary>Multiplier over CellHeight (RcConfig semantics).</summary>
+    public const float DetailSampleMaxErrorFactor = 1f;
+
+    public const int VertsPerPoly = 6;
+
+    // --- Areas & poly flags (TrinityCore NavArea/NavTerrainFlag values) --
+
+    public const int AreaMagmaSlime = 8;
+    public const int AreaWater = 9;
+    /// <summary>Highest area value wins on span merge: shallow water stays walkable ground.</summary>
+    public const int AreaGround = 11;
+
+    public const int FlagGround = 0x01;
+    public const int FlagGroundSteep = 0x02; // reserved, no steep band is baked
+    public const int FlagWater = 0x04;
+    public const int FlagMagmaSlime = 0x08;
+
+    // --- Detour runtime -------------------------------------------------
+
+    /// <summary>64 ADT * 4 tiles per side.</summary>
+    public const int TilesPerSide = 256;
+    public const int MaxTiles = TilesPerSide * TilesPerSide;
+    public const int MaxPolysPerTile = 1 << 20;
+    public const int MaxSearchNodes = 65535;
+
+    /// <summary>
+    /// Cache directory discriminator: same inputs => same tiles.
+    /// Combines bake constants, format version, client expansion and the
+    /// DotRecast fork commit (informational version).
+    /// </summary>
+    public static string ComputeSettingsHash(string clientExpansion, string dotRecastVersion)
+    {
+        StringBuilder sb = new();
+        sb.Append(FormatVersion).Append('|')
+          .Append(CellSize).Append('|')
+          .Append(CellHeight).Append('|')
+          .Append(TileWorldSize).Append('|')
+          .Append(TileSizeCells).Append('|')
+          .Append(AgentHeight).Append('|')
+          .Append(AgentRadius).Append('|')
+          .Append(AgentMaxClimb).Append('|')
+          .Append(WalkableSlopeAngle).Append('|')
+          .Append(MinRegionAreaWorld).Append('|')
+          .Append(MergeRegionAreaWorld).Append('|')
+          .Append(MaxEdgeLenWorld).Append('|')
+          .Append(MaxSimplificationError).Append('|')
+          .Append(DetailSampleDistFactor).Append('|')
+          .Append(DetailSampleMaxErrorFactor).Append('|')
+          .Append(VertsPerPoly).Append('|')
+          .Append(clientExpansion).Append('|')
+          .Append(dotRecastVersion);
+
+        byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(sb.ToString()));
+        return Convert.ToHexString(hash.AsSpan(0, 4)).ToLowerInvariant();
+    }
+}

--- a/PPather/Navmesh/NavmeshTileBuilder.cs
+++ b/PPather/Navmesh/NavmeshTileBuilder.cs
@@ -1,0 +1,130 @@
+#nullable enable
+using DotRecast.Core;
+using DotRecast.Detour;
+using DotRecast.Recast;
+
+namespace PPather.Navmesh;
+
+/// <summary>
+/// Bakes one Detour tile from extracted WoW triangle soup.
+///
+/// Mirrors the TrinityCore mmaps pipeline: rasterize ground (slope-marked at
+/// 55 deg) -> low-hanging/ledge/low-height filters -> rasterize liquids with
+/// their areas -> compact -> erode by agent radius -> median filter ->
+/// watershed regions -> contours -> polymesh + detail -> DtMeshData.
+///
+/// Liquid spans merge with the max-area rule, and GROUND(11) > WATER(9), so
+/// shallow water over walkable terrain stays ground - swim-vs-walk is a
+/// runtime filter decision, not baked geometry.
+/// </summary>
+public static class NavmeshTileBuilder
+{
+    public static DtMeshData? Bake(TileGeometry geom, int dtTileX, int dtTileZ)
+    {
+        if (geom.IsEmpty)
+        {
+            return null;
+        }
+
+        RcConfig cfg = new(
+            useTiles: true,
+            NavmeshSettings.TileSizeCells, NavmeshSettings.TileSizeCells,
+            RcConfig.CalcBorder(NavmeshSettings.AgentRadius, NavmeshSettings.CellSize),
+            RcPartition.WATERSHED,
+            NavmeshSettings.CellSize, NavmeshSettings.CellHeight,
+            NavmeshSettings.WalkableSlopeAngle,
+            NavmeshSettings.AgentHeight, NavmeshSettings.AgentRadius, NavmeshSettings.AgentMaxClimb,
+            NavmeshSettings.MinRegionAreaWorld, NavmeshSettings.MergeRegionAreaWorld,
+            NavmeshSettings.MaxEdgeLenWorld, NavmeshSettings.MaxSimplificationError,
+            NavmeshSettings.VertsPerPoly,
+            NavmeshSettings.DetailSampleDistFactor, NavmeshSettings.DetailSampleMaxErrorFactor,
+            filterLowHangingObstacles: true, filterLedgeSpans: true, filterWalkableLowHeightSpans: true,
+            new RcAreaModification(NavmeshSettings.AreaGround),
+            buildMeshDetail: true);
+
+        RcBuilderConfig bcfg = new(cfg, geom.BMin, geom.BMax, 0, 0);
+        RcContext ctx = new();
+
+        RcHeightfield solid = new(bcfg.width, bcfg.height, bcfg.bmin, bcfg.bmax,
+            cfg.Cs, cfg.Ch, cfg.BorderSize);
+
+        // Ground: slope decides walkability (area GROUND or null).
+        int groundTriCount = geom.GroundTriangleCount;
+        int[] groundAreas = RcRecast.MarkWalkableTriangles(ctx, cfg.WalkableSlopeAngle,
+            geom.GroundVerts, geom.GroundTris, groundTriCount, cfg.WalkableAreaMod);
+        RcRasterizations.RasterizeTriangles(ctx, geom.GroundVerts, geom.GroundTris,
+            groundAreas, groundTriCount, solid, cfg.WalkableClimb);
+
+        RcFilters.FilterLowHangingWalkableObstacles(ctx, cfg.WalkableClimb, solid);
+        RcFilters.FilterLedgeSpans(ctx, cfg.WalkableHeight, cfg.WalkableClimb, solid);
+        RcFilters.FilterWalkableLowHeightSpans(ctx, cfg.WalkableHeight, solid);
+
+        // Liquids after the ground filters (TrinityCore order) with fixed areas.
+        int liquidTriCount = geom.LiquidTriangleCount;
+        if (liquidTriCount > 0)
+        {
+            RcRasterizations.RasterizeTriangles(ctx, geom.LiquidVerts, geom.LiquidTris,
+                geom.LiquidAreas, liquidTriCount, solid, cfg.WalkableClimb);
+        }
+
+        RcCompactHeightfield chf = RcCompacts.BuildCompactHeightfield(ctx,
+            cfg.WalkableHeight, cfg.WalkableClimb, solid);
+
+        RcAreas.ErodeWalkableArea(ctx, cfg.WalkableRadius, chf);
+        RcAreas.MedianFilterWalkableArea(ctx, chf);
+
+        RcRegions.BuildDistanceField(ctx, chf);
+        RcRegions.BuildRegions(ctx, chf, cfg.MinRegionArea, cfg.MergeRegionArea);
+
+        RcContourSet cset = RcContours.BuildContours(ctx, chf,
+            cfg.MaxSimplificationError, cfg.MaxEdgeLen,
+            RcBuildContoursFlags.RC_CONTOUR_TESS_WALL_EDGES);
+
+        RcPolyMesh pmesh = RcMeshs.BuildPolyMesh(ctx, cset, cfg.MaxVertsPerPoly);
+        if (pmesh.npolys == 0)
+        {
+            return null;
+        }
+
+        for (int i = 0; i < pmesh.npolys; i++)
+        {
+            pmesh.flags[i] = pmesh.areas[i] switch
+            {
+                NavmeshSettings.AreaWater => NavmeshSettings.FlagWater,
+                NavmeshSettings.AreaMagmaSlime => NavmeshSettings.FlagMagmaSlime,
+                _ => NavmeshSettings.FlagGround,
+            };
+        }
+
+        RcPolyMeshDetail dmesh = RcMeshDetails.BuildPolyMeshDetail(ctx, pmesh, chf,
+            cfg.DetailSampleDist, cfg.DetailSampleMaxError);
+
+        DtNavMeshCreateParams option = new()
+        {
+            verts = pmesh.verts,
+            vertCount = pmesh.nverts,
+            polys = pmesh.polys,
+            polyAreas = pmesh.areas,
+            polyFlags = pmesh.flags,
+            polyCount = pmesh.npolys,
+            nvp = pmesh.nvp,
+            detailMeshes = dmesh.meshes,
+            detailVerts = dmesh.verts,
+            detailVertsCount = dmesh.nverts,
+            detailTris = dmesh.tris,
+            detailTriCount = dmesh.ntris,
+            walkableHeight = NavmeshSettings.AgentHeight,
+            walkableRadius = NavmeshSettings.AgentRadius,
+            walkableClimb = NavmeshSettings.AgentMaxClimb,
+            bmin = pmesh.bmin,
+            bmax = pmesh.bmax,
+            cs = cfg.Cs,
+            ch = cfg.Ch,
+            buildBvTree = true,
+            tileX = dtTileX,
+            tileZ = dtTileZ,
+        };
+
+        return DtNavMeshBuilder.CreateNavMeshData(option);
+    }
+}

--- a/PPather/Navmesh/TileGeometry.cs
+++ b/PPather/Navmesh/TileGeometry.cs
@@ -1,0 +1,32 @@
+#nullable enable
+using System.Numerics;
+
+namespace PPather.Navmesh;
+
+/// <summary>
+/// Triangle soup for one navmesh tile, already in rc-space.
+/// Vertices are unshared (3 per triangle): the voxel rasterizer does not
+/// benefit from indexed sharing and this keeps extraction allocation-simple.
+/// </summary>
+public sealed class TileGeometry
+{
+    public required float[] GroundVerts { get; init; }
+    public required int[] GroundTris { get; init; }
+
+    public required float[] LiquidVerts { get; init; }
+    public required int[] LiquidTris { get; init; }
+    /// <summary>Per-liquid-triangle recast area (AreaWater or AreaMagmaSlime).</summary>
+    public required int[] LiquidAreas { get; init; }
+
+    /// <summary>Rc-space bounds: horizontal = unpadded tile edges, vertical from geometry.</summary>
+    public required Vector3 BMin { get; init; }
+    public required Vector3 BMax { get; init; }
+
+    /// <summary>ADT chunks that failed to load (missing/corrupt) and were skipped.</summary>
+    public int FailedChunkLoads { get; init; }
+
+    public int GroundTriangleCount => GroundTris.Length / 3;
+    public int LiquidTriangleCount => LiquidTris.Length / 3;
+
+    public bool IsEmpty => GroundTris.Length == 0;
+}

--- a/PPather/Navmesh/TileGeometryExtractor.cs
+++ b/PPather/Navmesh/TileGeometryExtractor.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+
+using PPather.Triangles;
+
+using WowTriangles;
+
+namespace PPather.Navmesh;
+
+/// <summary>
+/// Pulls the triangle soup for one navmesh tile out of the existing MPQ
+/// geometry pipeline (<see cref="ChunkedTriangleCollection"/>), split into
+/// ground (Terrain|Object|Model, slope-filtered later by recast) and liquid
+/// (Water/Magma/Slime as recast areas) sets, converted to rc-space.
+/// </summary>
+public static class TileGeometryExtractor
+{
+    /// <summary>
+    /// Extra padding beyond the recast border so border-cell voxels see
+    /// geometry that starts just outside the tile (border is 5 cells ≈ 1.33yd).
+    /// </summary>
+    public const float PaddingYd = 4f;
+
+    // Dev-baseline TriangleType has no lava/slime distinction; all liquid is
+    // Water. AreaMagmaSlime stays reserved for when the supplier learns to
+    // classify lethal liquids.
+    private const TriangleType LiquidMask = TriangleType.Water;
+
+    public static TileGeometry Extract(ChunkedTriangleCollection world, int dtTileX, int dtTileZ)
+    {
+        NavmeshCoords.GetTileWowBounds(dtTileX, dtTileZ,
+            out float tileMinX, out float tileMinY, out float tileMaxX, out float tileMaxY);
+
+        float border = (RcBorderCells * NavmeshSettings.CellSize) + PaddingYd;
+        float minX = tileMinX - border;
+        float minY = tileMinY - border;
+        float maxX = tileMaxX + border;
+        float maxY = tileMaxY + border;
+
+        // Touching every 256yd sample point inside the padded bounds loads all
+        // overlapping ADT chunks on demand (ADT = 533.33yd).
+        List<TriangleCollection> chunks = [];
+        int failedChunkLoads = 0;
+        for (float x = minX; ; x += 256f)
+        {
+            bool lastX = x >= maxX;
+            if (lastX)
+            {
+                x = maxX;
+            }
+
+            for (float y = minY; ; y += 256f)
+            {
+                bool lastY = y >= maxY;
+                if (lastY)
+                {
+                    y = maxY;
+                }
+
+                // A missing or unreadable ADT (ocean edges, corrupt archives)
+                // must not kill the whole tile - bake what did load.
+                try
+                {
+                    TriangleCollection tc = world.GetChunkAt(x, y);
+                    if (!chunks.Contains(tc))
+                    {
+                        chunks.Add(tc);
+                    }
+                }
+                catch (Exception)
+                {
+                    failedChunkLoads++;
+                }
+
+                if (lastY)
+                {
+                    break;
+                }
+            }
+
+            if (lastX)
+            {
+                break;
+            }
+        }
+
+        List<float> groundVerts = [];
+        List<int> groundTris = [];
+        List<float> liquidVerts = [];
+        List<int> liquidTris = [];
+        List<int> liquidAreas = [];
+
+        float minZ = float.MaxValue;
+        float maxZ = float.MinValue;
+
+        foreach (TriangleCollection tc in chunks)
+        {
+            ReadOnlySpan<Triangle<int>> tris = tc.TrianglesSpan;
+            ReadOnlySpan<Vector3> verts = tc.VerteciesSpan;
+
+            for (int i = 0; i < tris.Length; i++)
+            {
+                Triangle<int> t = tris[i];
+
+                Vector3 v0 = verts[t.V0];
+                Vector3 v1 = verts[t.V1];
+                Vector3 v2 = verts[t.V2];
+
+                // AABB reject against padded tile bounds (wow XY plane).
+                float triMinX = MathF.Min(v0.X, MathF.Min(v1.X, v2.X));
+                if (triMinX > maxX)
+                {
+                    continue;
+                }
+
+                float triMaxX = MathF.Max(v0.X, MathF.Max(v1.X, v2.X));
+                if (triMaxX < minX)
+                {
+                    continue;
+                }
+
+                float triMinY = MathF.Min(v0.Y, MathF.Min(v1.Y, v2.Y));
+                if (triMinY > maxY)
+                {
+                    continue;
+                }
+
+                float triMaxY = MathF.Max(v0.Y, MathF.Max(v1.Y, v2.Y));
+                if (triMaxY < minY)
+                {
+                    continue;
+                }
+
+                minZ = MathF.Min(minZ, MathF.Min(v0.Z, MathF.Min(v1.Z, v2.Z)));
+                maxZ = MathF.Max(maxZ, MathF.Max(v0.Z, MathF.Max(v1.Z, v2.Z)));
+
+                if ((t.Flags & LiquidMask) != 0)
+                {
+                    AppendTriangle(liquidVerts, liquidTris, v0, v1, v2);
+                    liquidAreas.Add(NavmeshSettings.AreaWater);
+                }
+                else
+                {
+                    AppendTriangle(groundVerts, groundTris, v0, v1, v2);
+                }
+            }
+        }
+
+        if (groundTris.Count == 0)
+        {
+            minZ = 0;
+            maxZ = 1;
+        }
+
+        // Horizontal bounds stay the unpadded tile edges: RcBuilderConfig
+        // expands them by borderSize*cs itself. Vertical from geometry with
+        // climb headroom.
+        Vector3 wowMin = new(tileMinX, tileMinY, minZ - NavmeshSettings.AgentMaxClimb);
+        Vector3 wowMax = new(tileMaxX, tileMaxY, maxZ + NavmeshSettings.AgentHeight);
+
+        return new TileGeometry
+        {
+            GroundVerts = [.. groundVerts],
+            GroundTris = [.. groundTris],
+            LiquidVerts = [.. liquidVerts],
+            LiquidTris = [.. liquidTris],
+            LiquidAreas = [.. liquidAreas],
+            BMin = NavmeshCoords.ToRc(wowMin),
+            BMax = NavmeshCoords.ToRc(wowMax),
+            FailedChunkLoads = failedChunkLoads,
+        };
+    }
+
+    /// <summary>Matches RcConfig.CalcBorder(AgentRadius, CellSize): 3 + ceil(r/cs) = 5.</summary>
+    public const int RcBorderCells = 5;
+
+    private static void AppendTriangle(List<float> verts, List<int> tris, in Vector3 v0, in Vector3 v1, in Vector3 v2)
+    {
+        int baseIndex = verts.Count / 3;
+
+        AppendVertex(verts, v0);
+        AppendVertex(verts, v1);
+        AppendVertex(verts, v2);
+
+        tris.Add(baseIndex);
+        tris.Add(baseIndex + 1);
+        tris.Add(baseIndex + 2);
+    }
+
+    private static void AppendVertex(List<float> verts, in Vector3 wow)
+    {
+        // rc order: (wow.Y, wow.Z, wow.X)
+        verts.Add(wow.Y);
+        verts.Add(wow.Z);
+        verts.Add(wow.X);
+    }
+}

--- a/PPather/PPather.csproj
+++ b/PPather/PPather.csproj
@@ -9,6 +9,13 @@
     <ProjectReference Include="..\SharedLib\SharedLib.csproj" />
   </ItemGroup>
 
+  <!-- DotRecast from the pinned submodule (Xian55/DotRecast @ wow-mods). -->
+  <ItemGroup>
+    <ProjectReference Include="..\external\DotRecast\src\DotRecast.Core\DotRecast.Core.csproj" />
+    <ProjectReference Include="..\external\DotRecast\src\DotRecast.Recast\DotRecast.Recast.csproj" />
+    <ProjectReference Include="..\external\DotRecast\src\DotRecast.Detour\DotRecast.Detour.csproj" />
+  </ItemGroup>
+
   <ItemGroup>
     <None Update="MPQ\StormLib_x64.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/PPather/Triangles/TriangleCollection.cs
+++ b/PPather/Triangles/TriangleCollection.cs
@@ -67,7 +67,10 @@ public sealed class TriangleCollection
 
         triangles.Clear();
         vertecies.Clear();
-        matrix.Clear();
+        // Lazily created by GetTriangleMatrix - chunks that were only ever
+        // read as raw triangle soup (e.g. navmesh tile extraction) never
+        // materialize it.
+        matrix?.Clear();
     }
 
     public TriangleMatrix GetTriangleMatrix()

--- a/PathingAPI/Controllers/PPatherController.cs
+++ b/PathingAPI/Controllers/PPatherController.cs
@@ -6,6 +6,7 @@ using PathingAPI.RateLimit;
 using PPather;
 using PPather.Data;
 using PPather.Graph;
+using PPather.Navmesh;
 
 using SharedLib.Data;
 
@@ -294,6 +295,51 @@ public sealed class PPatherController : ControllerBase
     }
 
     public sealed record CapabilitiesResponse(bool PathsAreSmoothed);
+
+    /// <summary>
+    /// Debug/diagnostic: bakes one DotRecast navmesh tile at the given world
+    /// position and reports geometry extraction + bake statistics. This is the
+    /// go/no-go probe for the navmesh engine's on-demand baking latency; it
+    /// does not persist or register the tile anywhere yet.
+    /// </summary>
+    /// <param name="x" example="-8898">world X</param>
+    /// <param name="y" example="-117">world Y</param>
+    /// <param name="mapid" example="0">ContientID ["Azeroth=0", "Kalimdor=1", "Outland/Expansion01=530", "Northrend=571"]</param>
+    [HttpGet("BakeTile")]
+    [ProducesResponseType(typeof(BakeTileResponse), StatusCodes.Status200OK, "application/json")]
+    [RateLimit]
+    public JsonResult BakeTile(float x, float y, float mapid)
+    {
+        // Ensures the continent (Search/PathGraph/triangle world) is initialised.
+        service.SetLocations(new(x, y, 0, mapid), new(x, y, 0, mapid));
+
+        NavmeshCoords.GetTileIndex(x, y, out int tileX, out int tileZ);
+
+        long extractStart = System.Diagnostics.Stopwatch.GetTimestamp();
+        TileGeometry geom = TileGeometryExtractor.Extract(service.TriangleWorld, tileX, tileZ);
+        double extractMs = System.Diagnostics.Stopwatch.GetElapsedTime(extractStart).TotalMilliseconds;
+
+        long bakeStart = System.Diagnostics.Stopwatch.GetTimestamp();
+        DotRecast.Detour.DtMeshData data = NavmeshTileBuilder.Bake(geom, tileX, tileZ);
+        double bakeMs = System.Diagnostics.Stopwatch.GetElapsedTime(bakeStart).TotalMilliseconds;
+
+        return new JsonResult(new BakeTileResponse(
+            data != null,
+            tileX, tileZ,
+            geom.GroundTriangleCount, geom.LiquidTriangleCount,
+            geom.FailedChunkLoads,
+            data?.header.polyCount ?? 0,
+            data?.header.vertCount ?? 0,
+            extractMs, bakeMs));
+    }
+
+    public sealed record BakeTileResponse(
+        bool Success,
+        int TileX, int TileZ,
+        int GroundTriangles, int LiquidTriangles,
+        int FailedChunkLoads,
+        int PolyCount, int VertCount,
+        double ExtractMs, double BakeMs);
 
     [HttpPost("DrawPathTest")]
     [ProducesResponseType(StatusCodes.Status202Accepted)]

--- a/PathingAPI/PathingAPI.xml
+++ b/PathingAPI/PathingAPI.xml
@@ -141,6 +141,17 @@
             all-capabilities-false.
             </summary>
         </member>
+        <member name="M:PathingAPI.Controllers.PPatherController.BakeTile(System.Single,System.Single,System.Single)">
+            <summary>
+            Debug/diagnostic: bakes one DotRecast navmesh tile at the given world
+            position and reports geometry extraction + bake statistics. This is the
+            go/no-go probe for the navmesh engine's on-demand baking latency; it
+            does not persist or register the tile anywhere yet.
+            </summary>
+            <param name="x" example="-8898">world X</param>
+            <param name="y" example="-117">world Y</param>
+            <param name="mapid" example="0">ContientID ["Azeroth=0", "Kalimdor=1", "Outland/Expansion01=530", "Northrend=571"]</param>
+        </member>
         <member name="M:PathingAPI.Controllers.PPatherController.DrawPath(PPather.DrawWorldPathRequest)">
             <summary>
             Draws a path based on continentID and world coordinates.

--- a/external/Directory.Packages.props
+++ b/external/Directory.Packages.props
@@ -1,0 +1,11 @@
+<Project>
+
+  <!-- Firewall: stops NuGet's upward search at this level so the DotRecast
+       submodule keeps its own multi-targeting and package versions instead of
+       inheriting the repo root Directory.Packages.props (which pins a global
+       windows TargetFramework and central package versions). -->
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
First slice of the in-process navmesh engine (plan PR-4). **Zero runtime behavior change** — everything is behind a new diagnostic endpoint.

- `external/DotRecast` **git submodule** → Xian55/DotRecast @ `wow-mods` (the `RcVec3f`→`System.Numerics.Vector3` alias fork, 182/182 upstream tests green). `PPather` consumes `Core/Recast/Detour` via ProjectReference; `external/Directory.Packages.props` firewalls the submodule from the repo-root CPM props (global windows TFM).
- `PPather/Navmesh/`:
  - **NavmeshSettings** — TrinityCore 3.3.5 bake params (cs=ch=0.2667, agent 1.6h/0.533r/1.6climb, slope 55°), 133.33yd Detour tiles (16/ADT), TC area/flag values (GROUND=11 > WATER=9 → shallow-water-walkable trick), `SettingsHash` for cache keying.
  - **NavmeshCoords** — wow↔rc axis map (`rc = {wowY, wowZ, wowX}`, Ameisen/TC convention) + Detour-native ascending tile indexing (conversion to the descending PPather ADT grid only via wow-space AABBs).
  - **TileGeometryExtractor** — padded-AABB triangle pull from `ChunkedTriangleCollection`, ground/liquid split, survives missing/corrupt ADTs (`failedChunkLoads`).
  - **NavmeshTileBuilder** — full TC-order pipeline: ground rasterize (slope-marked) → low-hanging/ledge/low-height filters → liquid areas → compact → erode → **median filter** (TC extra) → watershed → contours → polymesh+detail → `DtMeshData`.
- `GET api/PPather/BakeTile?x&y&mapid` — bakes one tile, returns `{tileX, tileZ, groundTriangles, liquidTriangles, failedChunkLoads, polyCount, vertCount, extractMs, bakeMs}`.
- **Bugfix**: `TriangleCollection.Clear()` NREd on the lazily-created `TriangleMatrix` — navmesh extraction reads raw triangle soup without materializing the matrix, so continent switching crashed. Now null-guarded.

## Go/no-go measurements (live MPQ data)
| Tile | tris | polys | extract | bake |
|---|---|---|---|---|
| Elwynn (cold chunks) | 6,603 | 173 | 438ms | 842ms |
| Elwynn (warm) | 6,603 | 173 | **1.8ms** | ~850ms |
| Neighbor tile | 18,668 | 561 | 16ms | 1106ms |
| Stormwind (WMO+canals) | 16,552+136 | 365 | 64ms | 1644ms |
| Durotar (continent switch) | 10,978+672 | 258 | 78ms | 947ms |
| Orgrimmar (WMO city) | 12,064 | 355 | 199ms | 2320ms |

**Verdict: GO** for 133yd tiles at cs=0.2667. Bake 0.8–2.3s/tile: bot traverses a tile in 10–19s, so a 2–4 worker background baker sustains prefetch comfortably, and the disk tile cache (next PR) makes each tile once-per-lifetime. Fallback knob (cs=0.5333, ~4× faster) reserved.

## Next (PR-5)
Tile cache (LRU + disk persistence + prefetch), `NavmeshPathfinder` query pipeline, endpoint resolver (z==0 column scan), `WowQueryFilter`, `PPatherService.Engine` dispatch. Coord round-trip unit checks land with the resolver tests there.

Stacked after #807 (uses nothing from it yet; merges clean either order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)