### PR TITLE
Addon: [1.11.4] - MoP talent trees

### DIFF
--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -81,6 +81,7 @@ local GetSpellBookItemName = GetSpellBookItemName
 local GetNumTalentTabs = GetNumTalentTabs
 local GetNumTalents = GetNumTalents
 local GetTalentInfo = GetTalentInfo
+local GetTalentRowSelectionInfo = GetTalentRowSelectionInfo -- 5.0+ only, nil before
 local GetNumSpellTabs = GetNumSpellTabs
 local IsSpellKnown = IsSpellKnown
 
@@ -785,28 +786,76 @@ function DataToColor:InitSpellBookQueue()
     end
 end
 
-function DataToColor:InitTalentQueue()
-    -- MoP 5.0 replaced the tab/tier/column/rank talent trees with six tiers of a single
-    -- pick each, and deleted GetNumTalentTabs/GetNumTalents with them (GetTalentInfo
-    -- survives but with a different signature, so it is not a usable probe). Without
-    -- them there is nothing to enumerate in this shape; bail rather than raise, which is
-    -- what took out InitUpdateQueues on a 5.4.8 client and left every later queue
-    -- uninitialised. The C# TalentReader already copes with an empty queue - TalentDB
-    -- loads talent.json through LoadJsonSafe, and legacy clients ship none.
-    if not GetNumTalentTabs or not GetNumTalents then
-        return
-    end
+-- MoP 5.0 replaced the tab/tier/column/rank trees with six tiers of a single pick
+-- each and deleted GetNumTalentTabs/GetNumTalents with them. GetTalentInfo survives
+-- with a different signature, so it is not a usable probe - GetTalentRowSelectionInfo
+-- is, and it reports which talent of a tier is taken.
+local MOP_TALENT_TIERS = 6      -- MAX_TALENT_TIERS is nil until Blizzard_TalentUI loads
+local MOP_TALENT_COLUMNS = 3
+local MOP_TALENT_TAB = 1        -- 5.0 has no tabs, but the wire format still carries one
+local MOP_TALENT_RANK = 1       -- one pick per tier, so a taken talent is always rank 1
 
-    for tab = 1, GetNumTalentTabs(false, false) do
-        for i = 1, GetNumTalents(tab) do
-            local _, _, tier, column, currentRank = GetTalentInfo(tab, i)
-            if currentRank > 0 then
-                --                     1-3 +         1-11 +          1-4 +         1-5
-                local hash = tab * 1000000 + tier * 10000 + column * 10 + currentRank
-                DataToColor.talentQueue:push(hash)
-                --DataToColor:Print("talentQueue tab: ", tab, " | tier: ", tier, " | column: ", column, " | rank: ", currentRank, " | hash: ", hash)
+-- Collected before anything is pushed so the batch can be headed by its count.
+-- Reused across calls; only ever read back up to the count of the current batch.
+local talentHashes = {}
+
+function DataToColor:InitTalentQueue()
+    -- The C# TalentReader copes with an empty batch - TalentDB loads talent.json
+    -- through LoadJsonSafe, and some clients ship none. Bailing rather than raising
+    -- matters here: an error took out InitUpdateQueues on 5.4.8 and left every
+    -- later queue uninitialised.
+    local count = 0
+
+    if GetNumTalentTabs and GetNumTalents then
+        for tab = 1, GetNumTalentTabs(false, false) do
+            for i = 1, GetNumTalents(tab) do
+                local _, _, tier, column, currentRank = GetTalentInfo(tab, i)
+                if currentRank > 0 then
+                    count = count + 1
+                    --                              1-3 +         1-11 +          1-4 +         1-5
+                    talentHashes[count] = tab * 1000000 + tier * 10000 + column * 10 + currentRank
+                    --DataToColor:Print("talentQueue tab: ", tab, " | tier: ", tier, " | column: ", column, " | rank: ", currentRank)
+                end
             end
         end
+    elseif GetTalentRowSelectionInfo then
+        -- GetTalentInfo(index) over the flat grid answers
+        --   name, texture, tier, column, selected, available
+        -- with tier and column already 1-based, which is what the hash wants.
+        --
+        -- Taking them from here rather than from GetTalentRowSelectionInfo, whose
+        -- second return is the talent's INDEX and not its column: on a level 90 with
+        -- every tier taken it reports 1, 4, 8, 10, 13, 18. Using those as columns put
+        -- 13 into the hash, which decoded as column 3 and rendered the wrong talent,
+        -- while 4, 8, 10 and 18 matched no talent at all - and tier 1 looked correct
+        -- only because index 1 happens to equal column 1.
+        --
+        -- tonumber guards the pair, so a client answering a different shape yields no
+        -- talents instead of raising: raising here aborts InitUpdateQueues and leaves
+        -- every later queue dead.
+        for index = 1, MOP_TALENT_TIERS * MOP_TALENT_COLUMNS do
+            local _, _, tier, column, selected = GetTalentInfo(index)
+
+            tier = tonumber(tier)
+            column = tonumber(column)
+
+            if selected and tier and column then
+                count = count + 1
+                talentHashes[count] = MOP_TALENT_TAB * 1000000 + tier * 10000 + column * 10 + MOP_TALENT_RANK
+                --DataToColor:Print("talentQueue tier: ", tier, " | column: ", column)
+            end
+        end
+    end
+
+    -- Batch header, the same convention the spellbook and binding queues use. The
+    -- bot replaces its talent set on receiving it instead of merging into what it
+    -- already had: a respec picks different talents, and the hashes of the old ones
+    -- are never sent again, so nothing else would ever retire them. Sent even when
+    -- the count is zero - unlearning every talent has to clear the set too.
+    DataToColor.talentQueue:push(QUEUE_COUNT_MARKER + count)
+
+    for i = 1, count do
+        DataToColor.talentQueue:push(talentHashes[i])
     end
 end
 

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Legacy Cataclysm 4.3.0)
-## Version: 1.11.3
+## Version: 1.11.4
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, cTimerBackport
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor_Classic.toc
+++ b/Addons/DataToColor/DataToColor_Classic.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic)
-## Version: 1.11.3
+## Version: 1.11.4
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor_TBC.toc
+++ b/Addons/DataToColor/DataToColor_TBC.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic TBC)
-## Version: 1.11.3
+## Version: 1.11.4
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor_Wrath.toc
+++ b/Addons/DataToColor/DataToColor_Wrath.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic Wrath)
-## Version: 1.11.3
+## Version: 1.11.4
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Core/Database/TalentDB.cs
+++ b/Core/Database/TalentDB.cs
@@ -63,6 +63,14 @@ public sealed class TalentDB
     /// </summary>
     public TalentTreeElement[][] GetTalentTreesForClass(UnitClass @class)
     {
+        // 5.0 and later: talents belong to the class, not to one of its tabs, and
+        // form a single six-tier grid. TalentTab still exists on those clients but
+        // its ids are the specialisations and no talent row references them, so
+        // the per-tab path below would hand back three empty trees.
+        TalentTreeElement[] classTalents = GetClassTalents(@class);
+        if (classTalents.Length > 0)
+            return [classTalents];
+
         int classMask = (int)Math.Pow(2, (int)@class - 1);
 
         // Get tab IDs for this class, ordered by OrderIndex (0, 1, 2)
@@ -86,43 +94,75 @@ public sealed class TalentDB
         return result;
     }
 
+    // The 5.0 grid: six tiers of three picks, and it is dense - every class has
+    // all 18. That is what lets the result be filled by slot instead of sorted.
+    private const int MopTalentTiers = 6;
+    private const int MopTalentColumns = 3;
+
+    /// <summary>
+    /// 5.0 and later rows, ordered tier then column. Empty on earlier clients.
+    /// UnitClass shares the numbering of the client's ClassID.
+    /// </summary>
+    private TalentTreeElement[] GetClassTalents(UnitClass @class)
+    {
+        int classId = (int)@class;
+
+        int count = 0;
+        for (int i = 0; i < talentTreeElements.Length; i++)
+        {
+            if (talentTreeElements[i].ClassID == classId)
+                count++;
+        }
+
+        if (count == 0)
+            return [];
+
+        // Only the returned array is allocated: no LINQ iterators, no sort
+        // comparer, no intermediate buffer.
+        TalentTreeElement[] result = new TalentTreeElement[count];
+        bool dense = count == MopTalentTiers * MopTalentColumns;
+
+        int next = 0;
+        for (int i = 0; i < talentTreeElements.Length; i++)
+        {
+            ref readonly TalentTreeElement e = ref talentTreeElements[i];
+            if (e.ClassID != classId)
+                continue;
+
+            // A tier/column pair addresses its own slot, so the result comes out
+            // ordered without sorting. Data that does not fit the grid keeps
+            // source order rather than landing out of bounds.
+            int slot = dense ? (e.TierID * MopTalentColumns) + e.ColumnIndex : next;
+            if ((uint)slot >= (uint)count)
+                slot = next;
+
+            result[slot] = e;
+            next++;
+        }
+
+        return result;
+    }
+
     public bool Update(ref Talent talent, UnitClass @class, out int spellId)
     {
-        int classMask = (int)Math.Pow(2, (int)@class - 1);
-
-        int tabId = -1;
-        int tabIndex = talent.TabNum - 1;
-        for (int i = 0; i < talentTabs.Length; i++)
-        {
-            var tab = talentTabs[i];
-            if (tab.ClassMask == classMask &&
-                tab.OrderIndex == tabIndex)
-            {
-                tabId = tab.Id;
-                break;
-            }
-        }
         spellId = 1;
-        if (tabId == -1) return false;
 
         int tierIndex = talent.TierNum - 1;
         int columnIndex = talent.ColumnNum - 1;
         int rankIndex = talent.CurrentRank - 1;
 
-        int index = -1;
-        for (int i = 0; i < talentTreeElements.Length; i++)
-        {
-            var treeElement = talentTreeElements[i];
-            if (treeElement.TabID == tabId &&
-                treeElement.TierID == tierIndex &&
-                treeElement.ColumnIndex == columnIndex)
-            {
-                index = i;
-                break;
-            }
-        }
+        int index = IndexOfClassTalent(@class, tierIndex, columnIndex);
+        if (index == -1)
+            index = IndexOfTabTalent(@class, talent.TabNum - 1, tierIndex, columnIndex);
 
-        spellId = talentTreeElements[index].SpellIds[rankIndex];
+        if (index == -1)
+            return false;
+
+        int[] spellIds = talentTreeElements[index].SpellIds;
+        if (rankIndex < 0 || rankIndex >= spellIds.Length)
+            return false;
+
+        spellId = spellIds[rankIndex];
         if (spellDB.Spells.TryGetValue(spellId, out Spell spell))
         {
             talent.Name = spell.Name;
@@ -130,5 +170,51 @@ public sealed class TalentDB
         }
 
         return false;
+    }
+
+    // 5.0+ layout: the tab the addon reports carries no meaning, the class does.
+    private int IndexOfClassTalent(UnitClass @class, int tierIndex, int columnIndex)
+    {
+        for (int i = 0; i < talentTreeElements.Length; i++)
+        {
+            TalentTreeElement e = talentTreeElements[i];
+            if (e.ClassID == (int)@class &&
+                e.TierID == tierIndex &&
+                e.ColumnIndex == columnIndex)
+                return i;
+        }
+
+        return -1;
+    }
+
+    private int IndexOfTabTalent(UnitClass @class, int tabIndex, int tierIndex, int columnIndex)
+    {
+        int classMask = (int)Math.Pow(2, (int)@class - 1);
+
+        int tabId = -1;
+        for (int i = 0; i < talentTabs.Length; i++)
+        {
+            TalentTab tab = talentTabs[i];
+            if (tab.ClassMask == classMask &&
+                tab.OrderIndex == tabIndex)
+            {
+                tabId = tab.Id;
+                break;
+            }
+        }
+
+        if (tabId == -1)
+            return -1;
+
+        for (int i = 0; i < talentTreeElements.Length; i++)
+        {
+            TalentTreeElement e = talentTreeElements[i];
+            if (e.TabID == tabId &&
+                e.TierID == tierIndex &&
+                e.ColumnIndex == columnIndex)
+                return i;
+        }
+
+        return -1;
     }
 }

--- a/Core/Talents/TalentReader.cs
+++ b/Core/Talents/TalentReader.cs
@@ -16,6 +16,21 @@ public sealed class TalentReader : IReader
     public Dictionary<int, Talent> Talents { get; } = new();
     public Dictionary<int, int> Spells { get; } = new();
 
+    // A batch arrives one hash per addon tick, so it is staged and swapped in whole.
+    // Clearing Talents up front instead would leave it empty or half filled for as
+    // many frames as the batch is long, and SPELLS_CHANGED resends one on every
+    // spell learnt - a Talent requirement would flip false mid-combat.
+    private readonly Dictionary<int, Talent> pendingTalents = new();
+    private readonly Dictionary<int, int> pendingSpells = new();
+    private int pendingCount;
+
+    private int expectedCount = -1;
+    private int receivedCount;
+
+    public int ExpectedCount => expectedCount;
+    public int ReceivedCount => receivedCount;
+    public bool IsInitialized => expectedCount >= 0 && receivedCount >= expectedCount;
+
     public TalentReader(PlayerReader playerReader, TalentDB talentDB)
     {
         this.playerReader = playerReader;
@@ -25,7 +40,28 @@ public sealed class TalentReader : IReader
     public void Update(IAddonDataProvider reader)
     {
         int hash = reader.GetInt(cTalent);
-        if (hash == 0 || Talents.ContainsKey(hash)) return;
+        if (hash == 0) return;
+
+        // Batch header. What follows is the complete talent set, which is what makes
+        // a respec resolvable: it picks different talents and the hashes of the
+        // previous ones are simply never sent again, so nothing else retires them.
+        if (hash >= AddonTicks.QUEUE_COUNT_MARKER)
+        {
+            expectedCount = hash - AddonTicks.QUEUE_COUNT_MARKER;
+            receivedCount = 0;
+
+            pendingTalents.Clear();
+            pendingSpells.Clear();
+            pendingCount = 0;
+
+            // Unlearning everything sends a header and nothing else.
+            if (expectedCount == 0)
+                Commit();
+
+            return;
+        }
+
+        receivedCount++;
 
         //           1-3 +         1-11 +         1-4 +         1-5
         // tab * 1000000 + tier * 10000 + column * 10 + currentRank
@@ -43,12 +79,49 @@ public sealed class TalentReader : IReader
             CurrentRank = rank
         };
 
-        if (talentDB.Update(ref talent, playerReader.Class, out int id))
+        // An addon older than the batch header never sends one, so keep the
+        // accumulating behaviour rather than showing nothing at all.
+        if (expectedCount < 0)
         {
-            Talents.Add(hash, talent);
-            Spells.Add(hash, id);
-            Count += talent.CurrentRank;
+            if (!Talents.ContainsKey(hash) &&
+                talentDB.Update(ref talent, playerReader.Class, out int legacyId))
+            {
+                Talents.Add(hash, talent);
+                Spells.Add(hash, legacyId);
+                Count += talent.CurrentRank;
+            }
+
+            return;
         }
+
+        if (!pendingTalents.ContainsKey(hash) &&
+            talentDB.Update(ref talent, playerReader.Class, out int id))
+        {
+            pendingTalents.Add(hash, talent);
+            pendingSpells.Add(hash, id);
+            pendingCount += talent.CurrentRank;
+        }
+
+        if (receivedCount >= expectedCount)
+            Commit();
+    }
+
+    /// <summary>
+    /// Swaps the staged batch in. An incomplete batch - a dropped pixel, a reload
+    /// mid-flight - simply never commits and the previous set stays live.
+    /// </summary>
+    private void Commit()
+    {
+        Talents.Clear();
+        Spells.Clear();
+
+        foreach ((int hash, Talent talent) in pendingTalents)
+            Talents.Add(hash, talent);
+
+        foreach ((int hash, int spellId) in pendingSpells)
+            Spells.Add(hash, spellId);
+
+        Count = pendingCount;
     }
 
     public void Reset()
@@ -56,6 +129,13 @@ public sealed class TalentReader : IReader
         Count = 0;
         Talents.Clear();
         Spells.Clear();
+
+        expectedCount = -1;
+        receivedCount = 0;
+
+        pendingCount = 0;
+        pendingTalents.Clear();
+        pendingSpells.Clear();
     }
 
     public bool HasTalent(string name, int rank)

--- a/Frontend/Pages/Talents.razor
+++ b/Frontend/Pages/Talents.razor
@@ -29,23 +29,21 @@
     </CardHeader>
     <CardBody>
         <div class="row g-2">
-            @foreach (var (tree, treeIndex) in talentTrees.Select((t, i) => (t, i)))
+            @for (int treeIndex = 0; treeIndex < talentTrees.Length; treeIndex++)
             {
+                TalentTreeElement[] tree = talentTrees[treeIndex];
                 <div class="col-12 col-lg-4">
                     <div class="talent-tree">
-                        @* A class tab with no rows renders empty rather than throwing out of
-                           Max(): the talent DBC of an era can carry tab ids that no talent
-                           row references, which is the case for 5.4.8. *@
-                        @for (int tier = 0; tier <= (tree.Length == 0 ? -1 : tree.Max(t => t.TierID)); tier++)
+                        @for (int tier = 0; tier <= treeMaxTier[treeIndex]; tier++)
                         {
                             <div class="talent-tier d-flex justify-content-center gap-1">
-                                @for (int col = 0; col <= 3; col++)
+                                @for (int col = 0; col < MaxTalentColumns; col++)
                                 {
-                                    var talent = tree.FirstOrDefault(t => t.TierID == tier && t.ColumnIndex == col);
+                                    TalentTreeElement talent = FindTalent(tree, tier, col);
                                     @if (talent.SpellIds != null && talent.SpellIds.Length > 0 && talent.SpellIds[0] != 0)
                                     {
-                                        var spellId = talent.SpellIds[0];
-                                        var spentRank = GetSpentRank(treeIndex + 1, tier + 1, col + 1);
+                                        int spellId = talent.SpellIds[0];
+                                        int spentRank = GetSpentRank(treeIndex + 1, tier + 1, col + 1);
                                         var isSpent = spentRank > 0;
 
                                         <div class="talent-icon-wrapper @(isSpent ? "" : "talent-unspent")">
@@ -120,14 +118,56 @@
 @code {
     private TalentTreeElement[][] talentTrees = [];
 
+    // Highest tier per tree, resolved once when the trees load. Doing it inline
+    // meant a Max() over every tree on every render, and it threw on a tree with
+    // no rows - which is every tree on 5.4.8, where the talent DBC carries tab
+    // ids that no talent row references.
+    private int[] treeMaxTier = [];
+
+    // Widest talent grid across the eras this renders: pre-5.0 trees are 4 columns.
+    private const int MaxTalentColumns = 4;
+
+    // Plain scan instead of FirstOrDefault: the predicate captured tier/col, so
+    // every cell of every tree allocated a closure on every render.
+    private static TalentTreeElement FindTalent(TalentTreeElement[] tree, int tier, int col)
+    {
+        for (int i = 0; i < tree.Length; i++)
+        {
+            if (tree[i].TierID == tier && tree[i].ColumnIndex == col)
+                return tree[i];
+        }
+
+        return default;
+    }
+
     protected override void OnInitialized()
     {
         if (playerReader.Class != UnitClass.None)
         {
-            talentTrees = talentDB.GetTalentTreesForClass(playerReader.Class);
+            LoadTalentTrees();
         }
 
         addonReader.AddonDataChanged += OnDataChanged;
+    }
+
+    private void LoadTalentTrees()
+    {
+        talentTrees = talentDB.GetTalentTreesForClass(playerReader.Class);
+        treeMaxTier = new int[talentTrees.Length];
+
+        for (int i = 0; i < talentTrees.Length; i++)
+        {
+            TalentTreeElement[] tree = talentTrees[i];
+            int max = -1;
+
+            for (int j = 0; j < tree.Length; j++)
+            {
+                if (tree[j].TierID > max)
+                    max = tree[j].TierID;
+            }
+
+            treeMaxTier[i] = max;
+        }
     }
 
     public void Dispose()
@@ -139,7 +179,7 @@
     {
         if (talentTrees.Length == 0 && playerReader.Class != UnitClass.None)
         {
-            talentTrees = talentDB.GetTalentTreesForClass(playerReader.Class);
+            LoadTalentTrees();
         }
         InvokeAsync(StateHasChanged);
     }

--- a/Json/dbc/legacy_mop/talent.json
+++ b/Json/dbc/legacy_mop/talent.json
@@ -3,6 +3,7 @@
     "TierID": 1,
     "ColumnIndex": 1,
     "TabID": 2053,
+    "ClassID": 1,
     "SpellIds": [
       29838,
       0,
@@ -15,6 +16,7 @@
     "TierID": 1,
     "ColumnIndex": 2,
     "TabID": 2053,
+    "ClassID": 1,
     "SpellIds": [
       103840,
       0,
@@ -27,8 +29,9 @@
     "TierID": 3,
     "ColumnIndex": 0,
     "TabID": 2053,
+    "ClassID": 1,
     "SpellIds": [
-      0,
+      46924,
       0,
       0,
       0,
@@ -39,23 +42,12 @@
     "TierID": 3,
     "ColumnIndex": 1,
     "TabID": 2053,
+    "ClassID": 1,
     "SpellIds": [
+      46968,
       0,
       0,
       0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 5,
-    "ColumnIndex": 3,
-    "TabID": 2053,
-    "SpellIds": [
-      102052,
-      102052,
-      102052,
-      102052,
       0
     ]
   },
@@ -63,8 +55,9 @@
     "TierID": 4,
     "ColumnIndex": 0,
     "TabID": 2053,
+    "ClassID": 1,
     "SpellIds": [
-      0,
+      114028,
       0,
       0,
       0,
@@ -75,8 +68,9 @@
     "TierID": 4,
     "ColumnIndex": 1,
     "TabID": 2053,
+    "ClassID": 1,
     "SpellIds": [
-      0,
+      114029,
       0,
       0,
       0,
@@ -87,8 +81,9 @@
     "TierID": 2,
     "ColumnIndex": 0,
     "TabID": 2053,
+    "ClassID": 1,
     "SpellIds": [
-      0,
+      107566,
       0,
       0,
       0,
@@ -99,6 +94,7 @@
     "TierID": 2,
     "ColumnIndex": 1,
     "TabID": 2053,
+    "ClassID": 1,
     "SpellIds": [
       12292,
       0,
@@ -111,8 +107,9 @@
     "TierID": 2,
     "ColumnIndex": 2,
     "TabID": 2053,
+    "ClassID": 1,
     "SpellIds": [
-      0,
+      102060,
       0,
       0,
       0,
@@ -123,6 +120,7 @@
     "TierID": 0,
     "ColumnIndex": 2,
     "TabID": 2053,
+    "ClassID": 1,
     "SpellIds": [
       103828,
       0,
@@ -135,6 +133,7 @@
     "TierID": 0,
     "ColumnIndex": 0,
     "TabID": 2053,
+    "ClassID": 1,
     "SpellIds": [
       103826,
       0,
@@ -147,6 +146,7 @@
     "TierID": 0,
     "ColumnIndex": 0,
     "TabID": 2058,
+    "ClassID": 8,
     "SpellIds": [
       82676,
       0,
@@ -159,6 +159,7 @@
     "TierID": 0,
     "ColumnIndex": 1,
     "TabID": 2058,
+    "ClassID": 8,
     "SpellIds": [
       120,
       0,
@@ -171,6 +172,7 @@
     "TierID": 0,
     "ColumnIndex": 2,
     "TabID": 2058,
+    "ClassID": 8,
     "SpellIds": [
       102051,
       0,
@@ -180,35 +182,12 @@
     ]
   },
   {
-    "TierID": 0,
-    "ColumnIndex": 3,
-    "TabID": 2058,
-    "SpellIds": [
-      102052,
-      102052,
-      102052,
-      102052,
-      0
-    ]
-  },
-  {
-    "TierID": 1,
-    "ColumnIndex": 3,
-    "TabID": 2058,
-    "SpellIds": [
-      102052,
-      102052,
-      102052,
-      102052,
-      0
-    ]
-  },
-  {
     "TierID": 2,
     "ColumnIndex": 0,
     "TabID": 2058,
+    "ClassID": 8,
     "SpellIds": [
-      0,
+      113724,
       0,
       0,
       0,
@@ -219,8 +198,9 @@
     "TierID": 2,
     "ColumnIndex": 1,
     "TabID": 2058,
+    "ClassID": 8,
     "SpellIds": [
-      0,
+      111264,
       0,
       0,
       0,
@@ -231,23 +211,12 @@
     "TierID": 2,
     "ColumnIndex": 2,
     "TabID": 2058,
+    "ClassID": 8,
     "SpellIds": [
+      102051,
       0,
       0,
       0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 2,
-    "ColumnIndex": 3,
-    "TabID": 2058,
-    "SpellIds": [
-      102052,
-      102052,
-      102052,
-      102052,
       0
     ]
   },
@@ -255,8 +224,9 @@
     "TierID": 1,
     "ColumnIndex": 0,
     "TabID": 2058,
+    "ClassID": 8,
     "SpellIds": [
-      0,
+      115610,
       0,
       0,
       0,
@@ -267,6 +237,7 @@
     "TierID": 1,
     "ColumnIndex": 1,
     "TabID": 2058,
+    "ClassID": 8,
     "SpellIds": [
       86949,
       0,
@@ -279,6 +250,7 @@
     "TierID": 1,
     "ColumnIndex": 2,
     "TabID": 2058,
+    "ClassID": 8,
     "SpellIds": [
       11958,
       0,
@@ -289,22 +261,11 @@
   },
   {
     "TierID": 3,
-    "ColumnIndex": 3,
-    "TabID": 2058,
-    "SpellIds": [
-      102052,
-      102052,
-      102052,
-      102052,
-      0
-    ]
-  },
-  {
-    "TierID": 3,
     "ColumnIndex": 0,
     "TabID": 2058,
+    "ClassID": 8,
     "SpellIds": [
-      0,
+      110959,
       0,
       0,
       0,
@@ -315,8 +276,9 @@
     "TierID": 3,
     "ColumnIndex": 1,
     "TabID": 2058,
+    "ClassID": 8,
     "SpellIds": [
-      0,
+      86949,
       0,
       0,
       0,
@@ -327,23 +289,12 @@
     "TierID": 3,
     "ColumnIndex": 2,
     "TabID": 2058,
+    "ClassID": 8,
     "SpellIds": [
+      11958,
       0,
       0,
       0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 4,
-    "ColumnIndex": 3,
-    "TabID": 2058,
-    "SpellIds": [
-      102052,
-      102052,
-      102052,
-      102052,
       0
     ]
   },
@@ -351,8 +302,9 @@
     "TierID": 5,
     "ColumnIndex": 0,
     "TabID": 2058,
+    "ClassID": 8,
     "SpellIds": [
-      0,
+      114003,
       0,
       0,
       0,
@@ -363,8 +315,9 @@
     "TierID": 5,
     "ColumnIndex": 1,
     "TabID": 2058,
+    "ClassID": 8,
     "SpellIds": [
-      0,
+      116011,
       0,
       0,
       0,
@@ -375,23 +328,12 @@
     "TierID": 5,
     "ColumnIndex": 2,
     "TabID": 2058,
+    "ClassID": 8,
     "SpellIds": [
+      1463,
       0,
       0,
       0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 5,
-    "ColumnIndex": 3,
-    "TabID": 2058,
-    "SpellIds": [
-      102052,
-      102052,
-      102052,
-      102052,
       0
     ]
   },
@@ -399,6 +341,7 @@
     "TierID": 0,
     "ColumnIndex": 1,
     "TabID": 2053,
+    "ClassID": 1,
     "SpellIds": [
       103827,
       0,
@@ -411,6 +354,7 @@
     "TierID": 1,
     "ColumnIndex": 0,
     "TabID": 2053,
+    "ClassID": 1,
     "SpellIds": [
       55694,
       0,
@@ -423,71 +367,12 @@
     "TierID": 3,
     "ColumnIndex": 2,
     "TabID": 2053,
+    "ClassID": 1,
     "SpellIds": [
+      118000,
       0,
       0,
       0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 0,
-    "ColumnIndex": 3,
-    "TabID": 2053,
-    "SpellIds": [
-      102052,
-      102052,
-      102052,
-      102052,
-      0
-    ]
-  },
-  {
-    "TierID": 1,
-    "ColumnIndex": 3,
-    "TabID": 2053,
-    "SpellIds": [
-      102052,
-      102052,
-      102052,
-      102052,
-      0
-    ]
-  },
-  {
-    "TierID": 2,
-    "ColumnIndex": 3,
-    "TabID": 2053,
-    "SpellIds": [
-      102052,
-      102052,
-      102052,
-      102052,
-      0
-    ]
-  },
-  {
-    "TierID": 3,
-    "ColumnIndex": 3,
-    "TabID": 2053,
-    "SpellIds": [
-      102052,
-      102052,
-      102052,
-      102052,
-      0
-    ]
-  },
-  {
-    "TierID": 4,
-    "ColumnIndex": 3,
-    "TabID": 2053,
-    "SpellIds": [
-      102052,
-      102052,
-      102052,
-      102052,
       0
     ]
   },
@@ -495,6 +380,7 @@
     "TierID": 0,
     "ColumnIndex": 0,
     "TabID": 2054,
+    "ClassID": 2,
     "SpellIds": [
       85499,
       0,
@@ -507,6 +393,7 @@
     "TierID": 0,
     "ColumnIndex": 1,
     "TabID": 2054,
+    "ClassID": 2,
     "SpellIds": [
       87172,
       0,
@@ -519,6 +406,7 @@
     "TierID": 0,
     "ColumnIndex": 2,
     "TabID": 2054,
+    "ClassID": 2,
     "SpellIds": [
       26023,
       0,
@@ -528,21 +416,10 @@
     ]
   },
   {
-    "TierID": 0,
-    "ColumnIndex": 3,
-    "TabID": 2054,
-    "SpellIds": [
-      102052,
-      102052,
-      102052,
-      102052,
-      0
-    ]
-  },
-  {
     "TierID": 1,
     "ColumnIndex": 0,
     "TabID": 2054,
+    "ClassID": 2,
     "SpellIds": [
       105593,
       0,
@@ -555,6 +432,7 @@
     "TierID": 1,
     "ColumnIndex": 1,
     "TabID": 2054,
+    "ClassID": 2,
     "SpellIds": [
       20066,
       0,
@@ -567,23 +445,12 @@
     "TierID": 1,
     "ColumnIndex": 2,
     "TabID": 2054,
+    "ClassID": 2,
     "SpellIds": [
+      110301,
       0,
       0,
       0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 1,
-    "ColumnIndex": 3,
-    "TabID": 2054,
-    "SpellIds": [
-      102052,
-      102052,
-      102052,
-      102052,
       0
     ]
   },
@@ -591,6 +458,7 @@
     "TierID": 2,
     "ColumnIndex": 0,
     "TabID": 2054,
+    "ClassID": 2,
     "SpellIds": [
       31829,
       0,
@@ -603,6 +471,7 @@
     "TierID": 2,
     "ColumnIndex": 1,
     "TabID": 2054,
+    "ClassID": 2,
     "SpellIds": [
       85285,
       0,
@@ -612,21 +481,10 @@
     ]
   },
   {
-    "TierID": 2,
-    "ColumnIndex": 3,
-    "TabID": 2054,
-    "SpellIds": [
-      102052,
-      102052,
-      102052,
-      102052,
-      0
-    ]
-  },
-  {
     "TierID": 3,
     "ColumnIndex": 0,
     "TabID": 2054,
+    "ClassID": 2,
     "SpellIds": [
       85804,
       0,
@@ -639,8 +497,9 @@
     "TierID": 3,
     "ColumnIndex": 1,
     "TabID": 2054,
+    "ClassID": 2,
     "SpellIds": [
-      0,
+      114154,
       0,
       0,
       0,
@@ -651,23 +510,12 @@
     "TierID": 3,
     "ColumnIndex": 2,
     "TabID": 2054,
+    "ClassID": 2,
     "SpellIds": [
+      105622,
       0,
       0,
       0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 3,
-    "ColumnIndex": 3,
-    "TabID": 2054,
-    "SpellIds": [
-      102052,
-      102052,
-      102052,
-      102052,
       0
     ]
   },
@@ -675,6 +523,7 @@
     "TierID": 4,
     "ColumnIndex": 0,
     "TabID": 2054,
+    "ClassID": 2,
     "SpellIds": [
       20925,
       0,
@@ -687,6 +536,7 @@
     "TierID": 4,
     "ColumnIndex": 1,
     "TabID": 2054,
+    "ClassID": 2,
     "SpellIds": [
       85795,
       0,
@@ -699,6 +549,7 @@
     "TierID": 4,
     "ColumnIndex": 2,
     "TabID": 2054,
+    "ClassID": 2,
     "SpellIds": [
       105622,
       0,
@@ -708,21 +559,10 @@
     ]
   },
   {
-    "TierID": 4,
-    "ColumnIndex": 3,
-    "TabID": 2054,
-    "SpellIds": [
-      102052,
-      102052,
-      102052,
-      102052,
-      0
-    ]
-  },
-  {
     "TierID": 5,
     "ColumnIndex": 0,
     "TabID": 2054,
+    "ClassID": 2,
     "SpellIds": [
       105809,
       0,
@@ -735,6 +575,7 @@
     "TierID": 5,
     "ColumnIndex": 1,
     "TabID": 2054,
+    "ClassID": 2,
     "SpellIds": [
       53376,
       0,
@@ -747,6 +588,7 @@
     "TierID": 5,
     "ColumnIndex": 2,
     "TabID": 2054,
+    "ClassID": 2,
     "SpellIds": [
       85696,
       0,
@@ -756,1835 +598,1975 @@
     ]
   },
   {
+    "TierID": 0,
+    "ColumnIndex": 0,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      131768,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 1,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      102280,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 2,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      102401,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 0,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      145108,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 2,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      102351,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 0,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      106707,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 1,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      102359,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 2,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      132469,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 1,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      106731,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 2,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      106737,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 0,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      99,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 1,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      102793,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 2,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      5211,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
     "TierID": 5,
-    "ColumnIndex": 3,
+    "ColumnIndex": 0,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      108288,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 1,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      108373,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 2,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      124974,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 0,
+    "TabID": 2053,
+    "ClassID": 1,
+    "SpellIds": [
+      107574,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 1,
+    "TabID": 2053,
+    "ClassID": 1,
+    "SpellIds": [
+      12292,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 2,
+    "TabID": 2053,
+    "ClassID": 1,
+    "SpellIds": [
+      107570,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 0,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      108170,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 1,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      123693,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 2,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      115989,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 0,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      49039,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 1,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      51052,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 2,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      114556,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 0,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      96268,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 1,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      50041,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 2,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      108194,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 0,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      48743,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 1,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      108196,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 0,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      45529,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 1,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      81229,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 2,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      51462,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 2,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      119975,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 0,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      108199,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 1,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      108200,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 2,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      108201,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 0,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      14062,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 1,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      108208,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 2,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      108209,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 0,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      26679,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 1,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      108210,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 2,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      74001,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 0,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      31230,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 1,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      108211,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 2,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      79008,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 0,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      138106,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 1,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      36554,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 2,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      108212,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 0,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      131511,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 1,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      108215,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 2,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      108216,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 0,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      114014,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 1,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      137619,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 2,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      114015,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 0,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      63374,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 1,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      51485,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 2,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      108273,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 0,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      30884,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 1,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      108270,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 2,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      108271,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 0,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      117012,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 1,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      117013,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 2,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      117014,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 0,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      147074,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 1,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      108281,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 2,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      108282,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 0,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      16166,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 1,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      16188,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 2,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      108283,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 1,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      108284,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 0,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      108285,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 2,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      108287,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 0,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      108359,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 1,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      108370,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 2,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      108371,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 1,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      108238,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 0,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      47897,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 1,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      6789,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 2,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      30283,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 0,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      108415,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 1,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      108416,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 2,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      110913,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 0,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      111397,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 1,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      111400,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 2,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      108482,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 0,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      108499,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 1,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      108501,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 2,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      108503,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 0,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      108505,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 1,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      137587,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 2,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      108508,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 0,
+    "TabID": 2058,
+    "ClassID": 8,
+    "SpellIds": [
+      114923,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 1,
+    "TabID": 2058,
+    "ClassID": 8,
+    "SpellIds": [
+      44457,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 2,
+    "TabID": 2058,
+    "ClassID": 8,
+    "SpellIds": [
+      112948,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 0,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      115173,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 2,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      115174,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 2,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      115008,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 0,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      109248,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 1,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      19386,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 2,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      120360,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 0,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      109304,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 2,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      109212,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 0,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      82726,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 1,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      120679,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 0,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      109215,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 1,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      109260,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 0,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      117050,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 1,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      109259,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 2,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      19577,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 0,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      131894,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 1,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      130392,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 2,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      120697,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 1,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      109298,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 2,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      118675,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 2,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      109306,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 2,
+    "TabID": 2053,
+    "ClassID": 1,
+    "SpellIds": [
+      114030,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 0,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      114107,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 0,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      108920,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 1,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      108921,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 2,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      605,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 2,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      108945,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 0,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      64129,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 1,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      121536,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 2,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      108942,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 0,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      109186,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 1,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      110744,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 2,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      139139,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 0,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      19236,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 2,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      120517,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 0,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      109142,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 1,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      10060,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 2,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      109175,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 0,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      121135,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 1,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      112833,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 1,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      123040,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 1,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      115396,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 2,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      115399,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 1,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      116841,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 0,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      116847,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 1,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      124081,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 2,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      123986,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 0,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      121817,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 0,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      116844,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 1,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      119392,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 2,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      119381,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 2,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      122783,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 0,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      122280,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 1,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      122278,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 1,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      123904,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 0,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      115098,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 2,
     "TabID": 2054,
+    "ClassID": 2,
     "SpellIds": [
-      102052,
-      102052,
-      102052,
-      102052,
-      0
-    ]
-  },
-  {
-    "TierID": 0,
-    "ColumnIndex": 0,
-    "TabID": 2096,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 0,
-    "ColumnIndex": 1,
-    "TabID": 2096,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 0,
-    "ColumnIndex": 2,
-    "TabID": 2096,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 1,
-    "ColumnIndex": 0,
-    "TabID": 2096,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 1,
-    "ColumnIndex": 2,
-    "TabID": 2096,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 2,
-    "ColumnIndex": 0,
-    "TabID": 2096,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 2,
-    "ColumnIndex": 1,
-    "TabID": 2096,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 2,
-    "ColumnIndex": 2,
-    "TabID": 2096,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 3,
-    "ColumnIndex": 1,
-    "TabID": 2096,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 3,
-    "ColumnIndex": 2,
-    "TabID": 2096,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 4,
-    "ColumnIndex": 0,
-    "TabID": 2096,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 4,
-    "ColumnIndex": 1,
-    "TabID": 2096,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 4,
-    "ColumnIndex": 2,
-    "TabID": 2096,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 5,
-    "ColumnIndex": 0,
-    "TabID": 2096,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 5,
-    "ColumnIndex": 1,
-    "TabID": 2096,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 5,
-    "ColumnIndex": 2,
-    "TabID": 2096,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 5,
-    "ColumnIndex": 0,
-    "TabID": 2053,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 5,
-    "ColumnIndex": 1,
-    "TabID": 2053,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 5,
-    "ColumnIndex": 2,
-    "TabID": 2053,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 0,
-    "ColumnIndex": 0,
-    "TabID": 2208,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 0,
-    "ColumnIndex": 1,
-    "TabID": 2208,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 0,
-    "ColumnIndex": 2,
-    "TabID": 2208,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 1,
-    "ColumnIndex": 0,
-    "TabID": 2208,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 1,
-    "ColumnIndex": 1,
-    "TabID": 2208,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 1,
-    "ColumnIndex": 2,
-    "TabID": 2208,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 2,
-    "ColumnIndex": 0,
-    "TabID": 2208,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 2,
-    "ColumnIndex": 1,
-    "TabID": 2208,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 2,
-    "ColumnIndex": 2,
-    "TabID": 2208,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 3,
-    "ColumnIndex": 0,
-    "TabID": 2208,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 3,
-    "ColumnIndex": 1,
-    "TabID": 2208,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 4,
-    "ColumnIndex": 0,
-    "TabID": 2208,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 4,
-    "ColumnIndex": 1,
-    "TabID": 2208,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 4,
-    "ColumnIndex": 2,
-    "TabID": 2208,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 3,
-    "ColumnIndex": 2,
-    "TabID": 2208,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 5,
-    "ColumnIndex": 0,
-    "TabID": 2208,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 5,
-    "ColumnIndex": 1,
-    "TabID": 2208,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 5,
-    "ColumnIndex": 2,
-    "TabID": 2208,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 0,
-    "ColumnIndex": 0,
-    "TabID": 2213,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 0,
-    "ColumnIndex": 1,
-    "TabID": 2213,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 0,
-    "ColumnIndex": 2,
-    "TabID": 2213,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 1,
-    "ColumnIndex": 0,
-    "TabID": 2213,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 1,
-    "ColumnIndex": 1,
-    "TabID": 2213,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 1,
-    "ColumnIndex": 2,
-    "TabID": 2213,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 2,
-    "ColumnIndex": 0,
-    "TabID": 2213,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 2,
-    "ColumnIndex": 1,
-    "TabID": 2213,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 2,
-    "ColumnIndex": 2,
-    "TabID": 2213,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 3,
-    "ColumnIndex": 0,
-    "TabID": 2213,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 3,
-    "ColumnIndex": 1,
-    "TabID": 2213,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 3,
-    "ColumnIndex": 2,
-    "TabID": 2213,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 4,
-    "ColumnIndex": 0,
-    "TabID": 2213,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 4,
-    "ColumnIndex": 1,
-    "TabID": 2213,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 4,
-    "ColumnIndex": 2,
-    "TabID": 2213,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 5,
-    "ColumnIndex": 0,
-    "TabID": 2213,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 5,
-    "ColumnIndex": 1,
-    "TabID": 2213,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 5,
-    "ColumnIndex": 2,
-    "TabID": 2213,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 1,
-    "ColumnIndex": 0,
-    "TabID": 2214,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 1,
-    "ColumnIndex": 1,
-    "TabID": 2214,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 1,
-    "ColumnIndex": 2,
-    "TabID": 2214,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 0,
-    "ColumnIndex": 0,
-    "TabID": 2214,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 0,
-    "ColumnIndex": 1,
-    "TabID": 2214,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 0,
-    "ColumnIndex": 2,
-    "TabID": 2214,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 5,
-    "ColumnIndex": 0,
-    "TabID": 2214,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 5,
-    "ColumnIndex": 1,
-    "TabID": 2214,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 5,
-    "ColumnIndex": 2,
-    "TabID": 2214,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 4,
-    "ColumnIndex": 0,
-    "TabID": 2214,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 4,
-    "ColumnIndex": 1,
-    "TabID": 2214,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 4,
-    "ColumnIndex": 2,
-    "TabID": 2214,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 3,
-    "ColumnIndex": 0,
-    "TabID": 2214,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 3,
-    "ColumnIndex": 1,
-    "TabID": 2214,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 3,
-    "ColumnIndex": 2,
-    "TabID": 2214,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 2,
-    "ColumnIndex": 1,
-    "TabID": 2214,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 2,
-    "ColumnIndex": 0,
-    "TabID": 2214,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 2,
-    "ColumnIndex": 2,
-    "TabID": 2214,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 0,
-    "ColumnIndex": 0,
-    "TabID": 2219,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 0,
-    "ColumnIndex": 1,
-    "TabID": 2219,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 0,
-    "ColumnIndex": 2,
-    "TabID": 2219,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 1,
-    "ColumnIndex": 1,
-    "TabID": 2096,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 1,
-    "ColumnIndex": 0,
-    "TabID": 2219,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 1,
-    "ColumnIndex": 1,
-    "TabID": 2219,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 1,
-    "ColumnIndex": 2,
-    "TabID": 2219,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 2,
-    "ColumnIndex": 0,
-    "TabID": 2219,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 2,
-    "ColumnIndex": 1,
-    "TabID": 2219,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 2,
-    "ColumnIndex": 2,
-    "TabID": 2219,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 3,
-    "ColumnIndex": 0,
-    "TabID": 2219,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 3,
-    "ColumnIndex": 1,
-    "TabID": 2219,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 3,
-    "ColumnIndex": 2,
-    "TabID": 2219,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 4,
-    "ColumnIndex": 0,
-    "TabID": 2219,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 4,
-    "ColumnIndex": 1,
-    "TabID": 2219,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 4,
-    "ColumnIndex": 2,
-    "TabID": 2219,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 5,
-    "ColumnIndex": 0,
-    "TabID": 2219,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 5,
-    "ColumnIndex": 1,
-    "TabID": 2219,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 5,
-    "ColumnIndex": 2,
-    "TabID": 2219,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 4,
-    "ColumnIndex": 0,
-    "TabID": 2058,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 4,
-    "ColumnIndex": 1,
-    "TabID": 2058,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 4,
-    "ColumnIndex": 2,
-    "TabID": 2058,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 0,
-    "ColumnIndex": 0,
-    "TabID": 2223,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 0,
-    "ColumnIndex": 2,
-    "TabID": 2223,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 5,
-    "ColumnIndex": 2,
-    "TabID": 2223,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 1,
-    "ColumnIndex": 0,
-    "TabID": 2239,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 1,
-    "ColumnIndex": 1,
-    "TabID": 2239,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 5,
-    "ColumnIndex": 2,
-    "TabID": 2239,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 2,
-    "ColumnIndex": 0,
-    "TabID": 2239,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 2,
-    "ColumnIndex": 2,
-    "TabID": 2239,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 3,
-    "ColumnIndex": 0,
-    "TabID": 2239,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 3,
-    "ColumnIndex": 1,
-    "TabID": 2239,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 0,
-    "ColumnIndex": 0,
-    "TabID": 2239,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 2,
-    "ColumnIndex": 1,
-    "TabID": 2239,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 5,
-    "ColumnIndex": 0,
-    "TabID": 2239,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 5,
-    "ColumnIndex": 1,
-    "TabID": 2239,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 1,
-    "ColumnIndex": 2,
-    "TabID": 2239,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 4,
-    "ColumnIndex": 0,
-    "TabID": 2239,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 4,
-    "ColumnIndex": 1,
-    "TabID": 2239,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 4,
-    "ColumnIndex": 2,
-    "TabID": 2239,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 0,
-    "ColumnIndex": 1,
-    "TabID": 2239,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 0,
-    "ColumnIndex": 2,
-    "TabID": 2239,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 3,
-    "ColumnIndex": 2,
-    "TabID": 2239,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 4,
-    "ColumnIndex": 2,
-    "TabID": 2053,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 3,
-    "ColumnIndex": 0,
-    "TabID": 2096,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 0,
-    "ColumnIndex": 0,
-    "TabID": 2356,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 0,
-    "ColumnIndex": 1,
-    "TabID": 2356,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 0,
-    "ColumnIndex": 2,
-    "TabID": 2356,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 3,
-    "ColumnIndex": 2,
-    "TabID": 2356,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 1,
-    "ColumnIndex": 0,
-    "TabID": 2356,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 1,
-    "ColumnIndex": 1,
-    "TabID": 2356,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 1,
-    "ColumnIndex": 2,
-    "TabID": 2356,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 2,
-    "ColumnIndex": 0,
-    "TabID": 2356,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 5,
-    "ColumnIndex": 1,
-    "TabID": 2356,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 2,
-    "ColumnIndex": 2,
-    "TabID": 2356,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 3,
-    "ColumnIndex": 0,
-    "TabID": 2356,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 5,
-    "ColumnIndex": 2,
-    "TabID": 2356,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 4,
-    "ColumnIndex": 0,
-    "TabID": 2356,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 4,
-    "ColumnIndex": 1,
-    "TabID": 2356,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 4,
-    "ColumnIndex": 2,
-    "TabID": 2356,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 5,
-    "ColumnIndex": 0,
-    "TabID": 2356,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 3,
-    "ColumnIndex": 1,
-    "TabID": 2356,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 2,
-    "ColumnIndex": 1,
-    "TabID": 2356,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 2,
-    "ColumnIndex": 1,
-    "TabID": 2223,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 2,
-    "ColumnIndex": 2,
-    "TabID": 2223,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 0,
-    "ColumnIndex": 1,
-    "TabID": 2223,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 5,
-    "ColumnIndex": 0,
-    "TabID": 2223,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 1,
-    "ColumnIndex": 1,
-    "TabID": 2223,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 1,
-    "ColumnIndex": 2,
-    "TabID": 2223,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 2,
-    "ColumnIndex": 0,
-    "TabID": 2223,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 3,
-    "ColumnIndex": 0,
-    "TabID": 2223,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 3,
-    "ColumnIndex": 1,
-    "TabID": 2223,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 3,
-    "ColumnIndex": 2,
-    "TabID": 2223,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 4,
-    "ColumnIndex": 2,
-    "TabID": 2223,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 4,
-    "ColumnIndex": 0,
-    "TabID": 2223,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 4,
-    "ColumnIndex": 1,
-    "TabID": 2223,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 5,
-    "ColumnIndex": 1,
-    "TabID": 2223,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 1,
-    "ColumnIndex": 0,
-    "TabID": 2223,
-    "SpellIds": [
-      0,
-      0,
-      0,
-      0,
-      0
-    ]
-  },
-  {
-    "TierID": 2,
-    "ColumnIndex": 2,
-    "TabID": 2054,
-    "SpellIds": [
-      0,
+      20925,
       0,
       0,
       0,

--- a/Json/dbc/mop/talent.json
+++ b/Json/dbc/mop/talent.json
@@ -1,1 +1,2576 @@
-[{"TierID":1,"ColumnIndex":1,"TabID":2053,"SpellIds":[29838,0,0,0,0]},{"TierID":1,"ColumnIndex":2,"TabID":2053,"SpellIds":[103840,0,0,0,0]},{"TierID":3,"ColumnIndex":0,"TabID":2053,"SpellIds":[0,0,0,0,0]},{"TierID":3,"ColumnIndex":1,"TabID":2053,"SpellIds":[0,0,0,0,0]},{"TierID":5,"ColumnIndex":3,"TabID":2053,"SpellIds":[102052,102052,102052,102052,0]},{"TierID":4,"ColumnIndex":0,"TabID":2053,"SpellIds":[0,0,0,0,0]},{"TierID":4,"ColumnIndex":1,"TabID":2053,"SpellIds":[0,0,0,0,0]},{"TierID":2,"ColumnIndex":0,"TabID":2053,"SpellIds":[0,0,0,0,0]},{"TierID":2,"ColumnIndex":1,"TabID":2053,"SpellIds":[12292,0,0,0,0]},{"TierID":2,"ColumnIndex":2,"TabID":2053,"SpellIds":[0,0,0,0,0]},{"TierID":0,"ColumnIndex":2,"TabID":2053,"SpellIds":[103828,0,0,0,0]},{"TierID":0,"ColumnIndex":0,"TabID":2053,"SpellIds":[103826,0,0,0,0]},{"TierID":0,"ColumnIndex":0,"TabID":2058,"SpellIds":[82676,0,0,0,0]},{"TierID":0,"ColumnIndex":1,"TabID":2058,"SpellIds":[120,0,0,0,0]},{"TierID":0,"ColumnIndex":2,"TabID":2058,"SpellIds":[102051,0,0,0,0]},{"TierID":0,"ColumnIndex":3,"TabID":2058,"SpellIds":[102052,102052,102052,102052,0]},{"TierID":1,"ColumnIndex":3,"TabID":2058,"SpellIds":[102052,102052,102052,102052,0]},{"TierID":2,"ColumnIndex":0,"TabID":2058,"SpellIds":[0,0,0,0,0]},{"TierID":2,"ColumnIndex":1,"TabID":2058,"SpellIds":[0,0,0,0,0]},{"TierID":2,"ColumnIndex":2,"TabID":2058,"SpellIds":[0,0,0,0,0]},{"TierID":2,"ColumnIndex":3,"TabID":2058,"SpellIds":[102052,102052,102052,102052,0]},{"TierID":1,"ColumnIndex":0,"TabID":2058,"SpellIds":[0,0,0,0,0]},{"TierID":1,"ColumnIndex":1,"TabID":2058,"SpellIds":[86949,0,0,0,0]},{"TierID":1,"ColumnIndex":2,"TabID":2058,"SpellIds":[11958,0,0,0,0]},{"TierID":3,"ColumnIndex":3,"TabID":2058,"SpellIds":[102052,102052,102052,102052,0]},{"TierID":3,"ColumnIndex":0,"TabID":2058,"SpellIds":[0,0,0,0,0]},{"TierID":3,"ColumnIndex":1,"TabID":2058,"SpellIds":[0,0,0,0,0]},{"TierID":3,"ColumnIndex":2,"TabID":2058,"SpellIds":[0,0,0,0,0]},{"TierID":4,"ColumnIndex":3,"TabID":2058,"SpellIds":[102052,102052,102052,102052,0]},{"TierID":5,"ColumnIndex":0,"TabID":2058,"SpellIds":[0,0,0,0,0]},{"TierID":5,"ColumnIndex":1,"TabID":2058,"SpellIds":[0,0,0,0,0]},{"TierID":5,"ColumnIndex":2,"TabID":2058,"SpellIds":[0,0,0,0,0]},{"TierID":5,"ColumnIndex":3,"TabID":2058,"SpellIds":[102052,102052,102052,102052,0]},{"TierID":0,"ColumnIndex":1,"TabID":2053,"SpellIds":[103827,0,0,0,0]},{"TierID":1,"ColumnIndex":0,"TabID":2053,"SpellIds":[55694,0,0,0,0]},{"TierID":3,"ColumnIndex":2,"TabID":2053,"SpellIds":[0,0,0,0,0]},{"TierID":0,"ColumnIndex":3,"TabID":2053,"SpellIds":[102052,102052,102052,102052,0]},{"TierID":1,"ColumnIndex":3,"TabID":2053,"SpellIds":[102052,102052,102052,102052,0]},{"TierID":2,"ColumnIndex":3,"TabID":2053,"SpellIds":[102052,102052,102052,102052,0]},{"TierID":3,"ColumnIndex":3,"TabID":2053,"SpellIds":[102052,102052,102052,102052,0]},{"TierID":4,"ColumnIndex":3,"TabID":2053,"SpellIds":[102052,102052,102052,102052,0]},{"TierID":0,"ColumnIndex":0,"TabID":2054,"SpellIds":[85499,0,0,0,0]},{"TierID":0,"ColumnIndex":1,"TabID":2054,"SpellIds":[87172,0,0,0,0]},{"TierID":0,"ColumnIndex":2,"TabID":2054,"SpellIds":[26023,0,0,0,0]},{"TierID":0,"ColumnIndex":3,"TabID":2054,"SpellIds":[102052,102052,102052,102052,0]},{"TierID":1,"ColumnIndex":0,"TabID":2054,"SpellIds":[105593,0,0,0,0]},{"TierID":1,"ColumnIndex":1,"TabID":2054,"SpellIds":[20066,0,0,0,0]},{"TierID":1,"ColumnIndex":2,"TabID":2054,"SpellIds":[0,0,0,0,0]},{"TierID":1,"ColumnIndex":3,"TabID":2054,"SpellIds":[102052,102052,102052,102052,0]},{"TierID":2,"ColumnIndex":0,"TabID":2054,"SpellIds":[31829,0,0,0,0]},{"TierID":2,"ColumnIndex":1,"TabID":2054,"SpellIds":[85285,0,0,0,0]},{"TierID":2,"ColumnIndex":3,"TabID":2054,"SpellIds":[102052,102052,102052,102052,0]},{"TierID":3,"ColumnIndex":0,"TabID":2054,"SpellIds":[85804,0,0,0,0]},{"TierID":3,"ColumnIndex":1,"TabID":2054,"SpellIds":[0,0,0,0,0]},{"TierID":3,"ColumnIndex":2,"TabID":2054,"SpellIds":[0,0,0,0,0]},{"TierID":3,"ColumnIndex":3,"TabID":2054,"SpellIds":[102052,102052,102052,102052,0]},{"TierID":4,"ColumnIndex":0,"TabID":2054,"SpellIds":[20925,0,0,0,0]},{"TierID":4,"ColumnIndex":1,"TabID":2054,"SpellIds":[85795,0,0,0,0]},{"TierID":4,"ColumnIndex":2,"TabID":2054,"SpellIds":[105622,0,0,0,0]},{"TierID":4,"ColumnIndex":3,"TabID":2054,"SpellIds":[102052,102052,102052,102052,0]},{"TierID":5,"ColumnIndex":0,"TabID":2054,"SpellIds":[105809,0,0,0,0]},{"TierID":5,"ColumnIndex":1,"TabID":2054,"SpellIds":[53376,0,0,0,0]},{"TierID":5,"ColumnIndex":2,"TabID":2054,"SpellIds":[85696,0,0,0,0]},{"TierID":5,"ColumnIndex":3,"TabID":2054,"SpellIds":[102052,102052,102052,102052,0]},{"TierID":0,"ColumnIndex":0,"TabID":2096,"SpellIds":[0,0,0,0,0]},{"TierID":0,"ColumnIndex":1,"TabID":2096,"SpellIds":[0,0,0,0,0]},{"TierID":0,"ColumnIndex":2,"TabID":2096,"SpellIds":[0,0,0,0,0]},{"TierID":1,"ColumnIndex":0,"TabID":2096,"SpellIds":[0,0,0,0,0]},{"TierID":1,"ColumnIndex":2,"TabID":2096,"SpellIds":[0,0,0,0,0]},{"TierID":2,"ColumnIndex":0,"TabID":2096,"SpellIds":[0,0,0,0,0]},{"TierID":2,"ColumnIndex":1,"TabID":2096,"SpellIds":[0,0,0,0,0]},{"TierID":2,"ColumnIndex":2,"TabID":2096,"SpellIds":[0,0,0,0,0]},{"TierID":3,"ColumnIndex":1,"TabID":2096,"SpellIds":[0,0,0,0,0]},{"TierID":3,"ColumnIndex":2,"TabID":2096,"SpellIds":[0,0,0,0,0]},{"TierID":4,"ColumnIndex":0,"TabID":2096,"SpellIds":[0,0,0,0,0]},{"TierID":4,"ColumnIndex":1,"TabID":2096,"SpellIds":[0,0,0,0,0]},{"TierID":4,"ColumnIndex":2,"TabID":2096,"SpellIds":[0,0,0,0,0]},{"TierID":5,"ColumnIndex":0,"TabID":2096,"SpellIds":[0,0,0,0,0]},{"TierID":5,"ColumnIndex":1,"TabID":2096,"SpellIds":[0,0,0,0,0]},{"TierID":5,"ColumnIndex":2,"TabID":2096,"SpellIds":[0,0,0,0,0]},{"TierID":5,"ColumnIndex":0,"TabID":2053,"SpellIds":[0,0,0,0,0]},{"TierID":5,"ColumnIndex":1,"TabID":2053,"SpellIds":[0,0,0,0,0]},{"TierID":5,"ColumnIndex":2,"TabID":2053,"SpellIds":[0,0,0,0,0]},{"TierID":0,"ColumnIndex":0,"TabID":2208,"SpellIds":[0,0,0,0,0]},{"TierID":0,"ColumnIndex":1,"TabID":2208,"SpellIds":[0,0,0,0,0]},{"TierID":0,"ColumnIndex":2,"TabID":2208,"SpellIds":[0,0,0,0,0]},{"TierID":1,"ColumnIndex":0,"TabID":2208,"SpellIds":[0,0,0,0,0]},{"TierID":1,"ColumnIndex":1,"TabID":2208,"SpellIds":[0,0,0,0,0]},{"TierID":1,"ColumnIndex":2,"TabID":2208,"SpellIds":[0,0,0,0,0]},{"TierID":2,"ColumnIndex":0,"TabID":2208,"SpellIds":[0,0,0,0,0]},{"TierID":2,"ColumnIndex":1,"TabID":2208,"SpellIds":[0,0,0,0,0]},{"TierID":2,"ColumnIndex":2,"TabID":2208,"SpellIds":[0,0,0,0,0]},{"TierID":3,"ColumnIndex":0,"TabID":2208,"SpellIds":[0,0,0,0,0]},{"TierID":3,"ColumnIndex":1,"TabID":2208,"SpellIds":[0,0,0,0,0]},{"TierID":4,"ColumnIndex":0,"TabID":2208,"SpellIds":[0,0,0,0,0]},{"TierID":4,"ColumnIndex":1,"TabID":2208,"SpellIds":[0,0,0,0,0]},{"TierID":4,"ColumnIndex":2,"TabID":2208,"SpellIds":[0,0,0,0,0]},{"TierID":3,"ColumnIndex":2,"TabID":2208,"SpellIds":[0,0,0,0,0]},{"TierID":5,"ColumnIndex":0,"TabID":2208,"SpellIds":[0,0,0,0,0]},{"TierID":5,"ColumnIndex":1,"TabID":2208,"SpellIds":[0,0,0,0,0]},{"TierID":5,"ColumnIndex":2,"TabID":2208,"SpellIds":[0,0,0,0,0]},{"TierID":0,"ColumnIndex":0,"TabID":2213,"SpellIds":[0,0,0,0,0]},{"TierID":0,"ColumnIndex":1,"TabID":2213,"SpellIds":[0,0,0,0,0]},{"TierID":0,"ColumnIndex":2,"TabID":2213,"SpellIds":[0,0,0,0,0]},{"TierID":1,"ColumnIndex":0,"TabID":2213,"SpellIds":[0,0,0,0,0]},{"TierID":1,"ColumnIndex":1,"TabID":2213,"SpellIds":[0,0,0,0,0]},{"TierID":1,"ColumnIndex":2,"TabID":2213,"SpellIds":[0,0,0,0,0]},{"TierID":2,"ColumnIndex":0,"TabID":2213,"SpellIds":[0,0,0,0,0]},{"TierID":2,"ColumnIndex":1,"TabID":2213,"SpellIds":[0,0,0,0,0]},{"TierID":2,"ColumnIndex":2,"TabID":2213,"SpellIds":[0,0,0,0,0]},{"TierID":3,"ColumnIndex":0,"TabID":2213,"SpellIds":[0,0,0,0,0]},{"TierID":3,"ColumnIndex":1,"TabID":2213,"SpellIds":[0,0,0,0,0]},{"TierID":3,"ColumnIndex":2,"TabID":2213,"SpellIds":[0,0,0,0,0]},{"TierID":4,"ColumnIndex":0,"TabID":2213,"SpellIds":[0,0,0,0,0]},{"TierID":4,"ColumnIndex":1,"TabID":2213,"SpellIds":[0,0,0,0,0]},{"TierID":4,"ColumnIndex":2,"TabID":2213,"SpellIds":[0,0,0,0,0]},{"TierID":5,"ColumnIndex":0,"TabID":2213,"SpellIds":[0,0,0,0,0]},{"TierID":5,"ColumnIndex":1,"TabID":2213,"SpellIds":[0,0,0,0,0]},{"TierID":5,"ColumnIndex":2,"TabID":2213,"SpellIds":[0,0,0,0,0]},{"TierID":1,"ColumnIndex":0,"TabID":2214,"SpellIds":[0,0,0,0,0]},{"TierID":1,"ColumnIndex":1,"TabID":2214,"SpellIds":[0,0,0,0,0]},{"TierID":1,"ColumnIndex":2,"TabID":2214,"SpellIds":[0,0,0,0,0]},{"TierID":0,"ColumnIndex":0,"TabID":2214,"SpellIds":[0,0,0,0,0]},{"TierID":0,"ColumnIndex":1,"TabID":2214,"SpellIds":[0,0,0,0,0]},{"TierID":0,"ColumnIndex":2,"TabID":2214,"SpellIds":[0,0,0,0,0]},{"TierID":5,"ColumnIndex":0,"TabID":2214,"SpellIds":[0,0,0,0,0]},{"TierID":5,"ColumnIndex":1,"TabID":2214,"SpellIds":[0,0,0,0,0]},{"TierID":5,"ColumnIndex":2,"TabID":2214,"SpellIds":[0,0,0,0,0]},{"TierID":4,"ColumnIndex":0,"TabID":2214,"SpellIds":[0,0,0,0,0]},{"TierID":4,"ColumnIndex":1,"TabID":2214,"SpellIds":[0,0,0,0,0]},{"TierID":4,"ColumnIndex":2,"TabID":2214,"SpellIds":[0,0,0,0,0]},{"TierID":3,"ColumnIndex":0,"TabID":2214,"SpellIds":[0,0,0,0,0]},{"TierID":3,"ColumnIndex":1,"TabID":2214,"SpellIds":[0,0,0,0,0]},{"TierID":3,"ColumnIndex":2,"TabID":2214,"SpellIds":[0,0,0,0,0]},{"TierID":2,"ColumnIndex":1,"TabID":2214,"SpellIds":[0,0,0,0,0]},{"TierID":2,"ColumnIndex":0,"TabID":2214,"SpellIds":[0,0,0,0,0]},{"TierID":2,"ColumnIndex":2,"TabID":2214,"SpellIds":[0,0,0,0,0]},{"TierID":0,"ColumnIndex":0,"TabID":2219,"SpellIds":[0,0,0,0,0]},{"TierID":0,"ColumnIndex":1,"TabID":2219,"SpellIds":[0,0,0,0,0]},{"TierID":0,"ColumnIndex":2,"TabID":2219,"SpellIds":[0,0,0,0,0]},{"TierID":1,"ColumnIndex":1,"TabID":2096,"SpellIds":[0,0,0,0,0]},{"TierID":1,"ColumnIndex":0,"TabID":2219,"SpellIds":[0,0,0,0,0]},{"TierID":1,"ColumnIndex":1,"TabID":2219,"SpellIds":[0,0,0,0,0]},{"TierID":1,"ColumnIndex":2,"TabID":2219,"SpellIds":[0,0,0,0,0]},{"TierID":2,"ColumnIndex":0,"TabID":2219,"SpellIds":[0,0,0,0,0]},{"TierID":2,"ColumnIndex":1,"TabID":2219,"SpellIds":[0,0,0,0,0]},{"TierID":2,"ColumnIndex":2,"TabID":2219,"SpellIds":[0,0,0,0,0]},{"TierID":3,"ColumnIndex":0,"TabID":2219,"SpellIds":[0,0,0,0,0]},{"TierID":3,"ColumnIndex":1,"TabID":2219,"SpellIds":[0,0,0,0,0]},{"TierID":3,"ColumnIndex":2,"TabID":2219,"SpellIds":[0,0,0,0,0]},{"TierID":4,"ColumnIndex":0,"TabID":2219,"SpellIds":[0,0,0,0,0]},{"TierID":4,"ColumnIndex":1,"TabID":2219,"SpellIds":[0,0,0,0,0]},{"TierID":4,"ColumnIndex":2,"TabID":2219,"SpellIds":[0,0,0,0,0]},{"TierID":5,"ColumnIndex":0,"TabID":2219,"SpellIds":[0,0,0,0,0]},{"TierID":5,"ColumnIndex":1,"TabID":2219,"SpellIds":[0,0,0,0,0]},{"TierID":5,"ColumnIndex":2,"TabID":2219,"SpellIds":[0,0,0,0,0]},{"TierID":4,"ColumnIndex":0,"TabID":2058,"SpellIds":[0,0,0,0,0]},{"TierID":4,"ColumnIndex":1,"TabID":2058,"SpellIds":[0,0,0,0,0]},{"TierID":4,"ColumnIndex":2,"TabID":2058,"SpellIds":[0,0,0,0,0]},{"TierID":0,"ColumnIndex":0,"TabID":2223,"SpellIds":[0,0,0,0,0]},{"TierID":0,"ColumnIndex":2,"TabID":2223,"SpellIds":[0,0,0,0,0]},{"TierID":5,"ColumnIndex":2,"TabID":2223,"SpellIds":[0,0,0,0,0]},{"TierID":1,"ColumnIndex":0,"TabID":2239,"SpellIds":[0,0,0,0,0]},{"TierID":1,"ColumnIndex":1,"TabID":2239,"SpellIds":[0,0,0,0,0]},{"TierID":5,"ColumnIndex":2,"TabID":2239,"SpellIds":[0,0,0,0,0]},{"TierID":2,"ColumnIndex":0,"TabID":2239,"SpellIds":[0,0,0,0,0]},{"TierID":2,"ColumnIndex":2,"TabID":2239,"SpellIds":[0,0,0,0,0]},{"TierID":3,"ColumnIndex":0,"TabID":2239,"SpellIds":[0,0,0,0,0]},{"TierID":3,"ColumnIndex":1,"TabID":2239,"SpellIds":[0,0,0,0,0]},{"TierID":0,"ColumnIndex":0,"TabID":2239,"SpellIds":[0,0,0,0,0]},{"TierID":2,"ColumnIndex":1,"TabID":2239,"SpellIds":[0,0,0,0,0]},{"TierID":5,"ColumnIndex":0,"TabID":2239,"SpellIds":[0,0,0,0,0]},{"TierID":5,"ColumnIndex":1,"TabID":2239,"SpellIds":[0,0,0,0,0]},{"TierID":1,"ColumnIndex":2,"TabID":2239,"SpellIds":[0,0,0,0,0]},{"TierID":4,"ColumnIndex":0,"TabID":2239,"SpellIds":[0,0,0,0,0]},{"TierID":4,"ColumnIndex":1,"TabID":2239,"SpellIds":[0,0,0,0,0]},{"TierID":4,"ColumnIndex":2,"TabID":2239,"SpellIds":[0,0,0,0,0]},{"TierID":0,"ColumnIndex":1,"TabID":2239,"SpellIds":[0,0,0,0,0]},{"TierID":0,"ColumnIndex":2,"TabID":2239,"SpellIds":[0,0,0,0,0]},{"TierID":3,"ColumnIndex":2,"TabID":2239,"SpellIds":[0,0,0,0,0]},{"TierID":4,"ColumnIndex":2,"TabID":2053,"SpellIds":[0,0,0,0,0]},{"TierID":3,"ColumnIndex":0,"TabID":2096,"SpellIds":[0,0,0,0,0]},{"TierID":0,"ColumnIndex":0,"TabID":2356,"SpellIds":[0,0,0,0,0]},{"TierID":0,"ColumnIndex":1,"TabID":2356,"SpellIds":[0,0,0,0,0]},{"TierID":0,"ColumnIndex":2,"TabID":2356,"SpellIds":[0,0,0,0,0]},{"TierID":3,"ColumnIndex":2,"TabID":2356,"SpellIds":[0,0,0,0,0]},{"TierID":1,"ColumnIndex":0,"TabID":2356,"SpellIds":[0,0,0,0,0]},{"TierID":1,"ColumnIndex":1,"TabID":2356,"SpellIds":[0,0,0,0,0]},{"TierID":1,"ColumnIndex":2,"TabID":2356,"SpellIds":[0,0,0,0,0]},{"TierID":2,"ColumnIndex":0,"TabID":2356,"SpellIds":[0,0,0,0,0]},{"TierID":5,"ColumnIndex":1,"TabID":2356,"SpellIds":[0,0,0,0,0]},{"TierID":2,"ColumnIndex":2,"TabID":2356,"SpellIds":[0,0,0,0,0]},{"TierID":3,"ColumnIndex":0,"TabID":2356,"SpellIds":[0,0,0,0,0]},{"TierID":5,"ColumnIndex":2,"TabID":2356,"SpellIds":[0,0,0,0,0]},{"TierID":4,"ColumnIndex":0,"TabID":2356,"SpellIds":[0,0,0,0,0]},{"TierID":4,"ColumnIndex":1,"TabID":2356,"SpellIds":[0,0,0,0,0]},{"TierID":4,"ColumnIndex":2,"TabID":2356,"SpellIds":[0,0,0,0,0]},{"TierID":5,"ColumnIndex":0,"TabID":2356,"SpellIds":[0,0,0,0,0]},{"TierID":3,"ColumnIndex":1,"TabID":2356,"SpellIds":[0,0,0,0,0]},{"TierID":2,"ColumnIndex":1,"TabID":2356,"SpellIds":[0,0,0,0,0]},{"TierID":2,"ColumnIndex":1,"TabID":2223,"SpellIds":[0,0,0,0,0]},{"TierID":2,"ColumnIndex":2,"TabID":2223,"SpellIds":[0,0,0,0,0]},{"TierID":0,"ColumnIndex":1,"TabID":2223,"SpellIds":[0,0,0,0,0]},{"TierID":5,"ColumnIndex":0,"TabID":2223,"SpellIds":[0,0,0,0,0]},{"TierID":1,"ColumnIndex":1,"TabID":2223,"SpellIds":[0,0,0,0,0]},{"TierID":1,"ColumnIndex":2,"TabID":2223,"SpellIds":[0,0,0,0,0]},{"TierID":2,"ColumnIndex":0,"TabID":2223,"SpellIds":[0,0,0,0,0]},{"TierID":3,"ColumnIndex":0,"TabID":2223,"SpellIds":[0,0,0,0,0]},{"TierID":3,"ColumnIndex":1,"TabID":2223,"SpellIds":[0,0,0,0,0]},{"TierID":3,"ColumnIndex":2,"TabID":2223,"SpellIds":[0,0,0,0,0]},{"TierID":4,"ColumnIndex":2,"TabID":2223,"SpellIds":[0,0,0,0,0]},{"TierID":4,"ColumnIndex":0,"TabID":2223,"SpellIds":[0,0,0,0,0]},{"TierID":4,"ColumnIndex":1,"TabID":2223,"SpellIds":[0,0,0,0,0]},{"TierID":5,"ColumnIndex":1,"TabID":2223,"SpellIds":[0,0,0,0,0]},{"TierID":1,"ColumnIndex":0,"TabID":2223,"SpellIds":[0,0,0,0,0]},{"TierID":2,"ColumnIndex":2,"TabID":2054,"SpellIds":[0,0,0,0,0]}]
+[
+  {
+    "TierID": 1,
+    "ColumnIndex": 1,
+    "TabID": 2053,
+    "ClassID": 1,
+    "SpellIds": [
+      29838,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 2,
+    "TabID": 2053,
+    "ClassID": 1,
+    "SpellIds": [
+      103840,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 0,
+    "TabID": 2053,
+    "ClassID": 1,
+    "SpellIds": [
+      46924,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 1,
+    "TabID": 2053,
+    "ClassID": 1,
+    "SpellIds": [
+      46968,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 0,
+    "TabID": 2053,
+    "ClassID": 1,
+    "SpellIds": [
+      114028,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 1,
+    "TabID": 2053,
+    "ClassID": 1,
+    "SpellIds": [
+      114029,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 0,
+    "TabID": 2053,
+    "ClassID": 1,
+    "SpellIds": [
+      107566,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 1,
+    "TabID": 2053,
+    "ClassID": 1,
+    "SpellIds": [
+      12292,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 2,
+    "TabID": 2053,
+    "ClassID": 1,
+    "SpellIds": [
+      102060,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 2,
+    "TabID": 2053,
+    "ClassID": 1,
+    "SpellIds": [
+      103828,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 0,
+    "TabID": 2053,
+    "ClassID": 1,
+    "SpellIds": [
+      103826,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 0,
+    "TabID": 2058,
+    "ClassID": 8,
+    "SpellIds": [
+      82676,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 1,
+    "TabID": 2058,
+    "ClassID": 8,
+    "SpellIds": [
+      120,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 2,
+    "TabID": 2058,
+    "ClassID": 8,
+    "SpellIds": [
+      102051,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 0,
+    "TabID": 2058,
+    "ClassID": 8,
+    "SpellIds": [
+      113724,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 1,
+    "TabID": 2058,
+    "ClassID": 8,
+    "SpellIds": [
+      111264,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 2,
+    "TabID": 2058,
+    "ClassID": 8,
+    "SpellIds": [
+      102051,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 0,
+    "TabID": 2058,
+    "ClassID": 8,
+    "SpellIds": [
+      115610,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 1,
+    "TabID": 2058,
+    "ClassID": 8,
+    "SpellIds": [
+      86949,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 2,
+    "TabID": 2058,
+    "ClassID": 8,
+    "SpellIds": [
+      11958,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 0,
+    "TabID": 2058,
+    "ClassID": 8,
+    "SpellIds": [
+      110959,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 1,
+    "TabID": 2058,
+    "ClassID": 8,
+    "SpellIds": [
+      86949,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 2,
+    "TabID": 2058,
+    "ClassID": 8,
+    "SpellIds": [
+      11958,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 0,
+    "TabID": 2058,
+    "ClassID": 8,
+    "SpellIds": [
+      114003,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 1,
+    "TabID": 2058,
+    "ClassID": 8,
+    "SpellIds": [
+      116011,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 2,
+    "TabID": 2058,
+    "ClassID": 8,
+    "SpellIds": [
+      1463,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 1,
+    "TabID": 2053,
+    "ClassID": 1,
+    "SpellIds": [
+      103827,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 0,
+    "TabID": 2053,
+    "ClassID": 1,
+    "SpellIds": [
+      55694,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 2,
+    "TabID": 2053,
+    "ClassID": 1,
+    "SpellIds": [
+      118000,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 0,
+    "TabID": 2054,
+    "ClassID": 2,
+    "SpellIds": [
+      85499,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 1,
+    "TabID": 2054,
+    "ClassID": 2,
+    "SpellIds": [
+      87172,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 2,
+    "TabID": 2054,
+    "ClassID": 2,
+    "SpellIds": [
+      26023,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 0,
+    "TabID": 2054,
+    "ClassID": 2,
+    "SpellIds": [
+      105593,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 1,
+    "TabID": 2054,
+    "ClassID": 2,
+    "SpellIds": [
+      20066,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 2,
+    "TabID": 2054,
+    "ClassID": 2,
+    "SpellIds": [
+      110301,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 0,
+    "TabID": 2054,
+    "ClassID": 2,
+    "SpellIds": [
+      31829,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 1,
+    "TabID": 2054,
+    "ClassID": 2,
+    "SpellIds": [
+      85285,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 0,
+    "TabID": 2054,
+    "ClassID": 2,
+    "SpellIds": [
+      85804,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 1,
+    "TabID": 2054,
+    "ClassID": 2,
+    "SpellIds": [
+      114154,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 2,
+    "TabID": 2054,
+    "ClassID": 2,
+    "SpellIds": [
+      105622,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 0,
+    "TabID": 2054,
+    "ClassID": 2,
+    "SpellIds": [
+      20925,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 1,
+    "TabID": 2054,
+    "ClassID": 2,
+    "SpellIds": [
+      85795,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 2,
+    "TabID": 2054,
+    "ClassID": 2,
+    "SpellIds": [
+      105622,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 0,
+    "TabID": 2054,
+    "ClassID": 2,
+    "SpellIds": [
+      105809,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 1,
+    "TabID": 2054,
+    "ClassID": 2,
+    "SpellIds": [
+      53376,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 2,
+    "TabID": 2054,
+    "ClassID": 2,
+    "SpellIds": [
+      85696,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 0,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      131768,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 1,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      102280,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 2,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      102401,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 0,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      145108,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 2,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      102351,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 0,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      106707,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 1,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      102359,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 2,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      132469,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 1,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      106731,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 2,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      106737,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 0,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      99,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 1,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      102793,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 2,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      5211,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 0,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      108288,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 1,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      108373,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 2,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      124974,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 0,
+    "TabID": 2053,
+    "ClassID": 1,
+    "SpellIds": [
+      107574,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 1,
+    "TabID": 2053,
+    "ClassID": 1,
+    "SpellIds": [
+      12292,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 2,
+    "TabID": 2053,
+    "ClassID": 1,
+    "SpellIds": [
+      107570,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 0,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      108170,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 1,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      123693,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 2,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      115989,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 0,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      49039,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 1,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      51052,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 2,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      114556,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 0,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      96268,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 1,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      50041,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 2,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      108194,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 0,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      48743,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 1,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      108196,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 0,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      45529,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 1,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      81229,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 2,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      51462,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 2,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      119975,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 0,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      108199,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 1,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      108200,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 2,
+    "TabID": 2208,
+    "ClassID": 6,
+    "SpellIds": [
+      108201,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 0,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      14062,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 1,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      108208,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 2,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      108209,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 0,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      26679,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 1,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      108210,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 2,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      74001,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 0,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      31230,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 1,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      108211,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 2,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      79008,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 0,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      138106,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 1,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      36554,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 2,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      108212,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 0,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      131511,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 1,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      108215,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 2,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      108216,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 0,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      114014,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 1,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      137619,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 2,
+    "TabID": 2213,
+    "ClassID": 4,
+    "SpellIds": [
+      114015,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 0,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      63374,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 1,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      51485,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 2,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      108273,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 0,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      30884,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 1,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      108270,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 2,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      108271,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 0,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      117012,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 1,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      117013,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 2,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      117014,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 0,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      147074,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 1,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      108281,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 2,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      108282,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 0,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      16166,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 1,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      16188,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 2,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      108283,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 1,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      108284,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 0,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      108285,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 2,
+    "TabID": 2214,
+    "ClassID": 7,
+    "SpellIds": [
+      108287,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 0,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      108359,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 1,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      108370,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 2,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      108371,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 1,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      108238,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 0,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      47897,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 1,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      6789,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 2,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      30283,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 0,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      108415,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 1,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      108416,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 2,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      110913,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 0,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      111397,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 1,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      111400,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 2,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      108482,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 0,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      108499,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 1,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      108501,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 2,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      108503,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 0,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      108505,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 1,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      137587,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 2,
+    "TabID": 2219,
+    "ClassID": 9,
+    "SpellIds": [
+      108508,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 0,
+    "TabID": 2058,
+    "ClassID": 8,
+    "SpellIds": [
+      114923,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 1,
+    "TabID": 2058,
+    "ClassID": 8,
+    "SpellIds": [
+      44457,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 2,
+    "TabID": 2058,
+    "ClassID": 8,
+    "SpellIds": [
+      112948,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 0,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      115173,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 2,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      115174,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 2,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      115008,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 0,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      109248,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 1,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      19386,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 2,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      120360,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 0,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      109304,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 2,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      109212,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 0,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      82726,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 1,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      120679,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 0,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      109215,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 1,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      109260,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 0,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      117050,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 1,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      109259,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 2,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      19577,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 0,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      131894,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 1,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      130392,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 2,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      120697,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 1,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      109298,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 2,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      118675,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 2,
+    "TabID": 2239,
+    "ClassID": 3,
+    "SpellIds": [
+      109306,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 2,
+    "TabID": 2053,
+    "ClassID": 1,
+    "SpellIds": [
+      114030,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 0,
+    "TabID": 2096,
+    "ClassID": 11,
+    "SpellIds": [
+      114107,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 0,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      108920,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 1,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      108921,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 2,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      605,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 2,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      108945,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 0,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      64129,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 1,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      121536,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 2,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      108942,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 0,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      109186,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 1,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      110744,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 2,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      139139,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 0,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      19236,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 2,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      120517,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 0,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      109142,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 1,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      10060,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 2,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      109175,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 0,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      121135,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 1,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      112833,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 1,
+    "TabID": 2356,
+    "ClassID": 5,
+    "SpellIds": [
+      123040,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 1,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      115396,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 2,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      115399,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 0,
+    "ColumnIndex": 1,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      116841,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 0,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      116847,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 1,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      124081,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 2,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      123986,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 0,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      121817,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 0,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      116844,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 1,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      119392,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 3,
+    "ColumnIndex": 2,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      119381,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 2,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      122783,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 0,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      122280,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 4,
+    "ColumnIndex": 1,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      122278,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 5,
+    "ColumnIndex": 1,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      123904,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 1,
+    "ColumnIndex": 0,
+    "TabID": 2223,
+    "ClassID": 10,
+    "SpellIds": [
+      115098,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  {
+    "TierID": 2,
+    "ColumnIndex": 2,
+    "TabID": 2054,
+    "ClassID": 2,
+    "SpellIds": [
+      20925,
+      0,
+      0,
+      0,
+      0
+    ]
+  }
+]

--- a/Json/dbc/mop/talenttab.json
+++ b/Json/dbc/mop/talenttab.json
@@ -1,1 +1,162 @@
-[{"Id":181,"OrderIndex":1,"ClassMask":8},{"Id":182,"OrderIndex":0,"ClassMask":8},{"Id":183,"OrderIndex":2,"ClassMask":8},{"Id":261,"OrderIndex":0,"ClassMask":64},{"Id":262,"OrderIndex":2,"ClassMask":64},{"Id":263,"OrderIndex":1,"ClassMask":64},{"Id":398,"OrderIndex":0,"ClassMask":32},{"Id":399,"OrderIndex":1,"ClassMask":32},{"Id":400,"OrderIndex":2,"ClassMask":32},{"Id":409,"OrderIndex":0,"ClassMask":0},{"Id":410,"OrderIndex":0,"ClassMask":0},{"Id":760,"OrderIndex":0,"ClassMask":16},{"Id":795,"OrderIndex":2,"ClassMask":16},{"Id":807,"OrderIndex":1,"ClassMask":4},{"Id":809,"OrderIndex":2,"ClassMask":4},{"Id":811,"OrderIndex":0,"ClassMask":4},{"Id":813,"OrderIndex":1,"ClassMask":16},{"Id":865,"OrderIndex":2,"ClassMask":256},{"Id":867,"OrderIndex":1,"ClassMask":256},{"Id":871,"OrderIndex":0,"ClassMask":256},{"Id":411,"OrderIndex":0,"ClassMask":0},{"Id":2053,"OrderIndex":0,"ClassMask":0},{"Id":2054,"OrderIndex":0,"ClassMask":0},{"Id":2058,"OrderIndex":0,"ClassMask":0},{"Id":2096,"OrderIndex":0,"ClassMask":0},{"Id":2208,"OrderIndex":0,"ClassMask":0},{"Id":2213,"OrderIndex":0,"ClassMask":0},{"Id":2214,"OrderIndex":0,"ClassMask":0},{"Id":2219,"OrderIndex":0,"ClassMask":0},{"Id":2223,"OrderIndex":0,"ClassMask":0},{"Id":2239,"OrderIndex":0,"ClassMask":0},{"Id":2356,"OrderIndex":0,"ClassMask":0}]
+[
+  {
+    "Id": 181,
+    "OrderIndex": 1,
+    "ClassMask": 8
+  },
+  {
+    "Id": 182,
+    "OrderIndex": 0,
+    "ClassMask": 8
+  },
+  {
+    "Id": 183,
+    "OrderIndex": 2,
+    "ClassMask": 8
+  },
+  {
+    "Id": 261,
+    "OrderIndex": 0,
+    "ClassMask": 64
+  },
+  {
+    "Id": 262,
+    "OrderIndex": 2,
+    "ClassMask": 64
+  },
+  {
+    "Id": 263,
+    "OrderIndex": 1,
+    "ClassMask": 64
+  },
+  {
+    "Id": 398,
+    "OrderIndex": 0,
+    "ClassMask": 32
+  },
+  {
+    "Id": 399,
+    "OrderIndex": 1,
+    "ClassMask": 32
+  },
+  {
+    "Id": 400,
+    "OrderIndex": 2,
+    "ClassMask": 32
+  },
+  {
+    "Id": 409,
+    "OrderIndex": 0,
+    "ClassMask": 0
+  },
+  {
+    "Id": 410,
+    "OrderIndex": 0,
+    "ClassMask": 0
+  },
+  {
+    "Id": 760,
+    "OrderIndex": 0,
+    "ClassMask": 16
+  },
+  {
+    "Id": 795,
+    "OrderIndex": 2,
+    "ClassMask": 16
+  },
+  {
+    "Id": 807,
+    "OrderIndex": 1,
+    "ClassMask": 4
+  },
+  {
+    "Id": 809,
+    "OrderIndex": 2,
+    "ClassMask": 4
+  },
+  {
+    "Id": 811,
+    "OrderIndex": 0,
+    "ClassMask": 4
+  },
+  {
+    "Id": 813,
+    "OrderIndex": 1,
+    "ClassMask": 16
+  },
+  {
+    "Id": 865,
+    "OrderIndex": 2,
+    "ClassMask": 256
+  },
+  {
+    "Id": 867,
+    "OrderIndex": 1,
+    "ClassMask": 256
+  },
+  {
+    "Id": 871,
+    "OrderIndex": 0,
+    "ClassMask": 256
+  },
+  {
+    "Id": 411,
+    "OrderIndex": 0,
+    "ClassMask": 0
+  },
+  {
+    "Id": 2053,
+    "OrderIndex": 0,
+    "ClassMask": 0
+  },
+  {
+    "Id": 2054,
+    "OrderIndex": 0,
+    "ClassMask": 0
+  },
+  {
+    "Id": 2058,
+    "OrderIndex": 0,
+    "ClassMask": 0
+  },
+  {
+    "Id": 2096,
+    "OrderIndex": 0,
+    "ClassMask": 0
+  },
+  {
+    "Id": 2208,
+    "OrderIndex": 0,
+    "ClassMask": 0
+  },
+  {
+    "Id": 2213,
+    "OrderIndex": 0,
+    "ClassMask": 0
+  },
+  {
+    "Id": 2214,
+    "OrderIndex": 0,
+    "ClassMask": 0
+  },
+  {
+    "Id": 2219,
+    "OrderIndex": 0,
+    "ClassMask": 0
+  },
+  {
+    "Id": 2223,
+    "OrderIndex": 0,
+    "ClassMask": 0
+  },
+  {
+    "Id": 2239,
+    "OrderIndex": 0,
+    "ClassMask": 0
+  },
+  {
+    "Id": 2356,
+    "OrderIndex": 0,
+    "ClassMask": 0
+  }
+]

--- a/SharedLib/Data/TalentTreeElement.cs
+++ b/SharedLib/Data/TalentTreeElement.cs
@@ -5,5 +5,13 @@ public readonly record struct TalentTreeElement
     public int TierID { get; init; }
     public int ColumnIndex { get; init; }
     public int TabID { get; init; }
+
+    /// <summary>
+    /// Only set from 5.0 on, where a talent belongs to a class rather than to one
+    /// of its three tabs. Zero on every earlier client, whose rows are grouped by
+    /// <see cref="TabID"/> through <see cref="TalentTab"/> instead.
+    /// </summary>
+    public int ClassID { get; init; }
+
     public int[] SpellIds { get; init; }
 }

--- a/Utilities/ReadDBC_CSV/TalentExtractor.cs
+++ b/Utilities/ReadDBC_CSV/TalentExtractor.cs
@@ -60,6 +60,18 @@ internal sealed class TalentExtractor : IExtractor
         return talenttabs;
     }
 
+    // 5.0 replaced the ranked per-tab trees with six tiers of a single pick each.
+    // Those rows identify their class on ClassID and carry the spell on SpellID,
+    // leaving SpellRank_* at zero - reading only the ranks dropped the spell of
+    // every 5.x talent. Pre-5.0 rows are the mirror image: ranks are filled,
+    // ClassID and SpellID are zero.
+    private const int MOP_TALENT_COLUMNS = 3;
+
+    // Column 4 of the 5.x grid is filler pointing at spell 102052 "Dummy 5.0
+    // Talent" for warrior, paladin and mage. It is not a talent and must not
+    // reach the UI.
+    private const int DUMMY_TALENT_SPELL_ID = 102052;
+
     public static List<TalentTreeElement> ExtractTalentTrees(string path)
     {
         using var reader = Sep.Reader(o => o with
@@ -73,6 +85,10 @@ internal sealed class TalentExtractor : IExtractor
         int columnIndex = reader.Header.IndexOf("ColumnIndex");
         int tabID = reader.Header.IndexOf("TabID");
 
+        // Absent from old enough exports, so both are optional.
+        bool hasClassID = reader.Header.TryIndexOf("ClassID", out int classID);
+        bool hasSpellID = reader.Header.TryIndexOf("SpellID", out int spellID);
+
         int spellRank0 = reader.Header.IndexOf("SpellRank_0", "SpellRank[0]");
         int spellRank1 = reader.Header.IndexOf("SpellRank_1", "SpellRank[1]");
         int spellRank2 = reader.Header.IndexOf("SpellRank_2", "SpellRank[2]");
@@ -83,19 +99,33 @@ internal sealed class TalentExtractor : IExtractor
         foreach (SepReader.Row row in reader)
         {
             //Console.WriteLine($"{values[entryIndex]} - {values[nameIndex]}");
+            int rowClassID = hasClassID ? row[classID].Parse<int>() : 0;
+            int rowColumnIndex = row[columnIndex].Parse<int>();
+            int rowSpellID = hasSpellID ? row[spellID].Parse<int>() : 0;
+
+            if (rowClassID != 0 &&
+                (rowColumnIndex >= MOP_TALENT_COLUMNS || rowSpellID == DUMMY_TALENT_SPELL_ID))
+                continue;
+
+            int[] spellIds =
+            [
+                row[spellRank0].Parse<int>(),
+                row[spellRank1].Parse<int>(),
+                row[spellRank2].Parse<int>(),
+                row[spellRank3].Parse<int>(),
+                row[spellRank4].Parse<int>()
+            ];
+
+            if (spellIds[0] == 0 && rowSpellID != 0)
+                spellIds[0] = rowSpellID;
+
             talents.Add(new TalentTreeElement
             {
                 TierID = row[tierID].Parse<int>(),
-                ColumnIndex = row[columnIndex].Parse<int>(),
+                ColumnIndex = rowColumnIndex,
                 TabID = row[tabID].Parse<int>(),
-                SpellIds =
-                [
-                    row[spellRank0].Parse<int>(),
-                    row[spellRank1].Parse<int>(),
-                    row[spellRank2].Parse<int>(),
-                    row[spellRank3].Parse<int>(),
-                    row[spellRank4].Parse<int>()
-                ]
+                ClassID = rowClassID,
+                SpellIds = spellIds
             });
         }
 


### PR DESCRIPTION
Makes the talent page work on the legacy Mists of Pandaria client (5.4.8), where it previously threw on open and, once that was guarded, rendered nothing. Verified on a private server with a level 90 Hunter holding all six picks.

## Nothing about MoP talents survived the pre-5.0 assumptions

5.0 replaced three per-class tabs of ranked talents with one per-class grid of six tiers, one pick each. Every layer still assumed the old shape, and each did so silently:

| layer | assumption | consequence |
|---|---|---|
| `TalentExtractor` | spells live in `SpellRank_0..4` | **172 of 216 rows had no spell id** - 5.0 rows carry it on `SpellID` |
| `TalentExtractor` | class comes from `TalentTab` | the `ClassID` column was ignored, so rows could not be attributed at all |
| `TalentDB` | a class owns three tabs | `TalentTab` ids are the *specialisations* on this client and no talent row references one, so it returned three empty trees |
| `InitTalentQueue` | `GetNumTalentTabs` exists | it does not; the addon sent no talents, so everything rendered unspent |

## The talent index is not the column

The near-miss worth recording. `GetTalentRowSelectionInfo(tier)` returns `(boolean, talentIndex)`, and that index is the slot in the flat 18-talent grid, not the column. A level 90 with every tier taken reports:

```
tier 1..6  ->  1, 4, 8, 10, 13, 18
```

Used as columns, the arithmetic produces a uniquely misleading failure:

```
tier 1, index 1  -> hash 1010011 -> tier 1, col 1   correct, by coincidence (index 1 == column 1)
tier 5, index 13 -> hash 1050131 -> tier 5, col 3   accidental match -> WRONG talent displayed
tier 4, index 10 -> hash 1040101 -> tier 4, col 0   no match
tier 2/3/6       ->                 col 4 / 8 / 8   no match
```

One tier right, one tier confidently wrong, four missing. Picks now come from `GetTalentInfo(index)`, which answers `name, texture, tier, column, selected, available` with tier and column already 1-based — no derivation, no assumption about grid ordering.

## Respec

A respec picks different talents and the hashes of the old ones are never sent again, so nothing retired them and both sets showed at once. Each batch is now headed by `QUEUE_COUNT_MARKER + count` — the convention the spellbook and binding queues already use — and sent even when the count is zero, since unlearning everything must clear the set too.

`TalentReader` **stages** the batch and swaps it in whole rather than clearing on the header. One hash arrives per addon tick, and `SPELLS_CHANGED` resends a batch on every spell learnt, so clearing up front would leave `Talents` empty or half filled for as many frames as the batch is long and flip a `Talent` requirement false mid-combat. An incomplete batch never commits and the previous set stays live.

## Frontend

Three allocations per render, the worst a **closure per cell** — `FirstOrDefault`'s predicate captured `tier`/`col`, so a Cataclysm class allocated ~84 per render on top of the scans. `Max(t => t.TierID)` enumerated every tree every render; it is resolved once on load. `Select((t, i) => (t, i))` became an indexed loop.

`GetClassTalents` is likewise allocation-free — the 5.0 grid is dense, so `tier * 3 + column` addresses its own slot and the result is ordered without a sort.

## Wire format

Unchanged: `tab * 1000000 + tier * 10000 + column * 10 + rank`, with tab and rank pinned to 1. `TalentDB.Update` tries class first and falls back to the tab lookup, so the tab number is simply ignored on a 5.x client and every earlier client behaves exactly as before. It also no longer indexes with `-1` when a talent is not found, which threw.

## Testing

Level 90 Hunter, all six tiers taken: every tier renders the correct talent, verified against the MoP hunter grid (Posthaste / Narrow Escape / Crouching Tiger on tier 1 through Glaive Toss / Powershot / Barrage on tier 6). Respec confirmed to replace rather than accumulate. `dotnet build` clean, `luac -p` clean.

Pre-5.0 clients are untouched by construction: `ClassID` is zero on every one of their rows, which selects the tab path throughout.

## Reference

- #702

🤖 Generated with [Claude Code](https://claude.com/claude-code)
