### PR TITLE
feat(PPather): navmesh engine live behind Pathing:Engine (PR-5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -307,3 +307,5 @@ PathingAPI/data_config.json
 
 # BenchmarkDotNet artifacts
 **/BenchmarkDotNet.Artifacts/
+# Runtime-baked navmesh tile cache
+Json/PathInfo/navmesh/

--- a/Core/DependencyInjection.cs
+++ b/Core/DependencyInjection.cs
@@ -505,6 +505,8 @@ public static class DependencyInjection
         }
 
         var service = sp.GetRequiredService<PPatherService>();
+        service.Engine = scp.EngineType;
+
         var pathingLogger = loggerFactory.CreateLogger<LocalPathingApi>();
 
         LocalPathingApi localApi = new(pathingLogger, service);

--- a/Core/PPather/LocalPathingApi.cs
+++ b/Core/PPather/LocalPathingApi.cs
@@ -4,6 +4,8 @@ using PPather;
 using PPather.Data;
 using PPather.Graph;
 
+using SharedLib;
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -16,6 +18,8 @@ namespace Core;
 
 public sealed class LocalPathingApi : IPPather
 {
+    public bool PathsAreSmoothed => service.Engine == PathingEngine.Navmesh;
+
     private const bool debug = false;
 
     private const SearchStrategy searchStrategy = SearchStrategy.A_Star_With_Model_Avoidance;

--- a/CoreTests/CLAUDE.md
+++ b/CoreTests/CLAUDE.md
@@ -175,3 +175,12 @@ Wrath expansion:
 ```
 
 Expansion values: `SoM`, `TBC`, `Wrath`, `Cata`, `Mop`, `Retail`
+
+### navmesh - Navmesh Coordinate Checks
+
+Pure math validation of the wow<->rc coordinate mapping and Detour tile
+indexing (no game data required):
+
+```powershell
+.\run.ps1 navmesh
+```

--- a/CoreTests/Program.cs
+++ b/CoreTests/Program.cs
@@ -43,6 +43,7 @@ internal sealed class Program
         ["minimap"] = Test_MinimapNodeFinder,
         ["find-target"] = Test_FindTargetByCursor,
         ["pather"] = Test_PPather,
+        ["navmesh"] = Test_NavmeshCoords,
     };
 
     public static void Main(string[] args)
@@ -86,6 +87,14 @@ internal sealed class Program
                     remaining.Add(args[a]);
                     break;
             }
+        }
+
+        // Suites that need neither a running WoW process nor screen capture.
+        if (remaining.Count > 0 && remaining[0].Equals("navmesh", StringComparison.OrdinalIgnoreCase))
+        {
+            Test_NavmeshCoords(remaining.GetRange(1, remaining.Count - 1).ToArray());
+            Log.CloseAndFlush();
+            return;
         }
 
         // its expected to have at least 2 DataFrame
@@ -316,6 +325,83 @@ internal sealed class Program
     {
         string expansion = args.Length > 0 ? args[0] : "SoM";
         PPatherV2.PPatherV2 pPather = new(logger, DataConfig.Load(expansion));
+    }
+
+    private static void Test_NavmeshCoords(string[] args)
+    {
+        // Pure math checks - no game data required. Sign conventions in the
+        // wow<->rc mapping are the likeliest navmesh bug source, so landmarks
+        // and a full-grid index sweep are asserted here.
+        (string name, System.Numerics.Vector3 wow)[] landmarks =
+        [
+            ("Stormwind gate", new(-9170.7f, 361.9f, 92.6f)),
+            ("Orgrimmar bank", new(1631.5f, -4375.0f, 30.9f)),
+            ("Goldshire", new(-9464.0f, 62.0f, 56.0f)),
+            ("Booty Bay", new(-14297.0f, 530.0f, 8.0f)),
+            ("Everlook", new(6721.0f, -4657.0f, 721.0f)),
+        ];
+
+        int failures = 0;
+
+        foreach ((string name, System.Numerics.Vector3 wow) in landmarks)
+        {
+            System.Numerics.Vector3 roundTrip =
+                PPather.Navmesh.NavmeshCoords.ToWow(PPather.Navmesh.NavmeshCoords.ToRc(wow));
+
+            if (roundTrip != wow)
+            {
+                logger.LogError("{Name}: round-trip mismatch {Wow} -> {RoundTrip}", name, wow, roundTrip);
+                failures++;
+            }
+
+            PPather.Navmesh.NavmeshCoords.GetTileIndex(wow.X, wow.Y, out int tx, out int tz);
+            PPather.Navmesh.NavmeshCoords.GetTileWowBounds(tx, tz,
+                out float minX, out float minY, out float maxX, out float maxY);
+
+            if (wow.X < minX || wow.X >= maxX || wow.Y < minY || wow.Y >= maxY)
+            {
+                logger.LogError("{Name}: tile ({TileX},{TileZ}) bounds [{MinX},{MinY}]..[{MaxX},{MaxY}] exclude {Wow}",
+                    name, tx, tz, minX, minY, maxX, maxY, wow);
+                failures++;
+            }
+
+            if (!PPather.Navmesh.NavmeshCoords.IsValidTile(tx, tz))
+            {
+                logger.LogError("{Name}: tile ({TileX},{TileZ}) out of range", name, tx, tz);
+                failures++;
+            }
+        }
+
+        // Full-grid inversion sweep: index -> bounds center -> same index.
+        for (int tx = 0; tx < PPather.Navmesh.NavmeshSettings.TilesPerSide; tx += 5)
+        {
+            for (int tz = 0; tz < PPather.Navmesh.NavmeshSettings.TilesPerSide; tz += 5)
+            {
+                PPather.Navmesh.NavmeshCoords.GetTileWowBounds(tx, tz,
+                    out float minX, out float minY, out float maxX, out float maxY);
+
+                float cx = (minX + maxX) * 0.5f;
+                float cy = (minY + maxY) * 0.5f;
+
+                PPather.Navmesh.NavmeshCoords.GetTileIndex(cx, cy, out int rtx, out int rtz);
+                if (rtx != tx || rtz != tz)
+                {
+                    logger.LogError("Tile inversion mismatch: ({TileX},{TileZ}) -> center ({CenterX},{CenterY}) -> ({RTileX},{RTileZ})",
+                        tx, tz, cx, cy, rtx, rtz);
+                    failures++;
+                }
+            }
+        }
+
+        if (failures == 0)
+        {
+            logger.LogInformation("NavmeshCoords: all landmark round-trips, tile bounds and {Count} grid inversions OK",
+                (PPather.Navmesh.NavmeshSettings.TilesPerSide / 5) * (PPather.Navmesh.NavmeshSettings.TilesPerSide / 5));
+        }
+        else
+        {
+            logger.LogError("NavmeshCoords: {Failures} failures", failures);
+        }
     }
 
     private static double Percentile(double[] sorted, double p)

--- a/PPather/Graph/Path.cs
+++ b/PPather/Graph/Path.cs
@@ -40,6 +40,11 @@ public sealed class Path
         }
     }
 
+    public Path(List<Vector3> points)
+    {
+        locations = points;
+    }
+
     public void Add(Vector3 l)
     {
         locations.Add(l);

--- a/PPather/Navmesh/CatmullRom.cs
+++ b/PPather/Navmesh/CatmullRom.cs
@@ -1,0 +1,78 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+
+namespace PPather.Navmesh;
+
+/// <summary>
+/// Centripetal Catmull-Rom spline (Barry-Goldman formulation, alpha 0.5).
+/// Standard textbook math - mirrors the output shape of the RemoteV3 server's
+/// SMOOTH_CATMULLROM option that the WASD follower is already tuned for.
+/// </summary>
+public static class CatmullRom
+{
+    public const float Alpha = 0.5f;
+    public const int PointsPerSegment = 4;
+
+    /// <summary>Endpoints are preserved; needs at least 4 control points.</summary>
+    public static List<Vector3> Smooth(List<Vector3> points, int pointsPerSegment = PointsPerSegment)
+    {
+        if (points.Count < 4)
+        {
+            return points;
+        }
+
+        List<Vector3> output = new((points.Count - 1) * pointsPerSegment + 1)
+        {
+            points[0]
+        };
+
+        for (int i = 0; i < points.Count - 1; i++)
+        {
+            Vector3 p0 = points[Math.Max(0, i - 1)];
+            Vector3 p1 = points[i];
+            Vector3 p2 = points[i + 1];
+            Vector3 p3 = points[Math.Min(points.Count - 1, i + 2)];
+
+            for (int s = 1; s <= pointsPerSegment; s++)
+            {
+                float t = s / (float)pointsPerSegment;
+                output.Add(Sample(p0, p1, p2, p3, t));
+            }
+        }
+
+        return output;
+    }
+
+    private static Vector3 Sample(in Vector3 p0, in Vector3 p1, in Vector3 p2, in Vector3 p3, float t)
+    {
+        float t0 = 0f;
+        float t1 = t0 + KnotInterval(p0, p1);
+        float t2 = t1 + KnotInterval(p1, p2);
+        float t3 = t2 + KnotInterval(p2, p3);
+
+        // Degenerate (duplicate) control points collapse the knot interval -
+        // fall back to linear interpolation on the middle segment.
+        if (t1 == t2 || t0 == t1 || t2 == t3)
+        {
+            return Vector3.Lerp(p1, p2, t);
+        }
+
+        float u = t1 + (t * (t2 - t1));
+
+        Vector3 a1 = ((t1 - u) / (t1 - t0) * p0) + ((u - t0) / (t1 - t0) * p1);
+        Vector3 a2 = ((t2 - u) / (t2 - t1) * p1) + ((u - t1) / (t2 - t1) * p2);
+        Vector3 a3 = ((t3 - u) / (t3 - t2) * p2) + ((u - t2) / (t3 - t2) * p3);
+
+        Vector3 b1 = ((t2 - u) / (t2 - t0) * a1) + ((u - t0) / (t2 - t0) * a2);
+        Vector3 b2 = ((t3 - u) / (t3 - t1) * a2) + ((u - t1) / (t3 - t1) * a3);
+
+        return ((t2 - u) / (t2 - t1) * b1) + ((u - t1) / (t2 - t1) * b2);
+    }
+
+    private static float KnotInterval(in Vector3 a, in Vector3 b)
+    {
+        return MathF.Pow(Vector3.DistanceSquared(a, b), Alpha * 0.5f);
+    }
+}

--- a/PPather/Navmesh/NavmeshEndpointResolver.cs
+++ b/PPather/Navmesh/NavmeshEndpointResolver.cs
@@ -1,0 +1,156 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+
+using DotRecast.Detour;
+
+namespace PPather.Navmesh;
+
+/// <summary>
+/// Resolves a WoW position (whose Z may be missing - the client API exposes
+/// none) to a navmesh polygon and a corrected position.
+///
+/// z != 0: trusted-ish height -> FindNearestPoly with TrinityCore extents
+/// (horizontal +-3, vertical +-5, retry +-50).
+///
+/// z == 0: column scan. A single huge-extent nearest-poly snap (Ameisen's
+/// {3,10000,3}) picks the floor closest to z=0, which is wrong in multi-floor
+/// WMOs. Instead all polys in a +-2000 vertical column are collected and the
+/// floor is picked with the Search.CreateWorldLocation semantics: outdoors
+/// prefer the highest surface, indoors prefer an interior floor that has a
+/// ceiling above it within headroom distance.
+/// </summary>
+public sealed class NavmeshEndpointResolver
+{
+    public const float HorizontalExtent = 3f;
+    public const float VerticalExtentNear = 5f;
+    public const float VerticalExtentFar = 50f;
+    public const float VerticalExtentColumn = 2000f;
+
+    /// <summary>Minimum clear space above a floor for the toon (Search.minHeadroom).</summary>
+    public const float MinHeadroom = 2.6f;
+
+    private const int MaxColumnCandidates = 128;
+
+    private readonly DtNavMeshQuery query;
+    private readonly IDtQueryFilter filter;
+
+    private readonly ColumnCollector collector = new();
+    private readonly List<Candidate> candidates = new(MaxColumnCandidates);
+
+    private readonly record struct Candidate(long PolyRef, Vector3 RcPos);
+
+    public NavmeshEndpointResolver(DtNavMeshQuery query, IDtQueryFilter filter)
+    {
+        this.query = query;
+        this.filter = filter;
+    }
+
+    public bool TryResolve(Vector3 wow, bool? startIndoors, out long polyRef, out Vector3 resolvedWow)
+    {
+        polyRef = 0;
+        resolvedWow = wow;
+
+        return wow.Z != 0
+            ? TryResolveNear(wow, ref polyRef, ref resolvedWow)
+            : TryResolveColumn(wow, startIndoors, ref polyRef, ref resolvedWow);
+    }
+
+    private bool TryResolveNear(Vector3 wow, ref long polyRef, ref Vector3 resolvedWow)
+    {
+        Vector3 rc = NavmeshCoords.ToRc(wow);
+
+        DtStatus status = query.FindNearestPoly(rc,
+            new Vector3(HorizontalExtent, VerticalExtentNear, HorizontalExtent),
+            filter, out long nearestRef, out Vector3 nearestPt, out _);
+
+        if (!status.Succeeded() || nearestRef == 0)
+        {
+            status = query.FindNearestPoly(rc,
+                new Vector3(HorizontalExtent, VerticalExtentFar, HorizontalExtent),
+                filter, out nearestRef, out nearestPt, out _);
+        }
+
+        if (!status.Succeeded() || nearestRef == 0)
+        {
+            return false;
+        }
+
+        polyRef = nearestRef;
+        resolvedWow = NavmeshCoords.ToWow(nearestPt);
+        return true;
+    }
+
+    private bool TryResolveColumn(Vector3 wow, bool? startIndoors, ref long polyRef, ref Vector3 resolvedWow)
+    {
+        Vector3 rcCenter = NavmeshCoords.ToRc(wow);
+
+        collector.Reset();
+        DtStatus status = query.QueryPolygons(rcCenter,
+            new Vector3(HorizontalExtent, VerticalExtentColumn, HorizontalExtent),
+            filter, collector);
+
+        if (!status.Succeeded() || collector.Refs.Count == 0)
+        {
+            return false;
+        }
+
+        candidates.Clear();
+        foreach (long refs in collector.Refs)
+        {
+            if (query.ClosestPointOnPoly(refs, rcCenter, out Vector3 closest, out _).Succeeded())
+            {
+                candidates.Add(new Candidate(refs, closest));
+            }
+        }
+
+        if (candidates.Count == 0)
+        {
+            return false;
+        }
+
+        // rc Y = wow Z (up). Highest first.
+        candidates.Sort(static (a, b) => b.RcPos.Y.CompareTo(a.RcPos.Y));
+
+        Candidate pick = candidates[0];
+
+        if (startIndoors == true && candidates.Count > 1)
+        {
+            // Indoors: prefer the highest floor that still has a ceiling
+            // (another candidate) above it with standing headroom - i.e. an
+            // interior floor rather than the roof.
+            for (int i = 1; i < candidates.Count; i++)
+            {
+                float gapToAbove = candidates[i - 1].RcPos.Y - candidates[i].RcPos.Y;
+                if (gapToAbove >= MinHeadroom)
+                {
+                    pick = candidates[i];
+                    break;
+                }
+            }
+        }
+
+        polyRef = pick.PolyRef;
+        resolvedWow = NavmeshCoords.ToWow(pick.RcPos);
+        return true;
+    }
+
+    private sealed class ColumnCollector : IDtPolyQuery
+    {
+        public List<long> Refs { get; } = new(MaxColumnCandidates);
+
+        public void Reset()
+        {
+            Refs.Clear();
+        }
+
+        public void Process(DtMeshTile tile, ReadOnlySpan<int> polys, ReadOnlySpan<long> polyRefs, int count)
+        {
+            for (int i = 0; i < count && Refs.Count < MaxColumnCandidates; i++)
+            {
+                Refs.Add(polyRefs[i]);
+            }
+        }
+    }
+}

--- a/PPather/Navmesh/NavmeshPathfinder.cs
+++ b/PPather/Navmesh/NavmeshPathfinder.cs
@@ -1,0 +1,215 @@
+#nullable enable
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Numerics;
+
+using DotRecast.Detour;
+
+using Microsoft.Extensions.Logging;
+
+using PPather.Graph;
+
+using WowTriangles;
+
+namespace PPather.Navmesh;
+
+/// <summary>
+/// In-process navmesh pathfinding engine for one continent:
+/// ensure tiles -> resolve endpoints -> FindPath -> FindStraightPath ->
+/// centripetal Catmull-Rom smoothing -> closest-point-on-poly re-validation.
+/// Output shape mirrors the RemoteV3 server (SMOOTH_CATMULLROM|VALIDATE_CPOP)
+/// that the WASD follower is already tuned for.
+/// </summary>
+public sealed class NavmeshPathfinder : IDisposable
+{
+    public const int MaxPolyPath = 4096;
+    public const int MaxStraightPath = 512;
+    /// <summary>Partial-result continuation budget (stitching from the furthest reached poly).</summary>
+    public const int MaxContinuations = 8;
+
+    private static readonly Vector3 ValidateExtents = new(2f, 4f, 2f);
+
+    private readonly ILogger logger;
+    private readonly NavmeshTileCache tiles;
+    private readonly DtNavMeshQuery query;
+    private readonly WowQueryFilter filter;
+    private readonly NavmeshEndpointResolver resolver;
+
+    public NavmeshStats LastStats;
+
+    public struct NavmeshStats
+    {
+        public double EnsureMs;
+        public double ResolveMs;
+        public double FindMs;
+        public double SmoothMs;
+        public int TilesBaked;
+        public int PolyPathLength;
+        public int PointCount;
+    }
+
+    public NavmeshPathfinder(ILogger logger, ChunkedTriangleCollection world, string cacheDir)
+    {
+        this.logger = logger;
+        tiles = new NavmeshTileCache(logger, world, cacheDir);
+        query = new DtNavMeshQuery(tiles.NavMesh);
+        filter = new WowQueryFilter();
+        resolver = new NavmeshEndpointResolver(query, filter);
+    }
+
+    public void Dispose()
+    {
+        tiles.Dispose();
+    }
+
+    public Path? FindPath(Vector3 wowFrom, Vector3 wowTo, bool? startIndoors)
+    {
+        LastStats = default;
+        int bakedBefore = tiles.TilesBakedThisSession;
+
+        long t0 = Stopwatch.GetTimestamp();
+        tiles.EnsureTilesForSegment(wowFrom, wowTo);
+        LastStats.EnsureMs = Stopwatch.GetElapsedTime(t0).TotalMilliseconds;
+        LastStats.TilesBaked = tiles.TilesBakedThisSession - bakedBefore;
+
+        tiles.Lock.EnterReadLock();
+        try
+        {
+            long t1 = Stopwatch.GetTimestamp();
+
+            if (!resolver.TryResolve(wowFrom, startIndoors, out long startRef, out Vector3 resolvedFrom) ||
+                !resolver.TryResolve(wowTo, null, out long endRef, out Vector3 resolvedTo))
+            {
+                LastStats.ResolveMs = Stopwatch.GetElapsedTime(t1).TotalMilliseconds;
+                return null;
+            }
+
+            LastStats.ResolveMs = Stopwatch.GetElapsedTime(t1).TotalMilliseconds;
+
+            Vector3 rcStart = NavmeshCoords.ToRc(resolvedFrom);
+            Vector3 rcEnd = NavmeshCoords.ToRc(resolvedTo);
+
+            long t2 = Stopwatch.GetTimestamp();
+            List<Vector3>? rcPoints = FindRcPath(startRef, endRef, rcStart, rcEnd);
+            LastStats.FindMs = Stopwatch.GetElapsedTime(t2).TotalMilliseconds;
+
+            if (rcPoints == null || rcPoints.Count == 0)
+            {
+                return null;
+            }
+
+            long t3 = Stopwatch.GetTimestamp();
+            List<Vector3> smoothed = CatmullRom.Smooth(rcPoints);
+            ValidateOnMesh(smoothed);
+            LastStats.SmoothMs = Stopwatch.GetElapsedTime(t3).TotalMilliseconds;
+            LastStats.PointCount = smoothed.Count;
+
+            List<Vector3> wowPoints = new(smoothed.Count);
+            for (int i = 0; i < smoothed.Count; i++)
+            {
+                wowPoints.Add(NavmeshCoords.ToWow(smoothed[i]));
+            }
+
+            return new Path(wowPoints);
+        }
+        finally
+        {
+            tiles.Lock.ExitReadLock();
+        }
+    }
+
+    private List<Vector3>? FindRcPath(long startRef, long endRef, Vector3 rcStart, Vector3 rcEnd)
+    {
+        long[] polyBuffer = ArrayPool<long>.Shared.Rent(MaxPolyPath);
+        DtStraightPath[] straightBuffer = ArrayPool<DtStraightPath>.Shared.Rent(MaxStraightPath);
+        try
+        {
+            List<Vector3> points = [];
+
+            long curStartRef = startRef;
+            Vector3 curStart = rcStart;
+
+            for (int leg = 0; leg < MaxContinuations; leg++)
+            {
+                Span<long> polys = polyBuffer.AsSpan(0, MaxPolyPath);
+
+                DtStatus status = query.FindPath(curStartRef, endRef, curStart, rcEnd,
+                    filter, polys, out int polyCount, MaxPolyPath);
+
+                if (!status.Succeeded() || polyCount == 0)
+                {
+                    return points.Count > 0 ? points : null;
+                }
+
+                LastStats.PolyPathLength += polyCount;
+
+                // A partial poly path ends short of endRef - clamp the straight
+                // path target onto the furthest reached poly, stitch, continue.
+                Vector3 legEnd = rcEnd;
+                bool partial = status.IsPartial() || polys[polyCount - 1] != endRef;
+                if (partial &&
+                    query.ClosestPointOnPoly(polys[polyCount - 1], rcEnd, out Vector3 clamped, out _).Succeeded())
+                {
+                    legEnd = clamped;
+                }
+
+                DtStatus spStatus = query.FindStraightPath(curStart, legEnd,
+                    polys.Slice(0, polyCount), polyCount,
+                    straightBuffer.AsSpan(0, MaxStraightPath), out int straightCount, MaxStraightPath, 0);
+
+                if (!spStatus.Succeeded() || straightCount == 0)
+                {
+                    return points.Count > 0 ? points : null;
+                }
+
+                int skip = points.Count > 0 ? 1 : 0; // dedupe stitch joint
+                for (int i = skip; i < straightCount; i++)
+                {
+                    points.Add(straightBuffer[i].pos);
+                }
+
+                if (!partial)
+                {
+                    return points;
+                }
+
+                long furthest = polys[polyCount - 1];
+                if (furthest == curStartRef)
+                {
+                    // No forward progress - unreachable with current tiles.
+                    return points;
+                }
+
+                curStartRef = furthest;
+                curStart = legEnd;
+            }
+
+            return points;
+        }
+        finally
+        {
+            ArrayPool<long>.Shared.Return(polyBuffer);
+            ArrayPool<DtStraightPath>.Shared.Return(straightBuffer);
+        }
+    }
+
+    /// <summary>
+    /// CPOP validation: re-projects every smoothed point onto the mesh so the
+    /// spline cannot cut through walls or float off the surface.
+    /// </summary>
+    private void ValidateOnMesh(List<Vector3> rcPoints)
+    {
+        for (int i = 0; i < rcPoints.Count; i++)
+        {
+            DtStatus status = query.FindNearestPoly(rcPoints[i], ValidateExtents, filter,
+                out long refs, out Vector3 nearest, out _);
+
+            if (status.Succeeded() && refs != 0)
+            {
+                rcPoints[i] = nearest;
+            }
+        }
+    }
+}

--- a/PPather/Navmesh/NavmeshTileCache.cs
+++ b/PPather/Navmesh/NavmeshTileCache.cs
@@ -1,0 +1,258 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Numerics;
+using System.Threading;
+
+using DotRecast.Core;
+using DotRecast.Detour;
+using DotRecast.Detour.Io;
+
+using Microsoft.Extensions.Logging;
+
+using WowTriangles;
+
+namespace PPather.Navmesh;
+
+/// <summary>
+/// Owns one continent's DtNavMesh: on-demand tile ensure (extract -> bake ->
+/// add), write-once disk persistence, and LRU residency eviction.
+///
+/// Tiles are immutable after bake: first visit pays the bake (~1-2s), the
+/// disk cache serves every later session in milliseconds.
+///
+/// Thread-safety: queries take the read lock, AddTile/RemoveTile the write
+/// lock (DtNavMesh must not be mutated during a query).
+/// </summary>
+public sealed class NavmeshTileCache : IDisposable
+{
+    public const int MaxResidentTiles = 1024;
+
+    private readonly ILogger logger;
+    private readonly ChunkedTriangleCollection world;
+    private readonly string cacheDir;
+
+    private readonly DtNavMesh navMesh;
+    private readonly ReaderWriterLockSlim rwLock = new();
+
+    // dtTile (x,z) -> last-touch stamp for LRU.
+    private readonly Dictionary<(int x, int z), long> resident = [];
+    private readonly HashSet<(int x, int z)> emptyTiles = [];
+
+    private long touchCounter;
+
+    public DtNavMesh NavMesh => navMesh;
+    public ReaderWriterLockSlim Lock => rwLock;
+
+    public int ResidentTileCount => resident.Count;
+    public int TilesBakedThisSession { get; private set; }
+
+    public NavmeshTileCache(ILogger logger, ChunkedTriangleCollection world, string cacheDir)
+    {
+        this.logger = logger;
+        this.world = world;
+        this.cacheDir = cacheDir;
+
+        Directory.CreateDirectory(cacheDir);
+
+        DtNavMeshParams param = new()
+        {
+            orig = new Vector3(NavmeshCoords.Origin, 0, NavmeshCoords.Origin),
+            tileWidth = NavmeshSettings.TileWorldSize,
+            tileHeight = NavmeshSettings.TileWorldSize,
+            maxTiles = NavmeshSettings.MaxTiles,
+            maxPolys = NavmeshSettings.MaxPolysPerTile,
+        };
+
+        navMesh = new DtNavMesh();
+        DtStatus status = navMesh.Init(param, NavmeshSettings.VertsPerPoly);
+        if (!status.Succeeded())
+        {
+            throw new InvalidOperationException($"DtNavMesh.Init failed: {status}");
+        }
+    }
+
+    public void Dispose()
+    {
+        rwLock.Dispose();
+    }
+
+    /// <summary>
+    /// Ensures every tile intersecting the from->to segment (plus one tile of
+    /// margin around both endpoints) is resident. Synchronous: first-ever
+    /// visits pay the bake here, cached tiles load in milliseconds.
+    /// </summary>
+    public void EnsureTilesForSegment(Vector3 wowFrom, Vector3 wowTo)
+    {
+        NavmeshCoords.GetTileIndex(wowFrom.X, wowFrom.Y, out int fromX, out int fromZ);
+        NavmeshCoords.GetTileIndex(wowTo.X, wowTo.Y, out int toX, out int toZ);
+
+        // Endpoint 3x3 rings first - they gate the endpoint resolution.
+        EnsureRing(fromX, fromZ);
+        EnsureRing(toX, toZ);
+
+        // Walk the segment at half-tile steps and ensure a 1-tile margin band.
+        Vector3 delta = wowTo - wowFrom;
+        float length = MathF.Sqrt((delta.X * delta.X) + (delta.Y * delta.Y));
+        float step = NavmeshSettings.TileWorldSize * 0.5f;
+
+        for (float d = step; d < length; d += step)
+        {
+            float t = d / length;
+            float x = wowFrom.X + (delta.X * t);
+            float y = wowFrom.Y + (delta.Y * t);
+
+            NavmeshCoords.GetTileIndex(x, y, out int tx, out int tz);
+            EnsureRing(tx, tz);
+        }
+    }
+
+    private void EnsureRing(int centerX, int centerZ)
+    {
+        for (int dx = -1; dx <= 1; dx++)
+        {
+            for (int dz = -1; dz <= 1; dz++)
+            {
+                EnsureTile(centerX + dx, centerZ + dz);
+            }
+        }
+    }
+
+    public void EnsureTile(int tx, int tz)
+    {
+        if (!NavmeshCoords.IsValidTile(tx, tz))
+        {
+            return;
+        }
+
+        rwLock.EnterUpgradeableReadLock();
+        try
+        {
+            if (resident.TryGetValue((tx, tz), out _))
+            {
+                resident[(tx, tz)] = ++touchCounter;
+                return;
+            }
+
+            if (emptyTiles.Contains((tx, tz)))
+            {
+                return;
+            }
+
+            DtMeshData? data = LoadOrBake(tx, tz);
+
+            rwLock.EnterWriteLock();
+            try
+            {
+                if (data == null)
+                {
+                    emptyTiles.Add((tx, tz));
+                    return;
+                }
+
+                DtStatus status = navMesh.AddTile(data, 0, 0, out _);
+                if (!status.Succeeded())
+                {
+                    logger.LogWarning("AddTile({TileX},{TileZ}) failed: {Status}", tx, tz, status);
+                    emptyTiles.Add((tx, tz));
+                    return;
+                }
+
+                resident[(tx, tz)] = ++touchCounter;
+                EvictIfOverBudget();
+            }
+            finally
+            {
+                rwLock.ExitWriteLock();
+            }
+        }
+        finally
+        {
+            rwLock.ExitUpgradeableReadLock();
+        }
+    }
+
+    private DtMeshData? LoadOrBake(int tx, int tz)
+    {
+        string path = TilePath(tx, tz);
+
+        if (File.Exists(path))
+        {
+            try
+            {
+                using FileStream fs = File.OpenRead(path);
+                using BinaryReader br = new(fs);
+                return new DtMeshDataReader().Read(br, NavmeshSettings.VertsPerPoly);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Corrupt navmesh tile {Path} - rebaking", path);
+                File.Delete(path);
+            }
+        }
+
+        long start = Stopwatch.GetTimestamp();
+
+        TileGeometry geom = TileGeometryExtractor.Extract(world, tx, tz);
+        DtMeshData? data = NavmeshTileBuilder.Bake(geom, tx, tz);
+
+        TilesBakedThisSession++;
+
+        if (logger.IsEnabled(LogLevel.Debug))
+        {
+            logger.LogDebug("Baked tile ({TileX},{TileZ}): {Polys} polys, {Tris} tris, {FailedChunks} failed chunks, {ElapsedMs:F0}ms",
+                tx, tz, data?.header.polyCount ?? 0, geom.GroundTriangleCount,
+                geom.FailedChunkLoads, Stopwatch.GetElapsedTime(start).TotalMilliseconds);
+        }
+
+        if (data != null)
+        {
+            try
+            {
+                using FileStream fs = File.Create(path);
+                using BinaryWriter bw = new(fs);
+                new DtMeshDataWriter().Write(bw, data, RcByteOrder.LITTLE_ENDIAN, false);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed persisting navmesh tile {Path}", path);
+            }
+        }
+
+        return data;
+    }
+
+    private void EvictIfOverBudget()
+    {
+        // Called under the write lock.
+        while (resident.Count > MaxResidentTiles)
+        {
+            (int x, int z) oldest = default;
+            long oldestTouch = long.MaxValue;
+
+            foreach (((int x, int z) key, long touch) in resident)
+            {
+                if (touch < oldestTouch)
+                {
+                    oldestTouch = touch;
+                    oldest = key;
+                }
+            }
+
+            long refs = navMesh.GetTileRefAt(oldest.x, oldest.z, 0);
+            if (refs != 0)
+            {
+                navMesh.RemoveTile(refs);
+            }
+
+            resident.Remove(oldest);
+        }
+    }
+
+    private string TilePath(int tx, int tz)
+    {
+        return Path.Combine(cacheDir, $"tile_{tx}_{tz}.dnm");
+    }
+}

--- a/PPather/Navmesh/WowQueryFilter.cs
+++ b/PPather/Navmesh/WowQueryFilter.cs
@@ -1,0 +1,49 @@
+#nullable enable
+using System.Numerics;
+
+using DotRecast.Detour;
+
+namespace PPather.Navmesh;
+
+/// <summary>
+/// Query filter with TrinityCore/AmeisenNavigation semantics:
+/// include GROUND | WATER | MAGMA_SLIME, area costs GROUND 1.0 / WATER 1.3 /
+/// MAGMA_SLIME 4.0. Road preference and danger zones hook in here later via
+/// the cost table.
+/// </summary>
+public sealed class WowQueryFilter : IDtQueryFilter
+{
+    public const int IncludeFlags =
+        NavmeshSettings.FlagGround | NavmeshSettings.FlagWater | NavmeshSettings.FlagMagmaSlime;
+
+    public const float CostGround = 1.0f;
+    public const float CostWater = 1.3f;
+    public const float CostMagmaSlime = 4.0f;
+
+    private readonly float[] areaCost;
+
+    public WowQueryFilter()
+    {
+        areaCost = new float[64];
+        for (int i = 0; i < areaCost.Length; i++)
+        {
+            areaCost[i] = CostGround;
+        }
+
+        areaCost[NavmeshSettings.AreaWater] = CostWater;
+        areaCost[NavmeshSettings.AreaMagmaSlime] = CostMagmaSlime;
+    }
+
+    public bool PassFilter(long refs, DtMeshTile tile, DtPoly poly)
+    {
+        return (poly.flags & IncludeFlags) != 0;
+    }
+
+    public float GetCost(Vector3 pa, Vector3 pb,
+        long prevRef, DtMeshTile prevTile, DtPoly prevPoly,
+        long curRef, DtMeshTile curTile, DtPoly curPoly,
+        long nextRef, DtMeshTile nextTile, DtPoly nextPoly)
+    {
+        return Vector3.Distance(pa, pb) * areaCost[curPoly.GetArea()];
+    }
+}

--- a/PPather/Search/PPatherService.cs
+++ b/PPather/Search/PPatherService.cs
@@ -2,6 +2,7 @@
 
 using PPather.Data;
 using PPather.Graph;
+using PPather.Navmesh;
 
 using SharedLib;
 using SharedLib.Data;
@@ -30,6 +31,18 @@ public sealed class PPatherService
 
     private Search search { get; set; }
 
+    private NavmeshPathfinder navmeshPathfinder;
+    private float navmeshMapId = -1;
+    private bool? lastStartIndoors;
+
+    /// <summary>
+    /// Selects the in-process engine. Runtime-settable so the benchmark can
+    /// A/B both engines without a server restart.
+    /// </summary>
+    public PathingEngine Engine { get; set; } = PathingEngine.SpotAStar;
+
+    public NavmeshPathfinder NavmeshPathfinder => navmeshPathfinder;
+
     public bool Initialised => search != null;
 
     public bool IsSearching { get; set; }
@@ -55,6 +68,10 @@ public sealed class PPatherService
 
     public void Reset()
     {
+        navmeshPathfinder?.Dispose();
+        navmeshPathfinder = null;
+        navmeshMapId = -1;
+
         if (search == null)
             return;
 
@@ -144,6 +161,8 @@ public sealed class PPatherService
 
         Initialise(wma.MapID);
 
+        lastStartIndoors = startIndoors;
+
         return search.CreateWorldLocation(x, y, z, wma.MapID, startIndoors);
     }
 
@@ -162,10 +181,42 @@ public sealed class PPatherService
     {
         SearchBegin?.Invoke();
         IsSearching = true;
-        var path = search.DoSearch(searchType);
+
+        Path path = Engine == PathingEngine.Navmesh
+            ? NavmeshSearch()
+            : search.DoSearch(searchType);
+
         IsSearching = false;
         OnPathCreated?.Invoke(path);
         return path;
+    }
+
+    private Path NavmeshSearch()
+    {
+        EnsureNavmeshPathfinder();
+
+        return navmeshPathfinder.FindPath(
+            search.From.AsVector3(), search.Target.AsVector3(), lastStartIndoors);
+    }
+
+    private void EnsureNavmeshPathfinder()
+    {
+        if (navmeshPathfinder != null && navmeshMapId == search.MapId)
+        {
+            return;
+        }
+
+        navmeshPathfinder?.Dispose();
+
+        string continent = ContinentDB.IdToName[search.MapId];
+        string hash = NavmeshSettings.ComputeSettingsHash(dataConfig.Exp,
+            typeof(NavmeshPathfinder).Assembly.GetName().Version?.ToString() ?? "0");
+        string cacheDir = System.IO.Path.Join(dataConfig.PathInfo, "navmesh", continent, hash);
+
+        navmeshPathfinder = new NavmeshPathfinder(logger, TriangleWorld, cacheDir);
+        navmeshMapId = search.MapId;
+
+        logger.LogInformation("Navmesh engine ready for {Continent} - tile cache: {CacheDir}", continent, cacheDir);
     }
 
     public void Save()

--- a/PathingAPI/Controllers/PPatherController.cs
+++ b/PathingAPI/Controllers/PPatherController.cs
@@ -8,6 +8,7 @@ using PPather.Data;
 using PPather.Graph;
 using PPather.Navmesh;
 
+using SharedLib;
 using SharedLib.Data;
 
 using System;
@@ -291,10 +292,59 @@ public sealed class PPatherController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     public JsonResult Capabilities()
     {
-        return new JsonResult(new CapabilitiesResponse(false));
+        return new JsonResult(new CapabilitiesResponse(
+            service.Engine == PathingEngine.Navmesh));
     }
 
     public sealed record CapabilitiesResponse(bool PathsAreSmoothed);
+
+    /// <summary>Returns the active in-process pathfinding engine.</summary>
+    [HttpGet("Engine")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public JsonResult GetEngine()
+    {
+        return new JsonResult(service.Engine.ToString());
+    }
+
+    /// <summary>
+    /// Switches the in-process pathfinding engine at runtime (benchmark A/B
+    /// without a server restart) and resets pathfinder state.
+    /// </summary>
+    /// <param name="engine" example="Navmesh">SpotAStar | Navmesh</param>
+    [HttpPost("Engine")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [RateLimit]
+    public IActionResult SetEngine(string engine)
+    {
+        if (!Enum.TryParse(engine, ignoreCase: true, out PathingEngine parsed))
+        {
+            return BadRequest($"Unknown engine '{engine}'");
+        }
+
+        service.Reset();
+        service.Engine = parsed;
+        return new JsonResult(parsed.ToString());
+    }
+
+    /// <summary>Timing breakdown of the most recent navmesh query.</summary>
+    [HttpGet("Stats")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public JsonResult Stats()
+    {
+        NavmeshPathfinder.NavmeshStats stats =
+            service.NavmeshPathfinder?.LastStats ?? default;
+
+        return new JsonResult(new StatsResponse(
+            service.Engine.ToString(),
+            stats.EnsureMs, stats.ResolveMs, stats.FindMs, stats.SmoothMs,
+            stats.TilesBaked, stats.PolyPathLength, stats.PointCount));
+    }
+
+    public sealed record StatsResponse(
+        string Engine,
+        double EnsureMs, double ResolveMs, double FindMs, double SmoothMs,
+        int TilesBaked, int PolyPathLength, int PointCount);
 
     /// <summary>
     /// Debug/diagnostic: bakes one DotRecast navmesh tile at the given world

--- a/PathingAPI/PathingAPI.xml
+++ b/PathingAPI/PathingAPI.xml
@@ -141,6 +141,19 @@
             all-capabilities-false.
             </summary>
         </member>
+        <member name="M:PathingAPI.Controllers.PPatherController.GetEngine">
+            <summary>Returns the active in-process pathfinding engine.</summary>
+        </member>
+        <member name="M:PathingAPI.Controllers.PPatherController.SetEngine(System.String)">
+            <summary>
+            Switches the in-process pathfinding engine at runtime (benchmark A/B
+            without a server restart) and resets pathfinder state.
+            </summary>
+            <param name="engine" example="Navmesh">SpotAStar | Navmesh</param>
+        </member>
+        <member name="M:PathingAPI.Controllers.PPatherController.Stats">
+            <summary>Timing breakdown of the most recent navmesh query.</summary>
+        </member>
         <member name="M:PathingAPI.Controllers.PPatherController.BakeTile(System.Single,System.Single,System.Single)">
             <summary>
             Debug/diagnostic: bakes one DotRecast navmesh tile at the given world

--- a/PathingAPI/Startup.cs
+++ b/PathingAPI/Startup.cs
@@ -135,6 +135,13 @@ public sealed class Startup
     // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
     public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
     {
+        // "Pathing:Engine" selects the in-process engine (SpotAStar | Navmesh).
+        if (System.Enum.TryParse(configuration.GetSection(StartupConfigPathing.Position)["Engine"],
+            out PathingEngine engine))
+        {
+            app.ApplicationServices.GetRequiredService<PPatherService>().Engine = engine;
+        }
+
         // Enable middleware to serve generated Swagger as a JSON endpoint.
         app.UseSwagger();
 

--- a/README.md
+++ b/README.md
@@ -667,6 +667,7 @@ run.bat --Reader:Type=WGC --Pathing:Mode=Local --Reader:UseGpu=true
 | `Reader` | `Type` | string | `DXGI` | `DXGI`, `WGC` | Screen reader type. `WGC` = Windows Graphics Capture (supports background window) |
 | `Reader` | `UseGpu` | bool | `false` | `true`, `false` | Use GPU acceleration for screen reading |
 | `Pathing` | `Mode` | string | `RemoteV3` | `Local`, `RemoteV1`, `RemoteV3` | Pathfinding mode |
+| `Pathing` | `Engine` | string | `SpotAStar` | `SpotAStar`, `Navmesh` | In-process engine for `Local` mode (and PathingAPI). `Navmesh` (experimental) bakes a DotRecast navmesh at runtime from your MPQ files and answers queries from it; tiles are cached under `Json/PathInfo/navmesh/` |
 | `Pathing` | `hostv1` | string | `localhost` | hostname/IP | RemoteV1 pathing server host |
 | `Pathing` | `portv1` | int | `5001` | port number | RemoteV1 pathing server port |
 | `Pathing` | `hostv3` | string | `127.0.0.1` | hostname/IP | RemoteV3 pathing server host |


### PR DESCRIPTION
## Summary
The DotRecast navmesh engine is now a **selectable in-process pathfinder**. `PPatherService.DoSearch` dispatches on `Engine` (`SpotAStar` default | `Navmesh`); LocalPathingApi, all PathingAPI endpoints, viz and the benchmark flow through unchanged. Default behavior unchanged — opt in via `"Pathing": { "Engine": "Navmesh" }` or `POST api/PPather/Engine?engine=Navmesh` at runtime.

### Engine pipeline (`PPather/Navmesh`)
- **NavmeshTileCache** — per-continent `DtNavMesh`; sync tile-ensure along route corridor (3×3 endpoint rings + half-tile walk); write-once disk cache (`DtMeshDataWriter`, ~50KB/tile, `Json/PathInfo/navmesh/{continent}/{settingsHash}/`, gitignored); LRU eviction via `RemoveTile` 1024 resident; RW-lock around mutate-vs-query.
- **NavmeshEndpointResolver** — z≠0: `FindNearestPoly` {3,5,3}→{3,50,3} (TC extents); z==0: polygon column scan {3,2000,3} with `CreateWorldLocation` floor-pick semantics (outdoors highest; indoors highest floor with ≥2.6yd headroom above).
- **NavmeshPathfinder** — `FindPath` (4096-poly budget, partial-result continuation up to 8 stitched legs) → `FindStraightPath` → centripetal Catmull-Rom (α=0.5, 4pts/seg) → CPOP re-validation. Mirrors RemoteV3's `SMOOTH_CATMULLROM|VALIDATE_CPOP` output shape the WASD follower is tuned for.
- **WowQueryFilter** — include GROUND|WATER|MAGMA_SLIME, costs 1.0/1.3/4.0.

### Endpoints
`GET/POST api/PPather/Engine` (runtime A/B switch + reset), `GET api/PPather/Stats` (ensure/resolve/find/smooth ms + tiles baked), `Capabilities` reports live engine.

### Measured (live MPQ, Release)
| Route | spot-A* warm | navmesh warm | pts spot → nav |
|---|---|---|---|
| Elwynn 193yd | 22.9ms | **<1ms** (find 0.48) | 134 → 13 |
| Coldridge 1355yd | 60.8ms | **~3ms** | 915 → 201 |
| Dun Morogh vendor (indoor) | 13.9ms | **~1ms** | 255 → 57 |
| Durotar 1206yd | 36.4ms | **~3ms** | 815 → 113 |

- Disk cache proven: server restart → 12 tiles reload in **22ms**, zero rebakes.
- Cold first-ever visit: bake-dominated (0.7–2.3s/tile, 12–27 tiles on virgin corridors) — once per tile per lifetime; background prefetch lands in PR-6.
- CoreTests `navmesh` suite (data-free): landmark round-trips + 2601 tile-index inversions green.
- Indoor vendor route resolved 8yd below the route-file Z — flagged for viz inspection with the PR-6 navmesh render + PR-7 indoor corpus.

## Verification
- `dotnet build MasterOfPuppets.sln` 0 errors.
- `CoreTests: .\run.ps1 navmesh` green.
- Smoke: engine switch, 4 routes across both continents + restart-reload — outputs above.
- README: `Pathing:Engine` documented.

Next (PR-6): background baker pool + prefetch, Babylon.js navmesh render mode, WatchHub tile events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)