### PR TITLE
feat(Benchmarks): engine A/B mode + comparison report (PR-7)

### DIFF
--- a/Benchmarks/PathingAPIBenchmark.cs
+++ b/Benchmarks/PathingAPIBenchmark.cs
@@ -81,14 +81,17 @@ public class PathingAPIBenchmark
         new("Z Honor hold issue no result", "api/PPather/WorldRoute2?x1=-732.031&y1=2448.2805&z1=58.940506&x2=-755.79004&y2=2491.16&z2=0&uimap=1944"),
         new("Duskwood issue", "api/PPather/MapRoute?uimap1=1431&x1=43.097&y1=18.38&uimap2=1431&x2=45.34&y2=16.438"),
 
-        // Building navigation tests
-        //new("Loch Modan building Yanni Stoutheart", "api/PPather/MapRoute?uimap1=1432&x1=35.2&y1=46.9&uimap2=1432&x2=34.8&y2=48.6"),
-        //new("Loch Modan building innkeeper", "api/PPather/MapRoute?uimap1=1432&x1=35.2&y1=46.9&uimap2=1432&x2=35.5&y2=48.5"),
-        //new("Loch Modan building Vidra Heartstove", "api/PPather/MapRoute?uimap1=1432&x1=35.2&y1=46.9&uimap2=1432&x2=34.8&y2=49.1"),
-        //new("Dun morogh building Grundel Harkin", "api/PPather/MapRoute?uimap1=1426&x1=28.7&y1=70.1&uimap2=1426&x2=28.8&y2=67.9"),
-        //new("Dun morogh building Grundel Harkin reverse", "api/PPather/MapRoute?uimap1=1426&x1=28.8&y1=67.9&uimap2=1426&x2=28.7&y2=70.1"),
+        // Building navigation tests (indoor corpus - multi-floor Z resolution)
+        new("Loch Modan building Yanni Stoutheart", "api/PPather/MapRoute?uimap1=1432&x1=35.2&y1=46.9&uimap2=1432&x2=34.8&y2=48.6"),
+        new("Loch Modan building innkeeper", "api/PPather/MapRoute?uimap1=1432&x1=35.2&y1=46.9&uimap2=1432&x2=35.5&y2=48.5"),
+        new("Loch Modan building Vidra Heartstove", "api/PPather/MapRoute?uimap1=1432&x1=35.2&y1=46.9&uimap2=1432&x2=34.8&y2=49.1"),
+        new("Dun morogh building Grundel Harkin", "api/PPather/MapRoute?uimap1=1426&x1=28.7&y1=70.1&uimap2=1426&x2=28.8&y2=67.9"),
+        new("Dun morogh building Grundel Harkin reverse", "api/PPather/MapRoute?uimap1=1426&x1=28.8&y1=67.9&uimap2=1426&x2=28.7&y2=70.1"),
         new("Dun morogh Coldridge pass - unable to find", "api/PPather/MapRoute?uimap1=1426&x1=33.90&y1=71.86&uimap2=1426&x2=38.94&y2=61.0"),
         new("Dun morogh Coldridge pass", "api/PPather/MapRoute?uimap1=1426&x1=33.76&y1=71.91&uimap2=1426&x2=39.0&y2=61.13"),
+
+        // Cross-zone long haul
+        new("Cross-zone Elwynn to Redridge", "api/PPather/WorldRoute?x1=-9170.5&y1=355.4&z1=81.05&x2=-9230.0&y2=-2211.0&z2=0&mapid=0"),
 
         // Other zones
         new("Hinterlands 1 water issue", "api/PPather/MapRoute?uimap1=1425&x1=82.2771&y1=48.698803&uimap2=1425&x2=81.65922&y2=49.87935"),
@@ -109,7 +112,7 @@ public class PathingAPIBenchmark
 
     private readonly record struct PathPoint(float X, float Y, float Z);
 
-    private sealed class BenchmarkResult
+    public sealed class BenchmarkResult
     {
         public string TestName { get; set; } = string.Empty;
         public double ColdMs { get; set; } = -1;
@@ -132,7 +135,42 @@ public class PathingAPIBenchmark
         public double WarmMedianMs => HasWarm ? Median(WarmMs.OrderBy(x => x).ToList()) : -1;
     }
 
-    public static async Task RunBenchmark(string baseUrl, int iterations = 3,
+    /// <summary>
+    /// Runs the suite against each engine in turn (switching via
+    /// POST api/PPather/Engine) and writes per-engine reports plus a
+    /// side-by-side comparison markdown.
+    /// </summary>
+    public static async Task RunEngineComparison(string baseUrl, int iterations,
+        string[] engines, ILogger? logger = null, string outputDir = "benchmark_results")
+    {
+        logger ??= Log.Logger;
+
+        using HttpClient client = new();
+        List<(string engine, List<BenchmarkResult> results)> runs = [];
+
+        foreach (string engine in engines)
+        {
+            HttpResponseMessage response = await client.PostAsync(
+                $"{baseUrl}/api/PPather/Engine?engine={engine}", null);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                logger.Error(string.Format("Engine switch to {0} failed: HTTP {1} - aborting comparison",
+                    engine, response.StatusCode));
+                return;
+            }
+
+            logger.Information(string.Format("\n===== Engine: {0} =====\n", engine));
+            List<BenchmarkResult> results = await RunBenchmark(baseUrl, iterations,
+                resetBetweenRuns: true, logger, label: engine, outputDir);
+            runs.Add((engine, results));
+        }
+
+        string path = WriteComparisonReport(outputDir, baseUrl, iterations, runs);
+        logger.Information(string.Format("\nComparison written: {0}", path));
+    }
+
+    public static async Task<List<BenchmarkResult>> RunBenchmark(string baseUrl, int iterations = 3,
         bool resetBetweenRuns = true, ILogger? logger = null,
         string label = "spot-astar", string outputDir = "benchmark_results")
     {
@@ -313,6 +351,103 @@ public class PathingAPIBenchmark
         logger.Information(string.Format("\nReport written: {0}", reportPath));
 
         logger.Information("\nBenchmark complete!");
+
+        return results;
+    }
+
+    private static string WriteComparisonReport(string outputDir, string baseUrl,
+        int iterations, List<(string engine, List<BenchmarkResult> results)> runs)
+    {
+        Directory.CreateDirectory(outputDir);
+
+        string fileName = string.Create(CultureInfo.InvariantCulture,
+            $"comparison_{DateTime.Now:yyyyMMdd_HHmmss}.md");
+        string path = Path.Combine(outputDir, fileName);
+
+        StringBuilder sb = new();
+        sb.AppendLine(string.Create(CultureInfo.InvariantCulture,
+            $"# Engine comparison - {string.Join(" vs ", runs.Select(r => r.engine))}"));
+        sb.AppendLine();
+        sb.AppendLine(string.Create(CultureInfo.InvariantCulture,
+            $"{DateTime.Now:yyyy-MM-dd HH:mm:ss} | {baseUrl} | {iterations} iterations (1 cold + {iterations - 1} warm)"));
+        sb.AppendLine();
+        sb.AppendLine("Cold = first query after server Reset. For SpotAStar that pays MPQ");
+        sb.AppendLine("chunk loading; for Navmesh it pays disk tile loads (or bakes on a");
+        sb.AppendLine("first-ever visit - a once-per-tile-per-lifetime cost).");
+        sb.AppendLine();
+
+        sb.AppendLine("## Overall");
+        sb.AppendLine();
+        sb.AppendLine("| Engine | OK | Reached | Cold Med | Cold P95 | Warm Med | Warm P95 | Avg Len yd | Avg Corners |");
+        sb.AppendLine("|---|---|---|---|---|---|---|---|---|");
+
+        foreach ((string engine, List<BenchmarkResult> results) in runs)
+        {
+            List<BenchmarkResult> ok = results.Where(r => r.Success).ToList();
+            List<double> cold = ok.Where(r => r.ColdMs >= 0).Select(r => r.ColdMs).OrderBy(t => t).ToList();
+            List<double> warm = ok.SelectMany(r => r.WarmMs).OrderBy(t => t).ToList();
+            List<BenchmarkResult> withPath = ok.Where(r => r.PointCount > 0).ToList();
+
+            int reached = results.Count(r => r.Reached == true);
+            int reachable = results.Count(r => r.Reached != null);
+
+            sb.AppendLine(string.Create(CultureInfo.InvariantCulture,
+                $"| {engine} | {ok.Count}/{results.Count} | {reached}/{reachable} | {MedianOrDash(cold)} | {PercentileOrDash(cold, 95)} | {MedianOrDash(warm)} | {PercentileOrDash(warm, 95)} | {(withPath.Count > 0 ? withPath.Average(r => r.PathLengthYd) : 0):F0} | {(withPath.Count > 0 ? withPath.Average(r => r.CornerCount) : 0):F0} |"));
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("## Per-route");
+        sb.AppendLine();
+
+        sb.Append("| Route |");
+        foreach ((string engine, _) in runs)
+        {
+            sb.Append(string.Create(CultureInfo.InvariantCulture,
+                $" {engine} Cold | {engine} Warm | {engine} Pts | {engine} Len | {engine} Crn | {engine} Reached |"));
+        }
+        sb.AppendLine();
+
+        sb.Append("|---|");
+        foreach ((string _, _) in runs)
+        {
+            sb.Append("---|---|---|---|---|---|");
+        }
+        sb.AppendLine();
+
+        int routeCount = runs[0].results.Count;
+        for (int i = 0; i < routeCount; i++)
+        {
+            sb.Append(string.Create(CultureInfo.InvariantCulture, $"| {runs[0].results[i].TestName} |"));
+
+            foreach ((string _, List<BenchmarkResult> results) in runs)
+            {
+                BenchmarkResult r = results[i];
+                if (r.Success)
+                {
+                    sb.Append(string.Create(CultureInfo.InvariantCulture,
+                        $" {r.ColdMs:F0} | {(r.HasWarm ? r.WarmAvgMs : double.NaN):F1} | {r.PointCount} | {r.PathLengthYd:F0} | {r.CornerCount} | {FormatReached(r.Reached)} |"));
+                }
+                else
+                {
+                    sb.Append(" FAIL | - | - | - | - | - |");
+                }
+            }
+
+            sb.AppendLine();
+        }
+
+        File.WriteAllText(path, sb.ToString());
+        return path;
+
+        static string MedianOrDash(List<double> sorted)
+        {
+            return sorted.Count == 0 ? "-" : string.Create(CultureInfo.InvariantCulture, $"{Median(sorted):F1}ms");
+        }
+
+        static string PercentileOrDash(List<double> sorted, int p)
+        {
+            return sorted.Count == 0 ? "-" : string.Create(CultureInfo.InvariantCulture, $"{Percentile(sorted, p):F1}ms");
+        }
     }
 
     private static void LogStats(ILogger logger, List<double> sortedTimes)

--- a/Benchmarks/Program.cs
+++ b/Benchmarks/Program.cs
@@ -12,7 +12,17 @@ if (args.Length > 0 && args[0] == "--pather-benchmark")
 {
     string baseUrl = args.Length > 1 ? args[1] : "http://localhost:5001";
     int iterations = args.Length > 2 && int.TryParse(args[2], out int iter) ? iter : 2;
-    string label = args.Length > 3 ? args[3] : "spot-astar";
+    string label = args.Length > 3 && !args[3].StartsWith("--") ? args[3] : "spot-astar";
+
+    // --engines SpotAStar,Navmesh -> run the suite per engine + comparison md
+    string[]? engines = null;
+    for (int i = 1; i < args.Length - 1; i++)
+    {
+        if (args[i] == "--engines")
+        {
+            engines = args[i + 1].Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        }
+    }
 
     Log.Logger = new LoggerConfiguration()
         .WriteTo.File(new ExpressionTemplate(LogOutputTemplates.Minimal),
@@ -22,7 +32,15 @@ if (args.Length > 0 && args[0] == "--pather-benchmark")
         .CreateLogger();
 
     Log.Information($"Running PathingAPI benchmark against {baseUrl}...\n");
-    await Benchmarks.PathingAPIBenchmark.RunBenchmark(baseUrl, iterations, logger: Log.Logger, label: label);
+
+    if (engines != null)
+    {
+        await Benchmarks.PathingAPIBenchmark.RunEngineComparison(baseUrl, iterations, engines, Log.Logger);
+    }
+    else
+    {
+        await Benchmarks.PathingAPIBenchmark.RunBenchmark(baseUrl, iterations, logger: Log.Logger, label: label);
+    }
 
     Log.CloseAndFlush();
 }

--- a/PPather/Navmesh/NavmeshPathfinder.cs
+++ b/PPather/Navmesh/NavmeshPathfinder.cs
@@ -220,12 +220,14 @@ public sealed class NavmeshPathfinder : IDisposable
     }
 
     /// <summary>
-    /// CPOP validation: re-projects every smoothed point onto the mesh so the
-    /// spline cannot cut through walls or float off the surface.
+    /// CPOP validation: re-projects smoothed interior points onto the mesh so
+    /// the spline cannot cut through walls or float off the surface. Endpoints
+    /// are excluded - they come straight from the resolver (already on-poly)
+    /// and re-projection can drift them past the consumer's arrival radius.
     /// </summary>
     private void ValidateOnMesh(List<Vector3> rcPoints)
     {
-        for (int i = 0; i < rcPoints.Count; i++)
+        for (int i = 1; i < rcPoints.Count - 1; i++)
         {
             DtStatus status = query.FindNearestPoly(rcPoints[i], ValidateExtents, filter,
                 out long refs, out Vector3 nearest, out _);

--- a/PPather/Search/PPatherService.cs
+++ b/PPather/Search/PPatherService.cs
@@ -201,8 +201,25 @@ public sealed class PPatherService
     {
         EnsureNavmeshPathfinder();
 
-        return navmeshPathfinder.FindPath(
-            search.From.AsVector3(), search.Target.AsVector3(), lastStartIndoors);
+        Vector3 from = search.From.AsVector3();
+        Vector3 to = search.Target.AsVector3();
+
+        // Callers that bypass ToWorldZ (raw WorldRoute) pass z=0. The navmesh
+        // column scan alone would pick the highest poly - which can be a tree
+        // canopy or roof. Seed the height with the spot-geometry surface
+        // heuristics (canopy/terrain preference) first; the resolver then only
+        // needs its small vertical extents.
+        if (from.Z == 0)
+        {
+            from = search.CreateWorldLocation(from.X, from.Y, 0, (int)search.MapId, lastStartIndoors).AsVector3();
+        }
+
+        if (to.Z == 0)
+        {
+            to = search.CreateWorldLocation(to.X, to.Y, 0, (int)search.MapId, null).AsVector3();
+        }
+
+        return navmeshPathfinder.FindPath(from, to, lastStartIndoors);
     }
 
     private void EnsureNavmeshPathfinder()

--- a/benchmark_results/comparison_20260719_224745.md
+++ b/benchmark_results/comparison_20260719_224745.md
@@ -1,0 +1,55 @@
+# Engine comparison - SpotAStar vs Navmesh
+
+2026-07-19 22:47:45 | http://127.0.0.1:5001 | 4 iterations (1 cold + 3 warm)
+
+Cold = first query after server Reset. For SpotAStar that pays MPQ
+chunk loading; for Navmesh it pays disk tile loads (or bakes on a
+first-ever visit - a once-per-tile-per-lifetime cost).
+
+## Overall
+
+| Engine | OK | Reached | Cold Med | Cold P95 | Warm Med | Warm P95 | Avg Len yd | Avg Corners |
+|---|---|---|---|---|---|---|---|---|
+| SpotAStar | 31/36 | 13/17 | 599.8ms | 1018.1ms | 21.2ms | 63.1ms | 447 | 204 |
+| Navmesh | 31/36 | 14/17 | 473.2ms | 1365.0ms | 1.7ms | 75.3ms | 332 | 2 |
+
+## Per-route
+
+| Route | SpotAStar Cold | SpotAStar Warm | SpotAStar Pts | SpotAStar Len | SpotAStar Crn | SpotAStar Reached | Navmesh Cold | Navmesh Warm | Navmesh Pts | Navmesh Len | Navmesh Crn | Navmesh Reached |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| Elwynn vendor to path | 1018 | 23.3 | 134 | 193 | 57 | yes | 802 | 1.1 | 13 | 120 | 0 | yes |
+| Z Elwynn vendor to path | 939 | 23.3 | 134 | 193 | 57 | yes | 789 | 1.6 | 13 | 120 | 0 | yes |
+| Z Coldridge to 5_gnome | 1317 | 73.2 | 915 | 1355 | 374 | yes | 503 | 5.9 | 201 | 957 | 0 | yes |
+| Redridge Grave to North | 730 | 61.3 | 728 | 194 | 336 | n/a | 515 | 13.6 | 93 | 179 | 6 | n/a |
+| Alterac Mountains Horde grave | 590 | 15.5 | 702 | 1053 | 258 | yes | 446 | 6.4 | 97 | 832 | 4 | yes |
+| Z Durotar Sen'jin village to grind | 845 | 58.3 | 851 | 1265 | 504 | yes | 495 | 5.0 | 113 | 786 | 2 | yes |
+| Durotar Sen'jin village to grind | 836 | 39.0 | 815 | 1206 | 479 | yes | 441 | 3.6 | 113 | 785 | 2 | yes |
+| Z Orgrimmar to vendor | 600 | 1.5 | 0 | 0 | 0 | NO | 534 | 0.7 | 33 | 19 | 7 | NO |
+| Z Teldrassil to vendor | 520 | 1.0 | 0 | 0 | 0 | NO | 441 | 0.7 | 29 | 189 | 0 | yes |
+| Tanaris FP to ZF | 626 | 19.9 | 1047 | 330 | 479 | n/a | 524 | 7.8 | 85 | 95 | 5 | n/a |
+| Silithus Inn to AQ | 717 | 24.7 | 1392 | 257 | 589 | n/a | 1365 | 669.7 | 77 | 139 | 2 | n/a |
+| Kalimdor Search Barrens | 672 | 22.7 | 1363 | 2015 | 537 | yes | 425 | 9.1 | 33 | 1287 | 0 | yes |
+| Azeroth Dun morogh 1 | 706 | 33.9 | 548 | 809 | 272 | yes | 426 | 1.8 | 141 | 515 | 0 | yes |
+| Dun morogh Vendor to grind | 543 | 14.8 | 257 | 339 | 83 | yes | 474 | 0.9 | 57 | 303 | 1 | yes |
+| Azeroth Dun morogh 2 | 530 | 6.0 | 461 | 666 | 123 | yes | 436 | 4.4 | 25 | 504 | 0 | yes |
+| Z Dun morogh Vendor Rybrad Coldbank | 716 | 30.0 | 380 | 529 | 83 | yes | 477 | 22.4 | 101 | 428 | 9 | yes |
+| Azeroth Dun morogh Vendor Rybrad Coldbank | 642 | 29.8 | 380 | 529 | 83 | yes | 426 | 3.1 | 69 | 405 | 2 | yes |
+| Z Azshara issue no result | 426 | 1.0 | 32 | 49 | 15 | yes | 450 | 0.2 | 2 | 36 | 0 | yes |
+| Z Honor hold issue no result | 483 | 0.2 | 1 | 0 | 0 | NO | 464 | 0.2 | 1 | 0 | 0 | NO |
+| Duskwood issue | 465 | 1.0 | 68 | 9 | 18 | n/a | 477 | 0.2 | 2 | 4 | 0 | n/a |
+| Loch Modan building Yanni Stoutheart | 519 | 24.2 | 119 | 36 | 51 | n/a | 454 | 0.9 | 33 | 31 | 1 | n/a |
+| Loch Modan building innkeeper | 519 | 35.1 | 133 | 50 | 65 | n/a | 464 | 0.7 | 53 | 26 | 3 | n/a |
+| Loch Modan building Vidra Heartstove | 506 | 21.4 | 113 | 33 | 43 | n/a | 430 | 1.2 | 33 | 28 | 1 | n/a |
+| Dun morogh building Grundel Harkin | 614 | 9.2 | 0 | 0 | 0 | n/a | 444 | 2.2 | 21 | 7 | 0 | n/a |
+| Dun morogh building Grundel Harkin reverse | 553 | 0.4 | 0 | 0 | 0 | n/a | 448 | 0.2 | 2 | 2 | 0 | n/a |
+| Dun morogh Coldridge pass - unable to find | 595 | 28.0 | 557 | 153 | 273 | n/a | 491 | 1.8 | 141 | 108 | 1 | n/a |
+| Dun morogh Coldridge pass | 608 | 28.4 | 548 | 153 | 272 | n/a | 488 | 1.7 | 141 | 107 | 2 | n/a |
+| Cross-zone Elwynn to Redridge | 779 | 0.3 | 0 | 0 | 0 | NO | 3233 | 75.5 | 197 | 2150 | 2 | NO |
+| Hinterlands 1 water issue | 444 | 0.7 | 37 | 10 | 13 | n/a | 438 | 0.3 | 2 | 10 | 0 | n/a |
+| Hinterlands 2 water issue | 467 | 2.4 | 114 | 15 | 63 | n/a | 473 | 0.5 | 2 | 11 | 0 | n/a |
+| Azshara 1 | 490 | 10.2 | 389 | 181 | 166 | n/a | 490 | 1.8 | 41 | 99 | 0 | n/a |
+| Ammen Vale | FAIL | - | - | - | - | - | FAIL | - | - | - | - | - |
+| Hellfire 1 | FAIL | - | - | - | - | - | FAIL | - | - | - | - | - |
+| Hellfire 2 | FAIL | - | - | - | - | - | FAIL | - | - | - | - | - |
+| Zul'Drak stairs | FAIL | - | - | - | - | - | FAIL | - | - | - | - | - |
+| Zul'Drak stairs reverse | FAIL | - | - | - | - | - | FAIL | - | - | - | - | - |

--- a/benchmark_results/pathing_navmesh_20260719_224745.md
+++ b/benchmark_results/pathing_navmesh_20260719_224745.md
@@ -1,0 +1,77 @@
+# PathingAPI Benchmark - Navmesh
+
+| Setting | Value |
+|---|---|
+| Date | 2026-07-19 22:47:45 |
+| Base URL | http://127.0.0.1:5001 |
+| Routes | 36 |
+| Iterations | 4 (1 cold + 3 warm) |
+| Cold timings valid | True |
+| Total duration | 23.7s |
+
+## Cold (first query after Reset, includes chunk load)
+
+| Min | Max | Avg | Median | P95 | P99 | Samples |
+|---|---|---|---|---|---|---|
+| 425.1ms | 3233.2ms | 605.3ms | 473.2ms | 1365.0ms | 3233.2ms | 31 |
+
+## Warm
+
+| Min | Max | Avg | Median | P95 | P99 | Samples |
+|---|---|---|---|---|---|---|
+| 0.2ms | 690.5ms | 27.3ms | 1.7ms | 75.3ms | 690.5ms | 93 |
+
+## Failed
+
+- Ammen Vale: HTTP InternalServerError
+- Hellfire 1: HTTP InternalServerError
+- Hellfire 2: HTTP InternalServerError
+- Zul'Drak stairs: HTTP InternalServerError
+- Zul'Drak stairs reverse: HTTP InternalServerError
+
+## Endpoint not reached (last point > 5yd from target)
+
+- Z Orgrimmar to vendor: 33 points
+- Z Honor hold issue no result: 1 points
+- Cross-zone Elwynn to Redridge: 197 points
+
+## Per-route results
+
+| Route | Cold ms | Warm Min | Warm Avg | Warm Med | Warm Max | Pts | Len yd | Corners | Max Crn deg | Reached |
+|---|---|---|---|---|---|---|---|---|---|---|
+| Elwynn vendor to path | 801.8 | 1.0 | 1.1 | 1.0 | 1.5 | 13 | 119.8 | 0 | 23.3 | yes |
+| Z Elwynn vendor to path | 788.8 | 1.1 | 1.6 | 1.3 | 2.2 | 13 | 119.8 | 0 | 23.3 | yes |
+| Z Coldridge to 5_gnome | 503.5 | 5.1 | 5.9 | 5.2 | 7.4 | 201 | 957.3 | 0 | 23.9 | yes |
+| Redridge Grave to North | 514.6 | 11.8 | 13.6 | 12.8 | 16.2 | 93 | 179.1 | 6 | 96.8 | n/a |
+| Alterac Mountains Horde grave | 445.8 | 6.0 | 6.4 | 6.5 | 6.9 | 97 | 831.8 | 4 | 147.5 | yes |
+| Z Durotar Sen'jin village to grind | 495.3 | 4.3 | 5.0 | 4.4 | 6.4 | 113 | 785.9 | 2 | 36.0 | yes |
+| Durotar Sen'jin village to grind | 441.1 | 3.6 | 3.6 | 3.6 | 3.8 | 113 | 785.4 | 2 | 26.7 | yes |
+| Z Orgrimmar to vendor | 534.3 | 0.7 | 0.7 | 0.7 | 0.8 | 33 | 19.2 | 7 | 180.0 | NO |
+| Z Teldrassil to vendor | 440.7 | 0.6 | 0.7 | 0.7 | 0.7 | 29 | 189.0 | 0 | 16.5 | yes |
+| Tanaris FP to ZF | 524.1 | 7.6 | 7.8 | 7.9 | 8.0 | 85 | 95.3 | 5 | 34.0 | n/a |
+| Silithus Inn to AQ | 1365.0 | 644.4 | 669.7 | 674.2 | 690.5 | 77 | 139.4 | 2 | 40.3 | n/a |
+| Kalimdor Search Barrens | 425.1 | 9.0 | 9.1 | 9.1 | 9.2 | 33 | 1287.2 | 0 | 16.4 | yes |
+| Azeroth Dun morogh 1 | 426.4 | 1.7 | 1.8 | 1.8 | 1.9 | 141 | 515.2 | 0 | 24.0 | yes |
+| Dun morogh Vendor to grind | 474.3 | 0.9 | 0.9 | 0.9 | 1.0 | 57 | 303.4 | 1 | 37.5 | yes |
+| Azeroth Dun morogh 2 | 436.0 | 3.6 | 4.4 | 4.4 | 5.1 | 25 | 504.3 | 0 | 20.7 | yes |
+| Z Dun morogh Vendor Rybrad Coldbank | 476.9 | 19.7 | 22.4 | 20.1 | 27.5 | 101 | 428.2 | 9 | 180.0 | yes |
+| Azeroth Dun morogh Vendor Rybrad Coldbank | 426.0 | 1.7 | 3.1 | 2.4 | 5.1 | 69 | 405.3 | 2 | 36.9 | yes |
+| Z Azshara issue no result | 449.8 | 0.2 | 0.2 | 0.2 | 0.3 | 2 | 35.8 | 0 | 0.0 | yes |
+| Z Honor hold issue no result | 463.8 | 0.2 | 0.2 | 0.2 | 0.3 | 1 | 0.0 | 0 | 0.0 | NO |
+| Duskwood issue | 477.0 | 0.2 | 0.2 | 0.2 | 0.3 | 2 | 4.4 | 0 | 0.0 | n/a |
+| Loch Modan building Yanni Stoutheart | 454.3 | 0.7 | 0.9 | 0.8 | 1.0 | 33 | 30.8 | 1 | 35.6 | n/a |
+| Loch Modan building innkeeper | 464.4 | 0.6 | 0.7 | 0.7 | 0.7 | 53 | 26.3 | 3 | 70.4 | n/a |
+| Loch Modan building Vidra Heartstove | 430.4 | 1.1 | 1.2 | 1.1 | 1.4 | 33 | 28.2 | 1 | 42.8 | n/a |
+| Dun morogh building Grundel Harkin | 444.0 | 2.1 | 2.2 | 2.1 | 2.3 | 21 | 7.1 | 0 | 12.4 | n/a |
+| Dun morogh building Grundel Harkin reverse | 447.5 | 0.2 | 0.2 | 0.2 | 0.3 | 2 | 1.9 | 0 | 0.0 | n/a |
+| Dun morogh Coldridge pass - unable to find | 490.5 | 1.7 | 1.8 | 1.8 | 1.8 | 141 | 107.5 | 1 | 52.4 | n/a |
+| Dun morogh Coldridge pass | 487.9 | 1.6 | 1.7 | 1.6 | 1.8 | 141 | 107.0 | 2 | 52.4 | n/a |
+| Cross-zone Elwynn to Redridge | 3233.2 | 72.7 | 75.5 | 75.3 | 78.6 | 197 | 2149.6 | 2 | 31.5 | NO |
+| Hinterlands 1 water issue | 438.2 | 0.2 | 0.3 | 0.2 | 0.4 | 2 | 9.5 | 0 | 0.0 | n/a |
+| Hinterlands 2 water issue | 473.2 | 0.3 | 0.5 | 0.4 | 1.0 | 2 | 11.1 | 0 | 0.0 | n/a |
+| Azshara 1 | 490.0 | 1.6 | 1.8 | 1.8 | 2.1 | 41 | 98.6 | 0 | 20.4 | n/a |
+| Ammen Vale | FAIL | - | - | - | - | - | - | - | - | HTTP InternalServerError |
+| Hellfire 1 | FAIL | - | - | - | - | - | - | - | - | HTTP InternalServerError |
+| Hellfire 2 | FAIL | - | - | - | - | - | - | - | - | HTTP InternalServerError |
+| Zul'Drak stairs | FAIL | - | - | - | - | - | - | - | - | HTTP InternalServerError |
+| Zul'Drak stairs reverse | FAIL | - | - | - | - | - | - | - | - | HTTP InternalServerError |

--- a/benchmark_results/pathing_spotastar_20260719_224721.md
+++ b/benchmark_results/pathing_spotastar_20260719_224721.md
@@ -1,0 +1,78 @@
+# PathingAPI Benchmark - SpotAStar
+
+| Setting | Value |
+|---|---|
+| Date | 2026-07-19 22:47:21 |
+| Base URL | http://127.0.0.1:5001 |
+| Routes | 36 |
+| Iterations | 4 (1 cold + 3 warm) |
+| Cold timings valid | True |
+| Total duration | 24.3s |
+
+## Cold (first query after Reset, includes chunk load)
+
+| Min | Max | Avg | Median | P95 | P99 | Samples |
+|---|---|---|---|---|---|---|
+| 426.4ms | 1317.4ms | 645.7ms | 599.8ms | 1018.1ms | 1317.4ms | 31 |
+
+## Warm
+
+| Min | Max | Avg | Median | P95 | P99 | Samples |
+|---|---|---|---|---|---|---|
+| 0.2ms | 81.1ms | 20.7ms | 21.2ms | 63.1ms | 81.1ms | 93 |
+
+## Failed
+
+- Ammen Vale: HTTP InternalServerError
+- Hellfire 1: HTTP InternalServerError
+- Hellfire 2: HTTP InternalServerError
+- Zul'Drak stairs: HTTP InternalServerError
+- Zul'Drak stairs reverse: HTTP InternalServerError
+
+## Endpoint not reached (last point > 5yd from target)
+
+- Z Orgrimmar to vendor: 0 points
+- Z Teldrassil to vendor: 0 points
+- Z Honor hold issue no result: 1 points
+- Cross-zone Elwynn to Redridge: 0 points
+
+## Per-route results
+
+| Route | Cold ms | Warm Min | Warm Avg | Warm Med | Warm Max | Pts | Len yd | Corners | Max Crn deg | Reached |
+|---|---|---|---|---|---|---|---|---|---|---|
+| Elwynn vendor to path | 1018.1 | 18.1 | 23.3 | 21.3 | 30.5 | 134 | 192.9 | 57 | 135.0 | yes |
+| Z Elwynn vendor to path | 939.4 | 21.2 | 23.3 | 22.8 | 26.1 | 134 | 192.9 | 57 | 135.0 | yes |
+| Z Coldridge to 5_gnome | 1317.4 | 65.1 | 73.2 | 73.2 | 81.1 | 915 | 1354.7 | 374 | 135.0 | yes |
+| Redridge Grave to North | 730.5 | 52.7 | 61.3 | 63.1 | 68.0 | 728 | 193.7 | 336 | 180.0 | n/a |
+| Alterac Mountains Horde grave | 590.0 | 9.7 | 15.5 | 10.0 | 26.8 | 702 | 1052.6 | 258 | 135.0 | yes |
+| Z Durotar Sen'jin village to grind | 844.9 | 57.3 | 58.3 | 57.7 | 59.8 | 851 | 1265.3 | 504 | 136.8 | yes |
+| Durotar Sen'jin village to grind | 836.4 | 37.5 | 39.0 | 38.5 | 41.0 | 815 | 1206.3 | 479 | 136.8 | yes |
+| Z Orgrimmar to vendor | 599.8 | 0.7 | 1.5 | 0.9 | 2.9 | 0 | 0.0 | 0 | 0.0 | NO |
+| Z Teldrassil to vendor | 519.7 | 0.8 | 1.0 | 0.9 | 1.3 | 0 | 0.0 | 0 | 0.0 | NO |
+| Tanaris FP to ZF | 625.7 | 17.4 | 19.9 | 17.5 | 24.7 | 1047 | 330.5 | 479 | 146.3 | n/a |
+| Silithus Inn to AQ | 716.9 | 23.6 | 24.7 | 24.5 | 25.9 | 1392 | 257.2 | 589 | 123.7 | n/a |
+| Kalimdor Search Barrens | 671.7 | 21.2 | 22.7 | 21.6 | 25.3 | 1363 | 2015.4 | 537 | 135.0 | yes |
+| Azeroth Dun morogh 1 | 706.5 | 27.7 | 33.9 | 30.7 | 43.4 | 548 | 808.8 | 272 | 135.0 | yes |
+| Dun morogh Vendor to grind | 543.2 | 14.0 | 14.8 | 14.6 | 15.8 | 257 | 339.2 | 83 | 135.0 | yes |
+| Azeroth Dun morogh 2 | 530.3 | 5.8 | 6.0 | 5.9 | 6.5 | 461 | 666.1 | 123 | 135.0 | yes |
+| Z Dun morogh Vendor Rybrad Coldbank | 716.4 | 29.2 | 30.0 | 30.4 | 30.5 | 380 | 529.3 | 83 | 135.0 | yes |
+| Azeroth Dun morogh Vendor Rybrad Coldbank | 642.0 | 28.9 | 29.8 | 29.6 | 31.0 | 380 | 529.3 | 83 | 135.0 | yes |
+| Z Azshara issue no result | 426.4 | 0.9 | 1.0 | 1.0 | 1.0 | 32 | 48.6 | 15 | 135.0 | yes |
+| Z Honor hold issue no result | 482.6 | 0.2 | 0.2 | 0.2 | 0.2 | 1 | 0.0 | 0 | 0.0 | NO |
+| Duskwood issue | 465.5 | 1.0 | 1.0 | 1.0 | 1.1 | 68 | 8.7 | 18 | 123.7 | n/a |
+| Loch Modan building Yanni Stoutheart | 519.2 | 23.4 | 24.2 | 24.1 | 25.2 | 119 | 36.1 | 51 | 175.2 | n/a |
+| Loch Modan building innkeeper | 519.3 | 34.0 | 35.1 | 35.0 | 36.3 | 133 | 50.5 | 65 | 176.9 | n/a |
+| Loch Modan building Vidra Heartstove | 506.2 | 21.2 | 21.4 | 21.4 | 21.5 | 113 | 32.8 | 43 | 175.2 | n/a |
+| Dun morogh building Grundel Harkin | 614.1 | 7.7 | 9.2 | 9.0 | 11.1 | 0 | 0.0 | 0 | 0.0 | n/a |
+| Dun morogh building Grundel Harkin reverse | 552.6 | 0.4 | 0.4 | 0.4 | 0.5 | 0 | 0.0 | 0 | 0.0 | n/a |
+| Dun morogh Coldridge pass - unable to find | 594.8 | 27.6 | 28.0 | 28.2 | 28.4 | 557 | 152.9 | 273 | 146.3 | n/a |
+| Dun morogh Coldridge pass | 607.9 | 28.2 | 28.4 | 28.2 | 28.7 | 548 | 153.4 | 272 | 146.3 | n/a |
+| Cross-zone Elwynn to Redridge | 779.0 | 0.2 | 0.3 | 0.3 | 0.4 | 0 | 0.0 | 0 | 0.0 | NO |
+| Hinterlands 1 water issue | 444.3 | 0.6 | 0.7 | 0.7 | 0.8 | 37 | 10.3 | 13 | 146.3 | n/a |
+| Hinterlands 2 water issue | 467.1 | 2.1 | 2.4 | 2.1 | 3.1 | 114 | 14.8 | 63 | 146.3 | n/a |
+| Azshara 1 | 490.5 | 8.7 | 10.2 | 10.1 | 11.9 | 389 | 181.1 | 166 | 112.6 | n/a |
+| Ammen Vale | FAIL | - | - | - | - | - | - | - | - | HTTP InternalServerError |
+| Hellfire 1 | FAIL | - | - | - | - | - | - | - | - | HTTP InternalServerError |
+| Hellfire 2 | FAIL | - | - | - | - | - | - | - | - | HTTP InternalServerError |
+| Zul'Drak stairs | FAIL | - | - | - | - | - | - | - | - | HTTP InternalServerError |
+| Zul'Drak stairs reverse | FAIL | - | - | - | - | - | - | - | - | HTTP InternalServerError |


### PR DESCRIPTION
## Summary
`--engines SpotAStar,Navmesh` runs the suite per engine (runtime switch via `POST api/PPather/Engine`) and writes a side-by-side `comparison_*.md` next to the per-engine reports. Corpus +6: the five previously-commented indoor building routes (multi-floor Z coverage) and a 2500yd cross-zone Elwynn→Redridge haul.

Two engine fixes the first comparison runs surfaced:
- **CPOP validation excludes endpoints** — re-projection could drift the final point past the 5yd arrival radius.
- **z=0 endpoints seed through `Search.CreateWorldLocation`** before the navmesh resolver — the column scan alone picks the *highest* poly, which over the Goldshire path is a **tree canopy**, sending the query to an unreachable island. The spot pipeline's canopy/terrain heuristics already solve this; now both engines share cold-start semantics.

## Committed steady-state comparison (33 measurable routes, 4 iters)
| Engine | OK | **Reached** | Cold Med | Warm Med | Warm P95 | Avg Len | **Avg Corners** |
|---|---|---|---|---|---|---|---|
| SpotAStar | 31/36 | 13/17 | 600ms | 21.2ms | 63ms | 447yd | **204** |
| Navmesh | 31/36 | **14/17** | 473ms | **1.7ms** | 75ms | 332yd | **2** |

Navmesh-only wins: Teldrassil-Z reached, Grundel Harkin building paths, cross-zone partial (2150yd where spot returns nothing, converging via background bake).

## Flip-gate status (PR-8 readiness)
- ✅ Success ≥ spot (superior: 14/17 vs 13/17)
- ✅ Warm P95 ≤ 150ms (75ms; med 12× faster)
- ✅ Path length within +10% (−26%, funnel-shorter)
- ✅ Corner metrics (2 vs 204 — the WASD payoff)
- ⚠️ **Open**: Silithus→AQ truncates w/ 670ms warm (frontier loop re-spending budget; suspect 55° slope band at the gates ramp — investigate with the Watch navmesh overlay); Orgrimmar vendor fails on **both** engines (not a regression)
- ⏳ Two 30-min unattended grind soaks (user-run) before the default flip

🤖 Generated with [Claude Code](https://claude.com/claude-code)