### PR TITLE
Addon: [1.11.1] - Cataclysm addon support, Mists polyfills (3/3)

### DIFF
--- a/Addons/DataToColor/CLAUDE.md
+++ b/Addons/DataToColor/CLAUDE.md
@@ -6,10 +6,31 @@ World of Warcraft uses **Lua 5.1** (all versions including Classic). The addon e
 
 We track each addon change per Pull Request. PR titles start with "Addon: [x.y.z] - TITLE".
 
-When a change happens in `*.lua` files, bump the patch version (if not already bumped) in:
-- `Addons/DataToColor/DataToColor_TBC.toc`
-- `Addons/DataToColor/DataToColor.toc`
+When a change happens in `*.lua` files, bump the patch version (if not already bumped) in
+**all four** TOCs - they are separate files and drift silently if one is missed:
+- `Addons/DataToColor/DataToColor.toc` (legacy: 4.3.4 Cataclysm **and 5.4.8 MoP**)
 - `Addons/DataToColor/DataToColor_Classic.toc`
+- `Addons/DataToColor/DataToColor_TBC.toc`
+- `Addons/DataToColor/DataToColor_Wrath.toc`
+
+## Legacy clients (4.3.4 Cata, 5.4.8 MoP)
+
+Both load `DataToColor.toc` - old clients only read `<foldername>.toc`, so there is no
+per-flavour TOC for them and one file serves both. `WOW_PROJECT_ID` is nil there, which
+is what `DataToColor.IsLegacy()` detects.
+
+**`C_Timer` does not exist before 6.0.** It is supplied by the separate
+`Addons/cTimerBackport` addon, declared in `## OptionalDeps` so WoW loads it first.
+Do not inline it here: `Mail.lua` and `SellJunk.lua` capture `local C_Timer = C_Timer`
+at file scope, so the polyfill must be in place before they load, and OptionalDeps is
+what guarantees that.
+
+**Prefer feature detection over version branching.** 5.4.8 is not "Cata plus a bit" -
+MoP 5.0 deleted the point-based talent trees, so `GetUnspentTalentPoints`,
+`GetNumTalentTabs` and `GetNumTalents` are all absent while `GetTalentInfo` survives
+with a different signature. A polyfill written for 4.3.4 can therefore fail on 5.4.8;
+guard on the specific function, not on the build number. Watch for this in anything
+touching talents, pets (pet talents were removed too) or specialisations.
 
 ## Event-Driven Change Tracking
 

--- a/Addons/DataToColor/Constants.lua
+++ b/Addons/DataToColor/Constants.lua
@@ -66,7 +66,11 @@ DataToColor.C.CHARACTER_RACE_MAP = {
     ["Goblin"] = 9,
     ["BloodElf"] = 10,
     ["Draenei"] = 11,
-    ["Worgen"] = 22
+    ["Worgen"] = 22,
+    ["Gilnean"] = 23,
+    ["Pandaren"] = 24,
+    ["PandarenA"] = 25,
+    ["PandarenH"] = 26
 }
 
 -- Character info — wrapped so it can be re-detected from OnEnteringWorld.

--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -786,6 +786,17 @@ function DataToColor:InitSpellBookQueue()
 end
 
 function DataToColor:InitTalentQueue()
+    -- MoP 5.0 replaced the tab/tier/column/rank talent trees with six tiers of a single
+    -- pick each, and deleted GetNumTalentTabs/GetNumTalents with them (GetTalentInfo
+    -- survives but with a different signature, so it is not a usable probe). Without
+    -- them there is nothing to enumerate in this shape; bail rather than raise, which is
+    -- what took out InitUpdateQueues on a 5.4.8 client and left every later queue
+    -- uninitialised. The C# TalentReader already copes with an empty queue - TalentDB
+    -- loads talent.json through LoadJsonSafe, and legacy clients ship none.
+    if not GetNumTalentTabs or not GetNumTalents then
+        return
+    end
+
     for tab = 1, GetNumTalentTabs(false, false) do
         for i = 1, GetNumTalents(tab) do
             local _, _, tier, column, currentRank = GetTalentInfo(tab, i)

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Legacy Cataclysm 4.3.0)
-## Version: 1.11.0
+## Version: 1.11.1
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, cTimerBackport
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor_Classic.toc
+++ b/Addons/DataToColor/DataToColor_Classic.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic)
-## Version: 1.11.0
+## Version: 1.11.1
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor_TBC.toc
+++ b/Addons/DataToColor/DataToColor_TBC.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic TBC)
-## Version: 1.11.0
+## Version: 1.11.1
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor_Wrath.toc
+++ b/Addons/DataToColor/DataToColor_Wrath.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic Wrath)
-## Version: 1.11.0
+## Version: 1.11.1
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/Versions.lua
+++ b/Addons/DataToColor/Versions.lua
@@ -259,23 +259,42 @@ DataToColor.ContainerIDToInventoryID = ContainerIDToInventoryID or C_Container.C
 DataToColor.GetGossipOptions = GetGossipOptions or C_GossipInfo.GetOptions
 
 --------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 -- TALENT POINTS API COMPATIBILITY
 -- Legacy Cataclysm 4.3.4 lacks UnitCharacterPoints
 -- Polyfill uses GetUnspentTalentPoints which exists in that client
 --------------------------------------------------------------------------------
 
 if not UnitCharacterPoints then
+    -- Which replacement exists depends on the client, so feature-detect rather than
+    -- branch on build number:
+    --   Cata 4.3.4 and earlier  GetUnspentTalentPoints(isInspect, isPet)
+    --   MoP 5.x                 GetNumUnspentTalents() - 5.0 deleted the point-based
+    --                           trees for six tiers of one pick each, and removed pet
+    --                           talents outright
+    -- Captured once here because DataToColor:Bits1 calls this every frame: on a 5.4.8
+    -- client the old body raised "attempt to call global 'GetUnspentTalentPoints'"
+    -- thousands of times, which then drowned Blizzard_DebugTools itself.
+    local GetUnspentTalentPoints = GetUnspentTalentPoints
+    local GetNumUnspentTalents = GetNumUnspentTalents
+
     UnitCharacterPoints = function(unit)
         if not UnitExists(unit) then
             return 0
         end
+
         if UnitIsUnit(unit, "pet") then
-            return GetUnspentTalentPoints(false, true)
+            -- No pet talents after 5.0, so nothing is ever unspent.
+            return GetUnspentTalentPoints and GetUnspentTalentPoints(false, true) or 0
         elseif UnitIsUnit(unit, "player") then
-            return GetUnspentTalentPoints(false)
-        else
-            return 0
+            if GetUnspentTalentPoints then
+                return GetUnspentTalentPoints(false)
+            elseif GetNumUnspentTalents then
+                return GetNumUnspentTalents()
+            end
         end
+
+        return 0
     end
 end
 

--- a/Addons/SoundKitBackport/SoundKitBackport.lua
+++ b/Addons/SoundKitBackport/SoundKitBackport.lua
@@ -13,5 +13,10 @@ SOUNDKIT = {
     IG_SPELLBOOK_CLOSE        = "igSpellBookClose",
     IG_BACKPACK_OPEN          = "igBackPackOpen",
     IG_BACKPACK_CLOSE         = "igBackPackClose",
-    -- add any other ones BindPad uses here
+
+    -- BindPad references these two and they were missing, so PlaySound received nil:
+    -- BindPad.lua:607 (GS_TITLE_OPTION_OK), :963 and :1491 (IG_ABILITY_ICON_DROP).
+    -- Keep this list in step with `grep -ohE "SOUNDKIT\.[A-Z_]+" Addons/BindPad/*.lua`.
+    GS_TITLE_OPTION_OK        = "gsTitleOptionOK",
+    IG_ABILITY_ICON_DROP      = "igAbilityIconDrop",
 }

--- a/Addons/cTimerBackport/cTimerBackport.lua
+++ b/Addons/cTimerBackport/cTimerBackport.lua
@@ -1,4 +1,6 @@
--- Optimized backport of C_Timer for Cataclysm 4.3.4 (Lua 5.1)
+-- Backport of C_Timer for legacy clients (Cataclysm 4.3.4, MoP 5.4.8 - Lua 5.1).
+-- C_Timer arrived in 6.0; DataToColor's Mail.lua / SellJunk.lua / SetupDefaultBindings.lua
+-- need it, and declare this addon in ## OptionalDeps so it loads first.
 if C_Timer then return end
 
 C_Timer = {}
@@ -9,13 +11,10 @@ C_Timer = {}
 local timers = {}
 local frame = CreateFrame("Frame")
 
--------------------------------------------------------------
--- Locals for speed
--------------------------------------------------------------
-local tinsert = table.insert
+local tremove = table.remove
 
 -------------------------------------------------------------
--- Metatable for WoD-style instance methods
+-- WoD-style instance methods
 -------------------------------------------------------------
 local TimerProto = {}
 TimerProto.__index = TimerProto
@@ -24,54 +23,67 @@ function TimerProto:Cancel()
     self.cancelled = true
 end
 
+function TimerProto:IsCancelled()
+    return self.cancelled == true
+end
+
 -------------------------------------------------------------
 -- Core update loop
+--
+-- Iterates BACKWARDS and removes with table.remove rather than the swap-with-last
+-- trick. Both details matter, because callbacks routinely mutate this list:
+--
+--   * A callback may schedule another timer (Mail.lua's Tick re-arms itself with
+--     C_Timer.After). Appends land at the end, i.e. at indices this backwards pass
+--     has already gone by, so a new timer cannot fire in the same frame it was
+--     created and cannot shift anything still to be visited.
+--   * A callback may Cancel a timer, including its own.
+--
+-- The previous version cached `local count = #timers` up front and swap-removed
+-- against it. Once a callback appended, that cached count pointed at the wrong slot:
+-- removing the last live timer self-assigned and then nil'd it, leaving the appended
+-- one stranded at a higher index with a hole below it. The next frame then read
+-- timers[1] == nil while #timers still reported 2, and every subsequent frame threw
+-- "attempt to index local 't' (a nil value)" - hundreds of times, because OnUpdate
+-- runs continuously.
+--
+-- Going backwards over a freshly-read #timers keeps the array hole-free, so no
+-- defensive nil check is needed.
 -------------------------------------------------------------
 frame:SetScript("OnUpdate", function(_, elapsed)
-    local count = #timers
-    local i = 1
-    while i <= count do
+    for i = #timers, 1, -1 do
         local t = timers[i]
-        -- timer may have been removed by a Cancel call during a prior callback
-        if not t then
-            timers[i] = timers[count]
-            timers[count] = nil
-            count = count - 1
-        elseif t.cancelled then
-            timers[i] = timers[count]
-            timers[count] = nil
-            count = count - 1
+
+        if t.cancelled then
+            tremove(timers, i)
         else
             t.remaining = t.remaining - elapsed
 
             if t.remaining <= 0 then
-                -- run callback
-                t.callback(t.arg)
+                local fire = true
 
+                -- Decide this timer's fate BEFORE running it: a callback that
+                -- cancels or reschedules must not be undone afterwards, and one
+                -- that errors must not leave an expired entry firing every frame.
                 if t.repeating then
                     if t.iterations then
                         t.iterations = t.iterations - 1
                         if t.iterations <= 0 then
-                            timers[i] = timers[count]
-                            timers[count] = nil
-                            count = count - 1
+                            tremove(timers, i)
                         else
-                            t.remaining = t.duration
-                            i = i + 1
+                            t.remaining = t.remaining + t.duration
                         end
                     else
-                        -- infinite repeating
-                        t.remaining = t.duration
-                        i = i + 1
+                        t.remaining = t.remaining + t.duration
                     end
                 else
-                    -- one-shot, remove
-                    timers[i] = timers[count]
-                    timers[count] = nil
-                    count = count - 1
+                    tremove(timers, i)
                 end
-            else
-                i = i + 1
+
+                if fire then
+                    -- Blizzard hands the ticker to its callback.
+                    t.callback(t)
+                end
             end
         end
     end
@@ -82,13 +94,15 @@ end)
 -------------------------------------------------------------
 local function NewTimer(seconds, callback, repeating, iterations)
     local t = setmetatable({
-        duration   = seconds,
-        remaining  = seconds,
+        duration   = seconds or 0,
+        remaining  = seconds or 0,
         callback   = callback,
         repeating  = repeating,
         iterations = iterations,
+        cancelled  = false,
     }, TimerProto)
-    tinsert(timers, t)
+
+    timers[#timers + 1] = t
     return t
 end
 
@@ -96,7 +110,7 @@ end
 -- Public API
 -------------------------------------------------------------
 function C_Timer.After(seconds, callback)
-    return NewTimer(seconds, callback, false)
+    NewTimer(seconds, callback, false)
 end
 
 function C_Timer.NewTicker(seconds, callback, iterations)

--- a/Addons/cTimerBackport/cTimerBackport.toc
+++ b/Addons/cTimerBackport/cTimerBackport.toc
@@ -1,5 +1,6 @@
 ## Interface: 40300
 ## Title: cTimerBackport
-## Notes: Cataclysm 4.3.4 cTimer backport
+## Notes: C_Timer backport for legacy clients (Cataclysm 4.3.4, MoP 5.4.8)
+## Version: 1.0.1
 
 cTimerBackport.lua


### PR DESCRIPTION
## Summary

Addon-side client support. **Cataclysm and legacy Cataclysm are complete end to end**; Mists and legacy Mists load and run without Lua errors, but still need addon work of their own before they can be called supported.

**PR 3 of 3 in a stack — base is `feature/era-data-pipeline`, not `dev`.** Review PRs 1 and 2 first; this branch contains their commits.

| PR | Branch | Base |
|---|---|---|
| 1 | `feature/multi-era-navmesh-leaflet` | `dev` |
| 2 | `feature/era-data-pipeline` | `feature/multi-era-navmesh-leaflet` |
| 3 (this) | `feature/cata-mop-addon-support` | `feature/era-data-pipeline` |

Small branch — 11 files, all Lua and `.toc`.

## Related issues

- **#704 — 3.3.5 / 4.3.4 backport.** This is the addon half of the 4.3.4 side: `legacy_cata` is fully supported from the addon down. The 3.3.5 frame-detection problem reported in that issue (`Addon Rect(Size [ Width=0, Height=0 ])`, `DataFrames 0`) is a separate defect and is **not** fixed here.
- **#702 — MoP classic support.** Advances it but does not close it. The addon now *loads and runs* on 5.4.8 — the errors below are fixed — but Mists-specific work remains, which is planned as follow-up.

## What changed

### Talent API — the load-blocking error

Mists 5.0 removed point-based talents, so `GetUnspentTalentPoints` and `GetNumTalentTabs` are nil on 5.4.8 and the addon errored on load:

```
Versions.lua:275  GetUnspentTalentPoints  nil
DataToColor.lua:789  GetNumTalentTabs  nil
```

`UnitCharacterPoints` now feature-detects rather than branching on client version: it probes `GetUnspentTalentPoints`, then `GetNumUnspentTalents`, and reports zero when neither exists. One file serves every client, and a future client that changes the API again degrades instead of erroring.

### `C_Timer` and `SOUNDKIT` polyfills

Both APIs arrived in 6.0, so a Mists client needs them supplied. `cTimerBackport` stays a **separate addon** rather than folded into `Versions.lua`, so a client that already has the API loads nothing at all.

The ticker loop had a real bug — it indexed a table it had already removed from, throwing on the very first fired timer:

```
cTimerBackport.lua:41: attempt to index local 't' (a nil value)
```

It now iterates backwards, decides a timer's fate *before* invoking the callback rather than after (a callback that cancels its own ticker previously corrupted the iteration), and passes the ticker to its own callback as the real API does.

### `.toc` files

Interface versions updated across the Classic/TBC/Wrath/Cata variants so the addon is not flagged out-of-date, plus the Mists entries.

## Verification

Loaded and exercised in-game on a legacy Mists 5.4.8 client with no Lua errors, and on Cataclysm. The `cTimerBackport` fix was confirmed against the reported repro (first timer firing).

Note that `cTimerBackport` is consumed via a junction in local dev setups; the copy in this repo is the source of truth.

## Follow-up (not in this PR)

Mists-specific addon work for #702 — the remaining gap between "loads and runs" and "supported".
