### PR TITLE
feat: multi-era navmesh and Leaflet scaffolding (1/3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -315,3 +315,8 @@ PathingAPI/data_config.json
 Json/PathInfo/navmesh/
 # Local-only working files (benchmark reports, scratch) - never committed
 local/
+
+# Locally built StormLib for macOS/Linux (scripts/build-stormlib-unix.sh).
+# Host-specific native binary; the Windows DLLs are committed, these are not.
+PPather/MPQ/libstorm.dylib
+PPather/MPQ/libstorm.so

--- a/Benchmarks/CLAUDE.md
+++ b/Benchmarks/CLAUDE.md
@@ -1,0 +1,58 @@
+# Benchmarks
+
+BenchmarkDotNet suites plus several custom CLI modes. Always Release.
+
+```powershell
+dotnet run --project Benchmarks -c Release                       # BenchmarkDotNet switcher
+dotnet run --project Benchmarks -c Release -- --bake-profile <label> [iterations]
+dotnet run --project Benchmarks -c Release -- --alloc-profile
+dotnet run --project Benchmarks -c Release -- --dump-geometry [outdir]
+dotnet run --project Benchmarks -c Release -- --pather-benchmark <baseUrl> [iters] [label] --engines SpotAStar,Navmesh
+```
+
+## `--bake-profile` is the byte-identity gate
+
+This is the regression test for any change under `PPather/Triangles` or
+`PPather/Navmesh`. It bakes a fixed 6-tile corpus and writes
+`local/benchmark_results/bake_<label>_*.md` with cold/warm timings, triangle counts,
+allocations **and a per-tile SHA-256**. Those hashes must not move for the precata era:
+
+| tile | hash |
+|---|---|
+| elwynn-open | `6d6edc442008b805` |
+| stormwind-wmo | `c3f074b363b36063` |
+| dunmorogh-indoor | `34a1a2d4f25ad55b` |
+| barrens-open | `12c83529658aba79` |
+| durotar-water | `fb06c81c3603f8e4` |
+| orgrimmar-wmo | `a64ee4ee73bb3e33` |
+
+`a64ee4ee73bb3e33` is orgrimmar's tile hash, not a digest of the whole corpus — all six
+are the gate.
+
+## Layout
+
+```
+Navmesh/NavmeshCorpus.cs      the 6 corpus tiles + GeometryFixture (per-continent world)
+Navmesh/BakeProfiler.cs       --bake-profile
+Navmesh/AllocProfiler.cs      --alloc-profile
+Navmesh/GeometryDumper.cs     --dump-geometry (rcdump for external inspection)
+Navmesh/Navmesh_*.cs          BenchmarkDotNet tile extract / bake / MPQ load
+PathingAPIBenchmark.cs        --pather-benchmark, drives a running server over HTTP
+```
+
+## Things that will bite you
+
+**BenchmarkDotNet runs from a generated temp directory**, so `DataConfig`'s relative
+Root (`..\json`) resolves to nothing. `NavmeshCorpus.SetWorkingDirectory()` chdirs into
+`HeadlessServer` first; every later relative path resolves against *that*, so use
+`SolutionRoot()` for anything written back to the repo.
+
+**`GeometryFixture` defaults to `wrath`** and needs that client's archives in
+`Json/MPQ`. It deliberately reuses one triangle world across iterations — call `Evict`
+for a cold ADT read without paying archive-open again.
+
+**`delaunayHull: Removing dangling face` is normal.** DotRecast emits it on healthy
+tiles; real failures are on stdout, not stderr.
+
+**Getting a baseline without mutating git:** `git show HEAD:<path>` into the scratchpad,
+swap files, re-run, swap back — back up your edits first.

--- a/BlazorServer/CLAUDE.md
+++ b/BlazorServer/CLAUDE.md
@@ -1,0 +1,53 @@
+# BlazorServer — the bot, with a web UI
+
+The main entry point. Composes `Core` + `Game` + `Frontend` into a running bot and
+serves the browser UI on **:5000**. Almost no logic of its own — if you are changing
+behaviour, the change usually belongs in `Core`, and if you are changing a page, in
+`Frontend`.
+
+```
+Program.cs                  host + DI composition
+DependencyInjection.cs      wires Core/Game/Frontend services
+MdnsAdvertisingService.cs   advertises http://wowbot.local over mDNS
+app.manifest                per-monitor DPI awareness (required for correct capture)
+addon_config.json           addon layout, written by the in-app configurator
+frame_config.json           screen frame rectangles, written by the configurator
+data_config.json            DataConfig Root for this host
+appsettings.json            Pathing / Navmesh / SplineFollower options
+run.bat / build.bat         opens the browser, then `dotnet run -c Release --no-build`
+```
+
+## Running
+
+```powershell
+.\build.bat
+.\run.bat [-- args]
+```
+
+`run.bat` launches `http://localhost:5000` first, then starts the host with
+`--no-build`, so **build first** or you run a stale binary.
+
+## Things that will bite you
+
+**The `*.json` config files here are live state, not just settings.**
+`addon_config.json` and `frame_config.json` are rewritten by the in-app configurator
+against the user's actual screen. Do not hand-edit them expecting them to survive, and
+do not treat a diff in them as a code change.
+
+**`data_config.json` decides where all data comes from**, and it is read from the
+**process working directory** — so this file, not the repo root's, is what a running
+BlazorServer uses. See `DataConfig/CLAUDE.md`.
+
+**DPI awareness is load-bearing.** `app.manifest` declares `PerMonitor` /
+`dpiAware=true`. Without it the captured screen rectangle does not match what the addon
+draws, and every pixel read is wrong. Do not drop the manifest to "simplify" packaging.
+
+**`out*.log` files litter this directory.** They are gitignored (`*.log`) and are
+Serilog output from previous runs — not fixtures. Ignore them when scanning the folder.
+
+**mDNS is best-effort.** `MdnsAdvertisingService` learns the real Kestrel port from the
+`ApplicationStarted` event rather than assuming 5000, and hostname comes from
+`MDNS_HOSTNAME`. A failure here must never stop the bot starting.
+
+**Stopping must release input before tearing down components.** See `Game/CLAUDE.md` —
+ordering at shutdown is how held movement keys get stranded.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,14 +37,25 @@ Existing `.editorconfig` defines style rules. Key conventions:
 - Prefer braces for control statements
 
 ## Project Structure
-- `BlazorServer/` - Main web application entry point
-- `Core/` - Core business logic
-- `Game/` - Game interaction layer
-- `Frontend/` - Blazor UI components
-- `PPather/` - Pathfinding implementation
-- `Benchmarks/` - BenchmarkDotNet performance tests
-- `SharedLib/` - Shared utilities
-- `WinAPI/` - Windows API interop
+Directories marked ✎ have their own `CLAUDE.md` with the gotchas that live there - read it
+before working in one.
+
+- `BlazorServer/` ✎ - Main entry point: bot + web UI on :5000
+- `HeadlessServer/` ✎ - Same bot, CLI only; benchmarks chdir here
+- `Core/` ✎ - Core business logic (GOAP, goals, requirements, input)
+- `Game/` ✎ - WoW process, input (stateful - read before touching), screen contracts
+- `Frontend/` ✎ - Blazor UI shared by BlazorServer and PathingAPI
+- `PPather/` ✎ - Pathfinding (DotRecast navmesh + legacy spot A*, MPQ reading)
+- `PathingAPI/` ✎ - Standalone pathing server, bake host, Leaflet map
+- `DataConfig/` ✎ - Every on-disk path; era vs client partitioning
+- `Benchmarks/` ✎ - BenchmarkDotNet + the `--bake-profile` byte-identity gate
+- `CoreTests/` ✎ - Integration test suites
+- `Utilities/` ✎ - Offline data tools (BakeTool, ReadDBC_CSV, ...) - **not in the .sln**
+- `scripts/` ✎ - Data generation and CDN upload/download
+- `Addons/DataToColor/` ✎ - The in-game Lua addon
+- `SharedLib/` ✎ - Shared bottom layer (ClientVersion, startup options, DBC models)
+- `WowheadDB/` ✎ - Zone data model (Area/NPC/Node); field names are the wire format
+- `WinAPI/` ✎ - Win32 interop; the only Windows-only dependency, keep it isolated
 
 ## Dependencies
 Central package management via `Directory.Packages.props`:

--- a/Core/Addon/PlayerReader.cs
+++ b/Core/Addon/PlayerReader.cs
@@ -136,6 +136,8 @@ public sealed partial class PlayerReader : IMouseOverReader, IReader
         UnitRace.Troll => PlayerFaction.Horde,
         UnitRace.BloodElf => PlayerFaction.Horde,
         UnitRace.Goblin => PlayerFaction.Horde,
+        UnitRace.PandarenA => PlayerFaction.Alliance,
+        UnitRace.PandarenH => PlayerFaction.Horde,
         _ => throw new ArgumentNullException(nameof(Faction)),
     };
 

--- a/Core/AddonComponent/UnitRace.cs
+++ b/Core/AddonComponent/UnitRace.cs
@@ -14,5 +14,9 @@ public enum UnitRace
     Goblin,
     BloodElf,
     Draenei,
-    Worgen = 22
+    Worgen = 22,
+    Gilnean = 23,
+    Pandaren = 24,
+    PandarenA = 25,
+    PandarenH = 26
 }

--- a/Core/CLAUDE.md
+++ b/Core/CLAUDE.md
@@ -1,0 +1,58 @@
+# Core — bot logic
+
+The decision loop. Reads game state produced by the `DataToColor` addon (pixels →
+`AddonDataProvider` → `PlayerReader`), picks a goal via GOAP, and drives input.
+
+## Layout
+
+```
+GOAP/                GoapAgent, goal selection, world state
+Goals/               28 goals (Combat, Pull, Loot, Skin, AdhocNPC, FollowRoute, WalkToCorpse, ...)
+GoalsFactory/        wires goals from the class profile
+GoalsComponent/      shared machinery: CastingHandler, Navigation, MountHandler, CombatTracker
+Requirement/         the class-profile expression language (see below)
+RPN/                 expression parsing for Requirement
+ClassConfig/         class profile model (Json/class/*.json)
+AddonComponent/      PlayerReader and the typed views over addon data
+AddonDataProvider/   pixel capture -> ints
+Input/               keyboard/mouse simulation
+PPather/             pathing clients: LocalPathingApi, RemotePathingAPI (V1), RemotePathingAPIV3
+Path/                route model, RouteInfo
+WowheadAPI/          per-version wowhead/zamimg URLs
+```
+
+## Rules that matter
+
+**Store almost no state in goals or components.** The app can be started at any moment —
+mid-combat, mid-flight, dead — and must adapt to whatever the game reports. Anything
+cached is a chance to be wrong about the live world. Prefer re-reading `PlayerReader`
+over remembering.
+
+**User-facing API changes must update `README.md`.** Any add/remove/rename in
+`Core/Requirement/RequirementFactory.cs` changes the class-profile language that users
+write, so the README's requirement tables are part of the change, not follow-up.
+
+**Input is latched — release what you press.** Runaway forward movement and endless
+jumping have both been caused by an early-return skipping a `KeyUp`, or a reset that
+cleared state without releasing the key. When touching `Input/` or goal exits, make the
+release path unconditional.
+
+**Navigation re-requests constantly.** `Navigation` asks the pather again every few
+seconds while walking, so a single failed request is not fatal — but an engine that
+returns a *wrong* path (rather than none) is, and one that returns empty on a rate limit
+is indistinguishable from "no route exists".
+
+**`PathsAreSmoothed` gates route thinning.** The navmesh returns a dense funnel path;
+`SimplifyRouteToWaypoint`/`ReduceByDistance` were tuned for sparse SpotAStar output and
+will gut it. Check the capability, not the engine type.
+
+## Pathing backends
+
+`DependencyInjection` picks one at startup: `RemoteV3` (AmeisenNavigation over AnTCP) →
+`RemoteV1` (PathingAPI over HTTP) → `Local` (in-process `PPatherService`). Local +
+`Pathing:Engine=Navmesh` is the default and needs no game archives — see
+`PPather/CLAUDE.md`.
+
+**Do not gate behaviour on a hardcoded `ClientVersion` list.** `WApi.cs` and the Leaflet
+UI both went stale that way. Pair each modern Classic version with its `Legacy_*` twin,
+or derive from `DataConfig.ClientEra`.

--- a/Core/Database/AreaDB.cs
+++ b/Core/Database/AreaDB.cs
@@ -83,6 +83,25 @@ public sealed class AreaDB : IDisposable
         resetEvent.Set();
     }
 
+    /// <summary>
+    /// Reads an optional json file. Absent is a normal state here, not an error, so it
+    /// is reported once at Debug rather than raised - the caller substitutes a default.
+    /// </summary>
+    private T? ReadJsonOrNull<T>(string path, JsonSerializerSettings? settings = null)
+    {
+        if (!System.IO.File.Exists(path))
+        {
+            if (logger.IsEnabled(LogLevel.Debug))
+                logger.LogDebug("AreaDB: no {Path}", path);
+
+            return default;
+        }
+
+        return settings is null
+            ? JsonConvert.DeserializeObject<T>(ReadAllText(path))
+            : JsonConvert.DeserializeObject<T>(ReadAllText(path), settings);
+    }
+
     private void ReadArea()
     {
         resetEvent.Wait();
@@ -91,19 +110,32 @@ public sealed class AreaDB : IDisposable
         {
             try
             {
-                CurrentArea = JsonConvert.DeserializeObject<Area>(
-                    ReadAllText(Join(dataConfig.ExpArea, $"{areaId}.json")));
+                // Both files are optional enrichment and both are generated per client,
+                // so a zone or a whole map legitimately has none - Json/area/<exp> is
+                // scraped from Wowhead, npcspawnlocations from an emulator dump, and
+                // neither covers every map of every client. Previously a miss threw out
+                // of the whole block, so Changed never fired and the area data silently
+                // stopped updating for that map (hit on Kezan, map 648, which had no
+                // npcspawnlocations file).
+                CurrentArea = ReadJsonOrNull<Area>(Join(dataConfig.ExpArea, $"{areaId}.json"));
 
                 CurrentWorldMapArea = worldMapAreaDB.GetByAreaId(areaId);
 
                 Hitbox = worldMapAreaDB.GetByAreaIdHit(areaId);
 
-                var data = JsonConvert.DeserializeObject<Dictionary<int, Vector3[]>>(
-                    ReadAllText(Join(dataConfig.NpcSpawnLocations, $"{CurrentWorldMapArea.Value.MapID}.json")), npcJsonSettings);
+                NpcWorldLocations = FrozenDictionary<int, Vector3[]>.Empty;
 
-                NpcWorldLocations = data != null
-                    ? data.ToFrozenDictionary()
-                    : FrozenDictionary<int, Vector3[]>.Empty;
+                if (CurrentWorldMapArea.HasValue)
+                {
+                    var data = ReadJsonOrNull<Dictionary<int, Vector3[]>>(
+                        Join(dataConfig.NpcSpawnLocations, $"{CurrentWorldMapArea.Value.MapID}.json"),
+                        npcJsonSettings);
+
+                    if (data != null)
+                    {
+                        NpcWorldLocations = data.ToFrozenDictionary();
+                    }
+                }
 
                 Changed?.Invoke();
             }

--- a/Core/Database/CreatureDB.cs
+++ b/Core/Database/CreatureDB.cs
@@ -1,5 +1,8 @@
-﻿using SharedLib;
+using Microsoft.Extensions.Logging;
 
+using SharedLib;
+
+using System;
 using System.Collections.Frozen;
 
 using static Newtonsoft.Json.JsonConvert;
@@ -12,12 +15,35 @@ public sealed class CreatureDB
 {
     public FrozenDictionary<int, Creature> Entries { get; }
 
-    public CreatureDB(DataConfig dataConfig)
+    public CreatureDB(ILogger<CreatureDB> logger, DataConfig dataConfig)
     {
-        Creature[] creatures = DeserializeObject<Creature[]>(
-            ReadAllText(Join(dataConfig.ExpDbc, "creatures.json")))!;
+        string path = Join(dataConfig.ExpDbc, "creatures.json");
 
-        Entries = creatures
-            .ToFrozenDictionary(c => c.Entry, c => c);
+        // Degrade rather than throw, matching TalentDB's LoadJsonSafe. This data is
+        // optional enrichment - names for creature ids - and it is generated per client
+        // from an emulator world database, so a newly supported client legitimately has
+        // none yet. Throwing from the constructor kills the whole host at startup, which
+        // is how a missing legacy_mop/creatures.json took BlazorServer down.
+        // Qualified: both File and Path are imported statically and each has Exists.
+        if (!System.IO.File.Exists(path))
+        {
+            logger.LogWarning("Missing file: {Path}", path);
+            Entries = FrozenDictionary<int, Creature>.Empty;
+            return;
+        }
+
+        try
+        {
+            Creature[]? creatures = DeserializeObject<Creature[]>(ReadAllText(path));
+
+            Entries = creatures is null
+                ? FrozenDictionary<int, Creature>.Empty
+                : creatures.ToFrozenDictionary(c => c.Entry, c => c);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError("Failed to read {Path}: {Message}", path, ex.Message);
+            Entries = FrozenDictionary<int, Creature>.Empty;
+        }
     }
 }

--- a/Core/WowheadAPI/WApi.cs
+++ b/Core/WowheadAPI/WApi.cs
@@ -10,21 +10,33 @@ public sealed class WApi
 
     public WApi(StartupClientVersion scv)
     {
+        // Each case pairs the modern Classic client with its Legacy_* equivalent:
+        // they are the same expansion's content, so listing only the modern one
+        // silently sent every legacy client to the retail site.
         BaseUrl = scv.Version switch
         {
-            ClientVersion.SoM => "https://classic.wowhead.com",
-            ClientVersion.TBC => "https://tbc.wowhead.com",
-            ClientVersion.Wrath => "https://www.wowhead.com/wotlk",
-            ClientVersion.Cata => "https://www.wowhead.com/cata",
+            ClientVersion.SoM or ClientVersion.Legacy_Vanilla => "https://classic.wowhead.com",
+            ClientVersion.TBC or ClientVersion.Legacy_TBC => "https://tbc.wowhead.com",
+            ClientVersion.Wrath or ClientVersion.Legacy_Wrath => "https://www.wowhead.com/wotlk",
+            ClientVersion.Cata or ClientVersion.Legacy_Cata => "https://www.wowhead.com/cata",
+            ClientVersion.Mop or ClientVersion.Legacy_Mop => "https://www.wowhead.com/mop-classic",
             _ => "https://www.wowhead.com",
         };
 
         BaseUIMapUrl = scv.Version switch
         {
-            ClientVersion.SoM => "https://wow.zamimg.com/images/wow/classic/maps/enus/original/",
-            ClientVersion.TBC => "https://wow.zamimg.com/images/wow/tbc/maps/enus/original/",
-            ClientVersion.Wrath => "https://wow.zamimg.com/images/wow/wrath/maps/enus/original/",
-            ClientVersion.Cata => "https://wow.zamimg.com/images/wow/cata/maps/enus/original/",
+            ClientVersion.SoM or ClientVersion.Legacy_Vanilla => "https://wow.zamimg.com/images/wow/classic/maps/enus/original/",
+            ClientVersion.TBC or ClientVersion.Legacy_TBC => "https://wow.zamimg.com/images/wow/tbc/maps/enus/original/",
+            ClientVersion.Wrath or ClientVersion.Legacy_Wrath => "https://wow.zamimg.com/images/wow/wrath/maps/enus/original/",
+            ClientVersion.Cata or ClientVersion.Legacy_Cata => "https://wow.zamimg.com/images/wow/cata/maps/enus/original/",
+
+            // Mists deliberately uses the unversioned (retail) branch: zamimg has
+            // no mop/ or mop-classic/ directory, and the retail one does carry the
+            // Pandaria maps. Measured - area 5785 (The Jade Forest), 5840 (Vale of
+            // Eternal Blossoms) and 5841 (Kun-Lai Summit) all 200 there and 404
+            // under cata/. Do not "fix" this into a /mop/ path.
+            ClientVersion.Mop or ClientVersion.Legacy_Mop => "https://wow.zamimg.com/images/wow/maps/enus/original/",
+
             _ => "https://wow.zamimg.com/images/wow/maps/enus/original/",
         };
 

--- a/DataConfig/CLAUDE.md
+++ b/DataConfig/CLAUDE.md
@@ -1,0 +1,45 @@
+# DataConfig — where every data path comes from
+
+One class, and it is the single source of truth for **every** on-disk location the app
+reads or writes. Change a path here, not at a call site.
+
+`Root` comes from `data_config.json` in the **process working directory** (default
+`..\json`), so which file wins depends on which project you run. There is no env-var
+override; `BakeTool --root` exists precisely because of that.
+
+## Partitioning — three different keys, on purpose
+
+| key | properties | why |
+|---|---|---|
+| **era** (`ClientEra`) | `Navmesh`, `Leaflet`, `Road`, `AreaGrid` | clients that share a world share these |
+| **client** (`Exp`) | `ExpDbc`, `Subzones`, `ExpArea`, `NpcSpawnLocations`, `ExpHistory`, ... | id spaces and addon mappings differ per client |
+| **neither** | `MPQ`, `Class`, `Path`, `PPather` | one directory, whatever you point it at |
+
+`ClientEra`: vanilla/tbc/wrath and their `legacy_*` → `precata`; `cata`/`legacy_cata` →
+`cata`; `mop`/`legacy_mop` → `mop`.
+
+## Things that will bite you
+
+**`MPQ` is not era- or client-aware.** It is `Join(Root, "MPQ")` full stop, so a root
+can only hold one client's archives. Running `--exp=cata` against wrath archives loads
+wrath geometry silently and only fails on a continent wrath lacks. To use another
+client, build a mirror root: junction every `Json/*` subdir back to the repo except
+`MPQ`, which points at that client's `Data`.
+
+**`TileEra` is not `ClientEra`.** Minimap art is shared for `TileSharedContinents`
+(Northrend, Outland) on the **cata era only**, because that art was measured against
+precata and found effectively identical. Navmesh tiles are *never* shared — a stale mesh
+routes the bot through solid geometry. Mists is deliberately excluded from the sharing
+whitelist: its art was never compared. Measure before adding to it, and never turn it
+into a blanket "fall back if missing" — that would serve precata *Azeroth* art to a cata
+client, which is a different world.
+
+**`LeafletEras` / `HasLeaflet` gate the UI.** Gate on these, never on a
+`ClientVersion` list; the map stayed hidden on wrath/cata/mop for exactly that reason.
+
+**Keep the JS in step.** `Frontend/wwwroot/script/leaflet-watch.js` mirrors `ClientEra`,
+`TileEra`, `TileSharedContinents` and `LeafletEras`. Changing one without the other
+renders one era's art against another's data.
+
+**TFM is plain `net10.0`** so the pathing chain runs on macOS/Linux. Do not take a
+Windows-only dependency here.

--- a/DataConfig/DataConfig.cs
+++ b/DataConfig/DataConfig.cs
@@ -51,7 +51,16 @@ public sealed class DataConfig
     /// (leaflet tiles, navmesh, area grids, cost zones) live in one folder per
     /// era instead of one per expansion. Mirrors PPather NavmeshSettings.MeshEra:
     /// vanilla..wotlk (incl. their legacy_* clients) read the same pre-Cataclysm
-    /// world -> "precata"; Cataclysm rewrote it and switched MPQ -> CASC -> "cata".
+    /// world -> "precata"; Cataclysm rewrote it -> "cata".
+    ///
+    /// Mists is its OWN era rather than sharing Cataclysm's. The two are close but
+    /// not equal - comparing 40 Azeroth ADTs between a 4.3.4 and a 5.4.8 client,
+    /// 39 hash identically and one does not - and Mists adds a continent
+    /// (HawaiiMainLand / Pandaria) that Cataclysm has no geometry for at all.
+    /// Sharing the era would put both clients' bakes in the same
+    /// `<era>/<continent>/<hash>/` directory, so a Mists-baked tile could be
+    /// served to a Cataclysm user and vice versa.
+    ///
     /// An unrecognized client gets its own era.
     /// </summary>
     public static string ClientEra(string client)
@@ -60,10 +69,78 @@ public sealed class DataConfig
         {
             "vanilla" or "classic" or "som" or "tbc" or "bcc" or "wrath" or "wotlk"
                 or "legacy_vanilla" or "legacy_tbc" or "legacy_wrath" => "precata",
-            "cata" or "mop" or "legacy_cata" or "legacy_mop" => "cata",
+            "cata" or "legacy_cata" => "cata",
+            "mop" or "legacy_mop" => "mop",
             _ => client.ToLowerInvariant(),
         };
     }
+    /// <summary>
+    /// Continents whose minimap art a later era reuses from an earlier one
+    /// instead of regenerating it. See <see cref="TileEra"/>.
+    /// </summary>
+    public static readonly string[] TileSharedContinents = ["Northrend", "Expansion01"];
+
+    /// <summary>
+    /// Which era's leaflet tiles a continent is served from. Cataclysm rebuilt
+    /// the old world but left Northrend and Outland essentially as they were, so
+    /// those two read the precata tiles rather than duplicating ~1950 minimap
+    /// blocks per era.
+    ///
+    /// Measured against a 4.3.4 client with 3.3.5 as the control: Northrend has
+    /// the same 1131 blocks with 34/40 sampled images pixel-identical, and
+    /// Expansion01 shares 800 blocks with 38/40 identical. Azeroth managed 8/40
+    /// with 152 blocks that exist only in Cata, which is why the old world is
+    /// not on this list.
+    ///
+    /// TILES ONLY - deliberately not applied to the navmesh. The same comparison
+    /// found real geometry drift behind that near-identical art: Northrend ADTs
+    /// 29_11 and 30_11 carry thousands of M2 collision triangles the pre-Cata
+    /// client has no obstacle for, and most Outland ADTs differ in liquid. A
+    /// stale minimap block just looks slightly dated; a stale navmesh routes the
+    /// bot through something solid, so <see cref="Navmesh"/> stays per-era.
+    ///
+    /// Only the cata era inherits. Mists is deliberately excluded: its minimap art
+    /// has not been compared against precata the way Cataclysm's was, and guessing
+    /// would serve the wrong world's art. Measure first, then add "mop" here.
+    /// </summary>
+    public static string TileEra(string client, string continent)
+    {
+        string era = ClientEra(client);
+        if (era != "cata")
+        {
+            return era;
+        }
+
+        foreach (string shared in TileSharedContinents)
+        {
+            if (shared.Equals(continent, System.StringComparison.OrdinalIgnoreCase))
+                return "precata";
+        }
+
+        return era;
+    }
+
+    /// <summary>Leaflet tile directory for one continent, honouring <see cref="TileEra"/>.</summary>
+    public string LeafletFor(string continent) =>
+        Join(Root, "leaflet", TileEra(Exp, continent), continent);
+
+    /// <summary>
+    /// Geometry eras that have minimap tiles and a leaflet map config. Mirrors the
+    /// Configs blocks in Frontend/wwwroot/script/leaflet-watch.js: a client whose
+    /// era is missing there resolves to no config and renders a blank map, so the
+    /// UI gates on this rather than on a hand-listed set of client versions.
+    /// </summary>
+    public static readonly string[] LeafletEras = ["precata", "cata", "mop"];
+
+    /// <summary>
+    /// Whether this client has a leaflet map. Era-based on purpose - listing client
+    /// versions instead goes stale every time an era is added, which is exactly how
+    /// the map stayed gated to vanilla+TBC long after wrath, Cataclysm and Mists
+    /// worked. Only Retail and an unset version have no era here.
+    /// </summary>
+    public static bool HasLeaflet(string client) =>
+        System.Array.IndexOf(LeafletEras, ClientEra(client)) >= 0;
+
     [JsonIgnore]
     public string Subzones => Join(Root, "subzones", Exp);
 

--- a/DataConfig/DataConfig.csproj
+++ b/DataConfig/DataConfig.csproj
@@ -1,5 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- Plain net10.0, overriding the solution-wide net10.0-windows TFM: that TFM
+       exists for the bot's Windows Graphics Capture, which the pathing chain
+       never touches. Keeping this chain OS-neutral is what lets the navmesh be
+       baked/queried on macOS and Linux. A net10.0-windows project can reference
+       a net10.0 one, so the bot is unaffected.
+       See docs/headless-pathing-server-design.md §2 and §12. -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>

--- a/Frontend/CLAUDE.md
+++ b/Frontend/CLAUDE.md
@@ -1,0 +1,59 @@
+# Frontend — shared Blazor UI
+
+A razor class library shared by `BlazorServer` (the bot) and `PathingAPI` (the pathing
+server). Both host the same pages, so **anything added here must tolerate the other
+host**: PathingAPI has no `PlayerReader` and no game client, BlazorServer has no bake
+API.
+
+## Layout
+
+```
+DependencyInjection.cs   static file routes (/path, /tiles, /dbc, /area, ...)
+Pages/                   Leaflet, RecordPath, ClassConfig, ... (routable)
+Shared/MainLayout.razor  nav menu, incl. which items a client version gets
+Controllers/             Road / DangerZone / Path authoring endpoints
+wwwroot/script/
+  leaflet-watch.js       the map: eras, tile bases, zone/subzone resolution, POIs
+  leaflet-navmesh.js     navmesh tile overlay
+  leaflet-bake.js        bake controls
+  leaflet-zones.js       zone polygons
+  babylonjs.js           3D route view (PathingAPI only)
+```
+
+## Things that will bite you
+
+**Static file routes are order-sensitive.** `DependencyInjection` registers
+`/tiles/<continent>` for shared-art continents *before* the general `/tiles`. Reversing
+that serves the wrong era's art.
+
+**`PhysicalFileProvider` throws on a missing directory** — it does not create one. Use
+the `UseDataFolder` helper, which `CreateDirectory`s first. A missing folder here does
+not break one route, it kills host startup.
+
+**Never gate UI on a hardcoded client-version list.** Use `DataConfig.HasLeaflet(...)`
+(era-derived). The map and its nav entry were stuck on `SoM or TBC` long after wrath,
+cata and mop worked, which is exactly how that goes stale.
+
+**The JS mirrors `DataConfig` and must be kept in step.** `clientEra()`, `tileEra()`,
+`TILE_SHARED_CONTINENTS` and the `Configs` blocks in `leaflet-watch.js` duplicate
+`ClientEra` / `TileEra` / `TileSharedContinents` / `LeafletEras`. Change one, change both.
+
+**Tiles fall back to the CDN automatically.** `resolveTileBase()` HEAD-probes a few
+low-zoom local tiles per continent and uses `https://bot.tortoiseclothing.org/<era>`
+when they are absent. The candidate list has five entries because offset-cropped
+continents have no `z2x0y0`. The choice is made once at map load —
+`localStorage.leafletTilesLocal = '0'` forces the CDN.
+
+**Area names come from `WorldMapArea.json`, not `AreaTable.json`.** The worldmaparea
+carries subzone rows (name + `ParentAreaId` + bounds) when `Json/subzones/<exp>` existed
+at generation time. `AreaTable` is only a fallback for an era whose file predates that.
+
+**PathingAPI decides the era, not the URL.** `Pages/Leaflet.razor` in this project reads
+`PlayerReader.Version`; PathingAPI's copy reads `DataConfig.Exp`. Neither should trust
+the `{expansion}` route segment.
+
+## Editing JS
+
+`wwwroot/script/*.js` is served straight from disk — no bundler, no build step. A
+browser reload is enough; only C# changes need a rebuild. Cache-bust query strings
+(`?v=…`) are appended by the host.

--- a/Frontend/DependencyInjection.cs
+++ b/Frontend/DependencyInjection.cs
@@ -19,45 +19,61 @@ public static class DependencyInjection
         return services;
     }
 
+    /// <summary>
+    /// Serves a data folder, creating it when absent. <see cref="PhysicalFileProvider"/>
+    /// throws <see cref="DirectoryNotFoundException"/> on a missing root, which
+    /// takes down host startup rather than merely 404ing that route - and these
+    /// roots are era- and expansion-derived, so a client whose assets have not
+    /// been generated yet (a new era, or a fresh install with no leaflet tiles)
+    /// legitimately has none of them.
+    /// </summary>
+    private static void UseDataFolder(IApplicationBuilder app, string root, string requestPath)
+    {
+        Directory.CreateDirectory(root);
+
+        app.UseStaticFiles(new StaticFileOptions
+        {
+            FileProvider = new PhysicalFileProvider(root),
+            RequestPath = requestPath
+        });
+    }
+
     public static IApplicationBuilder UseCustomStaticFiles(this IApplicationBuilder app, IWebHostEnvironment env)
     {
         DataConfig dataConfig = app.ApplicationServices.GetRequiredService<DataConfig>();
 
-        app.UseStaticFiles(new StaticFileOptions
-        {
-            FileProvider = new PhysicalFileProvider(Path.Combine(env.ContentRootPath, dataConfig.Path)),
-            RequestPath = "/path"
-        });
+        UseDataFolder(app, Path.Combine(env.ContentRootPath, dataConfig.Path), "/path");
 
-        app.UseStaticFiles(new StaticFileOptions
+        // Continents whose art this era shares with an earlier one are served
+        // from that era's folder (see DataConfig.TileEra), so Northrend and
+        // Outland are not duplicated for Cataclysm. Registered BEFORE the
+        // general /tiles route below: static file middleware runs in order, so
+        // the more specific RequestPath has to be first to win.
+        foreach (string continent in DataConfig.TileSharedContinents)
         {
-            FileProvider = new PhysicalFileProvider(Path.Combine(env.ContentRootPath, dataConfig.Leaflet)),
-            RequestPath = "/tiles"
-        });
+            if (DataConfig.TileEra(dataConfig.Exp, continent) == DataConfig.ClientEra(dataConfig.Exp))
+            {
+                continue;
+            }
 
-        app.UseStaticFiles(new StaticFileOptions
-        {
-            FileProvider = new PhysicalFileProvider(Path.Combine(env.ContentRootPath, dataConfig.ExpDbc)),
-            RequestPath = "/dbc"
-        });
+            string shared = Path.Combine(env.ContentRootPath, dataConfig.LeafletFor(continent));
+            if (!Directory.Exists(shared))
+            {
+                continue;
+            }
 
-        app.UseStaticFiles(new StaticFileOptions
-        {
-            FileProvider = new PhysicalFileProvider(Path.Combine(env.ContentRootPath, dataConfig.ExpArea)),
-            RequestPath = "/area"
-        });
+            app.UseStaticFiles(new StaticFileOptions
+            {
+                FileProvider = new PhysicalFileProvider(shared),
+                RequestPath = "/tiles/" + continent
+            });
+        }
 
-        app.UseStaticFiles(new StaticFileOptions
-        {
-            FileProvider = new PhysicalFileProvider(Path.Combine(env.ContentRootPath, dataConfig.NpcSpawnLocations)),
-            RequestPath = "/npcspawnlocations"
-        });
-
-        app.UseStaticFiles(new StaticFileOptions
-        {
-            FileProvider = new PhysicalFileProvider(Path.Combine(env.ContentRootPath, dataConfig.MailboxLocations)),
-            RequestPath = "/mailboxlocations"
-        });
+        UseDataFolder(app, Path.Combine(env.ContentRootPath, dataConfig.Leaflet), "/tiles");
+        UseDataFolder(app, Path.Combine(env.ContentRootPath, dataConfig.ExpDbc), "/dbc");
+        UseDataFolder(app, Path.Combine(env.ContentRootPath, dataConfig.ExpArea), "/area");
+        UseDataFolder(app, Path.Combine(env.ContentRootPath, dataConfig.NpcSpawnLocations), "/npcspawnlocations");
+        UseDataFolder(app, Path.Combine(env.ContentRootPath, dataConfig.MailboxLocations), "/mailboxlocations");
 
         return app;
     }

--- a/Frontend/Pages/Index.razor
+++ b/Frontend/Pages/Index.razor
@@ -54,7 +54,7 @@
                 </div>
 
                 <div class="bottom-section">
-                    @if (client.Version is ClientVersion.SoM or ClientVersion.TBC)
+                    @if (DataConfig.HasLeaflet(client.Version.ToString()))
                     {
                         <LeafletComponent Size="400px" />
                     }

--- a/Frontend/Shared/MainLayout.razor
+++ b/Frontend/Shared/MainLayout.razor
@@ -156,7 +156,7 @@
             
         };
 
-        if (client.Version is ClientVersion.SoM or ClientVersion.TBC)
+        if (DataConfig.HasLeaflet(client.Version.ToString()))
         {
             navItems.Insert(5, new() { Id = "6", Href = "/Leaflet", Text = "Leaflet" });
         }

--- a/Frontend/wwwroot/script/leaflet-watch.js
+++ b/Frontend/wwwroot/script/leaflet-watch.js
@@ -42,6 +42,169 @@ const Configs = {
             }
         }
     },
+    // Cataclysm re-terraformed the old world and added zones, so the cata era
+    // has its own art with a different extent/offset than precata - Azeroth is
+    // 839 minimap blocks here against precata's 687.
+    // Generate with: LEAFLET_ERA=cata WOW_MPQ=<cata client>\Data
+    //                python scripts/extract-minimap.py
+    'cata': {
+        'Azeroth': {
+            resX: 14848,
+            resY: 21504,
+            maxZoom: 6,
+            MapID: 0,
+            offset: {
+                min: { x: 20, y: 17 },
+            }
+        },
+        'Kalimdor': {
+            resX: 29184,
+            resY: 28672,
+            maxZoom: 6,
+            MapID: 1,
+            offset: {
+                min: { x: 0, y: 0 },
+            }
+        },
+        // Standalone maps Cataclysm added. They are not zones of Azeroth/Kalimdor -
+        // each has its own MapID - which is why they were missing until now.
+        'Deephome': {           // Deepholm
+            resX: 5120,
+            resY: 5120,
+            maxZoom: 6,
+            MapID: 646,
+            offset: {
+                min: { x: 25, y: 26 },
+            }
+        },
+        'LostIsles': {          // The Lost Isles + Kezan (goblin start)
+            resX: 5120,
+            resY: 14336,
+            maxZoom: 6,
+            MapID: 648,
+            offset: {
+                min: { x: 24, y: 23 },
+            }
+        },
+        'Gilneas2': {           // Gilneas (worgen start)
+            resX: 4608,
+            resY: 3584,
+            maxZoom: 6,
+            MapID: 654,
+            offset: {
+                min: { x: 31, y: 24 },
+            }
+        },
+        'MaelstromZone': {      // The Maelstrom
+            resX: 2560,
+            resY: 2560,
+            maxZoom: 6,
+            MapID: 730,
+            offset: {
+                min: { x: 28, y: 28 },
+            }
+        }
+        // Expansion01 and Northrend are intentionally absent: their art is
+        // inherited from precata via TILE_SHARED_CONTINENTS below.
+    },
+    // Mists has its own era (see clientEra). HawaiiMainLand is Pandaria, which
+    // exists only here - no earlier era has art for it.
+    // Generated with:
+    //   LEAFLET_ERA=mop WOW_MPQ=<mop client>\Data python scripts/extract-minimap.py
+    'mop': {
+        'Azeroth': {
+            resX: 14848,
+            resY: 21504,
+            maxZoom: 6,
+            MapID: 0,
+            offset: {
+                min: { x: 20, y: 17 },
+            }
+        },
+        'Kalimdor': {
+            resX: 29184,
+            resY: 28672,
+            maxZoom: 6,
+            MapID: 1,
+            offset: {
+                min: { x: 0, y: 0 },
+            }
+        },
+        'Expansion01': {
+            resX: 25088,
+            resY: 19968,
+            maxZoom: 6,
+            MapID: 530,
+            offset: {
+                min: { x: 6, y: 12 },
+            }
+        },
+        'Northrend': {
+            resX: 19968,
+            resY: 14848,
+            maxZoom: 6,
+            MapID: 571,
+            offset: {
+                min: { x: 9, y: 11 },
+            }
+        },
+        'HawaiiMainLand': {
+            resX: 15360,
+            resY: 12288,
+            maxZoom: 6,
+            MapID: 870,
+            offset: {
+                min: { x: 18, y: 16 },
+            }
+        },
+        // Carried over from Cataclysm - Mists ships the same art for these, so the
+        // values match the cata block above.
+        'Deephome': {           // Deepholm
+            resX: 5120,
+            resY: 5120,
+            maxZoom: 6,
+            MapID: 646,
+            offset: {
+                min: { x: 25, y: 26 },
+            }
+        },
+        'LostIsles': {          // The Lost Isles + Kezan (goblin start)
+            resX: 5120,
+            resY: 14336,
+            maxZoom: 6,
+            MapID: 648,
+            offset: {
+                min: { x: 24, y: 23 },
+            }
+        },
+        'Gilneas2': {           // Gilneas (worgen start)
+            resX: 4608,
+            resY: 3584,
+            maxZoom: 6,
+            MapID: 654,
+            offset: {
+                min: { x: 31, y: 24 },
+            }
+        },
+        'MaelstromZone': {      // The Maelstrom
+            resX: 2560,
+            resY: 2560,
+            maxZoom: 6,
+            MapID: 730,
+            offset: {
+                min: { x: 28, y: 28 },
+            }
+        },
+        'NewRaceStartZone': {   // The Wandering Isle (pandaren start) - Mists only
+            resX: 5120,
+            resY: 5120,
+            maxZoom: 6,
+            MapID: 860,
+            offset: {
+                min: { x: 26, y: 20 },
+            }
+        }
+    },
 };
 
 // Mirrors DataConfig.ClientEra: which tile/config era a client uses.
@@ -49,12 +212,46 @@ function clientEra(expansion) {
     switch ((expansion || '').toLowerCase()) {
         case 'vanilla': case 'classic': case 'som':
         case 'tbc': case 'bcc': case 'wrath': case 'wotlk':
+        case 'legacy_vanilla': case 'legacy_tbc': case 'legacy_wrath':
             return 'precata';
-        case 'cata': case 'mop':
+        case 'cata': case 'legacy_cata':
             return 'cata';
+        // Mists is its own era, not Cataclysm's: the two worlds are close but
+        // not equal, and Mists adds Pandaria, which Cataclysm has no art for.
+        case 'mop': case 'legacy_mop':
+            return 'mop';
         default:
             return (expansion || '').toLowerCase();
     }
+}
+
+// Mirrors DataConfig.TileSharedContinents / TileEra: Cataclysm rebuilt the old
+// world but left Northrend and Outland essentially alone, so those two keep
+// reading the precata tiles instead of duplicating ~1950 minimap blocks. Tiles
+// only - the navmesh is always baked per era, because the near-identical art
+// hides real geometry drift (see the C# doc comment).
+const TILE_SHARED_CONTINENTS = ['Northrend', 'Expansion01'];
+
+function tileEra(expansion, continent) {
+    const era = clientEra(expansion);
+    return era === 'cata' && TILE_SHARED_CONTINENTS.includes(continent) ? 'precata' : era;
+}
+
+// The continent's tile config, following the shared-art fallback above.
+function continentConfig(expansion, continent) {
+    const cfgs = Configs[tileEra(expansion, continent)];
+    return cfgs ? cfgs[continent] : undefined;
+}
+
+// Every continent this client can show, including the ones it inherits.
+function eraContinents(expansion) {
+    const names = Object.keys(Configs[clientEra(expansion)] || {});
+    for (const c of TILE_SHARED_CONTINENTS) {
+        if (!names.includes(c) && continentConfig(expansion, c)) {
+            names.push(c);
+        }
+    }
+    return names;
 }
 
 const aSize = 32;
@@ -151,11 +348,18 @@ var baseUrl = "https://www.wowhead.com/classic";
 // CDN. Decided once per continent by probing a known low-zoom tile, so a remote
 // user does not 404 on every tile. `leafletTilesLocal=0` in localStorage forces
 // the CDN even when local tiles exist.
-const R2_TILE_BASE = 'https://bot.tortoiseclothing.org/precata';
+const R2_TILE_ROOT = 'https://bot.tortoiseclothing.org';
+
+// The CDN is laid out per era, the same as the local /tiles route, so the base
+// has to follow the era this continent's tiles actually come from - which for
+// Northrend/Outland on a cata client is still precata.
+function r2TileBase(c) {
+    return R2_TILE_ROOT + '/' + tileEra(expansion, c);
+}
 
 async function resolveTileBase(c) {
     if (localStorage.getItem('leafletTilesLocal') === '0') {
-        return R2_TILE_BASE;
+        return r2TileBase(c);
     }
 
     // If any of these local tiles is present the full set was downloaded. The
@@ -169,7 +373,7 @@ async function resolveTileBase(c) {
         } catch { /* fall through to CDN */ }
     }
 
-    return R2_TILE_BASE;
+    return r2TileBase(c);
 }
 
 var config;
@@ -596,10 +800,9 @@ async function init(e, c, z, x, y, urlEdit, flags, dotNetRef) {
     expansion = e;
     enableUrlEdit = urlEdit;
 
-    // Supported when the client's era has a config for this continent
-    // (precata: Azeroth/Kalimdor/Expansion01/Northrend). Cata+ not yet.
-    const era = clientEra(expansion);
-    if (!Configs[era] || !Configs[era][c]) {
+    // Supported when the client's era has a config for this continent, either
+    // its own or one inherited via the shared-art fallback (Northrend/Outland).
+    if (!continentConfig(expansion, c)) {
         return;
     }
 
@@ -608,7 +811,7 @@ async function init(e, c, z, x, y, urlEdit, flags, dotNetRef) {
     continent = c;
     startZoom = z;
 
-    config = Configs[era][continent];
+    config = continentConfig(expansion, continent);
 
     maxSize = Math.max(config.resX, config.resY);
     const multi = 17066.66666666667 / maxSize;
@@ -700,22 +903,40 @@ async function init(e, c, z, x, y, urlEdit, flags, dotNetRef) {
         noWrap: true
     }).addTo(LeafletMap);
 
-    WMADB = await getDBC("WorldMapArea");
-    WMADB = WMADB.sort((a, b) => a.AreaID - b.AreaID);
+    const wmaRaw = await getDBC("WorldMapArea");
+
+    // areaId -> name + parent, built from the FULL response before the
+    // per-continent filter below. WorldMapArea already carries subzone rows
+    // (name, ParentAreaId and bounds, extended from the baked area grids by
+    // ReadDBC_CSV's worldmap extractor), so it answers what AreaTable.json used
+    // to and there is no reason to fetch a second file for the same data.
+    AreaTableById = {};
+    let subZoneRows = 0;
+    if (Array.isArray(wmaRaw)) {
+        for (const a of wmaRaw) {
+            if (!a.AreaID) continue;          // continent/instance maps carry no areaId
+            AreaTableById[a.AreaID] = a;
+            if (!a.UIMapId) subZoneRows++;    // no UI map of its own => a subzone row
+        }
+    }
+
+    // An era whose worldmaparea was generated before the subzone extension (or
+    // without Json/subzones/<exp> present) has UI-map rows only, and then the
+    // parent walk has nothing to climb. Fall back to AreaTable.json for those
+    // rather than silently losing every subzone label.
+    if (subZoneRows === 0) {
+        const areaTableRaw = await getDBC("AreaTable");
+        if (Array.isArray(areaTableRaw)) {
+            for (const a of areaTableRaw) {
+                AreaTableById[a.AreaID] = a;
+            }
+        }
+    }
+
+    WMADB = wmaRaw.sort((a, b) => a.AreaID - b.AreaID);
     WMADB = filterContientsAndInvalid(WMADB, config.MapID);
     Zones = createZoneLookup(WMADB);
     SubZones = createSubZoneLookup(WMADB);
-
-    // Full AreaTable (all continents) so subzone areaIds with no WorldMapArea
-    // row can be named and walked up to their parent zone. Optional - if the
-    // file is absent the map falls back to spatial zone resolution.
-    const areaTableRaw = await getDBC("AreaTable");
-    AreaTableById = {};
-    if (Array.isArray(areaTableRaw)) {
-        for (const a of areaTableRaw) {
-            AreaTableById[a.AreaID] = a;
-        }
-    }
 
     let creaturesFile = await getDBC("creatures");
     creatures = createCreaturesLookup(creaturesFile);
@@ -1770,8 +1991,10 @@ function worldToPercentage(p, areaId) {
             bestParentArea = Zones[wmaSub.ParentAreaId];
         }
         else {
-            // Walk the AreaTable parent chain up to a WorldMapArea zone. This is
-            // what resolves TBC/WotLK terrain subzones (e.g. 4254 -> Borean).
+            // Walk the areaId parent chain up to a zone that has its own map.
+            // This is what resolves TBC/WotLK terrain subzones (e.g. 4254 ->
+            // Borean). Source is AreaTableById, itself built from the subzone
+            // rows in WorldMapArea.
             let cur = areaId, guard = 0;
             while (cur && guard++ < 32) {
                 if (Zones[cur] != null) {
@@ -1797,7 +2020,7 @@ function worldToPercentage(p, areaId) {
         return { p: new L.Point(0, 0), name: "not found", subZoneName: '' };
     }
 
-    // Subzone label: prefer the fine AreaTable name for the clicked areaId,
+    // Subzone label: prefer the fine-grained name for the clicked areaId,
     // then any WMA subzone, else the zone itself.
     const leaf = AreaTableById[areaId];
     const bestSubZone = leaf != null
@@ -2189,7 +2412,16 @@ async function addNpcSpawns(npcId, groupName = 'Spawn', iconName = 'red') {
     const spawns = spawnLocations[npcId];
     if (!spawns) return;
 
+    // A spawn can outlive its creature entry: the two files are generated separately,
+    // so an npcspawnlocations built from a newer dump than creatures.json references
+    // ids that are simply absent. Unguarded, that threw out of the whole layer and the
+    // zone rendered nothing - which reads as "the area json is broken" when it is not.
     const creature = creatures[npcId];
+    if (!creature) {
+        console.warn(`addNpcSpawns: no creature entry for ${npcId} - regenerate creatures.json`);
+        return;
+    }
+
     const npcName = creature.Name || npcId;
     const toggleControlName = `${npcName} - ${npcId} (${spawns.length})`;
     //var groupLayer = addGroupLayer(groupName, toggleControlName);
@@ -2953,7 +3185,7 @@ function createSidebar() {
                 continentLabel.textContent = 'Continent:';
                 const continentSelect = L.DomUtil.create('select', '', continentRow);
                 const continentNames = { 'Expansion01': 'Outland' };
-                for (const key of Object.keys(Configs[clientEra(expansion)] || {})) {
+                for (const key of eraContinents(expansion)) {
                     const opt = L.DomUtil.create('option', '', continentSelect);
                     opt.value = key;
                     opt.textContent = continentNames[key] || key;

--- a/Game/CLAUDE.md
+++ b/Game/CLAUDE.md
@@ -1,0 +1,54 @@
+# Game — the game process and input
+
+Everything that touches the running WoW process: finding it, sending it keys and mouse
+events, and the screen-capture interfaces. Small, but this is where a bug moves the
+player's character, so it gets more care than its size suggests.
+
+```
+WoWProcess/WowProcess.cs      finds the process, reads its path + FileVersion
+Input/IInput.cs               keyboard contract
+Input/IMouseInput.cs          mouse contract
+Input/InputWindowsNative.cs   the Win32 implementation (PostMessage based)
+Input/WowProcessInput.cs      the layer everything else uses; tracks what is held
+Input/InputDuration.cs        press-duration constants
+WoWScreen/IWowScreen.cs       capture contract (implementations live in Core/WinAPI)
+```
+
+## Input is stateful — that is the whole risk
+
+`WowProcessInput` keeps a `keysDown` belief and **short-circuits on it**: `KeyDown`
+returns early if it thinks the key is already down, and `KeyUp` returns early if it
+thinks it is already up (unless `forced: true`). Two consequences that have both caused
+real bugs:
+
+* **Clearing the belief without releasing strands the key.** The game keeps holding it,
+  and because `KeyUp` now believes it is up, the release can never be issued — a held
+  movement key runs the character on forever. `Reset()` releases first, *then* clears,
+  and releases the four movement keys **unconditionally** because a key the user pressed
+  themselves is exactly the case the belief cannot describe.
+* **An early `return` on a stop/exit path skips the release.** Runaway forward movement
+  and endless jumping have both come from this. When adding a bail-out to a goal or an
+  input path, make the release unconditional (`forced: true`) rather than conditional on
+  believed state.
+
+Ordering matters too: whoever stops the agent must release keys before tearing down the
+components that would have released them.
+
+## Other things worth knowing
+
+**Input goes through `PostMessage`, not `SendInput`.** Keys are posted to the WoW window
+handle, so the game does not need foreground focus and other windows are unaffected.
+That also means modifiers are posted as explicit `WM_KEYDOWN`/`WM_KEYUP` pairs around
+the key, and extended-key lParam flags have to be built by hand — see
+`MakeKeyDownLParam`/`MakeKeyUpLParam`.
+
+**Press durations are randomised.** `PressRandom` adds `Random.Shared.Next(maxDelay)` to
+the requested duration. Do not "fix" a flaky timing test by removing that.
+
+**`WowProcess` matches a list of known executable names** and throws at construction when
+none is running, so it is a hard dependency for anything in the bot path — that is why
+`PathingAPI` and the utilities do not reference this project.
+
+**Screen capture is an interface here, implemented elsewhere.** `IWowScreen` /
+`IGpuTextureProvider` stay abstract so `SharedLib` and the pathing chain remain
+platform-neutral; the WGC/DXGI implementations live in `Core/WoWScreen` and `WinAPI`.

--- a/HeadlessServer/CLAUDE.md
+++ b/HeadlessServer/CLAUDE.md
@@ -1,0 +1,61 @@
+# HeadlessServer — the bot without a UI
+
+Same bot as `BlazorServer`, minus the web front end: a console `Exe` driven entirely by
+command-line options. Used for running several bots, for unattended runs, and as the
+working directory that benchmarks chdir into.
+
+```
+Program.cs           config + CommandLineParser + Serilog, then hands off
+HeadlessServer.cs    Run / RunLoadOnly
+RunOptions.cs        the whole CLI surface
+headless_appsettings.json   options (note the prefix - NOT appsettings.json)
+data_config.json, addon_config.json, frame_config.json   as per BlazorServer
+run.bat / rundev.bat / build.bat / install.bat / loadall.bat
+```
+
+## Running
+
+```powershell
+.\build.bat
+.\run.bat -c Warrior_1.json -m Local -p <wow-pid>
+```
+
+`run.bat` passes `--no-build --no-restore`, so **build first** or you run a stale binary.
+
+## Options
+
+| flag | meaning |
+|---|---|
+| `-c, --classconfig` | class profile from `Json\class\` (e.g. `Warrior_1.json`) |
+| `-m, --mode` | `Local` / `RemoteV1` / `RemoteV3` |
+| `-p, --pid` | WoW process id — needed when several clients run |
+| `-r, --reader` | screen reader backend |
+| `--hostv1/--portv1`, `--hostv3/--portv3` | remote pathing endpoints |
+| `-n, --viz` | path visualizer |
+| `-g, --gpu` | GPU capture |
+| `-t/-s/-v` | targeting / skinning / target-vs-add overlays |
+| `--loadonly` | load the class config, report, exit — no bot |
+
+`--loadonly` is the cheap validation path: `loadall.bat` uses it to parse every profile
+in `Json\class\` and catch a broken one without attaching to the game.
+
+## Things that will bite you
+
+**Config file is `headless_appsettings.json`, not `appsettings.json`.** Copying settings
+from `BlazorServer` into the wrong filename here silently changes nothing.
+
+**Options come from both places.** `Program.cs` builds configuration from the json files
+**and** `AddCommandLine(args)`, then `CommandLineParser` parses `RunOptions` separately.
+Hierarchical keys (`--Pathing:Engine=Navmesh`) reach configuration; the short flags above
+reach `RunOptions`. They are two different mechanisms — do not expect one to populate the
+other.
+
+**This is the working directory benchmarks assume.** `NavmeshCorpus.SetWorkingDirectory()`
+chdirs here so `DataConfig`'s relative `..\json` resolves. Moving or renaming this
+project breaks the benchmark harness.
+
+**One bot per process, one process per WoW client.** `-p` exists because `WowProcess`
+otherwise picks the first matching client. For several bots, give each its own instance
+and its own in-process navmesh — see the README's "Running multiple bots".
+
+**Shutdown must release input.** Same rule as `BlazorServer`; see `Game/CLAUDE.md`.

--- a/PPather/CLAUDE.md
+++ b/PPather/CLAUDE.md
@@ -1,0 +1,88 @@
+# PPather — pathfinding engine
+
+Two engines behind one service. **Navmesh (DotRecast) is the default and the one to
+work on**; the spot-grid A* is legacy and kept only as a fallback.
+
+TFM is plain **`net10.0`** (not `net10.0-windows`) so the pathing chain runs on
+macOS/Linux — see `docs/headless-pathing-server-design.md`. Do not add a Windows-only
+dependency here.
+
+## Layout
+
+```
+Navmesh/       DotRecast engine (the current one)
+  NavmeshPathfinder.cs     query entry: FindPath, TryGetHeight, corridor widening, retarget
+  NavmeshTileCache.cs      tile residency + on-demand bake; accepts a NULL world = disk-only
+  NavmeshTileBuilder.cs    geometry -> DtMeshData
+  TileGeometryExtractor.cs triangle soup -> tile geometry (MinWorldZ filter lives here)
+  NavmeshSettings.cs       MeshEra() + ComputeSettingsHash() -> the cache directory name
+  NavmeshCoords.cs         wow <-> recast conversion, tile indexing
+  NavmeshEndpointResolver.cs  snap a world point to a poly (tight vertical extents on purpose)
+  CostZones.cs/CostZoneLoader.cs  authored road/danger costs, query-time only
+  AreaGrid.cs              standalone area-id grid, answers without game files
+  CatmullRom.cs            path smoothing
+StormDll/      MPQ archive access via StormLib P/Invoke
+  ArchiveSet.cs            base archives + PTCH patch chaining (build-order ascending)
+  Archive.cs               one archive; empty (listfile) is tolerated, not fatal
+  StormDll.cs              [LibraryImport]; OS+arch resolver, W/A marshalling split
+Triangles/     ADT/WMO/M2 geometry -> triangle soup
+  MPQTriangleSupplier.cs   per-continent supplier; opens the archive set + WDT eagerly
+  ChunkedTriangleCollection.cs  LRU ADT cache (maxCache=128)
+  Game/MapTileFile.cs      ADT parsing, incl. split (Cata+) root/_obj0 feature detection
+  Game/WDTFile.cs          WDT MAIN; bit 0 = has_adt
+Search/PPatherService.cs   the facade everything else uses (engine choice, bake, area grid)
+Graph/         legacy spot-grid A* (PathGraph, Spot, SpotManager)
+MPQ/           bundled StormLib natives (x64/x86/arm64 .dll, .dylib/.so are gitignored)
+```
+
+## Things that will bite you
+
+**Settings hash = cache directory.** `ComputeSettingsHash(era, version, agentRadius,
+agentMaxClimb, walkableSlope, minWorldZ)` names the tile dir. Change any of those and
+every previously baked tile is invisible — not wrong, *invisible*. Outland is the live
+case: it only resolves with `MinWorldZ["Expansion01"] = -700`.
+
+**Disk-only is a supported mode, not a degraded one.** `NavmeshTileCache` takes a
+nullable world; null means "answer from baked tiles, never bake". `PPatherService`
+falls back to it per continent when archives are missing. Baking, area-grid extraction
+and SpotAStar are the only things that genuinely need `Json/MPQ` — they call
+`RequireGeometry()` and fail with a stated reason.
+
+**Paths inside an MPQ are always backslash-separated.** Never `Path.Join` them; it
+yields `World/Maps/...` on macOS and matches nothing. Use interpolation with `\\`.
+
+**Geometry eras never share tiles.** `MeshEra()` maps vanilla…wrath to `precata`, and
+`cata`/`mop` to themselves. A stale mesh routes the bot through solid geometry, so this
+is deliberately stricter than the minimap-art sharing in `DataConfig.TileEra`.
+
+**`PPather.Graph.Path` collides with `System.IO.Path`.** Fully qualify it in any file
+doing I/O.
+
+**`PPatherService` is a singleton with a two-call search** (`SetLocations` then
+`DoSearch`). It is not re-entrant; concurrent callers must serialize.
+
+**`GetAreaIdAndZ` leaves the tile flagged loaded**, so a later `GetTriangles` on the
+same tile returns zero triangles. Use a fresh supplier when doing both.
+
+## Verifying a change
+
+Geometry must stay byte-identical for the old eras. The gate:
+
+```powershell
+dotnet run --project Benchmarks -c Release -- --bake-profile <label> 1
+```
+
+Writes `local/benchmark_results/bake_<label>_*.md` with a per-tile SHA-256. Wrath
+6-tile baseline, which must not move:
+
+| tile | hash |
+|---|---|
+| elwynn-open | `6d6edc442008b805` |
+| stormwind-wmo | `c3f074b363b36063` |
+| dunmorogh-indoor | `34a1a2d4f25ad55b` |
+| barrens-open | `12c83529658aba79` |
+| durotar-water | `fb06c81c3603f8e4` |
+| orgrimmar-wmo | `a64ee4ee73bb3e33` |
+
+`delaunayHull: Removing dangling face` on stderr is normal DotRecast noise — real
+failures go to stdout.

--- a/PPather/Navmesh/NavmeshSettings.cs
+++ b/PPather/Navmesh/NavmeshSettings.cs
@@ -117,7 +117,8 @@ public sealed class NavmeshSettings
     /// a client that has no geometry for a tile simply never bakes it - the
     /// "this tile is empty" marker is per-session, never written to disk, so it
     /// cannot leak from one client to another. Cataclysm rewrote the old world,
-    /// which is also where the storage changes to CASC, so it starts a new era.
+    /// so it starts a new era, and Mists starts another: its old world is close
+    /// to Cataclysm's but not identical, and it adds Pandaria outright.
     ///
     /// An unrecognised client gets an era of its own: silently handing it
     /// another client's mesh is the one failure that would be hard to notice.

--- a/PPather/PPather.csproj
+++ b/PPather/PPather.csproj
@@ -1,6 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- See DataConfig.csproj for why this overrides the solution-wide
+       net10.0-windows TFM. The bake's only native dependency is StormLib, which
+       StormDll resolves per-OS (libstorm.dylib / .so / StormLib_*.dll). -->
   <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <Nullable>annotations</Nullable>
   </PropertyGroup>
@@ -30,6 +34,21 @@
     </None>
     <None Update="MPQ\StormLib_arm64.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <!-- macOS/Linux StormLib, built locally by scripts/build-stormlib-unix.sh and
+       not committed (it is host-specific). Conditioned on existence so a Windows
+       build, or a checkout that has not built it, is unaffected. StormDll.Resolve
+       probes <output>/MPQ for these names. -->
+  <ItemGroup>
+    <None Include="MPQ\libstorm.dylib" Condition="Exists('MPQ\libstorm.dylib')">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>MPQ\libstorm.dylib</Link>
+    </None>
+    <None Include="MPQ\libstorm.so" Condition="Exists('MPQ\libstorm.so')">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>MPQ\libstorm.so</Link>
     </None>
   </ItemGroup>
 

--- a/PPather/Search/PPatherService.cs
+++ b/PPather/Search/PPatherService.cs
@@ -41,11 +41,38 @@ public sealed class PPatherService : IDisposable
     public Action<LinesEventArgs> OnLinesAdded;
     public Action<SphereEventArgs> OnSphereAdded;
 
-    private Search search { get; set; }
+    /// <summary>
+    /// Geometry-backed search (MPQ triangle world + PathGraph). Null in a
+    /// disk-only run: see <see cref="geometryUnavailable"/>.
+    /// </summary>
+    private Search? search { get; set; }
 
     private NavmeshPathfinder navmeshPathfinder;
     private float navmeshMapId = -1;
     private bool? lastStartIndoors;
+
+    /// <summary>
+    /// Continent of the active query, tracked here rather than read off
+    /// <see cref="search"/> so a disk-only run still knows where it is.
+    /// </summary>
+    private float activeMapId = -1;
+
+    private Vector4 activeFrom;
+    private Vector4 activeTarget;
+
+    /// <summary>
+    /// Continents whose geometry could not be opened - no client archives
+    /// installed, or archives that do not carry this continent (a wrath client
+    /// has no Pandaria). The navmesh answers from baked tiles alone, so this is
+    /// a normal operating mode, not a failure: post-Cata clients are tens of GB
+    /// and there is no reason to keep one installed just to path over tiles that
+    /// are already baked. Remembered per continent so a missing client costs one
+    /// archive-open attempt instead of one per query.
+    /// </summary>
+    private readonly HashSet<float> geometryUnavailable = [];
+
+    /// <summary>True when this continent is pathing off baked tiles with no game files.</summary>
+    public bool DiskOnly => search == null && activeMapId >= 0;
 
     private readonly Lock areaGridLock = new();
     private readonly Dictionary<string, AreaGrid?> areaGrids = new();
@@ -83,12 +110,12 @@ public sealed class PPatherService : IDisposable
     /// </summary>
     public bool ReloadCostZones()
     {
-        if (navmeshPathfinder == null || search == null)
+        if (navmeshPathfinder == null || activeMapId < 0)
         {
             return false;
         }
 
-        string continent = ContinentDB.IdToName[search.MapId];
+        string continent = ContinentDB.IdToName[activeMapId];
 
         // All or nothing. These files are hand-editable and the watcher can fire
         // mid-write, so a partial read is expected rather than exceptional -
@@ -107,12 +134,13 @@ public sealed class PPatherService : IDisposable
         return true;
     }
 
-    public bool Initialised => search != null;
+    /// <summary>A continent is active and queries can be answered - with or without geometry.</summary>
+    public bool Initialised => activeMapId >= 0;
 
     public bool IsSearching { get; set; }
 
-    public Vector4 SearchFrom => search.From;
-    public Vector4 SearchTo => search.Target;
+    public Vector4 SearchFrom => activeFrom;
+    public Vector4 SearchTo => activeTarget;
     public Vector3 ClosestLocation => search?.PathGraph?.ClosestSpot?.Loc ?? Vector3.Zero;
     public Vector3 PeekLocation => search?.PathGraph?.PeekSpot?.Loc ?? Vector3.Zero;
 
@@ -258,6 +286,7 @@ public sealed class PPatherService : IDisposable
         navmeshPathfinder?.Dispose();
         navmeshPathfinder = null;
         navmeshMapId = -1;
+        activeMapId = -1;
 
         if (search == null)
             return;
@@ -268,18 +297,44 @@ public sealed class PPatherService : IDisposable
 
     public void Initialise(float mapId)
     {
-        if (search != null && mapId == search.MapId)
+        if (activeMapId == mapId && (search != null || geometryUnavailable.Contains(mapId)))
         {
             return;
         }
 
-        if (search != null && mapId != search.MapId)
+        if (activeMapId >= 0 && activeMapId != mapId)
         {
             Reset();
         }
 
-        search = new Search(mapId, logger, dataConfig);
-        search.PathGraph.triangleWorld.NotifyChunkAdded = ChunkAdded;
+        activeMapId = mapId;
+
+        if (geometryUnavailable.Contains(mapId))
+        {
+            return;
+        }
+
+        try
+        {
+            search = new Search(mapId, logger, dataConfig);
+            search.PathGraph.triangleWorld.NotifyChunkAdded = ChunkAdded;
+        }
+        catch (Exception e) when (Engine == PathingEngine.Navmesh)
+        {
+            // Disk-only fallback. The navmesh engine reads baked tiles straight
+            // off disk and never needs the client, so a missing or wrong-era
+            // archive set is recoverable here - but only for Navmesh: SpotAStar
+            // walks the triangle world itself and has nothing to fall back to,
+            // hence the `when` filter rethrowing for it.
+            geometryUnavailable.Add(mapId);
+            search = null;
+
+            logger.LogWarning(
+                "No usable geometry for {Continent} ({Message}). Pathing disk-only over baked navmesh tiles; " +
+                "baking and SpotAStar are unavailable for this continent.",
+                ContinentDB.IdToName.TryGetValue(mapId, out string? name) ? name : mapId.ToString(),
+                e.Message);
+        }
     }
 
     public bool MPQSelfTest()
@@ -297,17 +352,126 @@ public sealed class PPatherService : IDisposable
         return true;
     }
 
-    public TriangleCollection GetChunkAt(int grid_x, int grid_y)
+    /// <summary>Baked navmesh tiles on disk for one continent of the active era.</summary>
+    public readonly record struct NavmeshCoverage(string Continent, string Hash, string CacheDir, int Tiles);
+
+    /// <summary>
+    /// What <see cref="SelfTest"/> found. <see cref="Ok"/> is the single yes/no; the rest
+    /// is there so a failure says which era and which directory were looked at, instead of
+    /// a bare false.
+    /// </summary>
+    public sealed record SelfTestReport(
+        bool Ok, string Engine, string Exp, string Era, string Detail,
+        bool MpqPresent, int TotalTiles, NavmeshCoverage[] Continents);
+
+    /// <summary>
+    /// Per-continent baked tile counts for the active era. Counts files only - never loads
+    /// a mesh - so it is cheap enough for a health endpoint.
+    /// </summary>
+    public NavmeshCoverage[] GetNavmeshCoverage()
     {
-        return search.PathGraph.triangleWorld.GetChunkAt(grid_x, grid_y);
+        List<string> continents = KnownWorldContinents();
+        NavmeshCoverage[] result = new NavmeshCoverage[continents.Count];
+
+        for (int i = 0; i < continents.Count; i++)
+        {
+            string dir = NavmeshCacheDir(continents[i]);
+            int tiles = System.IO.Directory.Exists(dir)
+                ? System.IO.Directory.EnumerateFiles(dir, "*.dnm").Count()
+                : 0;
+
+            result[i] = new(continents[i], System.IO.Path.GetFileName(dir), dir, tiles);
+        }
+
+        return result;
     }
 
-    public ChunkedTriangleCollection TriangleWorld => search.PathGraph.triangleWorld;
+    /// <summary>
+    /// Can this install actually path? The answer depends on the engine, which is why it
+    /// is not <see cref="MPQSelfTest"/> any more: the navmesh engine reads baked tiles and
+    /// treats game archives as optional, so on a tiles-only install (or any CASC client)
+    /// the MPQ check reports a failure that does not exist. SpotAStar has no tile cache to
+    /// fall back on, so for it the archives really are the answer.
+    /// </summary>
+    public SelfTestReport SelfTest()
+    {
+        string era = DataConfig.ClientEra(dataConfig.Exp);
+        bool mpq = MPQTriangleSupplier.GetArchiveNames(dataConfig).Length > 0;
+
+        if (Engine != PathingEngine.Navmesh)
+        {
+            return new(mpq, Engine.ToString(), dataConfig.Exp, era,
+                mpq
+                    ? "SpotAStar: game archives present."
+                    : $"SpotAStar needs game archives in {dataConfig.MPQ}; none found.",
+                mpq, 0, []);
+        }
+
+        NavmeshCoverage[] coverage = GetNavmeshCoverage();
+        int total = 0;
+        for (int i = 0; i < coverage.Length; i++)
+        {
+            total += coverage[i].Tiles;
+        }
+
+        if (total == 0)
+        {
+            string detail =
+                $"No baked navmesh tiles for era '{era}' under {dataConfig.Navmesh}. " +
+                $"Download them (scripts/download-navmesh.ps1 -Era {era}) or bake with --bake=all.";
+
+            logger.LogWarning("Navmesh self-test FAILED: {Detail}", detail);
+            return new(false, Engine.ToString(), dataConfig.Exp, era, detail, mpq, 0, coverage);
+        }
+
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            foreach (NavmeshCoverage c in coverage)
+            {
+                logger.LogInformation("Navmesh {Era}/{Continent}/{Hash}: {Tiles} tiles",
+                    era, c.Continent, c.Hash, c.Tiles);
+            }
+        }
+
+        int missing = 0;
+        for (int i = 0; i < coverage.Length; i++)
+        {
+            if (coverage[i].Tiles == 0)
+                missing++;
+        }
+
+        return new(true, Engine.ToString(), dataConfig.Exp, era,
+            missing == 0
+                ? $"{total} tiles across {coverage.Length} continent(s)."
+                : $"{total} tiles; {missing} of {coverage.Length} continent(s) have none baked.",
+            mpq, total, coverage);
+    }
+
+    public TriangleCollection GetChunkAt(int grid_x, int grid_y)
+    {
+        return RequireGeometry().PathGraph.triangleWorld.GetChunkAt(grid_x, grid_y);
+    }
+
+    /// <summary>Triangle world of the active continent; null in a disk-only run.</summary>
+    public ChunkedTriangleCollection? TriangleWorld => search?.PathGraph.triangleWorld;
 
     public IEnumerable<Spot> GetSpots()
     {
-        return search.PathGraph.SpotManager.AllSpots();
+        return search == null ? [] : search.PathGraph.SpotManager.AllSpots();
     }
+
+    /// <summary>
+    /// The geometry-backed search, or a clear failure. For the operations that
+    /// genuinely cannot work off baked tiles alone - baking, SpotAStar, spot
+    /// graph authoring - so they report the missing client instead of throwing
+    /// NullReferenceException somewhere deeper.
+    /// </summary>
+    private Search RequireGeometry() =>
+        search ?? throw new InvalidOperationException(
+            $"This operation needs the game archives for " +
+            $"{(ContinentDB.IdToName.TryGetValue(activeMapId, out string? n) ? n : activeMapId.ToString())}, " +
+            $"which are not available in {dataConfig.MPQ}. Baked navmesh tiles alone " +
+            $"support path and height queries, not baking or SpotAStar.");
 
     public void ChunkAdded(ChunkEventArgs e)
     {
@@ -338,7 +502,8 @@ public sealed class PPatherService : IDisposable
 
         Initialise(wma.MapID);
 
-        return search.CreateWorldLocation(worldX, worldY, z, wma.MapID, null);
+        return search?.CreateWorldLocation(worldX, worldY, z, wma.MapID, null)
+            ?? NavmeshWorldLocation(worldX, worldY, z, wma.MapID);
     }
 
     public Vector4 ToWorldZ(int uiMap, float x, float y, float z, bool? startIndoors = null)
@@ -350,7 +515,31 @@ public sealed class PPatherService : IDisposable
 
         lastStartIndoors = startIndoors;
 
-        return search.CreateWorldLocation(x, y, z, wma.MapID, startIndoors);
+        return search?.CreateWorldLocation(x, y, z, wma.MapID, startIndoors)
+            ?? NavmeshWorldLocation(x, y, z, wma.MapID);
+    }
+
+    /// <summary>
+    /// Surface height from the baked navmesh, for when there is no triangle world
+    /// to run <see cref="Search.CreateWorldLocation"/> against. Coarser than the
+    /// geometry path - it cannot apply the canopy/indoor heuristics, only the
+    /// walkable surface the navmesh already encodes - which is the right trade
+    /// when the alternative is no answer at all. A non-zero caller z is kept as
+    /// given, matching the geometry path's treatment of an explicit height.
+    /// </summary>
+    private Vector4 NavmeshWorldLocation(float worldX, float worldY, float z, float mapId)
+    {
+        if (z != 0)
+        {
+            return new(worldX, worldY, z, mapId);
+        }
+
+        string continent = ContinentDB.IdToName[mapId];
+        NavmeshPathfinder? nav = GetQueryNavmesh(continent, mapId);
+
+        return nav != null && nav.TryGetHeight(worldX, worldY, out float found)
+            ? new(worldX, worldY, found, mapId)
+            : new(worldX, worldY, 0, mapId);
     }
 
     public int GetMapId(int uiMap)
@@ -371,7 +560,7 @@ public sealed class PPatherService : IDisposable
 
         Path path = Engine == PathingEngine.Navmesh
             ? NavmeshSearch()
-            : search.DoSearch(searchType);
+            : RequireGeometry().DoSearch(searchType);
 
         IsSearching = false;
         OnPathCreated?.Invoke(path);
@@ -386,22 +575,25 @@ public sealed class PPatherService : IDisposable
         navmeshPathfinder.JitterSeed = PathJitterSeed;
         navmeshPathfinder.EdgeMarginYards = PathEdgeMarginYards ?? queryOptions.EdgeMargin;
 
-        Vector3 from = search.From.AsVector3();
-        Vector3 to = search.Target.AsVector3();
+        Vector3 from = activeFrom.AsVector3();
+        Vector3 to = activeTarget.AsVector3();
 
         // Callers that bypass ToWorldZ (raw WorldRoute) pass z=0. The navmesh
         // column scan alone would pick the highest poly - which can be a tree
         // canopy or roof. Seed the height with the spot-geometry surface
         // heuristics (canopy/terrain preference) first; the resolver then only
-        // needs its small vertical extents.
+        // needs its small vertical extents. Disk-only runs have no geometry to
+        // ask, so they fall back to the navmesh surface via TryGetHeight.
         if (from.Z == 0)
         {
-            from = search.CreateWorldLocation(from.X, from.Y, 0, (int)search.MapId, lastStartIndoors).AsVector3();
+            from = search?.CreateWorldLocation(from.X, from.Y, 0, (int)activeMapId, lastStartIndoors).AsVector3()
+                ?? NavmeshWorldLocation(from.X, from.Y, 0, activeMapId).AsVector3();
         }
 
         if (to.Z == 0)
         {
-            to = search.CreateWorldLocation(to.X, to.Y, 0, (int)search.MapId, null).AsVector3();
+            to = search?.CreateWorldLocation(to.X, to.Y, 0, (int)activeMapId, null).AsVector3()
+                ?? NavmeshWorldLocation(to.X, to.Y, 0, activeMapId).AsVector3();
         }
 
         return navmeshPathfinder.FindPath(from, to, lastStartIndoors);
@@ -504,7 +696,7 @@ public sealed class PPatherService : IDisposable
         try
         {
             List<string> continents = continent is null
-                ? [.. WorldContinents]
+                ? KnownWorldContinents()
                 : [continent];
 
             foreach (string name in continents)
@@ -548,13 +740,18 @@ public sealed class PPatherService : IDisposable
         float mapId = ContinentDB.IdToName.First(kvp => kvp.Value == name).Key;
 
         Initialise(mapId);
+
+        // Baking reads ADT geometry, so unlike querying it cannot run off the
+        // tile cache. Fail here with the reason rather than inside the loop.
+        _ = RequireGeometry();
+
         EnsureNavmeshPathfinder();
 
         NavmeshTileCache tiles = navmeshPathfinder!.Tiles;
 
         List<(int x, int y)> adts = adt.HasValue
             ? [adt.Value]
-            : TriangleWorld.ExistingAdts();
+            : TriangleWorld!.ExistingAdts();
 
         lock (bakeLock)
         {
@@ -752,14 +949,14 @@ public sealed class PPatherService : IDisposable
 
     private void EnsureNavmeshPathfinder()
     {
-        if (navmeshPathfinder != null && navmeshMapId == search.MapId)
+        if (navmeshPathfinder != null && navmeshMapId == activeMapId)
         {
             return;
         }
 
         navmeshPathfinder?.Dispose();
 
-        string continent = ContinentDB.IdToName[search.MapId];
+        string continent = ContinentDB.IdToName[activeMapId];
         string cacheDir = NavmeshCacheDir(continent);
 
         navmeshPathfinder = new NavmeshPathfinder(logger, TriangleWorld, cacheDir, bakeOptions, queryOptions,
@@ -770,16 +967,24 @@ public sealed class PPatherService : IDisposable
             (x, z, data) => OnNavmeshTileAdded?.Invoke(x, z, data);
         navmeshPathfinder.Tiles.NotifyTileRemoved =
             (x, z) => OnNavmeshTileRemoved?.Invoke(x, z);
-        navmeshMapId = search.MapId;
+        navmeshMapId = activeMapId;
 
         if (logger.IsEnabled(LogLevel.Information))
         {
-            logger.LogInformation("Navmesh engine ready for {Continent} - tile cache: {CacheDir}", continent, cacheDir);
+            logger.LogInformation("Navmesh engine ready for {Continent} ({Mode}) - tile cache: {CacheDir}",
+                continent, search == null ? "disk-only, no game files" : "geometry available", cacheDir);
         }
     }
 
     public void Save()
     {
+        // Nothing to persist without a PathGraph - the navmesh tile cache is
+        // already on disk.
+        if (search == null)
+        {
+            return;
+        }
+
         long timestamp = GetTimestamp();
 
         search.PathGraph.Save();
@@ -792,8 +997,14 @@ public sealed class PPatherService : IDisposable
     {
         Initialise(from.W);
 
-        search.From = from;
-        search.Target = to;
+        activeFrom = from;
+        activeTarget = to;
+
+        if (search != null)
+        {
+            search.From = from;
+            search.Target = to;
+        }
     }
 
     public List<Vector3> GetCurrentSearchPath()
@@ -833,9 +1044,11 @@ public sealed class PPatherService : IDisposable
 
         SetLocations(from, to);
 
-        if (search.PathGraph == null)
+        Search geometry = RequireGeometry();
+
+        if (geometry.PathGraph == null)
         {
-            search.CreatePathGraph(mapId);
+            geometry.CreatePathGraph(mapId);
         }
 
         List<Spot> spots = new(path.Length);
@@ -843,7 +1056,7 @@ public sealed class PPatherService : IDisposable
         {
             Spot spot = new(path[i]);
             spots.Add(spot);
-            search.PathGraph.CreateSpotsAroundSpot(spot, false, spot);
+            geometry.PathGraph.CreateSpotsAroundSpot(spot, false, spot);
         }
 
         OnPathCreated?.Invoke(new(spots));
@@ -943,9 +1156,41 @@ public sealed class PPatherService : IDisposable
         Converters = { new SharedLib.Converters.Vector3Converter(true) }
     };
 
-    /// <summary>The world continents `--bake-area=all` covers (skips instances).</summary>
+    /// <summary>
+    /// The world continents an "all" bake covers (skips instances). Superset
+    /// across every supported client - HawaiiMainLand is Pandaria, which only a
+    /// Mists client has - so it is filtered per client by
+    /// <see cref="KnownWorldContinents"/> rather than used directly.
+    /// </summary>
     private static readonly string[] WorldContinents =
-        ["Azeroth", "Kalimdor", "Expansion01", "Northrend"];
+    [
+        "Azeroth", "Kalimdor", "Expansion01", "Northrend",
+        "HawaiiMainLand",    // 870 Pandaria                    - Mists
+        "Deephome",          // 646 Deepholm                    - Cataclysm
+        "LostIsles",         // 648 The Lost Isles + Kezan      - Cataclysm (goblin start)
+        "Gilneas2",          // 654 Gilneas                     - Cataclysm (worgen start)
+        "MaelstromZone",     // 730 The Maelstrom               - Cataclysm
+        "NewRaceStartZone",  // 860 The Wandering Isle          - Mists (pandaren start)
+    ];
+
+    /// <summary>
+    /// The subset of <see cref="WorldContinents"/> the loaded client actually
+    /// has. Without this an "all" bake throws on the first continent the client
+    /// does not know - Pandaria on anything pre-Mists, and equally Northrend on a
+    /// vanilla client.
+    /// </summary>
+    private static List<string> KnownWorldContinents()
+    {
+        List<string> known = new(WorldContinents.Length);
+
+        foreach (string name in WorldContinents)
+        {
+            if (ContinentDB.NameToId.ContainsKey(name))
+                known.Add(name);
+        }
+
+        return known;
+    }
 
     /// <summary>
     /// Bakes, per continent, from the game files: the standalone area-id grid
@@ -957,7 +1202,7 @@ public sealed class PPatherService : IDisposable
     public bool BuildAreaGrid(string? continent)
     {
         List<string> continents = continent is null
-            ? [.. WorldContinents]
+            ? KnownWorldContinents()
             : [continent];
 
         foreach (string name in continents)
@@ -969,6 +1214,17 @@ public sealed class PPatherService : IDisposable
             }
 
             Initialise(mapId);
+
+            if (search == null)
+            {
+                // Area data comes from ADT area ids, not from the navmesh, so
+                // there is nothing to extract without the client archives.
+                logger.LogWarning(
+                    "Area data bake skipped for {Continent}: no game archives in {MPQ}.",
+                    name, dataConfig.MPQ);
+                continue;
+            }
+
             (AreaGrid grid, SubZoneArea[] subZones) = search.BuildAreaData();
 
             string gridPath = System.IO.Path.Combine(dataConfig.AreaGrid, name + ".grid");

--- a/PPather/StormDll/Archive.cs
+++ b/PPather/StormDll/Archive.cs
@@ -22,39 +22,60 @@ internal sealed class Archive
         if (!open)
             return;
 
-        using MpqFileStream mpq = GetStream("(listfile)".AsSpan());
-        int length = (int)mpq.Length;
-
         // MPQ paths are ASCII; Ordinal avoids ICU-backed hashing on every lookup.
         HashSet<string> fileList = new(StringComparer.OrdinalIgnoreCase);
 
-        if (length <= MpqFileStream.MaxStackLimit)
+        // A stub archive can carry an empty or missing (listfile) - Cataclysm
+        // ships a 1 KB OldWorld.MPQ placeholder like this. That is not a failure:
+        // the archive simply contributes no files, and ArchiveSet drops it. Only
+        // an archive that opens AND lists something is worth searching.
+        try
         {
-            Span<byte> stackBytes = stackalloc byte[length];
-            mpq.Read(stackBytes);
-            ParseFileLines(stackBytes, fileList);
-        }
-        else
-        {
-            var pooler = ArrayPool<byte>.Shared;
-            byte[] array = pooler.Rent(length);
-            try
-            {
-                Span<byte> spanBytes = array.AsSpan(0, length);
-                mpq.Read(spanBytes);
-                ParseFileLines(spanBytes, fileList);
-            }
-            finally
-            {
-                pooler.Return(array);
-            }
-        }
+            using MpqFileStream mpq = GetStream("(listfile)".AsSpan());
+            int length = (int)mpq.Length;
 
-        if (fileList.Count == 0)
-            throw new InvalidOperationException($"{nameof(fileList)} contains no elements!");
+            if (length <= MpqFileStream.MaxStackLimit)
+            {
+                Span<byte> stackBytes = stackalloc byte[length];
+                mpq.Read(stackBytes);
+                ParseFileLines(stackBytes, fileList);
+            }
+            else
+            {
+                var pooler = ArrayPool<byte>.Shared;
+                byte[] array = pooler.Rent(length);
+                try
+                {
+                    Span<byte> spanBytes = array.AsSpan(0, length);
+                    mpq.Read(spanBytes);
+                    ParseFileLines(spanBytes, fileList);
+                }
+                finally
+                {
+                    pooler.Return(array);
+                }
+            }
+        }
+        catch (IOException)
+        {
+            // No (listfile) at all - same as an empty one.
+        }
 
         this.fileList = fileList.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
     }
+
+    /// <summary>Number of files this archive lists; 0 means it holds nothing searchable.</summary>
+    public int FileCount => fileList.Count;
+
+    /// <summary>The names this archive lists, for overlap tests against patch archives.</summary>
+    public FrozenSet<string> Files => fileList;
+
+    /// <summary>
+    /// Chains a patch archive onto this one, so reads through this handle return
+    /// the patched content. Patches must be attached in ascending build order.
+    /// </summary>
+    public bool AttachPatch(string patchFile) =>
+        StormDll.SFileOpenPatchArchive(handle, patchFile, nint.Zero, 0);
 
     public static void ParseFileLines(ReadOnlySpan<byte> data, HashSet<string> fileList)
     {
@@ -76,9 +97,6 @@ internal sealed class Archive
 
             start += end + 1;
         }
-
-        if (fileList.Count == 0)
-            throw new InvalidOperationException("File contains no lines.");
     }
 
 

--- a/PPather/StormDll/ArchiveSet.cs
+++ b/PPather/StormDll/ArchiveSet.cs
@@ -3,11 +3,32 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 
 namespace StormDll;
 
-public sealed class ArchiveSet
+public sealed partial class ArchiveSet
 {
+    /// <summary>
+    /// Blizzard's incremental update archives, in both naming forms the clients
+    /// use: `patch[-<locale>][-<n>].MPQ` (vanilla..WotLK) and
+    /// `wow-update-<scope>-<build>.MPQ` (Cataclysm on). Their entries are PTCH
+    /// deltas, not whole files, so they must be chained onto a base archive
+    /// rather than searched alongside it.
+    ///
+    /// Getting this wrong is silent rather than loud: every one of these names
+    /// sorts after the base archives (`common`, `expansion`, `lichking`,
+    /// `world`...), so a first-match-wins scan simply never reaches them and
+    /// bakes pre-patch geometry. Mists makes the cost obvious - 23 update
+    /// archives holding updated terrain for 37% of its root ADTs - but a full
+    /// WotLK install has the same exposure through `patch-3.MPQ`.
+    ///
+    /// The trailing number is the apply order. `patch.MPQ` has none and is the
+    /// oldest, hence group 1 being optional.
+    /// </summary>
+    [GeneratedRegex(@"^(?:wow-update-|patch)[a-z\-]*?(\d*)\.mpq$", RegexOptions.IgnoreCase)]
+    private static partial Regex UpdateArchiveRegex();
+
     private readonly Archive[] archives;
     private readonly ILogger logger;
 
@@ -15,12 +36,64 @@ public sealed class ArchiveSet
     {
         this.logger = logger;
 
+        // Split before opening anything: patch archives are chained onto the
+        // bases, and the build number in the name is their apply order.
+        List<string> baseFiles = new(files.Length);
+        List<(string file, long build)> patchFiles = [];
+
+        foreach (string file in files)
+        {
+            Match m = UpdateArchiveRegex().Match(Path.GetFileName(file));
+            if (!m.Success)
+            {
+                baseFiles.Add(file);
+                continue;
+            }
+
+            // `patch.MPQ` carries no number and applies first.
+            _ = long.TryParse(m.Groups[1].ValueSpan, out long build);
+            patchFiles.Add((file, build));
+        }
+
+        patchFiles.Sort((a, b) => a.build != b.build
+            ? a.build.CompareTo(b.build)
+            : string.CompareOrdinal(a.file, b.file));
+
+        List<Archive> bases = OpenAll(baseFiles);
+
+        // Patch archives are also opened standalone, but only as a last-resort
+        // lookup: an update can introduce a wholly new file that no base lists,
+        // and such a file is stored complete rather than as a PTCH delta.
+        List<string> patchOnly = new(patchFiles.Count);
+        foreach ((string file, long _) in patchFiles)
+            patchOnly.Add(file);
+
+        List<Archive> patches = OpenAll(patchOnly);
+
+        if (patchFiles.Count > 0)
+            ChainPatches(bases, patchFiles);
+
+        // Bases first (they resolve to patched content), patch archives last -
+        // the same relative order the old alphabetical scan produced, since
+        // "wow-update-*" sorts after every base archive name.
+        bases.AddRange(patches);
+        archives = [.. bases];
+
+        if (archives.Length == 0)
+            logger.LogError(
+                "No MPQ archive could be opened from {Count} file(s). " +
+                "The native StormLib may be missing or built for the wrong " +
+                "architecture/charset - pathing will not work.", files.Length);
+    }
+
+    private List<Archive> OpenAll(List<string> files)
+    {
         // Only keep successfully opened archives. A failed open used to leave a
         // null slot that later NRE'd in GetStream/Exists. Now it is skipped and
         // logged, so a bad/mismatched native StormLib surfaces a clear message.
-        List<Archive> opened = new(files.Length);
+        List<Archive> opened = new(files.Count);
 
-        for (int i = 0; i < files.Length; i++)
+        for (int i = 0; i < files.Count; i++)
         {
             Archive a = new(files[i], out bool open, 0,
                 OpenArchive.MPQ_OPEN_NO_LISTFILE |
@@ -30,6 +103,19 @@ public sealed class ArchiveSet
 
             if (open && a.IsOpen())
             {
+                if (a.FileCount == 0)
+                {
+                    // Opened fine but lists nothing - a stub archive such as
+                    // Cataclysm's OldWorld.MPQ. Close it rather than searching
+                    // it on every lookup.
+                    a.SFileCloseArchive();
+
+                    if (logger.IsEnabled(LogLevel.Trace))
+                        logger.LogTrace("Archive[{Index}] empty listfile, skipped {File}", i, files[i]);
+
+                    continue;
+                }
+
                 opened.Add(a);
 
                 if (logger.IsEnabled(LogLevel.Trace))
@@ -39,13 +125,59 @@ public sealed class ArchiveSet
                 logger.LogWarning("Archive failed to open: {File}", files[i]);
         }
 
-        archives = opened.ToArray();
+        return opened;
+    }
 
-        if (archives.Length == 0)
-            logger.LogError(
-                "No MPQ archive could be opened from {Count} file(s). " +
-                "The native StormLib may be missing or built for the wrong " +
-                "architecture/charset - pathing will not work.", files.Length);
+    /// <summary>
+    /// Chains every patch onto each base that it actually touches. Skipping the
+    /// bases a patch does not overlap matters: Mists has 23 patches and 14 base
+    /// archives, and attaching blindly would open the same multi-hundred-MB
+    /// archives hundreds of times over.
+    /// </summary>
+    private void ChainPatches(List<Archive> bases, List<(string file, long build)> patchFiles)
+    {
+        HashSet<string> patchNames = new(StringComparer.OrdinalIgnoreCase);
+
+        List<Archive> probes = OpenAll([.. patchFiles.ConvertAll(p => p.file)]);
+        foreach (Archive p in probes)
+        {
+            foreach (string n in p.Files)
+                patchNames.Add(n);
+
+            p.SFileCloseArchive();
+        }
+
+        foreach (Archive b in bases)
+        {
+            bool overlaps = false;
+            foreach (string n in b.Files)
+            {
+                if (patchNames.Contains(n))
+                {
+                    overlaps = true;
+                    break;
+                }
+            }
+
+            if (!overlaps)
+                continue;
+
+            int attached = 0;
+            foreach ((string file, long _) in patchFiles)
+            {
+                if (b.AttachPatch(file))
+                    attached++;
+                else
+                    logger.LogWarning("Failed to attach patch {Patch}", Path.GetFileName(file));
+            }
+
+            if (logger.IsEnabled(LogLevel.Trace))
+                logger.LogTrace("Chained {Count} patch archive(s) onto a base", attached);
+        }
+
+        if (logger.IsEnabled(LogLevel.Information))
+            logger.LogInformation("MPQ patch chain: {Patches} update archive(s) over {Bases} base archive(s)",
+                patchFiles.Count, bases.Count);
     }
 
     public MpqFileStream GetStream(ReadOnlySpan<char> fileName)

--- a/PPather/StormDll/StormDll.cs
+++ b/PPather/StormDll/StormDll.cs
@@ -14,7 +14,7 @@ internal static partial class StormDll
 
     // Runs once before the first StormLib P/Invoke below (all are static members
     // of this class), so the resolver decides which native binary to load per
-    // architecture: x64, x86 or arm64.
+    // OS and architecture.
     static StormDll()
     {
         NativeLibrary.SetDllImportResolver(typeof(StormDll).Assembly, Resolve);
@@ -27,22 +27,69 @@ internal static partial class StormDll
             return nint.Zero;
         }
 
-        string fileName = RuntimeInformation.ProcessArchitecture switch
+        // The Windows binaries are named per-architecture; the unix ones are not,
+        // because a build only ever targets the host architecture.
+        string fileName;
+        if (OperatingSystem.IsWindows())
         {
-            Architecture.X64 => "StormLib_x64.dll",
-            Architecture.X86 => "StormLib_x86.dll",
-            Architecture.Arm64 => "StormLib_arm64.dll",
-            _ => throw new PlatformNotSupportedException(
-                $"StormLib: unsupported process architecture {RuntimeInformation.ProcessArchitecture}"),
-        };
+            fileName = RuntimeInformation.ProcessArchitecture switch
+            {
+                Architecture.X64 => "StormLib_x64.dll",
+                Architecture.X86 => "StormLib_x86.dll",
+                Architecture.Arm64 => "StormLib_arm64.dll",
+                _ => throw new PlatformNotSupportedException(
+                    $"StormLib: unsupported process architecture {RuntimeInformation.ProcessArchitecture}"),
+            };
+        }
+        else if (OperatingSystem.IsMacOS())
+        {
+            fileName = "libstorm.dylib";
+        }
+        else if (OperatingSystem.IsLinux())
+        {
+            fileName = "libstorm.so";
+        }
+        else
+        {
+            throw new PlatformNotSupportedException(
+                $"StormLib: unsupported platform {RuntimeInformation.OSDescription}");
+        }
 
         return NativeLibrary.Load(Path.Combine(AppContext.BaseDirectory, "MPQ", fileName));
     }
 
-    [LibraryImport(LibraryName)]
+    /// <summary>
+    /// StormLib types archive paths as <c>TCHAR</c>. On Windows we ship
+    /// <c>STORM_UNICODE=ON</c> builds so that is UTF-16, but
+    /// <c>StormPort.h</c>'s non-Windows branch does <c>typedef char TCHAR</c> -
+    /// there is no wide API to build against - so a macOS/Linux build wants UTF-8.
+    ///
+    /// This matters because the mismatch is SILENT: a wide string handed to an
+    /// ANSI <c>SFileOpenArchive</c> is not rejected, it simply fails to find the
+    /// file, so every archive "does not exist" and the failure only surfaces much
+    /// later as missing geometry. That is exactly how issue #803 presented on
+    /// Windows ARM64 before the DLL was rebuilt with STORM_UNICODE=ON.
+    ///
+    /// <see cref="SFileOpenFileEx"/> needs no such split - names *inside* an
+    /// archive are <c>const char*</c> on every platform.
+    /// </summary>
+    public static bool SFileOpenArchive(string szMpqName, uint dwPriority, OpenArchive dwFlags, out nint phMpq) =>
+        OperatingSystem.IsWindows()
+            ? SFileOpenArchiveW(szMpqName, dwPriority, dwFlags, out phMpq)
+            : SFileOpenArchiveA(szMpqName, dwPriority, dwFlags, out phMpq);
+
+    [LibraryImport(LibraryName, EntryPoint = "SFileOpenArchive")]
     [return: MarshalAs(UnmanagedType.Bool)]
-    public static partial bool SFileOpenArchive(
+    private static partial bool SFileOpenArchiveW(
         [MarshalAs(UnmanagedType.LPWStr)] string szMpqName,
+        uint dwPriority,
+        OpenArchive dwFlags,
+        out nint phMpq);
+
+    [LibraryImport(LibraryName, EntryPoint = "SFileOpenArchive", StringMarshalling = StringMarshalling.Utf8)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool SFileOpenArchiveA(
+        string szMpqName,
         uint dwPriority,
         OpenArchive dwFlags,
         out nint phMpq);
@@ -50,6 +97,37 @@ internal static partial class StormDll
     [LibraryImport(LibraryName)]
     [return: MarshalAs(UnmanagedType.Bool)]
     public static partial bool SFileCloseArchive(nint hMpq);
+
+    /// <summary>
+    /// Attaches a patch archive to an already-open base archive. Blizzard's
+    /// `wow-update-*.MPQ` archives hold incremental PTCH deltas rather than whole
+    /// files, so they are only readable through a base archive's patch chain -
+    /// opening one standalone yields a PTCH blob, not the file.
+    /// szPatchPathPrefix is passed as NULL (nint.Zero); StormLib then derives the
+    /// prefix itself, which is what the base/locale update archives need.
+    /// The patch path is <c>TCHAR</c> like <see cref="SFileOpenArchive"/>, hence
+    /// the same wide/UTF-8 split; the prefix is <c>const char*</c> everywhere.
+    /// </summary>
+    public static bool SFileOpenPatchArchive(nint hMpq, string szPatchMpqName, nint szPatchPathPrefix, uint dwFlags) =>
+        OperatingSystem.IsWindows()
+            ? SFileOpenPatchArchiveW(hMpq, szPatchMpqName, szPatchPathPrefix, dwFlags)
+            : SFileOpenPatchArchiveA(hMpq, szPatchMpqName, szPatchPathPrefix, dwFlags);
+
+    [LibraryImport(LibraryName, EntryPoint = "SFileOpenPatchArchive")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool SFileOpenPatchArchiveW(
+        nint hMpq,
+        [MarshalAs(UnmanagedType.LPWStr)] string szPatchMpqName,
+        nint szPatchPathPrefix,
+        uint dwFlags);
+
+    [LibraryImport(LibraryName, EntryPoint = "SFileOpenPatchArchive", StringMarshalling = StringMarshalling.Utf8)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool SFileOpenPatchArchiveA(
+        nint hMpq,
+        string szPatchMpqName,
+        nint szPatchPathPrefix,
+        uint dwFlags);
 
     [LibraryImport(LibraryName, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]

--- a/PPather/Triangles/Game/ChunkReader.cs
+++ b/PPather/Triangles/Game/ChunkReader.cs
@@ -49,6 +49,7 @@ internal static class ChunkReader
     public const uint MOVI = 0b_01001101_01001111_01010110_01001001;
     public const uint MOVT = 0b_01001101_01001111_01010110_01010100;
     public const uint MCIN = 0b_01001101_01000011_01001001_01001110;
+    public const uint MCNK = 0b_01001101_01000011_01001110_01001011;
     public const uint MMDX = 0b_01001101_01001101_01000100_01011000;
     public const uint MDDF = 0b_01001101_01000100_01000100_01000110;
     public const uint MCNR = 0b_01001101_01000011_01001110_01010010;

--- a/PPather/Triangles/Game/MapChunk.cs
+++ b/PPather/Triangles/Game/MapChunk.cs
@@ -49,9 +49,27 @@ internal readonly struct MapChunk
         0x8888 & 0x000F, 0x8888 & 0x00F0, 0x8888 & 0x0F00, 0x8888 & 0xF000
     ];
 
+    /// <summary>
+    /// Mists-era 8x8 hole mask, one bit per unit cell (bit index j*8+i), taken
+    /// from the MCNK header when <c>MCNK_FLAG_HIGH_RES_HOLES</c> is set. That
+    /// flag repurposes the header bytes that normally hold ofsHeight/ofsNormal,
+    /// and leaves the legacy 4x4 <see cref="holes"/> field meaningless - so a
+    /// reader that only knows the low-res field floors over real gaps. 0 when
+    /// the chunk uses the legacy field, which is every pre-Mists client.
+    /// </summary>
+    public readonly ulong holesHighRes;
+
     // 0 ..3, 0 ..3
     public bool IsHole(int i, int j)
     {
+        if (holesHighRes != 0)
+        {
+            if ((uint)i > 7 || (uint)j > 7)
+                return false;
+
+            return (holesHighRes & (1UL << ((j << 3) | i))) != 0;
+        }
+
         if (!hasholes)
             return false;
 
@@ -68,7 +86,7 @@ internal readonly struct MapChunk
 
 
     public MapChunk(float xbase, float ybase, float zbase,
-        uint areaID, bool haswater, uint holes, float[] vertices,
+        uint areaID, bool haswater, uint holes, ulong holesHighRes, float[] vertices,
         float water_height1, float water_height2, float[] water_height, byte[] water_flags, bool legacyWater)
     {
         this.xbase = xbase;
@@ -78,6 +96,7 @@ internal readonly struct MapChunk
         this.haswater = haswater;
         this.holes = holes;
         this.hasholes = holes != 0;
+        this.holesHighRes = holesHighRes;
         this.vertices = vertices;
 
         this.water_height1 = water_height1;

--- a/PPather/Triangles/Game/MapTileFile.cs
+++ b/PPather/Triangles/Game/MapTileFile.cs
@@ -39,11 +39,31 @@ internal static partial class MapTileFile // adt file
     private static readonly LiquidData eLiquidData = new(0, 0, 0, EmptyMH2OData1, [], []);
     public static ref readonly LiquidData EmptyLiquidData => ref eLiquidData;
 
+    /// <summary>
+    /// MCNK header flag 0x10000: the chunk carries a 64-bit 8x8 hole mask in the
+    /// header words that otherwise hold ofsHeight/ofsNormal. Mists-era only;
+    /// no pre-Cataclysm client sets it.
+    /// </summary>
+    private const uint MCNK_FLAG_HIGH_RES_HOLES = 0x10000;
+
+    /// <summary>ADT file extension, including the dot.</summary>
+    private const string AdtExtension = ".adt";
+
+    /// <summary>
+    /// Cataclysm-era companion file carrying the model/WMO placement chunks that
+    /// a pre-Cataclysm root ADT holds inline. Its sibling <c>_tex0</c>/<c>_tex1</c>
+    /// files are texture data only and are never read by the bake.
+    /// </summary>
+    private const string ObjectFileSuffix = "_obj0.adt";
+
     public static MapTile Read(ArchiveSet archive, ReadOnlySpan<char> name, WMOManager wmomanager, ModelManager modelmanager)
     {
         LiquidData[] LiquidDataChunk = [];
 
         Span<SMChunkInfo> mcin = stackalloc SMChunkInfo[MapTile.SIZE * MapTile.SIZE];
+        Span<uint> mcnkOffsets = stackalloc uint[MapTile.SIZE * MapTile.SIZE];
+        int mcnkCount = 0;
+        bool haveMcin = false;
 
         string[] models = [];
         string[] wmos = [];
@@ -66,6 +86,8 @@ internal static partial class MapTileFile // adt file
 
         do
         {
+            long chunkStart = file.BaseStream.Position;
+
             uint type = file.ReadUInt32();
             uint size = file.ReadUInt32();
             long nextPos = file.BaseStream.Position + size;
@@ -74,6 +96,12 @@ internal static partial class MapTileFile // adt file
             {
                 case ChunkReader.MCIN:
                     HandleMCIN(file, mcin);
+                    haveMcin = true;
+                    break;
+                case ChunkReader.MCNK when mcnkCount < mcnkOffsets.Length:
+                    // Only used when MCIN is absent, but recording the offsets
+                    // costs one store per chunk and keeps this a single pass.
+                    mcnkOffsets[mcnkCount++] = (uint)chunkStart;
                     break;
                 case ChunkReader.MMDX when size != 0:
                     models = ChunkReader.ExtractFileNames(file, size);
@@ -101,13 +129,36 @@ internal static partial class MapTileFile // adt file
         if (models.Length != 0)
             ArrayPool<string>.Shared.Return(models);
 
+        // Cataclysm split the ADT: the root lost MCIN and handed model/WMO
+        // placement to a `_obj0` companion. Keyed off the absence of MCIN in the
+        // file itself rather than the configured client version, so vanilla/TBC/
+        // WotLK keep the exact pre-existing path and one reader serves both
+        // layouts.
+        if (!haveMcin)
+            ReadObjectFile(archive, name, wmomanager, modelmanager, ref modelis, ref wmois);
+
         // NOTE: `file`/`stream` read directly out of `buffer`, so the buffer must
         // stay rented until the MCNK pass below is done. Returning it earlier
         // happened to work only because nothing else rented in between - it
         // corrupts geometry as soon as ADTs are parsed concurrently.
         for (int index = 0; index < MapTile.SIZE * MapTile.SIZE; index++)
         {
-            int off = (int)mcin[index].offset;
+            int off;
+            if (haveMcin)
+            {
+                off = (int)mcin[index].offset;
+            }
+            else
+            {
+                // A split ADT lists its MCNKs in grid order with no offset table,
+                // so encounter order is the index. A short tile leaves the tail
+                // unflagged rather than reading from offset 0.
+                if (index >= mcnkCount)
+                    continue;
+
+                off = (int)mcnkOffsets[index];
+            }
+
             file.BaseStream.Seek(off, SeekOrigin.Begin);
 
             chunks[index] = ReadMapChunk(file, LiquidDataChunk.Length > 0 ? LiquidDataChunk[index] : EmptyLiquidData);
@@ -120,19 +171,33 @@ internal static partial class MapTileFile // adt file
     }
 
     /// <summary>
-    /// Lean pass that pulls only the per-MCNK areaID for all 256 chunks and
-    /// skips geometry, models and WMOs entirely. areaID sits at offset 0x34 of
-    /// the MCNK header, i.e. the chunk's (tag + size) plus 13 header uints ==
-    /// 60 bytes past the MCIN-reported chunk start. Used to bake the standalone
-    /// <see cref="PPather.Navmesh.AreaGrid"/> cheaply and without touching (or
-    /// crashing on) tile collision geometry.
+    /// Loads the model/WMO placement chunks for a Cataclysm-era split ADT from its
+    /// <c>_obj0</c> companion. Leaves the outputs untouched when the companion is
+    /// absent, so a root ADT that simply carries no placements stays empty.
+    /// The companion's own MCNK chunks hold per-chunk doodad references, which the
+    /// bake does not use - <c>MPQTriangleSupplier</c> culls against instance bounds
+    /// instead - so they are skipped.
     /// </summary>
-    public static void ReadAreaIds(ArchiveSet archive, ReadOnlySpan<char> name, Span<uint> areaIds)
+    private static void ReadObjectFile(ArchiveSet archive, ReadOnlySpan<char> name,
+        WMOManager wmomanager, ModelManager modelmanager,
+        ref ModelInstance[] modelis, ref WMOInstance[] wmois)
     {
-        Span<SMChunkInfo> mcin = stackalloc SMChunkInfo[MapTile.SIZE * MapTile.SIZE];
-        bool haveMcin = false;
+        if (!name.EndsWith(AdtExtension, StringComparison.OrdinalIgnoreCase))
+            return;
 
-        using MpqFileStream mpq = archive.GetStream(name);
+        ReadOnlySpan<char> stem = name[..^AdtExtension.Length];
+
+        Span<char> objName = stackalloc char[stem.Length + ObjectFileSuffix.Length];
+        stem.CopyTo(objName);
+        ObjectFileSuffix.CopyTo(objName[stem.Length..]);
+
+        if (!archive.Exists(objName))
+            return;
+
+        string[] models = [];
+        string[] wmos = [];
+
+        using MpqFileStream mpq = archive.GetStream(objName);
         int length = (int)mpq.Length;
 
         var pooler = ArrayPool<byte>.Shared;
@@ -148,6 +213,68 @@ internal static partial class MapTileFile // adt file
             uint size = file.ReadUInt32();
             long nextPos = file.BaseStream.Position + size;
 
+            switch (type)
+            {
+                case ChunkReader.MMDX when size != 0:
+                    models = ChunkReader.ExtractFileNames(file, size);
+                    break;
+                case ChunkReader.MWMO when size != 0:
+                    wmos = ChunkReader.ExtractFileNames(file, size);
+                    break;
+                case ChunkReader.MDDF:
+                    HandleMDDF(file, modelmanager, models, size, out modelis);
+                    break;
+                case ChunkReader.MODF:
+                    HandleMODF(file, wmos, wmomanager, size, out wmois);
+                    break;
+            }
+
+            file.BaseStream.Seek(nextPos, SeekOrigin.Begin);
+        } while (!file.EOF());
+
+        if (wmos.Length != 0)
+            ArrayPool<string>.Shared.Return(wmos);
+
+        if (models.Length != 0)
+            ArrayPool<string>.Shared.Return(models);
+
+        pooler.Return(buffer);
+    }
+
+    /// <summary>
+    /// Lean pass that pulls only the per-MCNK areaID for all 256 chunks and
+    /// skips geometry, models and WMOs entirely. Handles both the pre-Cataclysm
+    /// layout (chunk starts from MCIN) and the Cataclysm-era split ADT (no MCIN;
+    /// MCNKs walked in grid order) - the MCNK header itself is unchanged between
+    /// the two. Used to bake the standalone
+    /// <see cref="PPather.Navmesh.AreaGrid"/> cheaply and without touching (or
+    /// crashing on) tile collision geometry.
+    /// </summary>
+    public static void ReadAreaIds(ArchiveSet archive, ReadOnlySpan<char> name, Span<uint> areaIds)
+    {
+        Span<SMChunkInfo> mcin = stackalloc SMChunkInfo[MapTile.SIZE * MapTile.SIZE];
+        Span<uint> mcnkOffsets = stackalloc uint[MapTile.SIZE * MapTile.SIZE];
+        int mcnkCount = 0;
+        bool haveMcin = false;
+
+        using MpqFileStream mpq = archive.GetStream(name);
+        int length = (int)mpq.Length;
+
+        var pooler = ArrayPool<byte>.Shared;
+        byte[] buffer = pooler.Rent(length);
+        mpq.ReadAllBytesTo(buffer);
+
+        using MemoryStream stream = new(buffer, 0, length, false);
+        using BinaryReader file = new(stream);
+
+        do
+        {
+            long chunkStart = file.BaseStream.Position;
+
+            uint type = file.ReadUInt32();
+            uint size = file.ReadUInt32();
+            long nextPos = file.BaseStream.Position + size;
+
             if (type == ChunkReader.MCIN)
             {
                 HandleMCIN(file, mcin);
@@ -155,9 +282,17 @@ internal static partial class MapTileFile // adt file
                 break;
             }
 
+            // Cataclysm-era split ADT: no offset table, MCNKs run in grid order.
+            // Keep walking to collect them - unlike the MCIN case there is no
+            // early chunk to stop on.
+            if (type == ChunkReader.MCNK && mcnkCount < mcnkOffsets.Length)
+                mcnkOffsets[mcnkCount++] = (uint)chunkStart;
+
             file.BaseStream.Seek(nextPos, SeekOrigin.Begin);
         } while (!file.EOF());
 
+        // areaID sits at offset 0x34 of the MCNK header, i.e. the chunk's
+        // (tag + size) plus 13 header uints == 60 bytes past the chunk start.
         if (haveMcin)
         {
             for (int i = 0; i < mcin.Length && i < areaIds.Length; i++)
@@ -169,6 +304,14 @@ internal static partial class MapTileFile // adt file
                 }
 
                 file.BaseStream.Seek(mcin[i].offset + (sizeof(uint) * 15), SeekOrigin.Begin);
+                areaIds[i] = file.ReadUInt32();
+            }
+        }
+        else
+        {
+            for (int i = 0; i < mcnkCount && i < areaIds.Length; i++)
+            {
+                file.BaseStream.Seek(mcnkOffsets[i] + (sizeof(uint) * 15), SeekOrigin.Begin);
                 areaIds[i] = file.ReadUInt32();
             }
         }
@@ -302,7 +445,18 @@ internal static partial class MapTileFile // adt file
         //_ = file.ReadUInt32(); // uint ofsShadow
         //_ = file.ReadUInt32(); // uint sizeShadow
 
-        file.BaseStream.Seek(sizeof(UInt32) * 15, SeekOrigin.Current);
+        // Header words are read rather than blind-skipped from here on, because
+        // Mists overlays holes_high_res on ofsHeight/ofsNormal (words 5-6) when
+        // the flag below is set. Layout is otherwise unchanged from vanilla.
+        file.BaseStream.Seek(sizeof(UInt32) * 2, SeekOrigin.Current); // magic + size
+        uint mcnkFlags = file.ReadUInt32();                           // [0] flags
+        file.BaseStream.Seek(sizeof(UInt32) * 4, SeekOrigin.Current); // [1..4]
+        ulong holesHighResRaw = file.ReadUInt64();                    // [5..6]
+        file.BaseStream.Seek(sizeof(UInt32) * 6, SeekOrigin.Current); // [7..12]
+
+        ulong holesHighRes = (mcnkFlags & MCNK_FLAG_HIGH_RES_HOLES) != 0
+            ? holesHighResRaw
+            : 0;
 
         uint areaID = file.ReadUInt32();
         //_ = file.ReadUInt32(); // uint nMapObjRefs
@@ -394,7 +548,7 @@ internal static partial class MapTileFile // adt file
         }
 
         return new(xbase, ybase, zbase,
-            areaID, haswater, holes,
+            areaID, haswater, holes, holesHighRes,
             vertices, water_height1, water_height2,
             water_height, water_flags, legacyWater);
     }

--- a/PPather/Triangles/Game/WDTFile.cs
+++ b/PPather/Triangles/Game/WDTFile.cs
@@ -55,7 +55,13 @@ internal sealed class WDTFile
         this.archive = archive;
 
         ReadOnlySpan<char> path = pathName.AsSpan();
-        ReadOnlySpan<char> wdtfile = Path.Join("World".AsSpan(), "Maps".AsSpan(), path, $"{path}.wdt".AsSpan());
+
+        // Interpolated, NOT Path.Join: these are paths *inside* the MPQ, whose
+        // entries are always backslash-separated regardless of host OS. Path.Join
+        // uses Path.DirectorySeparatorChar, which yields "World/Maps/..." on
+        // macOS/Linux and matches nothing in the archive - the sibling ADT lookups
+        // below already build their paths this way.
+        ReadOnlySpan<char> wdtfile = $"World\\Maps\\{path}\\{path}.wdt";
         using MpqFileStream mpq = archive.GetStream(wdtfile);
 
         var pooler = ArrayPool<byte>.Shared;
@@ -134,12 +140,22 @@ internal sealed class WDTFile
         }
     }
 
+    /// <summary>
+    /// SMAreaInfo.flags bit 0 - this grid cell actually has an ADT on disk.
+    /// Only bit 0 means that: Cataclysm marks the open-ocean cells that make up
+    /// most of the grid with flag 2 (3257 of Azeroth's 4096, 3085 of Kalimdor's),
+    /// so testing the whole word for non-zero claims every cell has terrain and
+    /// the loader then throws FileNotFoundException on the first one. Pre-Cata
+    /// WDTs only ever store 0 or 1, so masking changes nothing for them.
+    /// </summary>
+    private const int AreaInfoHasAdt = 0x1;
+
     private void HandleMAIN(BinaryReader file, uint size)
     {
         // global map objects
         for (int index = 0; index < WDT.SIZE * WDT.SIZE; index++)
         {
-            wdt.maps[index] = file.ReadInt32() != 0;
+            wdt.maps[index] = (file.ReadInt32() & AreaInfoHasAdt) != 0;
             //file.ReadInt32(); // kasta
             file.BaseStream.Seek(sizeof(Int32), SeekOrigin.Current);
         }

--- a/PPather/Triangles/MPQTriangleSupplier.cs
+++ b/PPather/Triangles/MPQTriangleSupplier.cs
@@ -103,6 +103,18 @@ public sealed class MPQTriangleSupplier
 
     public static string[] GetArchiveNames(DataConfig dataConfig)
     {
+        // No MPQ directory is a normal install now, not an error: the navmesh answers
+        // from baked tiles and needs no game files, so a user who only downloaded
+        // tiles has nothing here. Directory.GetFiles would throw
+        // DirectoryNotFoundException, and because PPatherService calls this from its
+        // constructor (via MPQSelfTest) that failure takes the whole service down -
+        // every request 500s rather than falling back to disk-only. Callers already
+        // treat an empty result as "no archives".
+        if (!Directory.Exists(dataConfig.MPQ))
+        {
+            return [];
+        }
+
         return Directory.GetFiles(dataConfig.MPQ, "*.MPQ");
     }
 

--- a/PathingAPI/AnTcp/AnTcpPathServer.cs
+++ b/PathingAPI/AnTcp/AnTcpPathServer.cs
@@ -86,7 +86,8 @@ public sealed class AnTcpPathServer : BackgroundService
         TcpListener listener = new(endpoint);
         listener.Start();
 
-        logger.LogInformation("AnTCP path server listening on {Endpoint} (PATH only)", endpoint);
+        if (logger.IsEnabled(LogLevel.Information))
+            logger.LogInformation("AnTCP path server listening on {Endpoint} (PATH only)", endpoint);
 
         try
         {
@@ -110,7 +111,8 @@ public sealed class AnTcpPathServer : BackgroundService
     private async Task ServeAsync(TcpClient client, CancellationToken token)
     {
         EndPoint? remote = client.Client.RemoteEndPoint;
-        logger.LogInformation("AnTCP client connected: {Remote}", remote);
+        if (logger.IsEnabled(LogLevel.Information))
+            logger.LogInformation("AnTCP client connected: {Remote}", remote);
 
         try
         {
@@ -151,7 +153,8 @@ public sealed class AnTcpPathServer : BackgroundService
         catch (Exception e) when (e is IOException or SocketException or OperationCanceledException)
         {
             // Client vanished or shutdown - not worth a stack trace.
-            logger.LogInformation("AnTCP client disconnected: {Remote}", remote);
+            if (logger.IsEnabled(LogLevel.Information))
+                logger.LogInformation("AnTCP client disconnected: {Remote}", remote);
         }
         catch (Exception e)
         {

--- a/PathingAPI/AnTcp/AnTcpPathServer.cs
+++ b/PathingAPI/AnTcp/AnTcpPathServer.cs
@@ -1,0 +1,311 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+using PPather;
+using PPather.Graph;
+
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Numerics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PathingAPI.AnTcp;
+
+/// <summary>
+/// Speaks AmeisenNavigation's AnTCP protocol so <c>RemotePathingAPIV3</c> can talk to
+/// this server instead of the external AmeisenNavigation binary - same wire format,
+/// but answered from this project's era-aware navmesh, so no MMAPs and no second
+/// process. Enable with <c>Pathing:AnTcp:Enabled=true</c>.
+///
+/// Only <see cref="MessageType.Path"/> is implemented, because it is the only message
+/// the bot ever sends: RemotePathingAPIV3 hardcodes <c>TYPE = EMessageType.PATH</c>
+/// and its sole other traffic is the TCP connect used as a ping. Any other type gets
+/// an explicit empty reply rather than silence, so a client that does send one fails
+/// fast instead of blocking on a read.
+///
+/// Wire format (little-endian, matching the C++ structs byte for byte):
+///   request   int32 size(payload+1) | byte type | int32 mapId | int32 flags | float start[3] | float end[3]
+///   response  int32 size(payload+1) | byte type | Vector3[n]
+/// A single all-zero Vector3 means "no path", which is what AmeisenNavigation returns
+/// on failure and what the client already tests for.
+/// </summary>
+public sealed class AnTcpPathServer : BackgroundService
+{
+    /// <summary>Request payload: int mapId, int flags, Vector3 start, Vector3 end.</summary>
+    private const int PathRequestSize = 4 + 4 + 12 + 12;
+
+    /// <summary>Bytes of a System.Numerics.Vector3 on the wire.</summary>
+    private const int Vector3Size = 12;
+
+    /// <summary>
+    /// Frame guard. The only request is 33 bytes; anything larger is a desynced
+    /// stream or a wrong-protocol client, and reading it would allocate blindly.
+    /// </summary>
+    private const int MaxFrameSize = 4096;
+
+    private enum MessageType : byte
+    {
+        Path = 0,
+        MoveAlongSurface = 1,
+        RandomPoint = 2,
+        RandomPointAround = 3,
+        CastRay = 4,
+        RandomPath = 5,
+        ExplorePoly = 6,
+        ConfigureFilter = 7,
+    }
+
+    private const SearchStrategy Search = SearchStrategy.A_Star_With_Model_Avoidance;
+
+    private readonly ILogger<AnTcpPathServer> logger;
+    private readonly PPatherService service;
+    private readonly IPEndPoint endpoint;
+
+    // PPatherService is a singleton whose search is a SetLocations-then-DoSearch
+    // sequence over shared state, so two clients interleaving would return each
+    // other's routes. Serialize instead of rejecting: a warm navmesh query is
+    // single-digit milliseconds, so waiting beats the HTTP API's 429 (which the
+    // V1 client cannot distinguish from "no path exists").
+    private readonly SemaphoreSlim searchLock = new(1, 1);
+
+    public AnTcpPathServer(ILogger<AnTcpPathServer> logger, PPatherService service,
+        string ip, int port)
+    {
+        this.logger = logger;
+        this.service = service;
+        endpoint = new IPEndPoint(IPAddress.Parse(ip), port);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        TcpListener listener = new(endpoint);
+        listener.Start();
+
+        logger.LogInformation("AnTCP path server listening on {Endpoint} (PATH only)", endpoint);
+
+        try
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                TcpClient client = await listener.AcceptTcpClientAsync(stoppingToken);
+                _ = Task.Run(() => ServeAsync(client, stoppingToken), CancellationToken.None);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Normal shutdown.
+        }
+        finally
+        {
+            listener.Stop();
+            logger.LogInformation("AnTCP path server stopped");
+        }
+    }
+
+    private async Task ServeAsync(TcpClient client, CancellationToken token)
+    {
+        EndPoint? remote = client.Client.RemoteEndPoint;
+        logger.LogInformation("AnTCP client connected: {Remote}", remote);
+
+        try
+        {
+            client.NoDelay = true;   // request/response, never batched - latency over throughput
+            using NetworkStream stream = client.GetStream();
+
+            byte[] header = new byte[sizeof(int)];
+
+            while (!token.IsCancellationRequested)
+            {
+                // ReadExactly, not Read: a 4-byte header can legitimately arrive split.
+                try
+                {
+                    await stream.ReadExactlyAsync(header, token);
+                }
+                catch (EndOfStreamException)
+                {
+                    break;   // client closed
+                }
+
+                int size = BinaryPrimitives.ReadInt32LittleEndian(header);
+                if (size < 1 || size > MaxFrameSize)
+                {
+                    logger.LogWarning("AnTCP {Remote}: bad frame size {Size}, dropping", remote, size);
+                    break;
+                }
+
+                byte[] frame = new byte[size];
+                await stream.ReadExactlyAsync(frame, token);
+
+                byte type = frame[0];
+                ReadOnlyMemory<byte> payload = frame.AsMemory(1);
+
+                byte[] response = Handle(type, payload.Span, remote);
+                await WriteAsync(stream, type, response, token);
+            }
+        }
+        catch (Exception e) when (e is IOException or SocketException or OperationCanceledException)
+        {
+            // Client vanished or shutdown - not worth a stack trace.
+            logger.LogInformation("AnTCP client disconnected: {Remote}", remote);
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "AnTCP client {Remote} failed", remote);
+        }
+        finally
+        {
+            client.Dispose();
+        }
+    }
+
+    private static async Task WriteAsync(NetworkStream stream, byte type, byte[] payload,
+        CancellationToken token)
+    {
+        byte[] buffer = new byte[sizeof(int) + 1 + payload.Length];
+        BinaryPrimitives.WriteInt32LittleEndian(buffer, payload.Length + 1);
+        buffer[sizeof(int)] = type;
+        payload.CopyTo(buffer, sizeof(int) + 1);
+
+        await stream.WriteAsync(buffer, token);
+    }
+
+    private byte[] Handle(byte type, ReadOnlySpan<byte> payload, EndPoint? remote)
+    {
+        if (type != (byte)MessageType.Path)
+        {
+            logger.LogWarning(
+                "AnTCP {Remote}: message type {Type} is not implemented (PATH only); replying empty",
+                remote, Enum.IsDefined(typeof(MessageType), type) ? (MessageType)type : type);
+            return [];
+        }
+
+        if (payload.Length < PathRequestSize)
+        {
+            logger.LogWarning("AnTCP {Remote}: PATH payload is {Actual} bytes, expected {Expected}",
+                remote, payload.Length, PathRequestSize);
+            return NoPath();
+        }
+
+        int mapId = BinaryPrimitives.ReadInt32LittleEndian(payload);
+        // flags (SMOOTH_*/VALIDATE_*) are read for completeness but not acted on: the
+        // navmesh engine always returns a Catmull-Rom smoothed, CPOP-validated path,
+        // which is exactly the combination RemotePathingAPIV3 asks for.
+        int flags = BinaryPrimitives.ReadInt32LittleEndian(payload[4..]);
+
+        Vector3 start = ReadVector3(payload[8..]);
+        Vector3 end = ReadVector3(payload[20..]);
+
+        return FindPath(mapId, flags, start, end, remote);
+    }
+
+    private static Vector3 ReadVector3(ReadOnlySpan<byte> b) => new(
+        BinaryPrimitives.ReadSingleLittleEndian(b),
+        BinaryPrimitives.ReadSingleLittleEndian(b[4..]),
+        BinaryPrimitives.ReadSingleLittleEndian(b[8..]));
+
+    /// <summary>
+    /// How far a requested z may sit from the navmesh surface before it is treated as
+    /// "the caller does not know its height" rather than a real floor.
+    ///
+    /// This exists because of what the client actually sends: when
+    /// <c>RemotePathingAPIV3</c> has no z it substitutes <c>area.LocTop / 2</c> - and
+    /// LocTop is a world *Y* bound, not a height, so for Elwynn it sends -3969 against
+    /// terrain at 82. AmeisenNavigation tolerates that through a very tall
+    /// findNearestPoly extent; our endpoint resolver uses tight vertical extents on
+    /// purpose (it is what keeps multi-floor buildings honest), so the search would
+    /// simply find nothing. Measured: -3969 returns NO PATH, 0 and 82 both return 410
+    /// points.
+    ///
+    /// The band is wide enough that a bot genuinely standing on an upper floor keeps
+    /// its own z and still disambiguates by height.
+    /// </summary>
+    private const float MaxPlausibleZDeltaYd = 128f;
+
+    /// <summary>
+    /// Replaces a height that lies nowhere near the mesh with the walkable surface at
+    /// that column. Uses the disk-only per-continent query navmesh, so it neither
+    /// switches the active continent nor needs game files.
+    /// </summary>
+    private Vector3 SnapImplausibleZ(int mapId, Vector3 p, string which, EndPoint? remote)
+    {
+        (_, float surface) = service.GetAreaIdAndZ(mapId, p.X, p.Y);
+
+        // 0 means "no navmesh covers this column" - there is nothing better to offer.
+        if (surface == 0f || MathF.Abs(p.Z - surface) <= MaxPlausibleZDeltaYd)
+        {
+            return p;
+        }
+
+        if (logger.IsEnabled(LogLevel.Debug))
+        {
+            logger.LogDebug("AnTCP {Remote}: {Which} z {Given} is {Delta:F0}yd off the mesh, using {Surface}",
+                remote, which, p.Z, MathF.Abs(p.Z - surface), surface);
+        }
+
+        return new(p.X, p.Y, surface);
+    }
+
+    private byte[] FindPath(int mapId, int flags, Vector3 start, Vector3 end, EndPoint? remote)
+    {
+        searchLock.Wait();
+        try
+        {
+            start = SnapImplausibleZ(mapId, start, "start", remote);
+            end = SnapImplausibleZ(mapId, end, "end", remote);
+
+            service.SetLocations(new(start, mapId), new(end, mapId));
+            // Fully qualified: System.IO.Path is in scope for the stream code above.
+            PPather.Graph.Path? path = service.DoSearch(Search);
+
+            if (path == null || path.locations.Count == 0)
+            {
+                return NoPath();
+            }
+
+            List<Vector3> points = path.locations;
+            byte[] result = new byte[points.Count * Vector3Size];
+            Span<byte> span = result;
+
+            for (int i = 0; i < points.Count; i++)
+            {
+                Vector3 p = points[i];
+                Span<byte> at = span[(i * Vector3Size)..];
+                BinaryPrimitives.WriteSingleLittleEndian(at, p.X);
+                BinaryPrimitives.WriteSingleLittleEndian(at[4..], p.Y);
+                BinaryPrimitives.WriteSingleLittleEndian(at[8..], p.Z);
+            }
+
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                logger.LogDebug("AnTCP {Remote}: PATH map {MapId} flags {Flags} {Start} -> {End} = {Count} points",
+                    remote, mapId, flags, start, end, points.Count);
+            }
+
+            return result;
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e, "AnTCP {Remote}: PATH map {MapId} {Start} -> {End} failed",
+                remote, mapId, start, end);
+            return NoPath();
+        }
+        finally
+        {
+            searchLock.Release();
+        }
+    }
+
+    /// <summary>One all-zero Vector3 - AmeisenNavigation's failure reply, which the client tests for.</summary>
+    private static byte[] NoPath() => new byte[Vector3Size];
+
+    public override void Dispose()
+    {
+        searchLock.Dispose();
+        base.Dispose();
+    }
+}

--- a/PathingAPI/CLAUDE.md
+++ b/PathingAPI/CLAUDE.md
@@ -1,0 +1,90 @@
+# PathingAPI — standalone pathing server
+
+Hosts `PPatherService` over HTTP (+ Swagger, + a Blazor route visualiser) without a game
+client attached. Used as **V1 Remote** by the bot, as the bake/authoring host, and as the
+map you open at `/Leaflet`.
+
+## Run
+
+```powershell
+dotnet run --project PathingAPI -c Release -- --exp=cata
+```
+
+| Argument | Meaning |
+|---|---|
+| `--exp=<client>` | `som`/`tbc`/`wrath`/`cata`/`mop`/`legacy_*`. Defaults to `som`. Decides `/dbc`, `/tiles` and the navmesh era. |
+| `--Pathing:Engine=` | `Navmesh` (default) or `SpotAStar` |
+| `--bake=<continent>` | background navmesh bake at startup; `all` for every continent |
+| `--bake-area=<continent>` | area-id grid + subzone bounds extraction |
+| `--urls http://…` | override the port (default 5001) |
+
+## Layout
+
+```
+Controllers/PPatherController.cs  the whole HTTP surface (routes, bake, stats, viz)
+AnTcp/AnTcpPathServer.cs          AmeisenNavigation binary protocol, opt-in
+RateLimit/                        one-at-a-time filter (see below)
+Pages/Leaflet.razor               the map page
+Hubs/                             SignalR for live route drawing
+Startup.cs                        DI, era selection, startup bake hooks
+```
+
+## Things that will bite you
+
+**One client at a time.** `RateLimitFilter` is a `static bool isBusy` that answers a
+concurrent request with **429**, and the V1 client turns that into an empty route —
+indistinguishable from "no path exists". It dates from the SpotAStar era when a search
+cost seconds. Do not point several bots at one instance; see the README's
+"Running multiple bots".
+
+**The service is a singleton with a two-call search.** `SetLocations` then `DoSearch`
+over shared state, plus `PathJitterYards` / `PathEdgeMarginYards` / `lastStartIndoors`.
+Anything new that searches must serialize (`AnTcpPathServer` uses a `SemaphoreSlim`).
+
+**Switching continent disposes the engine.** `Initialise(mapId)` calls `Reset()` on a
+different map, dropping resident tiles. Two callers on different continents thrash.
+
+**The era comes from `DataConfig.Exp`, never from the URL.** `Pages/Leaflet.razor` used
+to trust the `{expansion}` route segment (defaulting to `"som"`), which rendered one
+era's art against another's data. It now overrides from the server and logs the
+mismatch.
+
+**`Json/MPQ` is not era-aware** — it is one directory for whatever client you point it
+at. Running `--exp=cata` with wrath archives in there silently loads wrath geometry and
+only fails on a continent wrath lacks. For a different client, build a mirror root of
+junctions whose `MPQ` points at that client's `Data`.
+
+**A running instance locks the build output.** Solution builds fail with MSB3027 naming
+the pid. Compile-check with `-c Debug` instead of killing the user's server.
+
+**`GET SelfTest` reports what the *active engine* needs, not MPQ.** For `Navmesh` it
+counts baked `.dnm` per continent for the active era and returns
+`{ok, engine, exp, era, detail, mpqPresent, totalTiles, continents[]}`; for `SpotAStar`
+it falls back to the archive check, because that engine has no tile cache. It used to be
+`MPQSelfTest()` alone, which reported failure on every tiles-only or CASC install even
+though pathing worked perfectly.
+
+## AnTCP (binary, opt-in)
+
+Speaks AmeisenNavigation's protocol so a `RemoteV3`-configured bot can use this server
+instead of the external binary. Enable in `appsettings.json`:
+
+```json
+"Pathing": { "AnTcp": { "Enabled": true, "Ip": "127.0.0.1", "Port": 47110 } }
+```
+
+Wire format, little-endian:
+
+```
+request   int32 size(payload+1) | byte type | int32 mapId | int32 flags | float start[3] | float end[3]
+response  int32 size(payload+1) | byte type | Vector3[n]        (single all-zero Vector3 = no path)
+```
+
+Only `PATH` (type 0) is implemented — it is the only message `RemotePathingAPIV3` ever
+sends. Concurrent clients queue rather than 429.
+
+**The z trap:** when the client has no height it sends `area.LocTop / 2`, and `LocTop`
+is a world **Y** bound, not a height — for Elwynn that is -3969 against terrain at 82.
+AmeisenNavigation absorbs it with a very tall poly-search extent; this engine keeps tight
+vertical extents so multi-floor buildings resolve, so `SnapImplausibleZ` puts any z more
+than 128 yd off the surface back on it. Do not "fix" this by widening the resolver.

--- a/PathingAPI/Controllers/PPatherController.cs
+++ b/PathingAPI/Controllers/PPatherController.cs
@@ -383,11 +383,16 @@ public sealed class PPatherController : ControllerBase
     /// Returns true to indicate that the server is listening.
     /// </summary>
     /// <returns></returns>
+    /// <summary>
+    /// Whether this server can actually answer route requests, and why. For the navmesh
+    /// engine that means baked tiles for the active era - game archives are optional, so
+    /// the old MPQ-only check reported a failure on every tiles-only or CASC install.
+    /// </summary>
     [HttpGet("SelfTest")]
-    [ProducesResponseType(typeof(bool), StatusCodes.Status200OK, "application/json")]
+    [ProducesResponseType(typeof(PPatherService.SelfTestReport), StatusCodes.Status200OK, "application/json")]
     public JsonResult SelfTest()
     {
-        return new JsonResult(service.MPQSelfTest());
+        return new JsonResult(service.SelfTest(), options);
     }
 
     /// <summary>
@@ -494,11 +499,22 @@ public sealed class PPatherController : ControllerBase
     /// <param name="mapid" example="0">ContientID ["Azeroth=0", "Kalimdor=1", "Outland/Expansion01=530", "Northrend=571"]</param>
     [HttpGet("BakeTile")]
     [ProducesResponseType(typeof(BakeTileResponse), StatusCodes.Status200OK, "application/json")]
+    [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
     [RateLimit]
-    public JsonResult BakeTile(float x, float y, float mapid)
+    public IActionResult BakeTile(float x, float y, float mapid)
     {
         // Ensures the continent (Search/PathGraph/triangle world) is initialised.
         service.SetLocations(new(x, y, 0, mapid), new(x, y, 0, mapid));
+
+        // Returned directly, not wrapped in a JsonResult: wrapping serialises the
+        // ProblemDetails into a 200 body instead of setting the status code.
+        if (service.TriangleWorld == null)
+        {
+            return Problem(
+                "This continent has no geometry loaded - the client archives are absent or do not " +
+                "contain it. Tile baking needs them; path and height queries do not.",
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
 
         NavmeshCoords.GetTileIndex(x, y, out int tileX, out int tileZ);
 

--- a/PathingAPI/Pages/Leaflet.razor
+++ b/PathingAPI/Pages/Leaflet.razor
@@ -6,6 +6,7 @@
 @inject IHubContext<WatchHub> hubContext
 
 @inject PPatherService pPatherService
+@inject DataConfig dataConfig
 
 <Watch PathColour="@pathColour" Name="@name" BabylonJs="false" />
 
@@ -87,7 +88,10 @@
 </style>
 
 @code {
-    [Parameter] public string expansion { get; set; } = "som";
+    // No default era here on purpose: it is overwritten from DataConfig.Exp in
+    // OnAfterRenderAsync. A literal default ("som") is what made a bare
+    // /Leaflet URL misreport the era on every non-vanilla server.
+    [Parameter] public string expansion { get; set; }
     [Parameter] public string continent { get; set; } = "Azeroth";
     [Parameter] public int zoom { get; set; } = 4;
     [Parameter] public float x { get; set; } = 0;
@@ -104,8 +108,28 @@
             // From/To autocomplete. See leaflet-poi.js.
             dotNetRef = DotNetObjectReference.Create(this);
 
+            // The URL's expansion segment is advisory only - the server decides.
+            // Every data source this map reads is resolved server-side from
+            // DataConfig.Exp (set by --exp): /dbc/* is DataConfig.ExpDbc, /tiles
+            // is DataConfig.Leaflet, and the navmesh cache is per era. Honouring a
+            // different value from the URL renders one era's minimap art and
+            // continent list against another era's areas and navmesh - and since
+            // the route segment is optional with a "som" default, /Leaflet on a
+            // cata server silently claimed to be vanilla.
+            string serverExp = dataConfig.Exp;
+
+            if (!string.IsNullOrEmpty(expansion) &&
+                !expansion.Equals(serverExp, StringComparison.OrdinalIgnoreCase))
+            {
+                await jsRuntime.InvokeVoidAsync("log",
+                    $"URL expansion '{expansion}' ignored: this server runs '{serverExp}' " +
+                    $"(--exp). Showing '{serverExp}'.");
+            }
+
+            expansion = serverExp;
+
             await jsRuntime.InvokeVoidAsync("init",
-                expansion ?? "som", continent ?? "Azeroth",
+                expansion, continent ?? "Azeroth",
                 zoom, x, y, true,
                 NpcFlagsExtensions.ToDictionary(),
                 dotNetRef);

--- a/PathingAPI/Pages/Watch.razor
+++ b/PathingAPI/Pages/Watch.razor
@@ -378,9 +378,34 @@
         thread.Start();
     }
 
+    /// <summary>
+    /// Reported once per page so a disk-only install does not spam the log every frame.
+    /// </summary>
+    private bool loggedNoGeometry;
+
     private async Task DrawGeometry(CancellationToken token)
     {
         if (!BabylonJs) { return; }
+
+        // No triangle world = a disk-only install: navmesh tiles were downloaded (or
+        // baked elsewhere) and there are no game archives to build a mesh from. Every
+        // path below needs that geometry - GetChunkAt would throw and each queued chunk
+        // would surface as an error toast - so stop here rather than at the bottom. The
+        // navmesh tile overlay is unaffected: DrawNavmeshTiles reads the baked tiles.
+        if (pPatherService.TriangleWorld == null)
+        {
+            chunkEventArgs.Clear();
+
+            if (!loggedNoGeometry)
+            {
+                loggedNoGeometry = true;
+                await SendLog(
+                    "3D geometry is unavailable: no game archives for this continent " +
+                    "(disk-only navmesh). Routes and navmesh tiles still render.", token);
+            }
+
+            return;
+        }
 
         while (CurrentGeometryMode != GeometryMode.Off &&
             !token.IsCancellationRequested &&
@@ -457,6 +482,14 @@
 
     private /*async*/ void OnChunkAdded(ChunkEventArgs e)
     {
+        // Only the Babylon view consumes these. The Leaflet page hosts this component
+        // with BabylonJs="false", where DrawGeometry returns before draining, so
+        // enqueueing there grows the queue for the lifetime of the page.
+        if (!BabylonJs || CurrentGeometryMode == GeometryMode.Off)
+        {
+            return;
+        }
+
         chunkEventArgs.Enqueue(e);
         //_ = DequeueChunkEvent(e);
     }

--- a/PathingAPI/PathingAPI.xml
+++ b/PathingAPI/PathingAPI.xml
@@ -4,6 +4,66 @@
         <name>PathingAPI</name>
     </assembly>
     <members>
+        <member name="T:PathingAPI.AnTcp.AnTcpPathServer">
+             <summary>
+             Speaks AmeisenNavigation's AnTCP protocol so <c>RemotePathingAPIV3</c> can talk to
+             this server instead of the external AmeisenNavigation binary - same wire format,
+             but answered from this project's era-aware navmesh, so no MMAPs and no second
+             process. Enable with <c>Pathing:AnTcp:Enabled=true</c>.
+            
+             Only <see cref="F:PathingAPI.AnTcp.AnTcpPathServer.MessageType.Path"/> is implemented, because it is the only message
+             the bot ever sends: RemotePathingAPIV3 hardcodes <c>TYPE = EMessageType.PATH</c>
+             and its sole other traffic is the TCP connect used as a ping. Any other type gets
+             an explicit empty reply rather than silence, so a client that does send one fails
+             fast instead of blocking on a read.
+            
+             Wire format (little-endian, matching the C++ structs byte for byte):
+               request   int32 size(payload+1) | byte type | int32 mapId | int32 flags | float start[3] | float end[3]
+               response  int32 size(payload+1) | byte type | Vector3[n]
+             A single all-zero Vector3 means "no path", which is what AmeisenNavigation returns
+             on failure and what the client already tests for.
+             </summary>
+        </member>
+        <member name="F:PathingAPI.AnTcp.AnTcpPathServer.PathRequestSize">
+            <summary>Request payload: int mapId, int flags, Vector3 start, Vector3 end.</summary>
+        </member>
+        <member name="F:PathingAPI.AnTcp.AnTcpPathServer.Vector3Size">
+            <summary>Bytes of a System.Numerics.Vector3 on the wire.</summary>
+        </member>
+        <member name="F:PathingAPI.AnTcp.AnTcpPathServer.MaxFrameSize">
+            <summary>
+            Frame guard. The only request is 33 bytes; anything larger is a desynced
+            stream or a wrong-protocol client, and reading it would allocate blindly.
+            </summary>
+        </member>
+        <member name="F:PathingAPI.AnTcp.AnTcpPathServer.MaxPlausibleZDeltaYd">
+             <summary>
+             How far a requested z may sit from the navmesh surface before it is treated as
+             "the caller does not know its height" rather than a real floor.
+            
+             This exists because of what the client actually sends: when
+             <c>RemotePathingAPIV3</c> has no z it substitutes <c>area.LocTop / 2</c> - and
+             LocTop is a world *Y* bound, not a height, so for Elwynn it sends -3969 against
+             terrain at 82. AmeisenNavigation tolerates that through a very tall
+             findNearestPoly extent; our endpoint resolver uses tight vertical extents on
+             purpose (it is what keeps multi-floor buildings honest), so the search would
+             simply find nothing. Measured: -3969 returns NO PATH, 0 and 82 both return 410
+             points.
+            
+             The band is wide enough that a bot genuinely standing on an upper floor keeps
+             its own z and still disambiguates by height.
+             </summary>
+        </member>
+        <member name="M:PathingAPI.AnTcp.AnTcpPathServer.SnapImplausibleZ(System.Int32,System.Numerics.Vector3,System.String,System.Net.EndPoint)">
+            <summary>
+            Replaces a height that lies nowhere near the mesh with the walkable surface at
+            that column. Uses the disk-only per-continent query navmesh, so it neither
+            switches the active continent nor needs game files.
+            </summary>
+        </member>
+        <member name="M:PathingAPI.AnTcp.AnTcpPathServer.NoPath">
+            <summary>One all-zero Vector3 - AmeisenNavigation's failure reply, which the client tests for.</summary>
+        </member>
         <member name="M:PathingAPI.Controllers.PPatherController.MapRoute(System.Int32,System.Single,System.Single,System.Int32,System.Single,System.Single,System.Nullable{System.Single})">
              <summary>
              Allows a route to be calculated from one point to another using only minimap coords.
@@ -180,6 +240,11 @@
             Returns true to indicate that the server is listening.
             </summary>
             <returns></returns>
+            <summary>
+            Whether this server can actually answer route requests, and why. For the navmesh
+            engine that means baked tiles for the active era - game archives are optional, so
+            the old MPQ-only check reported a failure on every tiles-only or CASC install.
+            </summary>
         </member>
         <member name="M:PathingAPI.Controllers.PPatherController.Capabilities">
             <summary>
@@ -276,6 +341,11 @@
             <summary>
             Adds a map-authored point to the From/To autocomplete. Called from the
             Leaflet page when a custom POI is placed or restored.
+            </summary>
+        </member>
+        <member name="F:PathingAPI.Pages.Watch.loggedNoGeometry">
+            <summary>
+            Reported once per page so a disk-only install does not spam the log every frame.
             </summary>
         </member>
         <member name="M:PathingAPI.Pages.Watch.SendNavmeshTile(System.Int32,System.Int32,DotRecast.Detour.DtMeshData,System.Threading.CancellationToken)">

--- a/PathingAPI/Startup.cs
+++ b/PathingAPI/Startup.cs
@@ -101,6 +101,27 @@ public sealed class Startup
         services.Configure<SplineFollowerOptions>(configuration.GetSection(SplineFollowerOptions.Position));
 
         services.AddSingleton<PPatherService>();
+
+        // Opt-in AnTCP listener speaking AmeisenNavigation's binary protocol, so a bot
+        // configured for RemoteV3 can point at this server and get routes from this
+        // project's navmesh instead of running the external AmeisenNavigation binary.
+        // Off by default: it opens a socket, which a plain HTTP install should not.
+        if (bool.TryParse(configuration["Pathing:AnTcp:Enabled"], out bool anTcpEnabled) && anTcpEnabled)
+        {
+            string anTcpIp = configuration["Pathing:AnTcp:Ip"] ?? "127.0.0.1";
+            int anTcpPort = int.TryParse(configuration["Pathing:AnTcp:Port"], out int p)
+                ? p
+                : 47110;   // AmeisenNavigation's default, so existing hostv3/portv3 config just works
+
+            services.AddSingleton<Microsoft.Extensions.Hosting.IHostedService>(sp =>
+                new PathingAPI.AnTcp.AnTcpPathServer(
+                    sp.GetRequiredService<ILogger<PathingAPI.AnTcp.AnTcpPathServer>>(),
+                    sp.GetRequiredService<PPatherService>(),
+                    anTcpIp, anTcpPort));
+
+            Log.Information("AnTCP path server enabled on {Ip}:{Port}", anTcpIp, anTcpPort);
+        }
+
         services.AddSingleton<FactionTemplateDB>();
         services.AddSingleton<CreatureDB>();
         services.AddSingleton<AreaDB>();

--- a/PathingAPI/appsettings.json
+++ b/PathingAPI/appsettings.json
@@ -27,5 +27,12 @@
   },
   "SplineFollower": {
     "Enabled": false
+  },
+  "Pathing": {
+    "AnTcp": {
+      "Enabled": false,
+      "Ip": "127.0.0.1",
+      "Port": 47110
+    }
   }
 }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 The project current goal is to support the following client versions
 
 Legacy
-* 4.3.4 Cataclysm (2011) Work in progress - [Limitations](#supporting-cataclysm-classic-and-above-limitations) - [704](https://github.com/Xian55/WowClassicGrindBot/issues/704)
+* 4.3.4 Cataclysm (2011) Work in progress - navmesh pathfinding **supported** (MPQ-based, see [Pathfinders](#pathfinders)) - [704](https://github.com/Xian55/WowClassicGrindBot/issues/704)
 
 Classic (Since 2019)
 * 1.13.x Vanilla Classic
@@ -56,7 +56,13 @@ For experienced users, here's the minimal setup:
    git clone --recurse-submodules https://github.com/Xian55/WowClassicGrindBot.git
    ```
    Already cloned without it? Run `git submodule update --init --recursive`.
-3. **MPQ Files**: Download [MPQ files](#using-v1-localremote-pathing) and place in `Json\MPQ\`
+3. **Navigation data**: download the pre-baked navmesh for your client's era - no WoW
+   client or MPQ files needed (see [Pathfinders](#setting-up-navigation--the-short-version)):
+   ```powershell
+   .\scripts\download-navmesh.ps1 -Era precata   # precata | cata | mop
+   ```
+   Only needed if you intend to **bake** tiles yourself or run `SpotAStar`:
+   [MPQ files](#using-v1-localremote-pathing) in `Json\MPQ\`.
 4. **Build**: Run `BlazorServer\build.bat` or open solution in Visual Studio
 5. **Configure**: Start WoW, run `BlazorServer\run.bat`, configure addon in browser
 6. **Play**: Load a class profile, press Start
@@ -168,12 +174,12 @@ The host and pathfinder are independently composable — pick one from each colu
 
 | Host | Pathfinder | Notes |
 |------|-----------|-------|
-| **BlazorServer** | Navmesh (in-process) | **Recommended** - DotRecast navmesh, no external services (Vanilla-Wrath) |
+| **BlazorServer** | Navmesh (in-process) | **Recommended** - DotRecast navmesh, no external services, every client |
 | **BlazorServer** | PathingAPI (out-of-process) | Offloads pathfinding to a dedicated service |
-| **BlazorServer** | AmeisenNavigation (external) | Required for Cataclysm+ (CASC) |
+| **BlazorServer** | AmeisenNavigation (external) | Legacy; superseded by the in-process navmesh |
 | **HeadlessServer** | Navmesh (in-process) | **Recommended** - fully headless, single process |
 | **HeadlessServer** | PathingAPI (out-of-process) | Headless with remote pathfinding |
-| **HeadlessServer** | AmeisenNavigation (external) | Headless, required for Cataclysm+ |
+| **HeadlessServer** | AmeisenNavigation (external) | Legacy; superseded by the in-process navmesh |
 
 **Multi-instance support** — Using Windows Graphics Capture (WGC), each instance captures a specific window rather than the entire desktop. This allows running multiple bot instances on a single machine, each attached to a different game client, with no additional configuration needed.
 
@@ -323,30 +329,131 @@ The BlazorServer frontend provides deep runtime observability beyond basic UI co
 
 Pathfinding allows the bot to navigate the game world - walking around obstacles, across terrain, and to your defined routes.
 
+### Setting up navigation — the short version
+
+**For every supported client there is one answer: the built-in navmesh engine, with
+tiles downloaded from the CDN.** It is already the default, so setup is a single
+command:
+
+```powershell
+.\scripts\download-navmesh.ps1 -Era precata     # use your client's era from the table
+```
+
+**You do not need the WoW client, `Json\MPQ`, or any external service to navigate.**
+The engine answers from the downloaded tiles alone.
+
+| Your client | Era | What to run | Engine |
+|---|---|---|---|
+| Vanilla / SoM 1.13–1.15 | `precata` | `download-navmesh.ps1 -Era precata` | Navmesh (default) |
+| TBC 2.5.x | `precata` | `download-navmesh.ps1 -Era precata` | Navmesh (default) |
+| Wrath 3.3.5 | `precata` | `download-navmesh.ps1 -Era precata` | Navmesh (default) |
+| Cataclysm **4.3.4** | `cata` | `download-navmesh.ps1 -Era cata` | Navmesh (default) |
+| Cataclysm **Classic 4.4.x** | `cata` | `download-navmesh.ps1 -Era cata` | Navmesh (default) |
+| Mists **5.4.8** | `mop` | `download-navmesh.ps1 -Era mop` | Navmesh (default) |
+| MoP **Classic 5.5.x** | `mop` | `download-navmesh.ps1 -Era mop` | Navmesh (default) |
+
+**The CASC re-releases are included.** `DataConfig.ClientEra` folds `cata`/`legacy_cata`
+into the `cata` era and `mop`/`legacy_mop` into `mop`, so a mesh baked from the original
+4.3.4 / 5.4.8 MPQ client **is** the artifact Cataclysm Classic and MoP Classic consume —
+it is the same world. CASC only blocks *reading game files*, which downloaded tiles make
+unnecessary. Verified with a `cata` install holding zero game files: Elwynn→Stormwind 410
+points, Ratchet→Crossroads 569, the log reporting `disk-only, no game files`.
+
+Each era bundle is **self-contained**: `-Era cata` includes all four continents,
+`-Era mop` all five. Unlike the minimap art, navmesh tiles are **never** shared
+between eras — a stale mesh would route the bot through walls that exist in your
+world, so you download exactly one era and that is all you need.
+
+You only need the game archives in `Json\MPQ` if you want to **bake tiles yourself**
+(a custom agent config, or an era with no published bundle) or run the legacy
+`Pathing:Engine=SpotAStar` — and on a CASC client the MPQ reader cannot supply those, so
+use pre-baked tiles or bake from the matching original MPQ client. Details below.
+
+### Running multiple bots
+
+**Give every instance its own in-process navmesh engine** - the default. Point each
+BlazorServer / HeadlessServer at the same downloaded tiles (a shared `data_config.json`
+`Root` is fine, the tile cache is read-only) and run them independently. No pathing
+server, no MPQ, nothing shared at runtime.
+
+**Do not point several bots at one `PathingAPI` (V1 Remote).** It serves one search at
+a time: the `RateLimit` filter answers a concurrent request with **HTTP 429**, which the
+V1 client turns into an empty route - indistinguishable from "no path exists", so the
+second bot silently fails to navigate. Measured with two simultaneous `WorldRoute`
+calls: one 200 in 555 ms, the other 429 in 8 ms. V1 Remote is meant for a single client
+plus the route visualiser, not as a shared service.
+
+That limit dates from the `SpotAStar` era, when a search cost seconds and serialising
+made sense; a warm navmesh query is 1-8 ms. Serving N bots from one process is worth
+doing and the per-continent pathfinder cache is already in place, but it needs the
+search made re-entrant first (today it is `SetLocations` then `DoSearch` on singleton
+state, and switching continent disposes the engine). **Until then, one navmesh per bot
+is the supported setup.**
+
+Cost of running them separately is small: with disk-only pathing there is **no ADT
+geometry in memory at all**, just the navmesh tile cache - tiles average ~16 KB and only
+the tens-to-hundreds around the active route stay resident.
+
 ### Navmesh engine (default, recommended)
 
 The bot ships an in-process **[DotRecast](https://github.com/Xian55/DotRecast) navmesh** engine, now the default (`Pathing:Engine=Navmesh`). It runs from small **pre-baked navmesh tiles** and produces smooth, high-quality routes - the basis for the WASD spline follower. Versus the older backends it needs **no external service** and **no MPQ at query time**; the runtime query is pure managed, cross-platform code, and the tile data is tiny enough to distribute. Tiles are baked once from the game's MPQ files (or downloaded pre-baked).
 
-Recommended for **Vanilla through Wrath**, where it supersedes the legacy in-process grid pathfinder and removes the need for the external navigation service.
+Recommended for **Vanilla through Wrath**, and for the **original 4.3.4 Cataclysm** client, where it supersedes the legacy in-process grid pathfinder and removes the need for the external navigation service.
 
 **Get the tiles — download pre-baked (no client/MPQ needed):**
 ```powershell
 .\scripts\download-navmesh.ps1 -Force
 ```
-Pulls the pre-baked tiles from the CDN into `Json\PathInfo\navmesh\<era>\` (destination honors your `data_config.json` `Root`). Options: `-Continent Northrend`, `-Era precata`. If you run a custom agent config (different settings hash), bake instead (see [navmesh bake skill](.claude/skills/navmesh-bake-upload/SKILL.md)).
+Pulls the pre-baked tiles from the CDN into `Json\PathInfo\navmesh\<era>\` (destination honors your `data_config.json` `Root`). Options: `-Continent Northrend`, `-Era precata` / `-Era cata` / `-Era mop`. If you run a custom agent config (different settings hash), bake instead (see [navmesh bake skill](.claude/skills/navmesh-bake-upload/SKILL.md)).
 
-> **Cataclysm Classic and above** still require **V3 Remote** (below): the navmesh is baked from MPQ, so it does not cover CASC-based clients.
+Downloaded tiles are enough on their own: with no `Json\MPQ\` at all, the navmesh
+engine runs **disk-only** - it answers path and height queries from the baked tiles
+and logs `disk-only, no game files` per continent. This matters most from Cataclysm
+onward, where a client is tens of GB and there is no reason to keep one installed
+just to walk over tiles that are already baked. Two things still need the archives,
+and say so plainly rather than failing obscurely:
+
+* **Baking** tiles (`POST api/PPather/Bake`, `BakeTile`, area-grid extraction) - it reads ADT geometry.
+* **`Pathing:Engine=SpotAStar`** - it walks the triangle world directly and has no tile cache to fall back to.
+
+> Bake settings feed the tile cache directory name, so a disk-only install must be
+> configured the same as whatever baked the tiles or it computes a different hash and
+> sees none of them. Outland is the live example: it only resolves with
+> `Navmesh:Bake:MinWorldZ: { "Expansion01": -700 }`, which is already the shipped default.
+
+Tiles are published per **geometry era**, each complete on its own:
+
+| era | clients | continents | tiles |
+|---|---|---|---|
+| `precata` | Vanilla, TBC, Wrath (`som`/`tbc`/`wrath`, `legacy_*`) | 4 | 51,113 |
+| `cata` | Cataclysm 4.3.4 **and Cata Classic 4.4.x** (`cata`, `legacy_cata`) | 8 | 58,537 |
+| `mop` | Mists 5.4.8 **and MoP Classic 5.5.x** (`mop`, `legacy_mop`) | 10 | 70,363 |
+
+> Cataclysm and Mists ship maps that are **not** zones of the four originals and have
+> their own MapID, so they need their own bake: Deepholm (646), the Lost Isles + Kezan
+> (648), Gilneas (654) and the Maelstrom (730), plus the Wandering Isle (860) on Mists.
+> Vashj'ir, Uldum, Mount Hyjal and Twilight Highlands are *not* among them - those are
+> zones on Azeroth/Kalimdor and come with the main continents.
+
+> The split matters: Cataclysm's Shattering rebuilt Azeroth and Kalimdor, so the eras are
+> genuinely different worlds and never share navmesh tiles. Mists is separate from Cataclysm
+> for the same reason - their old worlds are close but not identical, and Mists adds Pandaria.
+
+> **Cataclysm *Classic* (4.4.x) and MoP Classic (5.5.x) use the same bundles** as their
+> original counterparts, because `ClientEra` maps them to the same era and the world is
+> the same. Those re-releases ship **CASC**, which the MPQ reader cannot open, but that
+> only prevents *baking from your own client* — downloading tiles sidesteps it entirely.
 
 **Which should you use?**
-- **Vanilla-Wrath (most users)**: the default in-process **navmesh** engine - high quality, no external service. Provide navmesh tiles (bake from MPQ, or download pre-baked).
-- **Cataclysm+**: **V3 Remote** (AmeisenNavigation) - the only backend that reads CASC.
-- **Legacy fallbacks**: the MPQ grid engine (`Pathing:Engine=SpotAStar`) and V1 Remote remain available.
+- **Everyone (including the CASC re-releases)**: the default in-process **navmesh** engine - high quality, no external service. Download pre-baked tiles for your era.
+- **Baking your own tiles**: needs an **MPQ** client (Vanilla-Wrath, 4.3.4, 5.4.8). On a CASC client, bake from the matching original client or use the published bundles.
+- **Legacy fallbacks**: the MPQ grid engine (`Pathing:Engine=SpotAStar`) and V1/V3 Remote remain available; V3 (AmeisenNavigation) is no longer required for anything.
 
 ### Legacy / alternative backends
 
 Different backends exist because WoW's map data format changed over time (MPQ to CASC). Outdoors the app can discover an available service in this order:
 
-* **V3 Remote**: Out of process [AmeisenNavigation](https://github.com/Xian55/AmeisenNavigation/tree/feature/multi-version-guess-z-coord) - external service; **required for Cataclysm+** (CASC). For Vanilla-Wrath it is superseded by the in-process navmesh engine.
+* **V3 Remote**: Out of process [AmeisenNavigation](https://github.com/Xian55/AmeisenNavigation/tree/feature/multi-version-guess-z-coord) - external service, superseded by the in-process navmesh engine on **every** client including the CASC re-releases. Kept for compatibility; `PathingAPI` can also [answer its protocol directly](#serving-v3-clients-from-pathingapi-antcp) if you want the wire format without the external binary.
 * **V1 Remote**: Out of process [PathingAPI](https://github.com/Xian55/WowClassicGrindBot/tree/dev/PathingAPI) more info [here](#v1-remote-pathing---pathingapi) - MPQ-based; can host either engine.
 * **V1 Local**: In process [PPather](https://github.com/Xian55/WowClassicGrindBot/tree/dev/PPather) - MPQ-based. Its legacy spot-grid A* engine (`Pathing:Engine=SpotAStar`) is superseded by the navmesh engine.
 * World map - Indoors pathfinder only works properly if `PathFilename` exists.
@@ -354,9 +461,42 @@ Different backends exist because WoW's map data format changed over time (MPQ to
 
 ## Supporting Cataclysm Classic and Above Limitations
 
-With Cataclysm (MoP, and above), the navigation will be limited. Only V3 Remote will be supported for now.
+The dividing line is the **archive container**, and it only limits **baking** — not
+pathfinding. StormLib opens **MPQ** but not **CASC**, so a CASC client cannot have tiles
+generated *from itself*. Since tiles are published per era and a downloaded set needs no
+game files at all, that limitation no longer reaches the user.
 
-V1 Local and V1 Remote does not have the capability as of this moment to read the CASC files only works with MPQs.
+| client | container | pathfinding | can bake its own tiles |
+|---|---|---|---|
+| Vanilla … Wrath | MPQ | in-process navmesh (default) | yes |
+| **4.3.4 Cataclysm (2011)** | **MPQ** | in-process navmesh | yes |
+| **5.4.8 MoP (2012)** | **MPQ** | in-process navmesh | yes |
+| Cataclysm Classic 4.4.x | CASC | in-process navmesh, `-Era cata` | no — download, or bake from 4.3.4 |
+| MoP Classic 5.5.x | CASC | in-process navmesh, `-Era mop` | no — download, or bake from 5.4.8 |
+
+The re-releases are the *same world* as their originals, and `DataConfig.ClientEra` maps
+both onto one era, so the bundle baked from 4.3.4 is exactly what Cata Classic loads.
+Verified against a `cata` install with no game files present at all: full routes on
+Azeroth and Kalimdor, the engine logging `disk-only, no game files`.
+
+CASC support (`CascLib`) would still be worth having — it would let a re-release user
+bake a custom agent config from their own install rather than relying on published
+bundles — but it is no longer a prerequisite for navigating.
+
+**5.4.8 MoP is supported end to end.** Its chunk formats match 4.3.4 (same split ADT, MCNK
+header, M2 v272, WMO v17). The client-level differences are handled: it ships a 5.0.x
+`world.MPQ` plus 23 `wow-update-base-*.MPQ` **incremental patch archives** carrying updated
+terrain for **37% of root ADTs**, which the MPQ layer chains through StormLib's patch API,
+and its `holes_high_res` terrain holes are read. Mists is its own geometry era (`mop`), so it
+never shares tiles with Cataclysm.
+
+Data is published: 26,972 leaflet tiles across all ten continents and a 70,363-tile navmesh
+bake (`download-leaflet.ps1 -Era mop`, `download-navmesh.ps1 -Era mop`). The DBC data is
+generated (`ReadDBC_CSV -v legacy_mop`, sourced from MoP Classic so its UiMapIDs line up with
+the addon's legacy `WorldMapAreaID` mapping).
+
+Design notes and the measured format differences are in
+[`docs/mpq-casc-storage-abstraction.md`](docs/mpq-casc-storage-abstraction.md).
 
 ## Features
 
@@ -499,6 +639,15 @@ Put the contents of the repo into a folder, e.g., `C:\WowClassicGrindBot`. I am 
 [**lichking.MPQ**](https://mega.nz/file/vDYWSTrK#fvaiuHpd-FTVsQT4ghGLK6QJLZyA87c1rlBEeu1_Btk) (2.5Gb)
 
 Copy these files under the **\Json\MPQ** folder (e.g., `C:\WowClassicGrindBot\Json\MPQ`)
+
+**Cataclysm 4.3.4 (2011):** no separate download — copy the archives from your own client's
+`Data\` folder (`world.MPQ`, `world2.MPQ`, `art.MPQ`, `expansion1-3.MPQ`, `alternate.MPQ`).
+`Data\enUS\*.MPQ` holds locale data only and is not needed for geometry. Only one client's
+archives may sit in `Json\MPQ` at a time — mixing eras makes ADT lookups resolve against
+whichever archive sorts first.
+
+> Most users can skip the archives entirely and just run `download-navmesh.ps1` — the MPQs
+> are only needed to *bake* tiles or to run the legacy `SpotAStar` engine.
 
 Technical details about **V1:**
 - Precompiled x86, x64 and arm64 [Stormlib](https://github.com/ladislav-zezula/StormLib)
@@ -3425,13 +3574,45 @@ Pathed routes are shown in Green.
 
 ### Leaflet
 
-**Supported:** `som` (1.13–1.15), `tbc` (2.5.x) and `wrath` (3.3.5). All three
-share one tile set because the old world is unchanged pre-Cataclysm.
+**Supported:** every era the bot supports — `precata` (`som` 1.13–1.15, `tbc`
+2.5.x, `wrath` 3.3.5), `cata` (4.3.4) and `mop` (5.4.8). Clients inside one era
+share a tile set, because the world art only changed between them.
 
-Map tiles are generated locally from your client's minimap art rather than
-downloaded. Tiles are stored per **mesh era** (`precata` = vanilla…wotlk) as
-`webp`, so a single run against a Wrath 3.3.5 client produces every continent:
+**Nothing is required to see the map.** With no tiles on disk the page streams them
+straight from the CDN: `resolveTileBase()` in `leaflet-watch.js` probes a few known
+low-zoom tiles on the local `/tiles` route per continent, and falls back to
+`https://bot.tortoiseclothing.org/<era>/<Continent>/...` when they are missing. So
+downloading is an **optimization** - worth it for offline use or to avoid per-tile
+latency - not a prerequisite.
 
+* The fallback is decided **once per continent at map load**, so a CDN that is
+  unreachable at that moment yields a blank map rather than a retry.
+* `localStorage.leafletTilesLocal = '0'` forces the CDN even when local tiles exist
+  (handy for checking what a fresh user sees).
+
+**Download them for offline use:**
+```powershell
+.\scripts\download-leaflet.ps1               # every published era
+.\scripts\download-leaflet.ps1 -Era mop
+```
+Pulls one `<era>-tiles.zip` per era into `<Root>/leaflet/<era>` (destination
+honors your `data_config.json` `Root`). `.bat\download-leaflet.bat` is a
+double-click wrapper. There is no `-Continent` switch: unlike the navmesh, which
+is bundled per continent and settings-hash, leaflet art has no bake parameters,
+so an era is a single object.
+
+| era | clients | tiles | bundle |
+|---|---|---|---|
+| `precata` | `som`, `tbc`, `wrath`, `legacy_*` | 19,562 | 77 MB |
+| `cata` | `cata`, `legacy_cata` | 12,262 | 53 MB |
+| `mop` | `mop`, `legacy_mop` | 26,972 | 101 MB |
+
+> The `cata` bundle holds only Azeroth and Kalimdor. Northrend and Outland are
+> served from `precata` (`DataConfig.TileEra`) because their minimap art is
+> effectively unchanged, so pair `-Era cata` with `-Era precata` for full
+> coverage. `mop` ships all five continents, Pandaria included.
+
+**Or generate them from your own client:**
 ```
 python scripts/extract-minimap.py
 ```
@@ -3439,8 +3620,8 @@ python scripts/extract-minimap.py
 * Requires `pip install Pillow` (decodes BLP, writes webp).
 * Reads the client archives from `Json\MPQ` by default (override with the
   `WOW_MPQ` env var); uses the bundled `PPather\MPQ\StormLib_x64.dll`.
-* Writes `Json\leaflet\precata\<Continent>\z{z}x{x}y{y}.webp` for Azeroth,
-  Kalimdor, Expansion01 (Outland) and Northrend.
+* Writes `Json\leaflet\<era>\<Continent>\z{z}x{x}y{y}.webp`; pick the era with
+  `LEAFLET_ERA` (default `precata`).
 * Prints the `Configs` entry (resX/resY/offset) for each continent, matching
   `Frontend\wwwroot\script\leaflet-watch.js`.
 
@@ -3596,7 +3777,44 @@ The best places to grind are:
 
 # V1 Remote Pathing - PathingAPI
 
-Pathing is built into the bot so you don't need to do anything special except download the MPQ files. You can though run it on its own server to visualise routes as they are created by the bot, or to play with route finding.
+Pathing is built into the bot, so you don't need to do anything special except provide
+navmesh tiles - `download-navmesh.ps1`, no MPQ files required (see
+[Setting up navigation](#setting-up-navigation--the-short-version)). You can though run
+it on its own server to visualise routes as they are created by the bot, or to play with
+route finding.
+
+> **One client at a time.** The `RateLimit` filter answers a concurrent request with
+> HTTP 429, so this is not a shared service for several bots - see
+> [Running multiple bots](#running-multiple-bots).
+
+### Serving V3 clients from PathingAPI (AnTCP)
+
+PathingAPI can also speak **AmeisenNavigation's binary AnTCP protocol**, so a bot
+configured for `RemoteV3` talks to this server and gets routes from this project's
+era-aware navmesh - no AmeisenNavigation binary, no MMAP files, no second process.
+
+Off by default (it opens a socket); enable in `PathingAPI\appsettings.json`:
+
+```json
+"Pathing": { "AnTcp": { "Enabled": true, "Ip": "127.0.0.1", "Port": 47110 } }
+```
+
+Then point the bot at it as usual - `Pathing:Mode=RemoteV3`, `hostv3`/`portv3`. Port
+47110 is AmeisenNavigation's own default, so existing config needs no change.
+
+Only the **PATH** message is implemented, because it is the only one the bot ever
+sends (`RemotePathingAPIV3` hardcodes it; its other traffic is the TCP connect used as
+a ping). Other message types get an explicit empty reply rather than hanging. Unlike
+the HTTP API, concurrent clients **queue** rather than receive 429 - a warm query is
+single-digit milliseconds, so several bots share it comfortably even though the search
+still serializes.
+
+> One deliberate difference from AmeisenNavigation: when the client has no z it sends
+> `area.LocTop / 2`, and `LocTop` is a world **Y** bound rather than a height - for
+> Elwynn that is -3969 against terrain at 82. AmeisenNavigation absorbs it with a very
+> tall poly-search extent; this engine uses tight vertical extents so multi-floor
+> buildings resolve correctly, so the server instead snaps any z further than 128 yd
+> from the walkable surface onto it. A bot that genuinely knows its height keeps it.
 
 The bot will try to calculate a path in the following situations:
 

--- a/SharedLib/CLAUDE.md
+++ b/SharedLib/CLAUDE.md
@@ -1,0 +1,56 @@
+# SharedLib — the common bottom layer
+
+Depended on by `Core`, `Game`, `PPather`, `PathingAPI`, `WowheadDB` and most of
+`Utilities/`. That breadth is the point and the constraint: **a change here reaches
+everything**, including the tools that regenerate `Json/` data.
+
+TFM is plain **`net10.0`** (overriding the repo-global `net10.0-windows`) so `PPather`,
+`BakeTool` and a future headless server run on macOS/Linux. **Do not take a Windows-only
+dependency here** — it would drag the whole pathing chain back onto Windows. Screen and
+NPC-finding types in here are deliberately interfaces or pure geometry; the Windows
+implementations live in `Core`/`WinAPI`.
+
+## Layout
+
+```
+StartupConfig/       DI options bound from configuration
+  NavmeshBakeOptions.cs      "Navmesh:Bake"    - feeds the tile cache hash
+  NavmeshQueryOptions.cs     "Navmesh:Query"   - query-time only, never rebakes
+  SplineFollowerOptions.cs   "SplineFollower"
+  StartupConfigPathing.cs    "Pathing"         - Engine, RemoteV1/V3 host+port
+  StartupClientVersion.cs    which client is running
+Data/                ContinentDB, WorldMapArea(DB), SubZoneArea, Creature, Item, Spell, NpcFlags
+AddonDataProviderType/ClientVersion.cs   the enum everything version-switches on
+NpcFinder/           NPC nameplate detection (colour matching, line segments)
+ImageProvider/, Screen/   capture interfaces only
+Converters/          System.Numerics <-> JSON (Vector2/3/4)
+Extensions/, Util/, Logging/
+```
+
+## Things that will bite you
+
+**`ClientVersion` has twelve values and `Legacy_*` are real clients.** `None`, `Retail`,
+`SoM`, `TBC`, `Wrath`, `Cata`, `Mop`, then `Legacy_Vanilla`/`_TBC`/`_Wrath`/`_Cata`/
+`_Mop`. Any `switch` that lists only the modern ones silently sends every legacy client
+down the default branch — that is how `WApi` pointed legacy clients at the retail
+Wowhead site. Pair each modern value with its `Legacy_*` twin, or better, derive from
+`DataConfig.ClientEra` so new eras do not need a new case.
+
+**`NavmeshBakeOptions` values are part of the tile cache identity.** `AgentRadius`,
+`AgentMaxClimb`, `WalkableSlope` and `MinWorldZ` feed `ComputeSettingsHash`, so changing
+a *default* here silently orphans every baked tile and every published CDN bundle.
+`NavmeshQueryOptions` is safe to change freely — it is query-time only, which is exactly
+why the two are separate classes.
+
+**`ContinentDB` is static mutable state, populated by `Init`.** `MPQTriangleSupplier`
+and anything resolving a continent name needs it filled first; `PPatherService` does
+that in its constructor, but a standalone harness (benchmarks, a utility) must call
+`ContinentDB.Init(new WorldMapAreaDB(cfg).Values)` itself or every continent lookup
+throws. `TryAdd` means the first client loaded wins for a given map id.
+
+**`WorldMapAreaDB` reads `dbc/<client>/WorldMapArea.json` and throws if it is absent** —
+that is the failure a new client hits before `ReadDBC_CSV -v <client>` has been run. The
+file is per **client**, not per era, because id spaces differ.
+
+**Casing matters off Windows.** `WorldMapArea.json` is requested by that exact name by
+the frontend; a lowercase file on disk works locally and 404s on Linux/macOS.

--- a/SharedLib/SharedLib.csproj
+++ b/SharedLib/SharedLib.csproj
@@ -1,6 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- See DataConfig.csproj for why this overrides the solution-wide
+       net10.0-windows TFM. -->
   <PropertyGroup>
+	  <TargetFramework>net10.0</TargetFramework>
 	  <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	  <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/WinAPI/CLAUDE.md
+++ b/WinAPI/CLAUDE.md
@@ -1,0 +1,40 @@
+# WinAPI — Win32 interop
+
+Three files, no logic. Every P/Invoke the bot needs lives here so the rest of the
+solution can stay declarative — and so the Windows dependency stays in one place.
+
+```
+NativeMethods.cs     user32 / gdi32 / dwmapi imports (input, window, cursor, DWM, monitors)
+ExecutablePath.cs    full path of a running Process
+StringOrderUtil.cs   NaturalStringComparer via StrCmpLogicalW ("item2" before "item10")
+```
+
+## Rules
+
+**`[LibraryImport]`, not `[DllImport]`.** The assembly declares
+`[assembly: DisableRuntimeMarshalling]`, so signatures must be blittable and source
+generated. That is why you see `nint` rather than `IntPtr`-with-marshalling, explicit
+`[return: MarshalAs(UnmanagedType.Bool)]` on `BOOL` returns, and `Point`/`RECT` structs
+passed by `ref` or `out`. Adding a `[DllImport]` here, or a signature with a `string`
+that needs marshalling, will not compile the way you expect — pick the `W` entry point
+and marshal explicitly.
+
+**Pick the entry point deliberately.** `PostMessage` is bound to `PostMessageA`,
+`VkKeyScanExW` and `StrCmpLogicalW` to the wide variants. The suffix is part of the
+contract; do not "tidy" it away.
+
+**This project is Windows-only and must stay isolated.** It is referenced by the bot
+side (`Core`, `Game`, `BlazorServer`) and **never** by the pathing chain — `DataConfig`,
+`SharedLib` and `PPather` are plain `net10.0` precisely so they run on macOS/Linux. If
+you find yourself wanting a `WinAPI` reference from any of those, the abstraction
+belongs in an interface instead (see `IWowScreen`, `IRectProvider`).
+
+## Areas covered
+
+Input posting (`PostMessage`, `SetCursorPos`/`GetCursorPos`), keyboard-layout
+translation (`GetKeyboardLayout`, `MapVirtualKeyA`, `VkKeyScanExW` — used to map a
+character to a virtual key on the user's actual layout, so non-US keyboards bind
+correctly), window geometry (`GetWindowRect`, `ClientToScreen`/`ScreenToClient`),
+DWM-aware bounds (`dwmapi`, so the capture rect excludes the invisible resize border),
+cursor inspection (`GetCursorInfo`, `DrawIconEx` for classifying the cursor bitmap) and
+monitor lookup (`MonitorFromWindow`).

--- a/WowheadDB/CLAUDE.md
+++ b/WowheadDB/CLAUDE.md
@@ -1,0 +1,42 @@
+# WowheadDB — zone data model
+
+Three POCOs and nothing else. They describe the per-zone data scraped from Wowhead:
+service NPCs, herb/vein nodes, and which mobs are skinnable/minable/etc.
+
+```
+Area/Area.cs   one zone: flightmaster, innkeeper, repair, vendor, trainer,
+               herb, vein, skinnable, gatherable, minable, salvegable
+NPC/NPC.cs     coords, level, name, type, id, reacthorde, reactalliance, description
+Herb/Node.cs   coords, level, name, type, id
+```
+
+**Producer:** `Utilities/WowheadDB_Extractor` writes `Json/area/<client>/<areaId>.json`.
+**Consumer:** `Core/Database/AreaDB.cs` deserializes the file for the zone the player is
+in, on a background thread, whenever the area changes. `Core/Goals/LootGoal.cs` and
+`Core/Path/RouteInfo.cs` read the result.
+
+## Things that will bite you
+
+**These are public *fields*, not properties, matched by name against the JSON.** There
+are no `[JsonProperty]` attributes — Newtonsoft binds on the identifier, so **renaming a
+field silently breaks deserialization** into a null/empty collection rather than an
+error. Same for casing: the JSON keys are lowercase and the fields are lowercase to
+match.
+
+**`salvegable` is misspelled, and that spelling is the wire format.** It is the key in
+every generated `Json/area/**/*.json`, so "fixing" the field name breaks every file on
+disk and every published data set. Correcting it means regenerating all area data across
+all clients — treat it as a data migration, not a typo fix.
+
+**`coords` are map coordinates, not world coordinates.** They are `[[x, y]]` pairs in the
+0-100 zone space (e.g. `[[30.0, 71.4]]`), which is why `MapCoords` is named that way.
+Convert through `WorldMapAreaDB` before handing them to a pathfinder — passing them
+straight to a world-coordinate API yields a point near the map origin.
+
+**`coords` is a list of lists because one entry can have many spawns.** A single vendor
+id may appear at several points; do not assume `coords[0]` is the only one.
+
+**Data is partitioned per client, not per era** (`DataConfig.ExpArea` →
+`Json/area/<Exp>`), because zone and area ids differ between clients. A missing
+`<areaId>.json` is normal — not every area has scraped data — so `AreaDB` must tolerate
+it rather than throw.

--- a/docs/headless-pathing-server-design.md
+++ b/docs/headless-pathing-server-design.md
@@ -1,7 +1,10 @@
 # Headless Pathing Server — Design Doc
 
-**Status:** Draft / proposal — compile probe running (§9 to be filled).
+**Status:** Draft / proposal — compile probe done (§9). macOS bake host scoped (§12).
 **Scope:** A minimal, standalone server whose only job is to host the DotRecast navmesh pathing engine and answer route requests over the existing RemoteV3 protocol. No MPQ / game files at runtime, no bot, no UI. Cross-platform (`net10.0`), shippable as a **multi-arch Docker image** (linux/amd64 + linux/arm64) published to GHCR, and runnable on Windows/macOS/Linux/arm64.
+
+**Also covered:** §12 extends this to Apple silicon, including running the **bake** natively on
+macOS — the interesting case being a spare Mac as a dedicated bake host.
 
 Related: this rides on the same navmesh the bot already uses; distribution reuses R2 (see `navmesh-bake-upload`).
 
@@ -13,6 +16,21 @@ Two things changed that make this practical:
 
 1. **MPQ is no longer a runtime requirement.** The navmesh is **pre-baked**; querying it loads serialized tiles and runs DotRecast Detour. No game files, no StormLib at query time.
 2. **The navmeshes are small.** Distributable (R2 today), mountable into a container.
+
+> **2026-07-26 — premise 1 is now actually true in `PPatherService`, not just in the
+> engine.** `NavmeshPathfinder`/`NavmeshTileCache` always accepted a null triangle
+> world ("disk-only": answer from baked tiles, never bake), but `PPatherService.Initialise`
+> unconditionally constructed `Search` → `MPQTriangleSupplier` → `ArchiveSet` + WDT, so a
+> query still died without archives. It now falls back to disk-only per continent and logs
+> `disk-only, no game files`; only baking, area-grid extraction and `SpotAStar` still demand
+> geometry, and they now refuse with a stated reason (`503` / bake status message) instead of
+> throwing. Verified by pathing Pandaria with a **wrath** archive set installed — which
+> contains no Pandaria at all — where the same query previously returned `HTTP 500`
+> `FileNotFoundException: World\Maps\HawaiiMainLand\HawaiiMainLand.wdt`.
+>
+> Practical driver: pre-Cata clients are ~9 GB, but 4.3.4 Cataclysm and 5.4.8 Mists are
+> ~19 GB each. Requiring a client just to *query* would mean keeping tens of GB installed
+> to walk over tiles that are already baked and only ~1 GB on the wire.
 
 The pathing **query path is pure managed C#** (DotRecast Core/Recast/Detour + `PPatherService`). The only Windows-flavored code in the wider engine is **bake-time** (`StormDll` P/Invoke for MPQ, `MapTileFile` ADT parsing) — never touched by a route request. So a query-only server has no Windows dependency.
 
@@ -64,6 +82,10 @@ The bake pipeline (MPQ read via `StormDll`/StormLib, ADT parse via `MapTileFile`
 - so it runs clean on Linux/arm64.
 
 *(Future nicety: split `PPather` into `PPather.Query` + `PPather.Bake` so the container image doesn't even carry the bake code. Not required for v1 — dead code that's never called is harmless.)*
+
+> **Baking is no longer inherently Windows-only.** §12 scopes running the bake on macOS
+> (Apple silicon) — the blocker is a native StormLib build plus two P/Invoke signatures, not
+> anything structural. The query server design here is unaffected either way.
 
 ---
 
@@ -157,7 +179,7 @@ The bot's existing RemoteV3 client speaks the same `PPatherController` protocol.
 3. ~~`StormDll` on a route request~~ — **resolved (§9):** bake-only. **But** the container must **ship pre-baked tiles** so `NavmeshTileCache.LoadOrBake` never cache-misses into the MPQ extractor. Optionally add a hard guard: on a Linux/query build, a cache miss should error ("tile not baked") rather than attempt StormDll.
 4. **RemoteV3 route subset** *(open)* — confirm exactly which `PPatherController` endpoints the bot's RemoteV3 client calls, so `PathingServer` exposes the right minimal set.
 5. **Submodule in CI/Docker** *(open)* — build context must `git submodule update --init external/DotRecast` (linked worktrees / clean CI checkouts don't auto-populate it).
-6. **Baking stays Windows-only** *(by design)* — StormLib is a Windows PE. Baking on Linux would need a native StormLib `.so` + a resolver branch; out of scope for the query server.
+6. ~~**Baking stays Windows-only**~~ — **scoped in §12.** Still out of scope for the *query server*, but no longer treated as impossible: it needs a native StormLib build, a resolver branch **and** platform-conditional marshalling on two P/Invokes (the `TCHAR` path arguments). Verified against StormLib source, not assumed.
 
 ---
 
@@ -166,6 +188,268 @@ The bot's existing RemoteV3 client speaks the same `PPatherController` protocol.
 - **P1 — Retarget + carve.** Pathing chain → `net10.0` (per §9); new minimal `PathingServer` hosting `PPatherController` + `PPatherService`; build + smoke-test a route locally against baked tiles.
 - **P2 — Docker + CI.** Multi-stage, multi-arch Dockerfile; GHCR publish Action (submodule-aware).
 - **P3 — Provisioning + polish.** R2-fetch entrypoint option; optional native self-contained RID builds; optional `PPather.Query`/`PPather.Bake` split.
+- **P4 — macOS bake host (§12).** Independent of P1–P3: turns an Apple-silicon box into a bake
+  machine. Only coupling is the `net10.0` retarget, which P1 already does.
+
+---
+
+## 12. macOS / Apple silicon — query *and* bake
+
+**Motivation.** An idle Apple-silicon machine (e.g. Mac mini M4) is attractive as a dedicated
+bake host: baking is the expensive, occasional, offline step, and its output is portable data
+that any platform can then consume.
+
+### 12.1 What already works today, with zero code changes
+
+**Windows-on-ARM in a VM.** Issue
+[#803](https://github.com/Xian55/WowClassicGrindBot/issues/803) is a user running the bot under
+Windows 11 ARM64 in a VM on an Apple-silicon host. It works: the repo already ships
+`StormLib_arm64.dll` and `StormDll.Resolve` already selects it from
+`RuntimeInformation.ProcessArchitecture`. Nothing to build, nothing to port.
+
+That issue is also where the shipped ARM64 DLL got its build flags settled, and the failure it
+produced is the single most important thing to know before attempting a native port — see
+§12.3.
+
+So: if the goal is just "use the Mac as a bake box", a Windows ARM VM is the zero-risk answer.
+Everything below is for running natively.
+
+### 12.2 The query path is already proven
+
+§9's compile probe stands unchanged: the pathing chain builds clean as plain `net10.0` and
+cross-builds for `linux-arm64` with **zero code changes** beyond three `<TargetFramework>`
+overrides. `osx-arm64` is the same shape — a RID swap, since nothing in the chain is
+platform-specific:
+
+```
+dotnet publish PathingServer/PathingServer.csproj -c Release -r osx-arm64 --self-contained
+```
+
+DotRecast multi-targets `net10.0`; every `System.Drawing` use is cross-platform Primitives
+structs. A query-only macOS host needs nothing further.
+
+### 12.3 The bake delta: StormLib, and the `TCHAR` trap
+
+The bake's only native dependency is StormLib. Two things must change, and the second is the
+one that will silently waste an afternoon if missed.
+
+**(a) Build StormLib for `osx-arm64`.** The three shipped binaries are Windows PEs —
+*including* `StormLib_arm64.dll`, which is Windows-on-ARM, not macOS. StormLib builds on macOS
+via CMake:
+
+```
+cmake -S StormLib -B build -DBUILD_SHARED_LIBS=ON -DCMAKE_OSX_ARCHITECTURES=arm64
+cmake --build build --config Release      # -> libstorm.dylib
+```
+
+Note there is deliberately **no `-DSTORM_UNICODE=ON`** here, unlike the Windows ARM64 build
+recipe in #803. That flag is Windows-only, which leads directly to:
+
+**(b) `TCHAR` is `char` off Windows — so two P/Invokes need platform-conditional marshalling.**
+Verified against `StormLib/src/StormPort.h`, non-Windows branch:
+
+```c
+typedef char TCHAR;      // not wchar_t
+#define _T(x)  x
+```
+
+And the affected exports (`StormLib/src/StormLib.h`):
+
+```c
+bool SFileOpenArchive     (const TCHAR * szMpqName, ...);                       // TCHAR
+bool SFileOpenPatchArchive(HANDLE, const TCHAR * szPatchMpqName,
+                           const char * szPatchPathPrefix, ...);                // TCHAR + char*
+bool SFileOpenFileEx      (HANDLE, const char  * szFileName, ...);              // always char*
+```
+
+Our P/Invokes currently declare both `TCHAR` paths as `LPWStr`, which is correct **only**
+against a `STORM_UNICODE=ON` Windows build:
+
+```csharp
+public static partial bool SFileOpenArchive(
+    [MarshalAs(UnmanagedType.LPWStr)] string szMpqName, ...);
+public static partial bool SFileOpenPatchArchive(
+    nint hMpq, [MarshalAs(UnmanagedType.LPWStr)] string szPatchMpqName, nint prefix, uint flags);
+```
+
+On macOS those must marshal as UTF-8 `LPStr`. Everything else is already portable —
+`SFileOpenFileEx` is `const char*` on every platform, which is why `Archive` already converts
+file names to a UTF-8 span and needs no change. The patch-path *prefix* is likewise always
+`char*`; we pass `nint.Zero` (NULL) and that stays correct.
+
+**Why this matters more than it looks.** #803's symptom was a `NullReferenceException` deep in
+`ArchiveSet.GetStream`, because an ANSI StormLib silently failed to open archives against a
+wide P/Invoke — wrong-encoding path in, open fails, `null` archive kept, crash much later. A
+macOS `.dylib` reached through the current `LPWStr` declaration reproduces exactly that class
+of failure, in mirror image. **It does not throw at the boundary; it returns "archive not
+found".** `ArchiveSet` now skips-and-logs a failed open instead of NRE'ing (hardened in #803,
+extended since for Cataclysm's empty-listfile stub archive), so the symptom will be a clear
+"No MPQ archive could be opened" error rather than a mystery — but only if you read the log.
+
+### 12.4 Implementation — status
+
+Implemented and verified on a real Mac mini M4 (macOS 26.5, arm64, 10 cores, 16 GB),
+2026-07-26. Everything except the native library is done.
+
+| Change | Where | Status |
+| --- | --- | --- |
+| `net10.0` retarget | DataConfig, SharedLib, PPather | **done** — `<TargetFramework>` override in each; Windows solution still builds and the 6-tile corpus stays byte-identical |
+| Resolver: OS **and** arch | `StormDll.Resolve` | **done** — `libstorm.dylib` / `libstorm.so` / `StormLib_*.dll` |
+| Platform-conditional marshalling | `SFileOpenArchive`, `SFileOpenPatchArchive` | **done** — `…W`/`…A` partials behind `OperatingSystem.IsWindows()`, sharing one `EntryPoint` |
+| Cross-platform bake entry point | `Utilities/BakeTool` | **done** — plain `net10.0` console; every other bake path (Benchmarks, PathingAPI, CoreTests) is `net10.0-windows` |
+| Ship the unix library | `PPather.csproj` | **done** — `None Include` conditioned on `Exists`, so Windows and fresh checkouts are unaffected |
+| Build helper | `scripts/build-stormlib-unix.sh` | **done** |
+| `libstorm.dylib` itself | `PPather/MPQ/` | **done** — built on the Mac, Mach-O arm64 |
+| MPQ-internal path separator | `WDTFile` | **done** — see §12.4.1 |
+
+The dylib is deliberately **gitignored**: it is a host-specific native binary, unlike the
+committed Windows DLLs.
+
+**Verified on the Mac, without the dylib present:**
+
+- .NET SDK 10.0.110 installed user-local (`~/.dotnet`) to match `global.json`'s `10.0.100`
+  feature band — a 10.0.3xx SDK is rejected by `latestPatch` roll-forward. Running the apphost
+  from a user-local install needs `DOTNET_ROOT=$HOME/.dotnet`.
+- `dotnet build Utilities/BakeTool` → **0 errors**, only the two pre-existing DotRecast CS8632
+  warnings Windows also emits. §9's "compile-clean as `net10.0`" now confirmed on macOS itself,
+  not just as a cross-build.
+- `DataConfig` resolves `legacy_mop` → era `mop`; the MPQ path (a symlink to the client's
+  `Data` folder) enumerates all 38 archives; `dbc/legacy_mop` loads.
+- The bake then fails exactly as intended — a `DllNotFoundException` naming
+  `…/bin/Release/net10.0/MPQ/libstorm.dylib`. That is the resolver arm working: an actionable
+  message, not a mystery.
+
+**Full recipe on a fresh Mac:**
+
+```
+# toolchain (all user-local, no admin except CLT)
+xcode-select --install                               # clang + git; GUI/admin
+curl -fsSL https://dot.net/v1/dotnet-install.sh -o ~/dotnet-install.sh
+~/dotnet-install.sh --version 10.0.110 --install-dir ~/.dotnet
+# cmake is NOT in CLT - grab the official universal tarball
+#   https://github.com/Kitware/CMake/releases -> cmake-<ver>-macos-universal.tar.gz
+#   binary lives at CMake.app/Contents/bin/cmake
+
+export PATH="$HOME/.dotnet:$HOME/tools/bin:$PATH"
+export DOTNET_ROOT="$HOME/.dotnet"
+
+scripts/build-stormlib-unix.sh                       # -> PPather/MPQ/libstorm.dylib
+dotnet build Utilities/BakeTool -c Release
+./Utilities/BakeTool/bin/Release/net10.0/BakeTool \
+    --exp legacy_mop --root ~/wcgb-data --continent HawaiiMainLand
+```
+
+The data root needs `MPQ/` (a symlink to the client's `Data` folder is fine) and
+`dbc/<exp>/` from `ReadDBC_CSV -v <exp>`.
+
+Toolchain gotchas, all of which cost time here:
+
+- **`global.json` pins `10.0.100`.** Roll-forward is `latestPatch`, which does not cross
+  feature bands, so a `10.0.3xx` SDK is *rejected*. Install a `10.0.1xx` - matching the Windows
+  box exactly is also one fewer variable for byte-identity.
+- **`DOTNET_ROOT` must be set** for a user-local `~/.dotnet`, or the apphost reports
+  "You must install .NET" despite `dotnet --version` working.
+- **`xcode-select --install` may say "already installed" while `xcode-select -p` errors** -
+  the CLT files exist but no active developer directory is set, so `/usr/bin/{git,clang}` stay
+  stubs. Running the install (or `sudo xcode-select --switch /Library/Developer/CommandLineTools`)
+  fixes it.
+- **cmake ships with neither macOS nor CLT.** Its binary is nested at
+  `CMake.app/Contents/bin/cmake` inside the tarball.
+
+### 12.4.1 The one code bug the port exposed
+
+`WDTFile` built its archive path with `Path.Join`:
+
+```csharp
+Path.Join("World", "Maps", path, $"{path}.wdt")   // "World/Maps/..." on macOS
+```
+
+MPQ entries are **always** backslash-separated, so on macOS this asked for
+`World/Maps/HawaiiMainLand/HawaiiMainLand.wdt` and matched nothing - the continent failed to
+load with `FileNotFoundException` even though every archive had opened. Every sibling lookup
+(`LoadMapTile`, `BuildAreaData`, `ReadObjectFile`) already used interpolated `\\` strings; this
+was the only `Path.Join` on an in-archive path, and on Windows it was invisible because the
+platform separator happened to be right.
+
+### 12.4.2 Verified: macOS output is byte-identical
+
+The gate from §12.5(4), run for real:
+
+| check | result |
+|---|---|
+| settings hash | `675b9b8a` on both platforms - so no platform component is needed |
+| single ADT (16 tiles) | **16/16 byte-identical** to the Windows bake |
+| full Pandaria overlap | **2320/2320 byte-identical**, 0 different |
+
+macOS-baked tiles can therefore be mixed with Windows-baked ones in the same cache directory
+and published to the same CDN bundle.
+
+`Resolve` today branches only on architecture and hardcodes `.dll`:
+
+```csharp
+string fileName = RuntimeInformation.ProcessArchitecture switch {
+    Architecture.X64   => "StormLib_x64.dll",
+    Architecture.Arm64 => "StormLib_arm64.dll",
+    ...
+};
+return NativeLibrary.Load(Path.Combine(AppContext.BaseDirectory, "MPQ", fileName));
+```
+
+It needs an OS arm first (`libstorm.dylib` on macOS, `libstorm.so` on Linux), keeping the
+existing Windows behaviour untouched.
+
+For the marshalling, `LibraryImport` cannot vary an attribute at runtime, so it wants two
+partial declarations selected by an `OperatingSystem.IsWindows()` check at the call site (or a
+`#if`-free wrapper method that picks one). Keep the wide path for Windows so the shipped DLLs
+and #803's ARM64 build keep working byte-for-byte.
+
+### 12.5 Verification — do not trust "it compiled"
+
+The failure mode here is quiet, so the gate must be "did it actually read game data", not
+"did it run". Minimum checks, in order:
+
+1. **Archive opens.** Log line count of successfully opened archives matches the `*.MPQ` files
+   present. A zero here is the `TCHAR` bug.
+2. **A known ADT reads.** Pull `World\Maps\Azeroth\Azeroth_32_48.adt` and compare its SHA-256
+   against the same read on Windows. Byte-identical, or the marshalling/patch chain is wrong.
+3. **Geometry matches.** Extract triangles for a handful of ADTs and compare counts *and* a
+   vertex hash against Windows. Counts alone are too weak — two clients can agree on counts
+   and differ in vertices.
+4. **Tiles match.** Bake a few tiles and compare the serialized `DtMeshData` SHA-256 against
+   the Windows output. This is the real gate: a macOS bake must be byte-identical, otherwise
+   the era/settings hash silently means two different things on two machines and mixed tiles
+   end up in one cache directory.
+
+(4) is the one that matters for distribution. If macOS output is *not* byte-identical, the
+settings hash must gain a platform component — otherwise `precata/Azeroth/<hash>/` could hold a
+mix of Windows- and macOS-baked tiles.
+
+### 12.6 Will it actually be faster?
+
+Unknown, and worth measuring rather than assuming. The honest arguments both ways:
+
+- **For:** `docs/dotrecast-fork.md` records that the worst C#-vs-C++ bake stages are the
+  **memory-bandwidth-bound** sweeps (`MEDIAN_AREA` 2.26x, `FILTER_BORDER` 2.18x,
+  `BUILD_DISTANCEFIELD` 1.88x) — they lose precisely because our storage is wider than C++'s.
+  Apple silicon's unified memory bandwidth is well above typical desktop DDR, so those stages
+  are where a real win would come from.
+- **Against:** the baker runs only 2–4 workers (`NavmeshTileCache` Min/MaxBakeWorkers), so most
+  of an M4's cores sit idle regardless. Observed peak RSS for a full-continent bake is ~3.4 GB,
+  so memory capacity is not a factor.
+
+Measuring is one command — `Benchmarks --bake-profile <label>` already emits the per-stage
+`RC_TIMER_*` breakdown plus a per-tile SHA-256, so a macOS run is directly comparable to the
+numbers already committed under `benchmark_results/`. That single run answers both §12.5(4)
+and §12.6 at once.
+
+### 12.7 Reach after P4
+
+| Target | Query | Bake |
+| --- | --- | --- |
+| Windows x64 / ARM64 | yes | yes (today) |
+| Linux x64 / arm64 (Docker) | yes | needs `libstorm.so` (same delta as §12.3) |
+| macOS arm64 native | yes (§12.2) | after P4 |
+| macOS via Windows ARM VM | yes | yes (today, #803) |
 
 ---
 

--- a/docs/mpq-casc-storage-abstraction.md
+++ b/docs/mpq-casc-storage-abstraction.md
@@ -1,5 +1,21 @@
 # Unifying MPQ and CASC game-data access
 
+> **Status note (2026-07-25).** This document originally assumed that reaching Cataclysm/MoP
+> geometry required CASC. That is only true for the *modern re-releases*. The **original
+> Cataclysm 4.3.4.15595 client ships MPQ**, and its archives were probed directly (see
+> [Measured ground truth](#measured-ground-truth)). The result: **CASC is not on the critical
+> path for Cata-era navmesh**, and the DB2 phase is already solved by an existing tool. The
+> phasing below has been re-sequenced accordingly.
+>
+> **Phase A is implemented and shipped** (2026-07-25/26) — see
+> [Phase A](#phase-a--cata-era-adt-parsing-the-only-blocker) and [Verification](#verification).
+> Vanilla/TBC/WotLK remain byte-identical; the original 4.3.4 Cataclysm client is supported
+> end to end: split-ADT parsing, all four continents baked (53,818 navmesh tiles), Leaflet
+> tiles for the rebuilt continents with Northrend/Outland inheriting precata art, and both
+> published to R2. Phases B (`IGameFileSource`) and C (CascLib, for the 4.4.x/5.5.x
+> re-releases) remain open. MoP 5.4.8 is MPQ and split-ADT too but is **untested** — it adds
+> `holes_high_res` over `ofsHeight` in the MCNK header.
+
 ## Why
 
 The navmesh bake reads terrain and object geometry (ADT / WMO / M2) straight from the
@@ -7,21 +23,28 @@ installed WoW client's data files. Today that path is MPQ-only: `MPQTriangleSupp
 a set of `.MPQ` archives through StormLib (P/Invoke in `PPather/StormDll/`).
 
 MPQ is the archive format up to and including the **original** Mists of Pandaria client
-(5.4.8) and WotLK (3.3.5). Blizzard replaced it with **CASC** (Content Addressable Storage
-Container) in Warlords of Draenor (6.0, 2014). The catch that matters here: the **modern
-Classic re-releases — Cataclysm Classic (2024) and the upcoming MoP Classic — run on the
-retail engine and ship CASC, not MPQ.** So although the bot already supports Cata and MoP at
-the game-client level, the navmesh cannot be baked for those clients: StormLib cannot open a
-CASC storage, so there is no geometry to voxelize.
+(5.4.8), the original Cataclysm client (4.3.4) and WotLK (3.3.5). Blizzard replaced it with
+**CASC** (Content Addressable Storage Container) in Warlords of Draenor (6.0, 2014). The
+**modern Classic re-releases — Cataclysm Classic (4.4.x) and MoP Classic — run on the retail
+engine and ship CASC, not MPQ.**
 
-Closing this needs a storage layer that reads the same logical files (`World\Maps\…\*.adt`
-and friends) from **either** an MPQ archive set **or** a CASC storage, chosen by client
-version. This document scopes that.
+So there are two separate gaps, and the original document conflated them:
+
+1. **A format gap.** From Cataclysm on, an ADT is split across several files and the root ADT
+   lost its chunk-offset table. The current parser cannot read a Cata-era ADT *from any
+   container*. This blocks Cata/MoP geometry.
+2. **A container gap.** StormLib cannot open a CASC storage. This blocks reading a
+   Cata-Classic / MoP-Classic *install*, but only those.
+
+Gap 1 is the blocker. Gap 2 is a convenience: with an original 4.3.4 client on disk, the
+Cata-era navmesh can be baked entirely over MPQ. And because `DataConfig.ClientEra` folds
+`cata` and `legacy_cata` into one `"cata"` era, a mesh baked from 4.3.4 is the artifact
+Cataclysm Classic consumes too. (`mop`/`legacy_mop` are a separate `"mop"` era — see
+[MoP implementation](#mop-implementation--patch-chain--high-res-holes).)
 
 ## What exists today
 
-The geometry path is already funnelled through one small storage seam, which is what makes
-this tractable.
+The geometry path is already funnelled through one small storage seam.
 
 - **`PPather/StormDll/`** — the StormLib P/Invoke wrapper.
   - `Archive` — one open `.MPQ`; `SFileOpenArchive` / `SFileOpenFileEx` / `SFileReadFile`.
@@ -37,17 +60,408 @@ this tractable.
   - `WmoGroupFile.Load(ArchiveSet, …)`, `WMOManager(ArchiveSet)` — WMO
 - **Selection** — `MPQTriangleSupplier.GetArchiveNames(DataConfig)` is
   `Directory.GetFiles(dataConfig.MPQ, "*.MPQ")`. The client/expansion is known from
-  `DataConfig.Exp` (e.g. `"wrath"`) and `DataConfig.Version`.
+  `DataConfig.Exp`.
+- **Client classification already exists.** `StartupClientVersion` maps
+  `{Major: 4, Minor: <= 3}` → `legacy_cata` and `{Major: 5, Minor: <= 4}` → `legacy_mop`;
+  `{Major: 4, Minor: >= 4}` → `cata`. `DataConfig.ClientEra` maps the two Cataclysm names to
+  the `"cata"` geometry era and the two Mists names to `"mop"`. Nothing new is needed to
+  *recognise* the client.
 
 The whole geometry stack touches storage through exactly two methods — `GetStream` and
 `Exists` — returning a `Stream`. That is the entire seam.
 
+## Measured ground truth
+
+Probed against a real install at `F:\Game\Cataclysm-4.3.4.15595-enUS-x64`, opening the
+archives with the project's own StormLib binary, with WotLK 3.3.5 (`json/MPQ`) as the
+control. These are observations, not format-wiki claims.
+
+### Archives
+
+`Data\*.MPQ` holds all world geometry (14 archives; `world.MPQ`, `world2.MPQ`, `art.MPQ`,
+`expansion1-3.MPQ`, …). `Data\enUS\*.MPQ` holds locale data including all DBCs.
+
+- `World\Maps\Azeroth\Azeroth_32_48.adt` resolves in exactly one archive (`world.MPQ`) —
+  **no cross-archive duplicate**, so `ArchiveSet`'s first-match-wins order is not a
+  correctness hazard for geometry.
+- The `wow-update-base-*.MPQ` patch archives carry creature/sound/interface assets only —
+  no ADT, WMO or WDT overrides.
+- **`OldWorld.MPQ` is a 1 KB stub with an empty `(listfile)`.** It opens fine but lists
+  nothing. This crashed `ArchiveSet` construction outright (see Phase A step 4).
+
+### ADT layout — the actual delta
+
+Every tile exists as a 1:1 family of four files (7192 of each: root, `_obj0`, `_tex0`,
+`_tex1`). There is no `_obj1` and no `_lod` in 4.3.4.
+
+| | WotLK 3.3.5 root `.adt` (control) | Cata 4.3.4 |
+|---|---|---|
+| root | `MVER, MHDR, `**`MCIN`**`, MTEX, `**`MMDX, MMID, MWMO, MWID, MDDF, MODF`**`, MH2O, MCNK×256` | `MVER, MHDR, MH2O, MFBO, MCNK×256` |
+| `_obj0` | — | `MVER, `**`MMDX, MMID, MWMO, MWID, MDDF, MODF`**`, MCNK×256` |
+| `_tex0` | — | `MVER, MAMP, MTEX, MCNK×256` |
+| `_tex1` | — | (texture data) |
+
+Consequences:
+
+- **`MCIN` is gone from the root ADT.** Its `MHDR` slot reads `0`. This is the hard breakage:
+  `MapTileFile.Read` populates its `mcin` span only inside `case ChunkReader.MCIN`, so on a
+  Cata ADT every one of the 256 entries stays `offset == 0` and the MCNK loop seeks all 256
+  chunks to file offset 0. `ReadAreaIds` has a `haveMcin` guard and degrades to all-zero area
+  ids instead of corrupting, but produces no data.
+- **Model and WMO placement moved to `_obj0`.** `MMDX`/`MMID`/`MWMO`/`MWID`/`MDDF`/`MODF` are
+  no longer in the root.
+- **`MH2O` stayed in the root.** Water parsing is unaffected.
+- **`_tex0` / `_tex1` are irrelevant to the bake** — the voxelizer never reads textures. They
+  can be ignored entirely.
+- `MFBO` (flight bounds) is new in the root and is simply skipped by the existing
+  `switch` default.
+
+### MCNK header — unchanged
+
+The 128-byte MCNK header layout is **identical** to WotLK. Verified on `Azeroth_32_48`
+chunk 0:
+
+- `ofsHeight` = 136 → `MCVT` at MCNK-chunk-start + 136 (same +8-for-header convention).
+- `ofsNormal` = 724 → `MCNR`. `MCVT` data is 580 bytes (145 floats), `MCNR` 448 — both as
+  in WotLK.
+- **`areaid` is still header index 13** (byte 0x34) and reads `12` = Elwynn Forest, correct
+  for tile 32_48. `ReadAreaIds`' `+ sizeof(uint) * 15` offset arithmetic stays valid.
+- `holes` still at index 15; position floats still at indices 26–28.
+- `nLayers`/`ofsLayer`/`ofsRefs`/`nDoodadRefs` are `0` in the root — that data lives in the
+  `_tex0` / `_obj0` MCNKs. The bake does not use any of it (`MPQTriangleSupplier` does its
+  own spatial culling in `MCNKHelper`), so the `_obj0` MCNKs can be skipped too.
+- Root MCNK sub-chunks are `MCVT`, `MCNR`, `MCSE` only.
+
+### M2 — no change needed
+
+Cata M2s are `MD20` **version 272** (WotLK is 264). Despite the version bump, the header
+fields the bake reads sit at the same offsets. `ModelFile.Read`'s hard-coded skips
+(`4 + 14×uint32` → `nVertices`/`ofsVertices`, then `23×uint32 + 14×float` →
+`nBoundingTriangles`/`ofsBoundingTriangles`/`nBoundingVertices`/`ofsBoundingVertices`) were
+run against 500 Cata M2s and 500 WotLK M2s:
+
+```
+WotLK 3.3.5 (control) : versions 264(0x108)x500 — parsed OK=500 FAILED=0
+Cataclysm 4.3.4       : versions 272(0x110)x500 — parsed OK=500 FAILED=0
+```
+
+Validation was not just bounds-checking: every bounding-triangle index was confirmed to
+address a real bounding vertex (`max(index) < nBoundingVertices`), which a mis-aligned
+header would not survive. **`ModelFile.cs` needs no changes.** (186 of the 500 Cata models
+carry no collision mesh at all, versus 27 in WotLK — that is a content difference, and
+`ModelFile` already returns empty arrays for it.)
+
+### WMO — no change needed
+
+Root and group chunk sets are identical to WotLK, `MVER` = 17 in both:
+
+- root: `MVER, MOHD, MOTX, MOMT, MOGN, MOGI, MOSB, MOPV, MOPT, MOPR, MOVV, MOVB, MOLT, MODS, MODN, MODD, MFOG`
+- group: `MVER, MOGP{ MOPY, MOVI, MOVT, MONR, MOTV, MOBA, MOLR, MOBN, MOBR }`
+
+### WDT — no change needed
+
+`Azeroth.wdt` is `MVER, MPHD, MAIN` — `MPHD` flags `0x5E`, bit 0 clear, so no global WMO,
+hence no `MWMO`/`MODF`. `WDTFile` switches on chunk type and tolerates their absence.
+`MAIN` is still 32768 bytes (64×64 × 8).
+
+### MoP 5.4.8 — measured, both blockers now fixed
+
+> **Update:** both blockers below are implemented and verified. Vanilla/TBC/WotLK stayed
+> byte-identical and Cata re-baked byte-identical (32/32 tiles), so nothing already shipped
+> moved. MoP now reads patched geometry and extracts Pandaria. See
+> [MoP implementation](#mop-implementation--patch-chain--high-res-holes) for what changed and
+> what is still missing before MoP can be called supported.
+
+Probed against `F:\Game\Mist of Pandaria` (5.4.8.18414). The **chunk formats are effectively
+the same as Cata 4.3.4**, so Phase A's parser already handles them — but two client-level
+differences block support, and neither is about chunk layout.
+
+What already matches Cata (no parser work needed):
+
+- Split ADT with the same root layout — `MVER, MHDR, MH2O, MFBO, MCNK×256`. It adds `_obj1`
+  (9764 files) alongside `_obj0`/`_tex0`/`_tex1`; still no `_lod`.
+- MCNK header identical: `areaid` at index 13 reads 12 (Elwynn) on `Azeroth_32_48`,
+  `ofsHeight` 0x88 / `ofsNormal` 0x2D4, sub-chunks `MCVT` 580 / `MCNR` 448 / `MCSE`.
+- `MD20` version **272** and WMO `MVER` **17** — same as Cata, so `ModelFile`/WMO need nothing.
+- WDT `MAIN` histogram `{1: 839, 2: 3257}` — identical to Cata, so the bit-0 mask fix
+  (Phase A step 4) is required here too and already covers it.
+- Minimaps use the Cata path form (`World\Minimaps\...`, 23,889 entries, no `.trs`), so the
+  extractor's listfile-scan fallback works unchanged.
+
+**Blocker 1 — MPQ patch chains (`PTCH`).** This is the serious one. MoP ships `world.MPQ` /
+`expansion1-4.MPQ` as a 5.0.x base plus **23 `wow-update-base-*.MPQ`** archives, several
+500 MB-1 GB. Those patch archives do *not* contain whole files; they hold **incremental
+`PTCH` deltas** that StormLib applies over the base via `SFileOpenPatchArchive`. Cata's
+three update archives carried no world data at all, so this never came up.
+
+`ArchiveSet` opens every archive as an independent peer and resolves by
+`Directory.GetFiles` alphabetical order, first match wins. `world.MPQ` sorts before every
+`wow-update-base-*`, so the base always wins and **every patch is ignored**:
+
+| file kind | patched | total | |
+|---|---|---|---|
+| root `.adt` | 5041 | 13,558 | **37.2%** |
+| `_obj0.adt` | 1811 | 9882 | 18.3% |
+| `_obj1.adt` | 1266 | 9764 | 13.0% |
+| `_tex0/_tex1` | 1245 | 19,563 | ~6% |
+
+Worst hit is `HawaiiMainLand` — Pandaria itself — at 1584 of 3420 ADTs patched, then
+Kalimdor 1366/5341 and Azeroth 827/4378. Baking MoP today would silently produce
+**pre-5.4.8 geometry for over a third of the world**, and reversing the sort order would be
+worse: it would feed a raw `PTCH` blob to the ADT parser.
+
+`PPather/StormDll/StormDll.cs` exposes no `SFileOpenPatchArchive` (confirmed absent), so the
+fix is real work: add the P/Invoke and restructure `ArchiveSet` from "peer archives, first
+match wins" into "base archives + patch chain attached in ascending build order".
+
+**Blocker 2 — `holes_high_res` is actually used.** 768 of 15,360 sampled MCNKs (5%, across
+3 of 60 sampled root ADTs) set flag `0x10000`, which repurposes the 8 bytes at header 0x14
+(`ofsHeight`/`ofsNormal`) as a 64-bit hole bitmask. Geometry still parses — `ReadMapChunk`
+walks sub-chunks rather than trusting `ofsHeight` — but the low-res `holes` field at index 15
+is then meaningless, so `MapChunk.IsHole` reports no holes and the bake floors over gaps that
+should be open. Localized, but it produces walkable surface where the world has none.
+
+### MoP implementation — patch chain + high-res holes
+
+**Patch chain.** `StormDll` gained `SFileOpenPatchArchive`; `Archive` gained `AttachPatch`;
+`ArchiveSet` now splits its input into base archives and `wow-update-<scope>-<build>.MPQ`
+patches (regex on the filename), sorts patches by **build number ascending**, and chains them
+onto each base they overlap. Overlap is checked against the patches' listfiles first, because
+attaching blindly would reopen MoP's multi-hundred-MB patch archives once per base
+(23 x 14 = 322 opens).
+
+Patch archives are still opened standalone and searched **last**, since an update can add a
+wholly new file that no base lists - those are stored complete rather than as a PTCH delta
+(e.g. Cata's `Creature\FlyingPanther\FlyingPanther.M2`, magic `MD20`). Bases are searched
+first and resolve to patched content, which preserves the previous alphabetical resolution
+order: `wow-update-*` sorted after every base archive name anyway.
+
+Verified end to end - the same ADT read through `ArchiveSet`:
+
+| source | bytes | sha256 |
+|---|---|---|
+| raw `world.MPQ` base | 381,610 | `e90e3032e265397c` |
+| through the patch chain | 381,610 | **`df788149c15f69bd`** |
+
+Identical length, different content: the delta is applied. (Length alone would have been a
+misleading check.)
+
+**High-res holes.** `MapChunk` gained `holesHighRes`, and `MapTileFile.ReadMapChunk` now reads
+the MCNK header words rather than blind-skipping them, taking the 64-bit mask from words 5-6
+when flag `0x10000` is set. `IsHole` tests that mask directly (bit `j*8+i`) and otherwise
+falls through to the legacy 4x4 field, so every pre-Mists client is bit-for-bit unaffected.
+
+Worth knowing: this is **defensive, not load-bearing**. Sampling 25 root ADTs per map dir
+across all 190 of them, `high_res_holes` carries real holes only in scenario/BG/raid maps -
+`GoldRushBG` (315 chunks), `HalfhillScenario` (139), `OrgrimmarRaid` (41),
+`ValeofEternalBlossoms_17116` (27) and a few more. **All five world continents the bot bakes
+report zero**, so world terrain still uses the legacy field. Pandaria holes do get applied
+through that legacy path - `HawaiiMainLand_21_19` extracts 65,520 terrain triangles rather
+than 65,536, i.e. four hole cells.
+
+**Mists now has its own era.** `ClientEra` previously folded `mop`/`legacy_mop` in with
+Cataclysm. That was unsafe: comparing 40 Azeroth ADTs between a 4.3.4 and a 5.4.8 client, 39
+hash identically but one (`37_23`) does not, so the two clients' bakes would have shared
+`cata/<continent>/<hash>/` and cross-served tiles - and Pandaria had no era at all. `mop` is
+now a separate era end to end (navmesh, leaflet, area grid, cost zones), verified per client:
+
+| client | cache directory |
+|---|---|
+| `wrath` | `navmesh/precata/Azeroth/b1473dae` (unchanged) |
+| `legacy_cata` | `navmesh/cata/Azeroth/bf03fdb6` (unchanged - shipped bundles still match) |
+| `mop` | `navmesh/mop/Azeroth/675b9b8a` |
+
+`TileEra`'s shared-art fallback deliberately stays cata-only: Mists' minimap art has not been
+compared against precata the way Cataclysm's was, and guessing would serve the wrong world.
+
+*Latent startup bug this surfaced:* `PhysicalFileProvider` throws `DirectoryNotFoundException`
+on a missing root, so registering `/tiles` for a brand-new era with no tiles folder took down
+host startup entirely rather than 404ing that one route. Any fresh install without generated
+leaflet tiles had the same exposure. `Frontend/DependencyInjection` now creates each data
+folder before serving it.
+
+**Still missing before MoP can be called supported:**
+
+- ~~`Json/dbc/legacy_mop/` does not exist~~ **done** - generated with
+  `ReadDBC_CSV -v legacy_mop` (524 zones). `legacy_mop` now starts and bakes.
+- No MoP leaflet tiles yet: `Configs['mop']` in `leaflet-watch.js` is an empty placeholder.
+  Generate with `LEAFLET_ERA=mop WOW_MPQ=<mop client>\Data python scripts/extract-minimap.py`
+  and paste the manifest output.
+- No MoP navmesh baked or published.
+
+#### Sourcing the legacy DBC data
+
+The addons target the modern Classic clients and bridge legacy ones through
+`Addons/DataToColor/Legacy/WorldMapAreaIDToUiMapID.lua`, which maps a legacy client's
+`WorldMapAreaID` to a modern `UiMapID`. `worldmaparea.json` therefore has to be keyed by
+UiMapIDs that agree with that table - which is why the `legacy_*` entries in `ReadDBC_CSV`
+point at a re-release build rather than the original client.
+
+`legacy_mop` is sourced from **MoP Classic `5.5.4.68806`**, not `legacy_cata`'s `8.1.0.27826`.
+Two reasons. It is the same expansion's content, and it verifies clean against the mapping
+table: 261 zone names match with 2 cosmetic differences, all Pandaria zones arrive on map 870
+(`HawaiiMainLand`) with real bounds, and of the 179 mapped UiMapIDs it lacks, 176 are
+Warlords-or-later zones a 5.4.8 client cannot reach (the three older ones are `Undercity`,
+`Outland` and `Dire Maul`, the last of which `legacy_cata` also lacks).
+
+The second reason is that **8.1.0.27826 no longer works**. wago.tools now answers `200` with an
+**empty body** for `Map`, `SpellName` and `ManifestInterfaceData` at that build and `404`s
+`TalentTab`. The first `legacy_mop` run against it produced no `worldmaparea.json`, no
+`spells.json`, no icons and no talents, failing with a cryptic
+`The given key 'ID' was not present in the dictionary` - because the extractor cached the
+zero-byte responses and only tripped over them later. The downloader now rejects an empty
+response instead of caching it. `Json/dbc/legacy_cata/` predates the regression; refreshing it
+would need the Cata Classic build (`4.4.2.60895`).
+
+### DBC — already solved, not a phase
+
+The original Phase 4 assumed a DB2/DB6 parser was needed. It is not, for two reasons:
+
+1. The 4.3.4 client still ships **`WDBC`**, not DB2: `WorldMapArea.dbc` (211 rows, 14 cols,
+   56-byte rows), `Map.dbc`, `AreaTable.dbc`, `LiquidType.dbc` — 328 `.dbc` versus only 5
+   `.db2` (all item-related, none map-related), in `Data\enUS\locale-enUS.MPQ`.
+2. **More importantly, the bot never reads DBC from the client at all.**
+   `Utilities/ReadDBC_CSV` pulls CSVs from [wago.tools](https://wago.tools) and emits JSON
+   into `json/dbc/{version}/`. `json/dbc/legacy_cata/WorldMapArea.json` **already exists**,
+   alongside `cata` and `mop`.
+
+So map metadata for the Cata era is done. No DB2 work is required for the navmesh.
+
+### Minimap / Leaflet tiles — the index file is gone
+
+`scripts/extract-minimap.py` stitches the client's per-ADT minimap BLPs into the Leaflet tile
+pyramid. Cataclysm changed how those blocks are addressed, and the script assumed the old
+form:
+
+| | vanilla…WotLK | Cata 4.3.4 |
+|---|---|---|
+| block location | `textures\Minimap\<md5>.blp` | `World\Minimaps\<MapDir>\map<col>_<row>.blp` |
+| index | `textures\Minimap\md5translate.trs` | **none — no `.trs` anywhere in the client** |
+
+The script `sys.exit`ed on the missing `.trs`. Fixed the same way as the ADT reader — detect
+from the client, not from config: use the `.trs` when present, otherwise discover the blocks
+by scanning the archive listfiles for `World\Minimaps\<MapDir>\map<col>_<row>.blp`. Both
+generations produce identical pyramid geometry (a block is 256×256 in both and is upscaled to
+the script's 512 `BLP` constant, unchanged).
+
+Cata ships *more* minimap coverage than WotLK, as expected from the new zones — Azeroth 839
+blocks vs 687, Kalimdor 1105 vs 1018 — with Expansion01 (826) and Northrend (1131) also
+present, so one Cata client covers the whole `cata` era. Run it with `LEAFLET_ERA=cata`.
+
+### What Cataclysm actually changed, per continent
+
+Cataclysm left Northrend and Outland *almost* alone, which is worth exploiting — but "almost"
+is doing real work, and it lands differently for art than for geometry. Measured against the
+4.3.4 client with 3.3.5 as the control.
+
+**Minimap imagery** (40-block sample per continent, decoded and pixel-hashed):
+
+| continent | blocks | identical | different | cata-only blocks |
+|---|---|---|---|---|
+| Northrend | 1131 both | 34/40 | 6 | 0 |
+| Expansion01 | 800 common | 38/40 | 2 | 26 |
+| Azeroth *(control)* | 687 common | 8/40 | 32 | 152 |
+
+**Geometry** (triangle-soup hash per ADT, via `MPQTriangleSupplier`):
+
+- **Northrend** — 52 of 60 ADTs hash identically. Of the 8 that differ, 6 have identical
+  triangle *counts* but different vertex data (sub-voxel float drift from Cata re-exporting
+  the ADTs), while **2 carry genuinely new collision geometry**: `29_11` gains 2454 M2
+  triangles and `30_11` gains 5030.
+- **Expansion01** — 4 of 5 sampled ADTs differ, mostly in liquid (water triangles 32768 →
+  32644, 22528 → 20312) plus WMO/M2 counts. Outland was *not* left alone.
+
+So the two assets get different treatment, and only one of them is shared:
+
+- **Leaflet tiles are shared** for Northrend and Expansion01 (`DataConfig.TileEra`). A stale
+  minimap block is cosmetic, the art is 85–95% identical, and it saves regenerating ~1950
+  blocks (~10k tiles) per era.
+- **The navmesh is never shared.** A stale mesh is not cosmetic — the bot would route
+  straight through those thousands of new Northrend collision triangles. `NavmeshCacheDir`
+  stays keyed on `MeshEra`, so Cata bakes its own.
+
+`TileEra` deliberately whitelists rather than falling back on "tiles missing". A blanket
+fallback would silently serve precata Azeroth art whenever the cata tiles had not been
+generated yet — the wrong world, rendered confidently. Kalimdor with no cata tiles 404s
+instead, which is the correct failure.
+
+Implementation: `DataConfig.TileSharedContinents` / `TileEra` / `LeafletFor` are the single
+source of truth; `Frontend/DependencyInjection` registers a `/tiles/<continent>` static route
+per shared continent *before* the general `/tiles` route (static file middleware is
+order-sensitive, so the specific path has to come first); `leaflet-watch.js` mirrors it with
+`TILE_SHARED_CONTINENTS` / `tileEra()` / `continentConfig()` / `eraContinents()`. Verified: a
+`legacy_cata` client serves Northrend and Expansion01 tiles from `precata` (Northrend renders
+35/35 tiles and appears in the continent selector), Kalimdor correctly 404s, and a `wrath`
+client still serves all four continents unchanged.
+
+Also fixed while verifying: `glob("*.MPQ") + glob("*.mpq")` returns every archive twice on
+Windows (case-insensitive glob), so the script opened and searched each archive twice.
+
+`CONTINENTS` is deliberately left at the four world continents that `PPatherService.WorldContinents`
+bakes; Cata's Deepholm (`Deephome`, map 646) is present in the client but out of scope.
+
 ## The design
 
-### Phase 1 — storage abstraction (no behaviour change)
+### Phase A — Cata-era ADT parsing (the only blocker)
 
-Introduce one interface and make MPQ implement it. Nothing about the bake changes; this is
-pure refactoring, gated by the existing byte-identity corpus.
+**Status: implemented 2026-07-25.** Scope came in close to the estimate — two methods in
+`PPather/Triangles/Game/MapTileFile.cs`, plus one `ChunkReader` constant and an unrelated
+robustness fix in the archive layer (step 4, found only by running against a real install).
+Everything else in the geometry stack was verified unchanged and needed no edits.
+
+**1. Make `MCIN` optional.** Walk the root ADT's chunk stream and record the file offset of
+each `MCNK` in encounter order, then use `MCIN` offsets when the chunk is present and the
+walked offsets when it is not.
+
+Prefer **feature detection over version gating**: branch on "did this ADT have an `MCIN`?"
+rather than on `DataConfig.Exp`. That keeps one code path for both eras, needs no config
+plumbing, and — because a WotLK ADT still takes the `MCIN` branch — preserves the byte-
+identity bake corpus as the regression gate.
+
+**2. Read placement chunks from `_obj0`.** If `<tile>_obj0.adt` exists, parse
+`MMDX`/`MMID`/`MWMO`/`MWID`/`MDDF`/`MODF` from it; otherwise from the root as today. The
+existing `HandleMDDF`/`HandleMODF`/`ChunkReader.ExtractFileNames` bodies are reusable as-is —
+only the stream they read from changes. Skip the `_obj0` `MCNK` chunks and both `_tex*`
+files entirely.
+
+**3. Apply the same `MCIN`-optional walk to `ReadAreaIds`**, so `BuildAreaData` produces a
+real `AreaGrid` for the Cata era instead of silently returning zeros.
+
+**4. Mask the WDT `MAIN` has-ADT flag.** `WDTFile.HandleMAIN` recorded a grid cell as having
+terrain with `file.ReadInt32() != 0`. Pre-Cata WDTs only ever store 0 or 1 there so that
+worked by luck, but **Cataclysm marks its open-ocean cells with flag `2`** — 3257 of Azeroth's
+4096 and 3085 of Kalimdor's. Testing the whole word therefore claims all 4096 cells have an
+ADT, and the loader throws `FileNotFoundException` on the first one, so any full-continent
+Cata bake died immediately. Now masks bit 0 (`AreaInfoHasAdt`), which leaves pre-Cata
+behaviour byte-identical (corpus re-verified) and yields exactly the 839 / 1011 real ADTs.
+
+**5. Tolerate a stub archive.** `Archive`'s constructor threw
+`InvalidOperationException("File contains no lines.")` when an archive's `(listfile)` was
+empty. Cataclysm's 1 KB `OldWorld.MPQ` placeholder is exactly that, and because the throw
+happened *inside* the constructor it bypassed `ArchiveSet`'s existing
+"skip archives that fail to open" guard and took down the whole set — no Cata client could
+be opened at all. Now an empty or missing `(listfile)` yields an empty file list (a missing
+one is caught as `IOException`), `Archive` exposes `FileCount`, and `ArchiveSet` closes and
+skips any archive listing nothing rather than searching it on every lookup. The diagnostic
+value of the original throw is preserved by `ArchiveSet`'s existing "no archive could be
+opened" error.
+
+Note that `ArchiveSet.Exists` already provides the `_obj0` probe, and `MPQTriangleSupplier`
+needs no change — it derives paths the same way for both eras.
+
+**Files touched:** `PPather/Triangles/Game/MapTileFile.cs` (`Read`, `ReadAreaIds`, new
+`ReadObjectFile`), `PPather/Triangles/Game/ChunkReader.cs` (`MCNK` fourcc),
+`PPather/StormDll/Archive.cs`, `PPather/StormDll/ArchiveSet.cs`.
+
+**Known quirk, pre-existing and untouched:** `MPQTriangleSupplier.GetAreaIdAndZ` leaves
+`wdt.loaded[index]` set, while `GetChunkData` early-returns on an already-loaded tile and
+clears the flag itself. Calling `GetAreaIdAndZ` before `GetTriangles` for the same tile
+therefore yields zero triangles. Not a Cata issue — worth a look independently.
+
+### Phase B — storage abstraction (no behaviour change)
+
+Worth doing regardless, but no longer load-bearing: it is prep for Phase C, not for Cata
+geometry.
 
 ```csharp
 // PPather/Storage/IGameFileSource.cs
@@ -62,26 +476,24 @@ public interface IGameFileSource : IDisposable
 }
 ```
 
-- `ArchiveSet` implements `IGameFileSource` — `OpenRead` forwards to `GetStream`, which already
-  returns `MpqFileStream : Stream`. `Exists` already exists. `Close` becomes `Dispose`.
+- `ArchiveSet` implements it — `OpenRead` forwards to `GetStream`, which already returns
+  `MpqFileStream : Stream`. `Exists` already exists. `Close` becomes `Dispose`.
 - Every consumer signature changes `ArchiveSet` → `IGameFileSource`, and
-  `using MpqFileStream mpq = …` → `using Stream s = …`. The consumers never call an
-  MPQ-specific method, so this is mechanical.
-- `MPQTriangleSupplier` takes an `IGameFileSource` instead of constructing `ArchiveSet`
-  directly; a factory (below) builds the right one.
+  `using MpqFileStream mpq = …` → `using Stream s = …`. No consumer calls an MPQ-specific
+  member, so this is mechanical.
 
-**Verification for Phase 1:** the six-tile bake corpus must stay byte-identical, and the
-`CoreTests navmesh` suite green. This phase ships no new capability — it only proves the seam
-is clean.
+**Verification:** six-tile bake corpus byte-identical, `CoreTests navmesh` green. Ships no
+capability.
 
-### Phase 2 — CASC backend
+### Phase C — CASC backend (deferred; only for the re-releases)
 
-Add `CascFileSource : IGameFileSource`. This is where the real work is.
+Needed to bake *from* a Cata-Classic / MoP-Classic install directly. Not needed to *have* a
+Cata-era mesh, since Phase A + a 4.3.4 client produces the `"cata"`-era artifact that those
+clients consume.
 
-**Library choice — native CascLib via P/Invoke (recommended).** The project already
-P/Invokes **StormLib** (Ladislav Zezula) for MPQ. **CascLib** is the same author's CASC
-counterpart with a deliberately parallel API, so a `PPather/CascDll/` wrapper mirrors
-`StormDll/` almost line for line:
+**Library choice — native CascLib via P/Invoke.** The project already P/Invokes StormLib
+(Ladislav Zezula); **CascLib** is the same author's CASC counterpart with a deliberately
+parallel API, so a `PPather/CascDll/` wrapper mirrors `StormDll/` almost line for line:
 
 | StormLib (MPQ) | CascLib (CASC) |
 |---|---|
@@ -93,57 +505,30 @@ counterpart with a deliberately parallel API, so a `PPather/CascDll/` wrapper mi
 | `SFileCloseFile` | `CascCloseFile` |
 | `SFileCloseArchive` | `CascCloseStorage` |
 
-Source: <https://github.com/ladislav-zezula/CascLib>. This keeps one native dependency style,
-one build story, and a `CascFileStream : Stream` that mirrors `MpqFileStream` exactly.
+Source: <https://github.com/ladislav-zezula/CascLib>. One native dependency style, one build
+story, and a `CascFileStream : Stream` mirroring `MpqFileStream`.
 
-*Alternative — managed CASCExplorer (TOM_RUS lineage)*, the C# reader vendored in TheNoobBot's
+*Alternative — managed CASCExplorer (TOM_RUS lineage)*, as vendored in TheNoobBot's
 `meshReader/CascLib`. No native dependency, but a much larger managed surface (BLTE decode,
-encoding/root/download handlers, DB2 readers) to carry and keep current. Prefer native CascLib
-for symmetry with the existing StormLib path; fall back to managed only if shipping a second
-native DLL per-RID is a problem.
+encoding/root/download handlers, DB2 readers) to carry and keep current. Prefer native
+CascLib for symmetry; fall back to managed only if shipping a second native DLL per-RID is a
+problem.
 
-**The naming problem — the one genuinely new concept.** MPQ addresses files by path string.
-CASC addresses them by **FileDataId** (an integer), with an optional name→id mapping:
+**The naming problem.** MPQ addresses files by path string; CASC addresses them by
+**FileDataId**, with an optional name→id mapping. Modern clients ship a **root** file mapping
+a Jenkins96 hash of the path → FileDataId, and CascLib resolves `CascOpenFile(name, …)`
+through it where the storage has name support; otherwise a community **listfile** is needed.
+Keep `IGameFileSource` path-based so consumers are unchanged; id resolution stays inside the
+CASC backend.
 
-- Modern clients ship a **root** file mapping a Jenkins96 hash of the path → FileDataId.
-  CascLib resolves `CascOpenFile(name, …)` through it when the storage has name support.
-- Where names are unavailable, a **community listfile** (path ↔ FileDataId) is needed.
-  CascLib accepts one via `CascOpenStorageEx` / a listfile path.
+**Construction differs.** MPQ opens a *list of archive files*. CASC opens *one storage rooted
+at the install directory* (the folder holding `.build.info`), via
+`CascOpenStorage(installDir, localeMask)`. Local storage only; no CDN path is needed.
 
-`CascFileSource.OpenRead(name)` therefore resolves the client path to a FileDataId (via root
-or listfile) and calls `CascOpenFile`. Keep the *interface* path-based so consumers are
-unchanged; the id resolution is entirely inside the CASC backend.
-
-**Storage construction differs from MPQ.** MPQ opens a *list of archive files*
-(`Directory.GetFiles(MPQ, "*.MPQ")`). CASC opens *one storage rooted at the install
-directory* (the folder containing `.build.info` / `Data/`), via `CascOpenStorage(installDir,
-localeMask)`. So the factory's inputs differ by backend — see below. Local storage only; no
-CDN/online path is needed for a locally installed client.
-
-### Phase 3 — version-aware chunk parsing
-
-Storage is necessary but not sufficient: the ADT/WMO/M2 **chunk formats evolved**, and the
-current parsers (`MapTileFile`, `WmoGroupFile`, `ModelFile`) assume the WotLK layout.
-
-- **Split ADTs.** From Cataclysm on, an ADT is split across `…_x_y.adt`, `…_x_y_tex0.adt`,
-  `…_x_y_obj0.adt` (and `_lod` later). Terrain geometry (MCNK/MCVT) and object placement
-  (MDDF/MODF) move between the root and `_obj0`. `MapTileFile.Read` must load the right
-  companion files for the client version.
-- **M2 header** gained fields; **WMO** group/root chunks changed. The bounding-collision
-  reads the geometry cares about (`MOPY`, bounding vertices/triangles) are stable in shape but
-  offset-sensitive.
-
-Gate this behind the client version already in `DataConfig`. This is the largest and least
-mechanical phase; scope it per-format with the existing geometry as the reference (a Cata/MoP
-tile that bakes to sane polys, eyeballed in the Leaflet viz).
-
-### Phase 4 — DB2/DB6 for map metadata
-
-`WorldMapAreaDB` and the coordinate conversions read **DBC** tables. Modern clients replaced
-DBC with **DB2** (and DB6). This is off the geometry hot path — it feeds map↔world coordinate
-conversion, not the bake — so it can land independently, but Cata/MoP navmesh is not *usable*
-without correct `WorldMapArea` bounds. CascLib's managed cousin ships DB2 readers; the native
-route needs a small DB2 parser (the format is well documented in the wowdev wiki).
+**Format caveat.** Cata Classic runs on the retail engine, so its ADT/M2/WMO versions may
+track *current retail* rather than 4.3.4 — expect `_obj1`/`_lod` ADTs, chunked `MD21` M2s and
+`FileDataId`-based `MDDF`/`MODF` variants that Phase A does not cover. Phase A validates the
+*4.3.4* formats specifically.
 
 ## Factory and selection
 
@@ -160,55 +545,188 @@ public static IGameFileSource Open(DataConfig cfg, ILogger logger)
 }
 ```
 
-`StorageKind` derives from the configured expansion/version — MPQ for vanilla…original-MoP
-and WotLK, CASC for the modern re-releases. Add `WowInstallDir` / `Locale` / `ListfilePath`
-to `DataConfig` for the CASC case (MPQ ignores them).
+`StorageKind` derives from the configured client: MPQ for vanilla…4.3.4/5.4.8 (including
+`legacy_cata` / `legacy_mop`), CASC for the modern re-releases. Add `WowInstallDir` /
+`Locale` / `ListfilePath` to `DataConfig` for the CASC case (MPQ ignores them).
 
 ## Phasing summary
 
 | phase | deliverable | risk | ships capability? |
 |---|---|---|---|
-| 1 | `IGameFileSource`, `ArchiveSet` implements it, consumers retargeted | low — byte-identity gated | no (refactor) |
-| 2 | `CascDll/` P/Invoke + `CascFileSource`, factory, config | medium — naming/FileDataId, native DLL packaging | opens CASC files |
-| 3 | version-aware ADT/WMO/M2 parsing (split ADTs) | high — format archaeology | Cata/MoP geometry |
-| 4 | DB2/DB6 for `WorldMapArea` metadata | medium | usable Cata/MoP coords |
+| **A** ✅ | `MCIN`-optional MCNK walk + `_obj0` placement chunks in `MapTileFile`, stub-archive tolerance in `Archive`/`ArchiveSet` | **done** — corpus byte-identical, Cata verified against 3 zones | **yes — Cata-era geometry from a 4.3.4 MPQ client** |
+| B | `IGameFileSource`, `ArchiveSet` implements it, consumers retargeted | low — byte-identity gated | no (refactor) |
+| C | `CascDll/` P/Invoke + `CascFileSource`, factory, config | medium — FileDataId naming, native DLL packaging, retail-era format drift | bakes directly from a Cata/MoP Classic install |
+| ~~D~~ | ~~DB2/DB6 for `WorldMapArea`~~ | — | **already done** — `json/dbc/legacy_cata/WorldMapArea.json` via `ReadDBC_CSV` |
 
-Phase 1 stands alone and is worth doing regardless — it isolates storage behind an interface
-and is the cheapest, lowest-risk step. Phases 2–4 are only for actually baking the modern
-Classic clients and can be sequenced later.
+Phase A is now the whole story for Cata-era navmesh. B and C are only needed to bake from a
+CASC install rather than from an original 4.3.4 one.
 
 ## Verification
 
-- **Phase 1:** six-tile bake corpus byte-identical (`bench.ps1 -Bake`), `CoreTests navmesh`
-  green, whole-solution build clean. No new behaviour.
-- **Phase 2:** open a real Cata-Classic install, list and read one known ADT by path, confirm
-  bytes match the client (spot-check against a known tool, e.g. a wow.tools export). No bake
-  yet — just prove the storage backend reads the right bytes.
-- **Phase 3:** bake one Cata/MoP tile, render it in the Leaflet/Babylon viz, confirm the
-  walkable surface matches the terrain (no holes, no runaway polys). Compare poly counts to a
-  reference tool if available.
-- **Phase 4:** a known landmark's world↔map round-trip matches the client's map, the same way
-  `NavmeshCoords` is validated for WotLK today.
+- **Phase A — results (2026-07-25):**
+
+  *Regression — vanilla/TBC/WotLK unchanged.* Six-tile bake corpus
+  (`Benchmarks --bake-profile`), pristine `HEAD` vs modified, all **byte-identical**,
+  including after the `Archive`/`ArchiveSet` change:
+
+  | tile | hash (both runs) |
+  |---|---|
+  | elwynn-open | `6d6edc442008b805` |
+  | stormwind-wmo | `c3f074b363b36063` |
+  | dunmorogh-indoor | `34a1a2d4f25ad55b` |
+  | barrens-open | `12c83529658aba79` |
+  | durotar-water | `fb06c81c3603f8e4` |
+  | orgrimmar-wmo | `a64ee4ee73bb3e33` |
+
+  Ground/liquid triangle counts and poly counts also identical. Whole-solution Release build
+  clean; `CoreTests navmesh` green ("all landmark round-trips, tile bounds and 2601 grid
+  inversions OK").
+
+  *New capability — Cata 4.3.4 geometry loads.* Driven through the real stack
+  (`MPQTriangleSupplier` over the 4.3.4 `Data` folder, `Exp=legacy_cata`), with the WotLK
+  client as a control at the same world positions:
+
+  | | Cata 4.3.4 | WotLK 3.3.5 |
+  |---|---|---|
+  | **Elwynn** (`Azeroth_31_48`) terrain / water tris | 65472 / 5376 | 65472 / 5376 |
+  | areaId / z | 9 / 81.83 | 9 / 81.83 |
+  | **Auberdine** (`Kalimdor_30_19`) terrain / water | 65536 / 30848 | 65536 / 32768 |
+  | areaId / z | 2078 / 9.67 | 2078 / 10.04 |
+  | **Westfall** (`Azeroth_29_51`) terrain / water | 65504 / 0 | 65504 / 0 |
+  | areaId / z | 108 / 34.03 | 108 / 34.47 |
+
+  Terrain triangle counts (hence hole masks) and area ids match the control exactly at all
+  three, confirming the split-ADT MCNK walk and the unchanged MCNK header offsets. WMO/M2
+  counts and water differ where Cataclysm actually changed the world — Auberdine's flooded,
+  wreckage-strewn coast (M2 1587 vs 777) and Westfall's added encampment (WMO 12803 vs
+  10863) — which is the content differing, not the parser.
+
+  *Leaflet tiles.* `scripts/extract-minimap.py` now handles both client generations
+  (see [above](#minimap--leaflet-tiles--the-index-file-is-gone)). Verified by exercising
+  discovery + `build_pyramid` on both clients: WotLK resolves via `md5translate.trs`, Cata via
+  the listfile scan, each producing 16 z6 tiles from a 4-block patch plus the same pyramid
+  levels above it, with all four continents discovered on both.
+
+  *End-to-end bake + viz (done).* Ran PathingAPI with `--exp=legacy_cata` against the 4.3.4
+  client and baked 6 ADTs around Elwynn via `POST api/PPather/Bake`, ~1s per ADT (16 tiles
+  each). Artifacts landed in the era-partitioned folders, leaving the precata set untouched:
+
+  | artifact | path | result |
+  |---|---|---|
+  | navmesh | `Json/PathInfo/navmesh/cata/Azeroth/bf03fdb6/tile_*.dnm` | 105 tiles, 4.5 MB |
+  | leaflet | `Json/leaflet/cata/Azeroth/z{z}x{x}y{y}.webp` | 4505 tiles, 18.4 MB |
+
+  `GET api/PPather/WorldRoute` across the baked mesh returned a **304-point path** from
+  (-8900,-100) to (-9400,300) with z resolved to 82.4 → 61.1 — plausible Elwynn terrain
+  heights. The Leaflet coverage overlay reports "ADT 32,14 - 16/16 tiles baked" over Cata-era
+  Stormwind/Elwynn art, and the Babylon view renders green walkable surface with blue liquid
+  tracking Elwynn's rivers and holes where trees and buildings block.
+
+  *Frontend changes this needed:* `leaflet-watch.js` had no `Configs['cata']` block (the code
+  even commented "Cata+ not yet"), and its `clientEra()` did not map `legacy_cata`/`legacy_mop`
+  even though `DataConfig.ClientEra` does — so the era resolved to a key with no config and
+  the map stayed blank. Added the cata block (Azeroth `resX 14848, resY 21504, offset
+  {x:20,y:17}` from the extractor manifest) and the missing `legacy_*` cases. Also made the R2
+  CDN base era-aware; it was hardcoded to `/precata`, so a cata client without local tiles
+  would have fetched precata art.
+
+  *Full continent bake (done).* Azeroth and Kalimdor baked end to end from the 4.3.4 client:
+
+  | continent | ADTs | tiles baked | written | time |
+  |---|---|---|---|---|
+  | Azeroth | 841/841 | 13,298 | 12,912 (263 MB) | 12.7 min |
+  | Kalimdor | 1013/1013 | 16,207 | 15,484 (305 MB) | 14.0 min |
+  | **total** | **1854** | **29,505** | **28,396 (568 MB)** | **~27 min** |
+
+  Sustained ~70 ADTs/min, peak process memory 2.9 GB, `precata` untouched at 51,113 tiles.
+  The 1109-tile gap between "baked" and written is the empty-tile accounting noted above -
+  ocean tiles with no geometry count as done and are never written. **One** tile genuinely
+  failed, Kalimdor `(68,159)`, with DotRecast's `rcBuildContours: Bad outline for region 9`;
+  that is a known upstream robustness edge case rather than anything Cata-specific, and at 1
+  in 29,505 the runtime simply routes around the hole. Everything else on stderr was the
+  usual `delaunayHull: Removing dangling face` chatter (7828 lines, all benign - the wrath
+  corpus emits the same).
+
+  Both continents verified queryable afterwards: Elwynn 304 points (z 82.4 → 61.1), Barrens
+  300 points (z 12 → 0.2).
+
+  Leaflet tiles now cover the cata era too - Azeroth 4505 and Kalimdor 5943 (46 MB total),
+  with `Configs['cata']` holding both; Northrend and Expansion01 are deliberately absent
+  there because they inherit precata art. All four continents render on a `legacy_cata`
+  client.
+
+  *Outland and Northrend baked as well*, since the navmesh is never shared across eras even
+  where the tiles are:
+
+  | continent | hash | ADTs | tiles baked | written | time |
+  |---|---|---|---|---|---|
+  | Azeroth | `bf03fdb6` | 841 | 13,298 | 12,912 (263 MB) | 12.7 min |
+  | Kalimdor | `bf03fdb6` | 1013 | 16,207 | 15,484 (305 MB) | 14.0 min |
+  | Expansion01 | `c480316e` | 780 | 12,480 | 8,399 (160 MB) | 7.8 min |
+  | Northrend | `bf03fdb6` | 1131 | 18,096 | 17,023 (187 MB) | 17.3 min |
+  | **total** | | **3765** | **60,081** | **53,818 (915 MB)** | **~52 min** |
+
+  Expansion01 lands in its **own hash directory** because `NavmeshBakeOptions.MinWorldZ`
+  sets a -700 floor for it (the floating-landmass filter that drops Outland's unreachable
+  base terrain); every other continent uses the default settings hash. That also explains its
+  larger baked-vs-written gap - 4081 tiles voxelize to nothing once the base terrain is
+  filtered out.
+
+  Outland and Northrend baked with **zero** tile failures; the only one across all four
+  continents remains Kalimdor `(68,159)`. Routes verified on both new continents: Northrend
+  243 points (z 53.4 → 99.1), Outland 282 / 785 / 52 points (z ~20-24 in Hellfire).
+  Peak process memory 3.4 GB, `precata` still untouched at 51,113 tiles.
+
+  *Published to R2 and validated on the CDN.* `scripts/upload-navmesh-r2.py --era cata` and
+  `scripts/upload-leaflet-r2.py --era cata`, both of which were already era-aware:
+
+  - `navmesh/index.json` now lists **8** bundles (4 precata + 4 cata). All 8 zips serve `206`
+    with `Content-Range` totals matching their index `bytes` exactly.
+  - Leaflet: a random 40-tile sample of the 10,448 cata tiles all served; the
+    `resolveTileBase` probe tiles resolve for both Azeroth and Kalimdor, so a remote user
+    with no local tiles falls through to the CDN correctly.
+  - Northrend and Expansion01 correctly **404 under `/cata/`** and serve under `/precata/`,
+    which is the shared-art fallback working end to end on the CDN rather than only locally.
+  - Both offline bundles (`cata-tiles.zip`, `precata-tiles.zip`) are present.
+
+  **One bug had to be fixed before publishing.** `upload-navmesh-r2.py` built
+  `index = {"continents": []}` from only the bundles it had just uploaded and `put_object`'d
+  it wholesale. An era-scoped run (`--era cata`) would therefore have **erased the four live
+  precata entries**, breaking `download-navmesh.ps1` for every existing user - the tiles
+  themselves would still be in the bucket, but nothing would reference them. It now GETs the
+  current index, merges by `(era, continent, hash)`, and refuses to overwrite an index it
+  cannot parse rather than silently replacing it.
+
+  *Wart found on the way:* `POST api/PPather/Bake`'s `adtX`/`adtY` are
+  `ChunkedTriangleCollection` grid indices, which are **transposed** relative to ADT file
+  naming (`MPQTriangleSupplier` derives chunk_x from world Y). `adtX=31&adtY=48` looks up
+  `Azeroth_48_31.adt`. Worse, when the ADT does not exist the bake still reports
+  "16 tiles baked" — empty tiles count as done and are never written — so a wrong-way-round
+  request looks like a success with an empty output directory.
+- **Phase B:** corpus byte-identical, whole-solution build clean. No new behaviour.
+- **Phase C:** open a real Cata-Classic install, read one known ADT by path, confirm the
+  bytes match a reference extraction. No bake yet.
 
 ## Open questions / unknowns
 
-- **Listfile dependency.** Do the Cata/MoP-Classic roots carry usable name hashes, or is a
-  community listfile required? If required, it becomes a shipped/managed data file with its own
-  update story. Determine before committing to Phase 2's scope.
-- **Native DLL packaging.** CascLib must be built and shipped per-RID alongside the existing
-  StormLib native. Confirm the build/pack story (the DotRecast submodule precedent shows the
-  repo already handles native-ish externals, but CascLib is a classic C++ DLL).
-- **Locale.** CASC storages are locale-partitioned; the extractor must open the installed
-  locale. Read it from the install's `.build.info` rather than hard-coding.
-- **Format drift within "Cata/MoP Classic."** These re-releases are patched on the retail
-  engine, so their file/table versions may track *current retail* rather than the historical
-  4.3.4/5.4.8 formats. Phase 3/4 parsing should target the shipped Classic client version, not
-  the original expansion's documented formats.
+- **Cata content drift 4.3.4 → 4.4.x.** `ClientEra` asserts `legacy_cata` and `cata` share
+  geometry. They share a world (both post-Shattering), but Cata Classic has had content
+  patches. Worth spot-checking a few tiles before treating a 4.3.4-baked mesh as
+  authoritative for Cata Classic.
+- **MoP 5.4.8 — probed 2026-07-26, NOT supported; two concrete blockers.** See
+  [MoP findings](#mop-548--measured-not-yet-supported).
+- **Listfile dependency (Phase C).** Do the Cata/MoP-Classic roots carry usable name hashes,
+  or is a community listfile required? If required, it becomes a shipped data file with its
+  own update story. Determine before committing to Phase C's scope.
+- **Native DLL packaging (Phase C).** CascLib must be built and shipped per-RID alongside
+  StormLib.
+- **Locale (Phase C).** CASC storages are locale-partitioned; read the installed locale from
+  `.build.info` rather than hard-coding.
 
 ## Reference
 
-- CascLib (native, recommended): <https://github.com/ladislav-zezula/CascLib>
-- StormLib (already used, same author): the `PPather/StormDll/` wrapper is the template
+- CascLib (native, for Phase C): <https://github.com/ladislav-zezula/CascLib>
+- StormLib (already used, same author): `PPather/StormDll/` is the wrapper template
 - TheNoobBot `meshReader/CascLib` — a working managed CASC reader (CASCExplorer lineage) and
-  a `MpqManager` that already unifies MPQ + CASC; useful as a reference implementation
-- wowdev wiki — ADT/WMO/M2 and DB2 format documentation across versions
+  an `MpqManager` that already unifies MPQ + CASC; useful as a reference implementation
+- wowdev wiki — ADT/WMO/M2 format documentation across versions


### PR DESCRIPTION
## Summary

Scaffolding for multi-era navmesh and Leaflet support. This is the runtime half: era-partitioned data roots, pathing that works with no game archives on disk, Cataclysm-era archive reading, and the UI/route plumbing that lets a single build serve seven clients.

**This is PR 1 of 3 in a stack.** It is self-contained and compiles on its own; the data and addon halves follow.

| PR | Branch | Base |
|---|---|---|
| 1 (this) | `feature/multi-era-navmesh-leaflet` | `dev` |
| 2 | `feature/era-data-pipeline` | `feature/multi-era-navmesh-leaflet` |
| 3 | `feature/cata-mop-addon-support` | `feature/era-data-pipeline` |

## Related issues

- **#702 — MoP classic support.** This stack is the groundwork for it. The runtime, data and Leaflet/navmesh sides land here and in PRs 2–3; the addon still needs Mists-specific work before #702 can be closed.
- **#704 — 3.3.5 / 4.3.4 backport.** Partially addressed. The era model introduced here gives legacy (private-server) clients first-class support alongside the modern Classic re-releases, and `legacy_cata` covers the 4.3.4 side. The 3.3.5 frame-detection problem reported in that issue is *not* touched by this stack.

## Motivation

Supporting Cataclysm and Mists meant three problems that all had to be solved before any data could be generated:

1. **Disk cost.** Pre-Wrath clients are small enough to keep around just to path against. Cataclysm and Mists are not. Requiring users to install a full client to use pathing was a non-starter, so the navmesh engine had to run from baked tiles alone.
2. **Archive format.** Cataclysm splits every ADT into root/tex/obj files and chains PTCH patch archives over the base MPQs. The existing reader handled neither.
3. **Staleness by construction.** Client support was gated in several places on hardcoded version lists, which had already gone stale — the Leaflet map was still gated on "SoM or TBC" long after wrath worked.

## What changed

### Pathing without game archives

`PPatherService` no longer assumes geometry exists:

- `GetArchiveNames` returns empty instead of throwing when the MPQ directory is absent.
- `Initialise` catches unusable geometry for a continent, records it, and leaves that map unsearchable rather than failing startup. One missing continent no longer takes down pathing for the others.
- The navmesh tile cache accepts a null world, so a query-only pathfinder never attempts a bake.
- `SelfTest` is engine-aware. It previously ran an MPQ check unconditionally and reported failure on every tiles-only install even though pathing worked perfectly; for the navmesh engine it now counts baked `.dnm` per continent for the active era and returns structured coverage.

Verified end to end with zero game files present: Elwynn → Stormwind (410 points), Ratchet → Crossroads (569 points).

### Cataclysm+ archive and terrain reading

`StormDll`/`Archive`/`ArchiveSet` handle chained PTCH patches; `ChunkReader`, `MapChunk`, `MapTileFile` and `WDTFile` handle split ADTs. `StormDll` resolves its native library per OS, so the same path serves the committed Windows DLLs and a locally built `.dylib`/`.so`.

### Cross-platform pathing chain

`DataConfig`, `SharedLib` and `PPather` override the solution-wide `net10.0-windows` TFM with plain `net10.0`. That TFM exists for the bot's Windows Graphics Capture, which the pathing chain never touches. A `net10.0-windows` project can reference a `net10.0` one, so the bot is unaffected — and the navmesh can now be baked and queried on macOS and Linux.

### Era partitioning

`DataConfig` gains era-derived roots so pre-Cata (MPQ) and Cataclysm+ (CASC) assets can never collide on disk, plus `LeafletEras`/`HasLeaflet` so UI gating derives from the era instead of a version list.

`Frontend/DependencyInjection` serves those roots, and registers per-continent tile routes for art an era inherits unchanged **before** the general `/tiles` route — static file middleware runs in order, so the specific path has to win, or Northrend and Outland get served from the wrong era. Missing folders are created rather than left to `PhysicalFileProvider`, which throws `DirectoryNotFoundException` on a missing root and kills host startup instead of 404ing one route.

### AnTCP binary protocol server

`PathingAPI/AnTcp` speaks AmeisenNavigation's framing (`int32 size | byte type | payload`), so an existing `RemoteV3`-configured bot can point at this server and drop the external dependency. `PATH` only — the only message `RemotePathingAPIV3` ever sends.

Two things worth reviewer attention:

- Requests are serialised through a `SemaphoreSlim`. `PPatherService` is a singleton with a two-call `SetLocations`/`DoSearch` search over shared state; anything that searches concurrently corrupts it.
- `SnapImplausibleZ`. When the client has no height it sends `area.LocTop / 2`, but `LocTop` is a world **Y** bound, not a height — for Elwynn that is -3969 against terrain at 82. AmeisenNavigation absorbs this with a very tall poly-search extent; this engine deliberately keeps tight vertical extents so multi-floor buildings resolve, so any z more than 128 yd off the surface is snapped back. Please don't "fix" this by widening the resolver.

### Robustness

- `CreatureDB` threw on a missing `creatures.json` and took down startup; `AreaDB` threw out of its whole read block, so `Changed` never fired and area data silently stopped updating for that map for the rest of the session. Both now degrade to empty. Hit in practice on Kezan (map 648).
- The self-test endpoint returned `Problem()` wrapped in a `JsonResult`, producing HTTP 200 carrying a 503 body. It now returns directly.
- `leaflet-watch.js` `addNpcSpawns` guarded `spawns` but dereferenced `creature.Name` unguarded, so one missing creature id threw out of the entire layer and the zone rendered nothing — which reads as broken area data when the area file is fine.

### Docs

A `CLAUDE.md` per project, covering the gotchas that actually cost time in each directory. README no longer claims Cata Classic 4.4.x and Mists Classic 5.5.x require the V3 remote server — local navmesh pathing serves them and needs no archives.

## Verification

- `dotnet build MasterOfPuppets.sln` — 0 warnings, 0 errors.
- Disk-only pathing exercised on both routes above with no client installed.
- Leaflet verified in-browser against the running PathingAPI for cata and mop.

## Review notes

Largest single file is `leaflet-watch.js`; the substantive parts are the `Configs` blocks and zone resolution. `PPatherService.cs` is the core of the disk-only change and is where I'd focus.
