### PR TITLE
feat(PPather): background baker pool + frontier ensure + navmesh viz (PR-6)

### DIFF
--- a/PPather/Navmesh/NavmeshPathfinder.cs
+++ b/PPather/Navmesh/NavmeshPathfinder.cs
@@ -39,6 +39,8 @@ public sealed class NavmeshPathfinder : IDisposable
 
     public NavmeshStats LastStats;
 
+    public NavmeshTileCache Tiles => tiles;
+
     public struct NavmeshStats
     {
         public double EnsureMs;
@@ -124,6 +126,7 @@ public sealed class NavmeshPathfinder : IDisposable
     {
         long[] polyBuffer = ArrayPool<long>.Shared.Rent(MaxPolyPath);
         DtStraightPath[] straightBuffer = ArrayPool<DtStraightPath>.Shared.Rent(MaxStraightPath);
+        long budgetStart = Stopwatch.GetTimestamp();
         try
         {
             List<Vector3> points = [];
@@ -133,6 +136,27 @@ public sealed class NavmeshPathfinder : IDisposable
 
             for (int leg = 0; leg < MaxContinuations; leg++)
             {
+                // The initial corridor ensure follows the straight from->to
+                // line; the real poly route can curve off it. Each leg re-
+                // ensures tiles along the remaining segment from the current
+                // frontier, spending whatever is left of the corridor budget.
+                if (leg > 0)
+                {
+                    TimeSpan remaining = NavmeshTileCache.CorridorWaitBudget
+                        - Stopwatch.GetElapsedTime(budgetStart);
+
+                    tiles.Lock.ExitReadLock();
+                    try
+                    {
+                        tiles.EnsureTilesForSegment(
+                            NavmeshCoords.ToWow(curStart), NavmeshCoords.ToWow(rcEnd), remaining);
+                    }
+                    finally
+                    {
+                        tiles.Lock.EnterReadLock();
+                    }
+                }
+
                 Span<long> polys = polyBuffer.AsSpan(0, MaxPolyPath);
 
                 DtStatus status = query.FindPath(curStartRef, endRef, curStart, rcEnd,

--- a/PPather/Navmesh/NavmeshTileCache.cs
+++ b/PPather/Navmesh/NavmeshTileCache.cs
@@ -5,6 +5,8 @@ using System.Diagnostics;
 using System.IO;
 using System.Numerics;
 using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
 
 using DotRecast.Core;
 using DotRecast.Detour;
@@ -17,18 +19,29 @@ using WowTriangles;
 namespace PPather.Navmesh;
 
 /// <summary>
-/// Owns one continent's DtNavMesh: on-demand tile ensure (extract -> bake ->
-/// add), write-once disk persistence, and LRU residency eviction.
+/// Owns one continent's DtNavMesh: on-demand tile bake through a small
+/// background worker pool, write-once disk persistence, and LRU residency
+/// eviction.
 ///
 /// Tiles are immutable after bake: first visit pays the bake (~1-2s), the
 /// disk cache serves every later session in milliseconds.
 ///
-/// Thread-safety: queries take the read lock, AddTile/RemoveTile the write
-/// lock (DtNavMesh must not be mutated during a query).
+/// Concurrency model:
+/// - N bake workers drain urgent-first channels; geometry extraction is
+///   serialized by <see cref="extractLock"/> (ChunkedTriangleCollection is not
+///   thread-safe), the recast bake itself runs in parallel.
+/// - Queries take the read lock; AddTile/RemoveTile take the write lock
+///   (DtNavMesh must not be mutated during a query).
 /// </summary>
 public sealed class NavmeshTileCache : IDisposable
 {
     public const int MaxResidentTiles = 1024;
+
+    /// <summary>How long a query waits for its corridor tiles before pathing
+    /// with whatever is resident (stitching self-heals on the next request).</summary>
+    public static readonly TimeSpan CorridorWaitBudget = TimeSpan.FromSeconds(5);
+
+    private static readonly int WorkerCount = Math.Clamp(Environment.ProcessorCount / 4, 2, 4);
 
     private readonly ILogger logger;
     private readonly ChunkedTriangleCollection world;
@@ -36,12 +49,34 @@ public sealed class NavmeshTileCache : IDisposable
 
     private readonly DtNavMesh navMesh;
     private readonly ReaderWriterLockSlim rwLock = new();
+    private readonly object extractLock = new();
 
-    // dtTile (x,z) -> last-touch stamp for LRU.
-    private readonly Dictionary<(int x, int z), long> resident = [];
+    private readonly Channel<TileRequest> urgent =
+        Channel.CreateUnbounded<TileRequest>(new UnboundedChannelOptions { SingleReader = false });
+    private readonly Channel<TileRequest> background =
+        Channel.CreateUnbounded<TileRequest>(new UnboundedChannelOptions { SingleReader = false });
+
+    private readonly CancellationTokenSource cts = new();
+    private readonly Task[] workers;
+
+    // dtTile (x,z) -> last-touch stamp for LRU. Concurrent: touched by query
+    // threads, enumerated under the write lock during eviction.
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<(int x, int z), long> resident = [];
+    // Guarded by stateLock.
     private readonly HashSet<(int x, int z)> emptyTiles = [];
+    // Tiles currently queued or baking - avoids duplicate work. Guarded by stateLock.
+    private readonly HashSet<(int x, int z)> inFlight = [];
+    private readonly object stateLock = new();
 
     private long touchCounter;
+
+    private readonly record struct TileRequest(int X, int Z, TaskCompletionSource? Done);
+
+    /// <summary>Raised after a tile lands in the mesh (viz). May fire on a worker thread.</summary>
+    public Action<int, int, DtMeshData>? NotifyTileAdded;
+
+    /// <summary>Raised after LRU eviction removes a tile (viz cleanup).</summary>
+    public Action<int, int>? NotifyTileRemoved;
 
     public DtNavMesh NavMesh => navMesh;
     public ReaderWriterLockSlim Lock => rwLock;
@@ -72,28 +107,57 @@ public sealed class NavmeshTileCache : IDisposable
         {
             throw new InvalidOperationException($"DtNavMesh.Init failed: {status}");
         }
+
+        workers = new Task[WorkerCount];
+        for (int i = 0; i < workers.Length; i++)
+        {
+            workers[i] = Task.Run(WorkerLoop);
+        }
     }
 
     public void Dispose()
     {
+        cts.Cancel();
+        urgent.Writer.TryComplete();
+        background.Writer.TryComplete();
+
+        try
+        {
+            Task.WaitAll(workers, TimeSpan.FromSeconds(10));
+        }
+        catch (AggregateException)
+        {
+            // cancellation
+        }
+
+        cts.Dispose();
         rwLock.Dispose();
     }
 
     /// <summary>
-    /// Ensures every tile intersecting the from->to segment (plus one tile of
-    /// margin around both endpoints) is resident. Synchronous: first-ever
-    /// visits pay the bake here, cached tiles load in milliseconds.
+    /// Ensures the tiles needed by a from->to query: 3x3 endpoint rings are
+    /// waited on fully (they gate endpoint resolution); corridor tiles are
+    /// waited on up to <see cref="CorridorWaitBudget"/>, after which pathing
+    /// proceeds with what is resident and the rest keeps baking behind.
+    /// All bakes run on the worker pool, so cold multi-tile ensures
+    /// parallelize across workers.
     /// </summary>
     public void EnsureTilesForSegment(Vector3 wowFrom, Vector3 wowTo)
     {
+        EnsureTilesForSegment(wowFrom, wowTo, CorridorWaitBudget);
+    }
+
+    public void EnsureTilesForSegment(Vector3 wowFrom, Vector3 wowTo, TimeSpan corridorBudget)
+    {
+        List<Task> endpointWaits = [];
+        List<Task> corridorWaits = [];
+
+        RequestEndpointTiles(wowFrom, endpointWaits);
+        RequestEndpointTiles(wowTo, endpointWaits);
+
         NavmeshCoords.GetTileIndex(wowFrom.X, wowFrom.Y, out int fromX, out int fromZ);
         NavmeshCoords.GetTileIndex(wowTo.X, wowTo.Y, out int toX, out int toZ);
 
-        // Endpoint 3x3 rings first - they gate the endpoint resolution.
-        EnsureRing(fromX, fromZ);
-        EnsureRing(toX, toZ);
-
-        // Walk the segment at half-tile steps and ensure a 1-tile margin band.
         Vector3 delta = wowTo - wowFrom;
         float length = MathF.Sqrt((delta.X * delta.X) + (delta.Y * delta.Y));
         float step = NavmeshSettings.TileWorldSize * 0.5f;
@@ -101,76 +165,194 @@ public sealed class NavmeshTileCache : IDisposable
         for (float d = step; d < length; d += step)
         {
             float t = d / length;
-            float x = wowFrom.X + (delta.X * t);
-            float y = wowFrom.Y + (delta.Y * t);
+            NavmeshCoords.GetTileIndex(
+                wowFrom.X + (delta.X * t),
+                wowFrom.Y + (delta.Y * t),
+                out int tx, out int tz);
 
-            NavmeshCoords.GetTileIndex(x, y, out int tx, out int tz);
-            EnsureRing(tx, tz);
+            for (int dx = -1; dx <= 1; dx++)
+            {
+                for (int dz = -1; dz <= 1; dz++)
+                {
+                    Request(tx + dx, tz + dz, corridorWaits, urgentQueue: true);
+                }
+            }
+        }
+
+        Task.WaitAll([.. endpointWaits], cts.Token);
+
+        if (corridorWaits.Count > 0 && corridorBudget > TimeSpan.Zero)
+        {
+            Task.WaitAll([.. corridorWaits], corridorBudget);
         }
     }
 
-    private void EnsureRing(int centerX, int centerZ)
+    /// <summary>Fire-and-forget low-priority bake (e.g. area warm-up).</summary>
+    public void Prefetch(int tx, int tz)
     {
-        for (int dx = -1; dx <= 1; dx++)
+        Request(tx, tz, waits: null, urgentQueue: false);
+    }
+
+    /// <summary>
+    /// The endpoint resolver searches horizontally +-3yd, so only the tile
+    /// containing the point is required - plus a neighbor when the point sits
+    /// within this margin of a tile edge. Typical: 1 tile; worst (corner): 4.
+    /// </summary>
+    public const float EndpointEdgeMargin = 8f;
+
+    private void RequestEndpointTiles(Vector3 wow, List<Task> waits)
+    {
+        NavmeshCoords.GetTileIndex(wow.X, wow.Y, out int tx, out int tz);
+        NavmeshCoords.GetTileWowBounds(tx, tz, out float minX, out float minY, out float maxX, out float maxY);
+
+        // dtTileX spans wow Y, dtTileZ spans wow X (see NavmeshCoords).
+        int dTxLo = wow.Y - minY < EndpointEdgeMargin ? -1 : 0;
+        int dTxHi = maxY - wow.Y < EndpointEdgeMargin ? 1 : 0;
+        int dTzLo = wow.X - minX < EndpointEdgeMargin ? -1 : 0;
+        int dTzHi = maxX - wow.X < EndpointEdgeMargin ? 1 : 0;
+
+        for (int dTx = dTxLo; dTx <= dTxHi; dTx++)
         {
-            for (int dz = -1; dz <= 1; dz++)
+            for (int dTz = dTzLo; dTz <= dTzHi; dTz++)
             {
-                EnsureTile(centerX + dx, centerZ + dz);
+                Request(tx + dTx, tz + dTz, waits, urgentQueue: true);
             }
         }
     }
 
-    public void EnsureTile(int tx, int tz)
+    private void Request(int tx, int tz, List<Task>? waits, bool urgentQueue)
     {
         if (!NavmeshCoords.IsValidTile(tx, tz))
         {
             return;
         }
 
-        rwLock.EnterUpgradeableReadLock();
-        try
+        if (resident.ContainsKey((tx, tz)))
         {
-            if (resident.TryGetValue((tx, tz), out _))
-            {
-                resident[(tx, tz)] = ++touchCounter;
-                return;
-            }
+            resident[(tx, tz)] = Interlocked.Increment(ref touchCounter);
+            return;
+        }
 
+        TaskCompletionSource? done = null;
+
+        lock (stateLock)
+        {
             if (emptyTiles.Contains((tx, tz)))
             {
                 return;
             }
 
-            DtMeshData? data = LoadOrBake(tx, tz);
+            if (!inFlight.Add((tx, tz)))
+            {
+                // Already queued or baking; nothing to await per-tile here -
+                // duplicate waiters are rare and the budget wait covers them.
+                return;
+            }
 
-            rwLock.EnterWriteLock();
+            if (waits != null)
+            {
+                done = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                waits.Add(done.Task);
+            }
+        }
+
+        TileRequest request = new(tx, tz, done);
+        Channel<TileRequest> queue = urgentQueue ? urgent : background;
+        queue.Writer.TryWrite(request);
+    }
+
+    private async Task WorkerLoop()
+    {
+        CancellationToken token = cts.Token;
+
+        while (!token.IsCancellationRequested)
+        {
+            TileRequest request;
+
+            if (urgent.Reader.TryRead(out request) ||
+                background.Reader.TryRead(out request))
+            {
+                ProcessRequest(request);
+                continue;
+            }
+
             try
             {
+                // Sleep until either queue has work; urgent is preferred on wake.
+                Task<bool> urgentWait = urgent.Reader.WaitToReadAsync(token).AsTask();
+                Task<bool> backgroundWait = background.Reader.WaitToReadAsync(token).AsTask();
+                await Task.WhenAny(urgentWait, backgroundWait);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+        }
+    }
+
+    private void ProcessRequest(in TileRequest request)
+    {
+        (int tx, int tz) = (request.X, request.Z);
+
+        try
+        {
+            DtMeshData? data = LoadOrBake(tx, tz);
+
+            if (data == null)
+            {
+                lock (stateLock)
+                {
+                    emptyTiles.Add((tx, tz));
+                }
+            }
+            else
+            {
+                rwLock.EnterWriteLock();
+                try
+                {
+                    DtStatus status = navMesh.AddTile(data, 0, 0, out _);
+                    if (!status.Succeeded())
+                    {
+                        logger.LogWarning("AddTile({TileX},{TileZ}) failed: {Status}", tx, tz, status);
+                        data = null;
+                    }
+                    else
+                    {
+                        resident[(tx, tz)] = Interlocked.Increment(ref touchCounter);
+                        EvictIfOverBudget();
+                    }
+                }
+                finally
+                {
+                    rwLock.ExitWriteLock();
+                }
+
                 if (data == null)
                 {
-                    emptyTiles.Add((tx, tz));
-                    return;
+                    lock (stateLock)
+                    {
+                        emptyTiles.Add((tx, tz));
+                    }
                 }
-
-                DtStatus status = navMesh.AddTile(data, 0, 0, out _);
-                if (!status.Succeeded())
-                {
-                    logger.LogWarning("AddTile({TileX},{TileZ}) failed: {Status}", tx, tz, status);
-                    emptyTiles.Add((tx, tz));
-                    return;
-                }
-
-                resident[(tx, tz)] = ++touchCounter;
-                EvictIfOverBudget();
             }
-            finally
+
+            if (data != null)
             {
-                rwLock.ExitWriteLock();
+                NotifyTileAdded?.Invoke(tx, tz, data);
             }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Baking tile ({TileX},{TileZ}) failed", tx, tz);
         }
         finally
         {
-            rwLock.ExitUpgradeableReadLock();
+            lock (stateLock)
+            {
+                inFlight.Remove((tx, tz));
+            }
+
+            request.Done?.TrySetResult();
         }
     }
 
@@ -195,7 +377,12 @@ public sealed class NavmeshTileCache : IDisposable
 
         long start = Stopwatch.GetTimestamp();
 
-        TileGeometry geom = TileGeometryExtractor.Extract(world, tx, tz);
+        TileGeometry geom;
+        lock (extractLock)
+        {
+            geom = TileGeometryExtractor.Extract(world, tx, tz);
+        }
+
         DtMeshData? data = NavmeshTileBuilder.Bake(geom, tx, tz);
 
         TilesBakedThisSession++;
@@ -247,7 +434,8 @@ public sealed class NavmeshTileCache : IDisposable
                 navMesh.RemoveTile(refs);
             }
 
-            resident.Remove(oldest);
+            resident.TryRemove(oldest, out _);
+            NotifyTileRemoved?.Invoke(oldest.x, oldest.z);
         }
     }
 

--- a/PPather/Search/PPatherService.cs
+++ b/PPather/Search/PPatherService.cs
@@ -26,6 +26,12 @@ public sealed class PPatherService
     public event Action<Path> OnPathCreated;
     public event Action<ChunkEventArgs> OnChunkAdded;
 
+    /// <summary>Baked navmesh tile landed in the mesh. May fire on a baker thread.</summary>
+    public event Action<int, int, DotRecast.Detour.DtMeshData> OnNavmeshTileAdded;
+
+    /// <summary>Navmesh tile evicted (LRU).</summary>
+    public event Action<int, int> OnNavmeshTileRemoved;
+
     public Action<LinesEventArgs> OnLinesAdded;
     public Action<SphereEventArgs> OnSphereAdded;
 
@@ -214,6 +220,10 @@ public sealed class PPatherService
         string cacheDir = System.IO.Path.Join(dataConfig.PathInfo, "navmesh", continent, hash);
 
         navmeshPathfinder = new NavmeshPathfinder(logger, TriangleWorld, cacheDir);
+        navmeshPathfinder.Tiles.NotifyTileAdded =
+            (x, z, data) => OnNavmeshTileAdded?.Invoke(x, z, data);
+        navmeshPathfinder.Tiles.NotifyTileRemoved =
+            (x, z) => OnNavmeshTileRemoved?.Invoke(x, z);
         navmeshMapId = search.MapId;
 
         logger.LogInformation("Navmesh engine ready for {Continent} - tile cache: {CacheDir}", continent, cacheDir);

--- a/PathingAPI/Pages/Watch.razor
+++ b/PathingAPI/Pages/Watch.razor
@@ -55,6 +55,9 @@
             <button @onclick="ToggleWireFrame">
                 <span style="@(WireFrameEnabled ? "color: green;" : "")">Wire</span>
             </button>
+            <button @onclick="() => NavmeshLayerEnabled = !NavmeshLayerEnabled">
+                <span style="@(NavmeshLayerEnabled ? "color: green;" : "")">Navmesh</span>
+            </button>
             <button @onclick="CycleGeometryMode">
                 <span style="@(CurrentGeometryMode != GeometryMode.Off ? "color: " + GetGeometryModeColor() + ";" : "")">
                     @GetGeometryModeText()
@@ -119,6 +122,11 @@
 
     private ConcurrentQueue<ChunkEventArgs> chunkEventArgs = new();
 
+    private ConcurrentQueue<(int x, int z, DotRecast.Detour.DtMeshData data)> navmeshTileAdds = new();
+    private ConcurrentQueue<(int x, int z)> navmeshTileRemovals = new();
+
+    private bool NavmeshLayerEnabled { get; set; } = true;
+
     private GeometryMode CurrentGeometryMode { get; set; } = GeometryMode.All;
 
     private bool DrawTestPoints { get; set; } = false;
@@ -153,6 +161,8 @@
 
         pPatherService.OnChunkAdded += OnChunkAdded;
         pPatherService.OnPathCreated += OnDrawFinalPath;
+        pPatherService.OnNavmeshTileAdded += OnNavmeshTileAdded;
+        pPatherService.OnNavmeshTileRemoved += OnNavmeshTileRemoved;
 
         pPatherService.OnLinesAdded += OnDrawLines;
         pPatherService.OnSphereAdded += OnDrawSphere;
@@ -168,6 +178,8 @@
         pPatherService.SearchBegin -= OnSearchBegin;
         pPatherService.OnChunkAdded -= OnChunkAdded;
         pPatherService.OnPathCreated -= OnDrawFinalPath;
+        pPatherService.OnNavmeshTileAdded -= OnNavmeshTileAdded;
+        pPatherService.OnNavmeshTileRemoved -= OnNavmeshTileRemoved;
         pPatherService.OnLinesAdded -= OnDrawLines;
         pPatherService.OnSphereAdded -= OnDrawSphere;
 
@@ -340,6 +352,8 @@
             }
 #pragma warning restore CS0162
 
+            await DrawNavmeshTiles(token);
+
             if (lastPeek != pPatherService.PeekLocation)
             {
                 lastPeek = pPatherService.PeekLocation;
@@ -386,6 +400,7 @@
             }
 
             await DrawGeometry(Token);
+            await DrawNavmeshTiles(Token);
 
             if (DrawTestPoints && BabylonJs)
             {
@@ -441,6 +456,81 @@
     {
         chunkEventArgs.Enqueue(e);
         //_ = DequeueChunkEvent(e);
+    }
+
+    private void OnNavmeshTileAdded(int x, int z, DotRecast.Detour.DtMeshData data)
+    {
+        navmeshTileAdds.Enqueue((x, z, data));
+    }
+
+    private void OnNavmeshTileRemoved(int x, int z)
+    {
+        navmeshTileRemovals.Enqueue((x, z));
+    }
+
+    private async Task DrawNavmeshTiles(CancellationToken token)
+    {
+        if (!BabylonJs) { return; }
+
+        while (!token.IsCancellationRequested &&
+            navmeshTileRemovals.TryDequeue(out (int x, int z) removed))
+        {
+            string name = NavmeshTileName(removed.x, removed.z);
+            await hubContext.Clients.All.SendAsync("removeMesh", name + "_g", token);
+            await hubContext.Clients.All.SendAsync("removeMesh", name + "_w", token);
+        }
+
+        while (NavmeshLayerEnabled &&
+            !token.IsCancellationRequested &&
+            navmeshTileAdds.TryDequeue(out (int x, int z, DotRecast.Detour.DtMeshData data) e))
+        {
+            await SendNavmeshTile(e.x, e.z, e.data, token);
+        }
+    }
+
+    private static string NavmeshTileName(int x, int z) => $"navmesh_{x}_{z}";
+
+    /// <summary>
+    /// Converts a Detour tile into a renderable triangle soup: fan-triangulate
+    /// each polygon and split indices by area (ground vs liquid). Vertices are
+    /// converted rc -> wow ({z, x, y}) - the js side applies the same axis
+    /// mapping as every other mesh.
+    /// </summary>
+    private async Task SendNavmeshTile(int x, int z, DotRecast.Detour.DtMeshData data, CancellationToken token)
+    {
+        int vertCount = data.header.vertCount;
+        float[] positions = new float[vertCount * 3];
+
+        for (int i = 0; i < vertCount; i++)
+        {
+            // rc (x=wowY, y=wowZ, z=wowX) -> wow (x, y, z)
+            positions[(i * 3) + 0] = data.verts[(i * 3) + 2];
+            positions[(i * 3) + 1] = data.verts[(i * 3) + 0];
+            positions[(i * 3) + 2] = data.verts[(i * 3) + 1];
+        }
+
+        List<int> groundIndices = [];
+        List<int> liquidIndices = [];
+
+        for (int p = 0; p < data.header.polyCount; p++)
+        {
+            DotRecast.Detour.DtPoly poly = data.polys[p];
+
+            List<int> target = poly.GetArea() == PPather.Navmesh.NavmeshSettings.AreaWater
+                ? liquidIndices
+                : groundIndices;
+
+            for (int v = 2; v < poly.vertCount; v++)
+            {
+                target.Add(poly.verts[0]);
+                target.Add(poly.verts[v - 1]);
+                target.Add(poly.verts[v]);
+            }
+        }
+
+        await hubContext.Clients.All.SendAsync("addNavmeshTile",
+            NavmeshTileName(x, z), positions,
+            groundIndices.ToArray(), liquidIndices.ToArray(), token);
     }
 
     private async ValueTask DequeueChunkEvent(ChunkEventArgs e, CancellationToken token)

--- a/PathingAPI/PathingAPI.xml
+++ b/PathingAPI/PathingAPI.xml
@@ -209,5 +209,13 @@
         <member name="M:PathingAPI.Pages.Index.MR(System.Int32,System.Double,System.Double,System.Int32,System.Double,System.Double)">
             <summary>MapRoute: uiMap coordinates</summary>
         </member>
+        <member name="M:PathingAPI.Pages.Watch.SendNavmeshTile(System.Int32,System.Int32,DotRecast.Detour.DtMeshData,System.Threading.CancellationToken)">
+            <summary>
+            Converts a Detour tile into a renderable triangle soup: fan-triangulate
+            each polygon and split indices by area (ground vs liquid). Vertices are
+            converted rc -> wow ({z, x, y}) - the js side applies the same axis
+            mapping as every other mesh.
+            </summary>
+        </member>
     </members>
 </doc>

--- a/PathingAPI/wwwroot/js/babylonjs.js
+++ b/PathingAPI/wwwroot/js/babylonjs.js
@@ -318,6 +318,54 @@ window.addEventListener('DOMContentLoaded', function () {
         requestRender();
     });
 
+    connection.on("addNavmeshTile", (name, flatPositions, groundIndices, liquidIndices) => {
+        if (scene == null) return;
+
+        removeMesh(name + "_g");
+        removeMesh(name + "_w");
+
+        if (flatPositions.length === 0)
+            return;
+
+        // flatPositions is [wowX, wowY, wowZ, ...]; same axis mapping as the
+        // other handlers: babylon(x, y, z) = wow(x, z, y) / div.
+        const count = flatPositions.length / 3;
+        const positions = new Float32Array(flatPositions.length);
+        for (let i = 0; i < count; i++) {
+            const index = i * 3;
+            positions[index] = flatPositions[index] / div;
+            positions[index + 1] = flatPositions[index + 2] / div;
+            positions[index + 2] = flatPositions[index + 1] / div;
+        }
+
+        const buildLayer = (suffix, indices, r, g, b, alpha) => {
+            if (indices.length === 0)
+                return;
+
+            const mesh = new BABYLON.Mesh(name + suffix, scene);
+            const normals = new Float32Array(positions.length);
+            BABYLON.VertexData.ComputeNormals(positions, indices, normals);
+
+            const vertexData = new BABYLON.VertexData();
+            vertexData.positions = positions;
+            vertexData.indices = indices;
+            vertexData.normals = normals;
+            vertexData.applyToMesh(mesh);
+
+            const mat = new BABYLON.StandardMaterial(name + suffix + "_mat", scene);
+            mat.emissiveColor = new BABYLON.Color3(r, g, b);
+            mat.disableLighting = true;
+            mat.alpha = alpha;
+            mat.backFaceCulling = false;
+            mesh.material = mat;
+        };
+
+        buildLayer("_g", groundIndices, 0.15, 0.9, 0.3, 0.35);
+        buildLayer("_w", liquidIndices, 0.15, 0.4, 0.95, 0.4);
+
+        requestRender();
+    });
+
     connection.on("drawBoundBox", (min, max, color, name) => {
         if (scene == null) return;
 


### PR DESCRIPTION
## Summary
Completes the navmesh engine's runtime story: cold bakes leave the request path, partial paths self-heal, and the Watch page renders the mesh.

### Baker pool (`NavmeshTileCache`)
- 2–4 workers, urgent-first channels; extraction serialized (MPQ chunk world isn't thread-safe), recast bake parallel.
- Endpoint wait shrinks from fixed 3×3 rings (18 tiles!) to containing-tile + edge-proximity neighbors (typical 1, worst 4) — resolver only searches ±3yd horizontally.
- Corridor tiles wait ≤5s (`CorridorWaitBudget`); the rest keeps baking in the background while the query paths through what's resident.
- Duplicate-work guard (`inFlight`), `ConcurrentDictionary` LRU touches, RW-lock only around `AddTile`/`RemoveTile` vs queries.

### Frontier ensure (`NavmeshPathfinder`)
Continuation legs re-ensure tiles along the **remaining segment from the current frontier** under the shared budget — the initial ensure follows the straight from→to line, but real routes curve off it.

### Measured (virgin 2015yd Barrens corridor, cache cleared)
| Request | time | result |
|---|---|---|
| 1st (virgin) | **12.4s** (was 18.6s) | usable partial path, budget-capped |
| after background drain | **48ms** | full path to exact target, 42 tiles on disk |
| warm/cached areas | sub-ms ensure | unchanged |

Self-healing matches Navigation's behavior: the bot walks the partial immediately; its natural re-request completes the route.

### Navmesh viz
- `PPatherService.OnNavmeshTileAdded/Removed` (baker-thread events) → Watch.razor queues → WatchHub streams fan-triangulated ground/liquid index sets → new `addNavmeshTile` handler in babylonjs.js renders semi-transparent overlays (green ground / blue liquid), LRU evictions remove them.
- **Navmesh** toggle button on the Watch top bar.
- This is the tool for eyeballing the flagged indoor-vendor Z question from #809 — bake the Dun Morogh tile with the Watch page open and compare mesh floors vs the triangle render.

## Verification
- Build 0 errors; smoke sequence above on live MPQ data.
- Viz render path exercised via hub message flow (page subscription unchanged pattern from chunk events).

Next (PR-7): benchmark `--engines` A/B mode + corpus additions + comparison report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)