### PR TITLE
Addon: [1.12.0] - Class trainer spell training

### DIFF
--- a/Addons/DataToColor/BitCache.lua
+++ b/Addons/DataToColor/BitCache.lua
@@ -117,6 +117,8 @@ local bits3Cache = {
     characterFrameOpen = false,     -- bit 13 (hooked)
     spellBookFrameOpen = false,     -- bit 14 (hooked)
     friendsFrameOpen = false,       -- bit 15 (hooked)
+    trainerFrameShown = false,      -- bit 16 (event-driven: TRAINER_SHOW/TRAINER_CLOSED)
+    merchantFrameShown = false,     -- bit 17 (polled)
 }
 
 -- Track if cache has been initialized
@@ -368,6 +370,13 @@ local function UpdateMailFrameCache()
     bits3Cache.mailFrameShown = MailFrame:IsShown() or false
 end
 
+-- Update merchant frame state. Polled rather than driven off MERCHANT_SHOW/CLOSED so it
+-- reports what is on screen right now: the bot uses it to decide whether interacting
+-- again would close a window that is already open.
+local function UpdateMerchantFrameCache()
+    bits3Cache.merchantFrameShown = MerchantFrame:IsShown() or false
+end
+
 --------------------------------------------------------------------------------
 -- Polled Values (called every frame)
 -- These values cannot be reliably event-driven but are few enough
@@ -386,6 +395,7 @@ local function UpdatePolledValues()
     bits2Cache.gameMenuShown = GameMenuFrame:IsShown() or false
     bits3Cache.chatInputActive = DataToColor:IsChatInputActive() or false
     UpdateMailFrameCache()
+    UpdateMerchantFrameCache()
 
     -- Focus target combat state - UNIT_FLAGS doesn't fire for derived units
     -- like "focustarget" / "party1target", so we must poll
@@ -421,6 +431,7 @@ local function InitializeCache()
     UpdateSoftInteractCache()
     UpdateLootFrameCache()
     UpdateMailFrameCache()
+    UpdateMerchantFrameCache()
 
     bits3Cache.anyBagOpen = DataToColor:AnyBagOpen()
     bits3Cache.characterFrameOpen = DataToColor:CharacterFrameOpen()
@@ -525,7 +536,9 @@ function DataToColor:Bits3Cached()
         (bits3Cache.anyBagOpen and 2 or 0) ^ 12 +
         (bits3Cache.characterFrameOpen and 2 or 0) ^ 13 +
         (bits3Cache.spellBookFrameOpen and 2 or 0) ^ 14 +
-        (bits3Cache.friendsFrameOpen and 2 or 0) ^ 15
+        (bits3Cache.friendsFrameOpen and 2 or 0) ^ 15 +
+        (bits3Cache.trainerFrameShown and 2 or 0) ^ 16 +
+        (bits3Cache.merchantFrameShown and 2 or 0) ^ 17
 end
 
 --------------------------------------------------------------------------------

--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -5,7 +5,7 @@
 -- Trigger between emitting game data and frame location data
 local SETUP_SEQUENCE = false
 -- Total number of data frames generated
-local NUMBER_OF_FRAMES = 117
+local NUMBER_OF_FRAMES = 118
 -- Set number of pixel rows
 local FRAME_ROWS = 1
 -- Size of data squares in px. Varies based on rounding errors as well as dimension size. Use as a guideline, but not 100% accurate.
@@ -187,6 +187,14 @@ local initPhase = 2 * FRAME_CHANGE_RATE
 local QUEUE_COUNT_MARKER = 16777000
 DataToColor.QUEUE_COUNT_MARKER = QUEUE_COUNT_MARKER
 
+-- Terminates the lower-rank half of the spellbook batch (must match
+-- AddonTicks.SPELLBOOK_ALL_RANKS_END in C#). A count header cannot be used there:
+-- a cell tops out at 16,777,215, so QUEUE_COUNT_MARKER + n saturates at n = 215 and a
+-- level 60+ spellbook holds more ranks than that. Only ever read on the spellbook cell,
+-- so it cannot collide with the binding queue, whose encoding does span the full 24 bits.
+local SPELLBOOK_ALL_RANKS_END = 16776999
+DataToColor.SPELLBOOK_ALL_RANKS_END = SPELLBOOK_ALL_RANKS_END
+
 -- How often item frames change
 local ITEM_ITERATION_FRAME_CHANGE_RATE = FRAME_CHANGE_RATE
 -- How often the actionbar frames change
@@ -251,6 +259,7 @@ DataToColor.inventoryQueue = DataToColor.TimedQueue:new(ITEM_ITERATION_FRAME_CHA
 DataToColor.gossipQueue = DataToColor.TimedQueue:new(GOSSIP_ITERATION_FRAME_CHANGE_RATE, 0)
 DataToColor.spellBookQueue = DataToColor.TimedQueue:new(SPELLBOOK_ITERATION_FRAME_CHANGE_RATE, nil)
 DataToColor.talentQueue = DataToColor.TimedQueue:new(TALENT_ITERATION_FRAME_CHANGE_RATE, nil)
+DataToColor.trainerQueue = DataToColor.TimedQueue:new(GOSSIP_ITERATION_FRAME_CHANGE_RATE, nil)
 
 DataToColor.actionBarCostQueue = DataToColor.struct:new(ACTION_BAR_ITERATION_FRAME_CHANGE_RATE)
 DataToColor.actionBarCooldownQueue = DataToColor.struct:new(ACTION_BAR_ITERATION_FRAME_CHANGE_RATE)
@@ -572,6 +581,7 @@ function DataToColor:ClearAllQueues()
     DataToColor.gossipQueue:clear()
     DataToColor.spellBookQueue:clear()
     DataToColor.talentQueue:clear()
+    DataToColor.trainerQueue:clear()
     DataToColor.CombatDamageDoneQueue:clear()
     DataToColor.CombatDamageTakenQueue:clear()
     DataToColor.CombatCreatureDiedQueue:clear()
@@ -775,15 +785,42 @@ function DataToColor:PopulateSpellBookInfo()
     DataToColor:PopulateSpellInRangeNames()
 end
 
+-- Set of the ids sent in the first block, so the second one can skip them.
+-- Reused across calls; fully cleared on entry.
+local spellBookHighestSent = {}
+
 function DataToColor:InitSpellBookQueue()
+    local S = DataToColor.S
+
+    -- First block: the highest rank of each spell, headed by its count. This is what the
+    -- bot gates DataReady on, so it stays exactly as small and as fast as it was - the
+    -- lower ranks below are not worth stalling the agent for after a /dcflush.
     local count = 0
-    for _ in pairs(DataToColor.S.playerSpellBookIdHighest) do
-        count = count + 1
+    for id in pairs(spellBookHighestSent) do
+        spellBookHighestSent[id] = nil
     end
+
+    for _, id in pairs(S.playerSpellBookIdHighest) do
+        count = count + 1
+        spellBookHighestSent[id] = true
+    end
+
     DataToColor.spellBookQueue:push(QUEUE_COUNT_MARKER + count)
-    for _, id in pairs(DataToColor.S.playerSpellBookIdHighest) do
+    for _, id in pairs(S.playerSpellBookIdHighest) do
         DataToColor.spellBookQueue:push(id)
     end
+
+    -- Second block: every remaining rank, so the bot can tell rank 2 from rank 7 - it
+    -- otherwise only ever sees the highest and cannot work out which rank to train next.
+    -- Terminated by a sentinel instead of counted, see SPELLBOOK_ALL_RANKS_END.
+    -- Cata and MoP dropped ranks entirely, so there this block is simply empty.
+    for id in pairs(S.playerSpellBookId) do
+        if not spellBookHighestSent[id] then
+            DataToColor.spellBookQueue:push(id)
+        end
+    end
+
+    DataToColor.spellBookQueue:push(SPELLBOOK_ALL_RANKS_END)
 end
 
 -- MoP 5.0 replaced the tab/tier/column/rank trees with six tiers of a single pick
@@ -1212,6 +1249,8 @@ function DataToColor:CreateFrames()
                 Pixel(int, gossipNum, 73)
             end
 
+            Pixel(int, DataToColor.trainerQueue:shift(globalTick) or 0, 115)
+
             Pixel(int, DataToColor:CustomTrigger(DataToColor.customTrigger1), 74)
             Pixel(int, DataToColor:getMeleeAttackSpeed(DataToColor.C.unitPlayer), 75)
 
@@ -1390,9 +1429,17 @@ function DataToColor:CreateFrames()
 
             Pixel(int, DataToColor:Bits3Cached(), 100)
 
-            Pixel(int, DataToColor:getGuidFromUUID(DataToColor.softInteractGuid), 101)
-            Pixel(int, DataToColor:getNpcIdFromUUID(DataToColor.softInteractGuid), 102)
-            Pixel(int, DataToColor:getTypeFromUUID(DataToColor.softInteractGuid), 103)
+            -- Falls back to a live read when the cached guid is nil. The cache is only
+            -- ever filled by PLAYER_SOFT_INTERACT_CHANGED, while the bit the bot gates
+            -- on comes from UnitExists polled every frame - so before that event has
+            -- fired the bot saw "a unit is there" alongside an id of 0, and interacted
+            -- with something it could not identify.
+            local softGuid = DataToColor.softInteractGuid or
+                UnitGUID(DataToColor.C.unitSoftInteract)
+
+            Pixel(int, DataToColor:getGuidFromUUID(softGuid), 101)
+            Pixel(int, DataToColor:getNpcIdFromUUID(softGuid), 102)
+            Pixel(int, DataToColor:getTypeFromUUID(softGuid), 103)
 
             -- player debuff
             textureId, expireTime = DataToColor.playerDebuffTime:getTimed(globalTick)

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Legacy Cataclysm 4.3.0)
-## Version: 1.11.4
+## Version: 1.12.0
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, cTimerBackport
 ## SavedVariables:
@@ -38,3 +38,4 @@ DataToColor.lua
 
 SellJunk.lua
 Mail.lua
+Trainer.lua

--- a/Addons/DataToColor/DataToColor_Classic.toc
+++ b/Addons/DataToColor/DataToColor_Classic.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic)
-## Version: 1.11.4
+## Version: 1.12.0
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:
@@ -35,3 +35,4 @@ DataToColor.lua
 
 SellJunk.lua
 Mail.lua
+Trainer.lua

--- a/Addons/DataToColor/DataToColor_TBC.toc
+++ b/Addons/DataToColor/DataToColor_TBC.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic TBC)
-## Version: 1.11.4
+## Version: 1.12.0
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:
@@ -35,3 +35,4 @@ DataToColor.lua
 
 SellJunk.lua
 Mail.lua
+Trainer.lua

--- a/Addons/DataToColor/DataToColor_Wrath.toc
+++ b/Addons/DataToColor/DataToColor_Wrath.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic Wrath)
-## Version: 1.11.4
+## Version: 1.12.0
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:
@@ -35,3 +35,4 @@ DataToColor.lua
 
 SellJunk.lua
 Mail.lua
+Trainer.lua

--- a/Addons/DataToColor/EventHandlers.lua
+++ b/Addons/DataToColor/EventHandlers.lua
@@ -212,6 +212,8 @@ function DataToColor:RegisterEvents()
     DataToColor:RegisterEvent('LOOT_OPENED', 'OnLootOpened_BitCache')
     DataToColor:RegisterEvent('MAIL_SHOW', 'OnMailShow_BitCache')
     DataToColor:RegisterEvent('MAIL_CLOSED', 'OnMailClosed_BitCache')
+    DataToColor:RegisterEvent('TRAINER_SHOW', 'OnTrainerShow_BitCache')
+    DataToColor:RegisterEvent('TRAINER_CLOSED', 'OnTrainerClosed_BitCache')
     DataToColor:RegisterEvent('BAG_OPEN', 'OnBagOpen_BitCache')
 
     ---------------------------------------------------------------------------
@@ -1162,6 +1164,20 @@ end
 function DataToColor:OnMailClosed_BitCache(event)
     if DataToColor.BitCache and DataToColor.BitCache.bits3 then
         DataToColor.BitCache.bits3.mailFrameShown = false
+    end
+end
+
+-- Tracked off the events rather than an OnShow hook: Blizzard_TrainerUI is loaded on
+-- demand, so ClassTrainerFrame does not exist yet when HookFrameVisibility runs.
+function DataToColor:OnTrainerShow_BitCache(event)
+    if DataToColor.BitCache and DataToColor.BitCache.bits3 then
+        DataToColor.BitCache.bits3.trainerFrameShown = true
+    end
+end
+
+function DataToColor:OnTrainerClosed_BitCache(event)
+    if DataToColor.BitCache and DataToColor.BitCache.bits3 then
+        DataToColor.BitCache.bits3.trainerFrameShown = false
     end
 end
 

--- a/Addons/DataToColor/Query.lua
+++ b/Addons/DataToColor/Query.lua
@@ -199,7 +199,15 @@ function DataToColor:Bits3()
         (DataToColor:AnyBagOpen() and 2 or 0) ^ 12 +
         (DataToColor:CharacterFrameOpen() and 2 or 0) ^ 13 +
         (DataToColor:SpellBookFrameOpen() and 2 or 0) ^ 14 +
-        (DataToColor:FriendsFrameOpen() and 2 or 0) ^ 15
+        (DataToColor:FriendsFrameOpen() and 2 or 0) ^ 15 +
+        (DataToColor:TrainerFrameShown() and 2 or 0) ^ 16 +
+        (MerchantFrame:IsShown() and 2 or 0) ^ 17
+end
+
+-- Blizzard_TrainerUI is loaded on demand, so the frame does not exist until the player
+-- has opened a trainer once - hence the existence check rather than a bare IsShown.
+function DataToColor:TrainerFrameShown()
+    return ClassTrainerFrame ~= nil and ClassTrainerFrame:IsShown()
 end
 
 function DataToColor:CustomTrigger(t)

--- a/Addons/DataToColor/Trainer.lua
+++ b/Addons/DataToColor/Trainer.lua
@@ -1,0 +1,252 @@
+local Load = select(2, ...)
+local DataToColor = unpack(Load)
+
+local CreateFrame = CreateFrame
+local UIParent = UIParent
+local C_Timer = C_Timer
+
+local GetMoney = GetMoney
+local GetSpellInfo = GetSpellInfo
+local GetCoinTextureString = GetCoinTextureString
+local gmatch = string.gmatch
+local tonumber = tonumber
+local pairs = pairs
+local wipe = wipe
+
+-- Deliberately not captured at file scope: the trainer API is absent on some clients,
+-- and a nil local would raise on call instead of degrading to TRAINER_NO_MATCH.
+
+-- Reported on the trainer cell. Both sit above any spell id and below
+-- QUEUE_COUNT_MARKER, and are only ever read on this cell.
+local TRAINER_NO_MATCH = 16776001
+local TRAINER_NO_MONEY = 16776002
+
+-- One purchase per tick: BuyTrainerService renumbers the service list, so the
+-- next index is only trustworthy after TRAINER_UPDATE has been processed.
+local ITERATION_INTERVAL = 0.3
+local ITERATION_COUNT = 60
+
+local tFrame = CreateFrame("Frame", nil, UIParent)
+tFrame:RegisterEvent("TRAINER_SHOW")
+tFrame:RegisterEvent("TRAINER_CLOSED")
+
+-- spellId -> true, filled by TAdd
+local mWanted = {}
+-- spellId -> localized name, spellId -> rank subtext. Resolved once per run so the
+-- match works on a localized client: GetSpellInfo answers for spells the player does
+-- not know yet, which is exactly the case here.
+local mName = {}
+local mRank = {}
+
+local mBought = {}
+local mBoughtCount = 0
+local mRunning = false
+local mSawMatch = false
+local mSawUnaffordable = false
+-- Buy everything the trainer offers instead of only the wanted ids.
+local mTrainAll = false
+local mTicker
+local mTicks = 0
+
+local function ReportAndStop()
+    if mTicker then
+        mTicker:Cancel()
+        mTicker = nil
+    end
+
+    if not mRunning then return end
+    mRunning = false
+
+    -- Reason first, then the batch. Nothing bought is still a completed visit, so the
+    -- header is sent even when the count is zero - it is the only completion signal.
+    if mBoughtCount == 0 then
+        if mSawMatch and mSawUnaffordable then
+            DataToColor:Print("Trainer: cannot afford any wanted spell")
+            DataToColor.trainerQueue:push(TRAINER_NO_MONEY)
+        elseif not mSawMatch then
+            DataToColor:Print("Trainer: teaches none of the wanted spells")
+            DataToColor.trainerQueue:push(TRAINER_NO_MATCH)
+        end
+    else
+        DataToColor:Print("Trainer: learned " .. mBoughtCount .. " spell(s)")
+    end
+
+    DataToColor.trainerQueue:push(DataToColor.QUEUE_COUNT_MARKER + mBoughtCount)
+    for i = 1, mBoughtCount do
+        DataToColor.trainerQueue:push(mBought[i])
+    end
+end
+
+-- The trainer UI is a separate Blizzard addon and MoP grants class spells on level up
+-- instead of selling them, so neither the API nor a non-empty list can be assumed.
+-- Returning 0 here reports TRAINER_NO_MATCH rather than raising: an error would take
+-- out the ticker and leave the bot waiting for a completion that never arrives.
+local function NumServices()
+    if not GetNumTrainerServices then return 0 end
+    return GetNumTrainerServices() or 0
+end
+
+-- Matches a trainer service against one wanted spell id.
+-- Ranked clients (som/tbc/wrath) carry "Rank N" in both subtexts, so name plus rank
+-- identifies the exact rank. Cata and MoP dropped ranks and answer an empty subtext,
+-- where the name alone is unambiguous.
+local function ServiceMatches(serviceName, serviceRank, spellId)
+    if serviceName ~= mName[spellId] then
+        return false
+    end
+
+    local rank = mRank[spellId]
+    if rank and rank ~= "" then
+        return rank == (serviceRank or "")
+    end
+
+    return true
+end
+
+-- The spell id behind a trainer service. Only needed for train-all, where no whitelist
+-- named it. The tooltip is the one API that answers it, so a service whose id cannot be
+-- resolved is skipped rather than bought blind - every id the bot is told about then
+-- corresponds to a real purchase, and the count it waits on stays honest.
+local function TrainerServiceSpellId(index)
+    if not GameTooltip or not GameTooltip.SetTrainerService or not GameTooltip.GetSpell then
+        return 0
+    end
+
+    GameTooltip:SetOwner(UIParent, "ANCHOR_NONE")
+    GameTooltip:SetTrainerService(index)
+
+    local _, spellId = GameTooltip:GetSpell()
+
+    GameTooltip:Hide()
+
+    return spellId or 0
+end
+
+local function Tick()
+    if not mRunning then return end
+
+    -- The ticker stops calling once its iterations run out. Reporting here rather than
+    -- letting it lapse silently is what stops the bot waiting on a batch that never comes.
+    mTicks = mTicks + 1
+    if mTicks > ITERATION_COUNT then
+        ReportAndStop()
+        return
+    end
+
+    local count = NumServices()
+    if count == 0 or not BuyTrainerService then
+        ReportAndStop()
+        return
+    end
+
+    local money = GetMoney()
+
+    for i = 1, count do
+        local serviceName, serviceRank, category = GetTrainerServiceInfo(i)
+
+        if serviceName and category == "available" then
+            -- Buy(spellId) returns true when a purchase happened, which ends this tick:
+            -- indices shift afterwards, so the list is rescanned next time round.
+            local function Buy(spellId)
+                mSawMatch = true
+
+                local cost = GetTrainerServiceCost(i) or 0
+                if cost > money then
+                    mSawUnaffordable = true
+                    return false
+                end
+
+                BuyTrainerService(i)
+
+                mBoughtCount = mBoughtCount + 1
+                mBought[mBoughtCount] = spellId
+                -- Learned, so it must not match again on the rescan.
+                mWanted[spellId] = nil
+
+                DataToColor:Print("Trainer: learning " .. serviceName ..
+                    (serviceRank and serviceRank ~= "" and (" (" .. serviceRank .. ")") or "") ..
+                    " for " .. (GetCoinTextureString and GetCoinTextureString(cost) or (cost .. "c")))
+
+                return true
+            end
+
+            if mTrainAll then
+                local spellId = TrainerServiceSpellId(i)
+                if spellId > 0 and Buy(spellId) then
+                    return
+                end
+            else
+                for spellId in pairs(mWanted) do
+                    if ServiceMatches(serviceName, serviceRank, spellId) and Buy(spellId) then
+                        return
+                    end
+                end
+            end
+        end
+    end
+
+    -- A full pass bought nothing, so nothing further is buyable this visit.
+    ReportAndStop()
+end
+
+tFrame:SetScript("OnEvent", function(self, event)
+    if event == "TRAINER_CLOSED" then
+        ReportAndStop()
+    end
+end)
+
+-- TC: Trainer Clear
+-- Drops any whitelist left over from a previous visit.
+function DataToColor:TC()
+    wipe(mWanted)
+    wipe(mName)
+    wipe(mRank)
+end
+
+-- TAdd: Add wanted spell ids
+-- Called 1-N times, paginated to stay under the 255 character chat limit.
+-- Parameters:
+--   ids: Comma-separated string of spell ids (e.g. "6673,5242,100")
+function DataToColor:TAdd(ids)
+    if not ids or ids == "" then return end
+    for id in gmatch(ids, "(%d+)") do
+        local spellId = tonumber(id)
+        if spellId then
+            mWanted[spellId] = true
+        end
+    end
+end
+
+-- TGo: Start training
+-- Buys every wanted spell the trainer offers and the player can afford.
+-- Parameters:
+--   trainAll: 1 to ignore the wanted list and buy whatever is available and affordable
+function DataToColor:TGo(trainAll)
+    if mRunning then return end
+
+    wipe(mBought)
+    mBoughtCount = 0
+    mSawMatch = false
+    mSawUnaffordable = false
+    mTicks = 0
+    mTrainAll = trainAll ~= nil and trainAll ~= 0
+    mRunning = true
+
+    -- Unhide everything so a service is never missed because of a leftover filter.
+    if SetTrainerServiceTypeFilter then
+        SetTrainerServiceTypeFilter("available", 1)
+        SetTrainerServiceTypeFilter("unavailable", 1)
+        SetTrainerServiceTypeFilter("used", 1)
+    end
+
+    for spellId in pairs(mWanted) do
+        local name, rank = GetSpellInfo(spellId)
+        mName[spellId] = name
+        mRank[spellId] = rank or ""
+    end
+
+    if mTicker then mTicker:Cancel() end
+    mTicker = C_Timer.NewTicker(ITERATION_INTERVAL, Tick, ITERATION_COUNT)
+
+    Tick()
+end

--- a/Core/Actionbar/ActionBarPopulator.cs
+++ b/Core/Actionbar/ActionBarPopulator.cs
@@ -140,6 +140,46 @@ public sealed class ActionBarPopulator
     }
 
     /// <summary>
+    /// Re-places every slotted KeyAction whose Name is one of <paramref name="spellNames"/>.
+    /// <para>
+    /// Learning a new rank does not touch the action bar - the button keeps pointing at
+    /// the rank that was dragged onto it - so a freshly trained spell has to be put back.
+    /// The addon's PS() picks the last spellbook match for a name, which is the highest
+    /// rank, so re-placing is what promotes the button.
+    /// </para>
+    /// </summary>
+    /// <returns>How many slots were re-placed.</returns>
+    public int PlaceByNames(IReadOnlyCollection<string> spellNames)
+    {
+        if (spellNames.Count == 0)
+            return 0;
+
+        int placed = 0;
+
+        foreach ((string _, KeyActions keyActions) in config.GetByType<KeyActions>())
+        {
+            foreach (KeyAction keyAction in keyActions.Sequence)
+            {
+                if (keyAction.Slot == 0 || string.IsNullOrEmpty(keyAction.Name))
+                    continue;
+
+                foreach (string spellName in spellNames)
+                {
+                    if (!keyAction.Name.Equals(spellName, System.StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    if (Place(keyAction))
+                        placed++;
+
+                    break;
+                }
+            }
+        }
+
+        return placed;
+    }
+
+    /// <summary>
     /// Places a single KeyAction on the action bar.
     /// Handles spells, macros, items, food, drink, and trinkets.
     /// </summary>

--- a/Core/Addon/AddonTicks.cs
+++ b/Core/Addon/AddonTicks.cs
@@ -14,4 +14,14 @@ public static class AddonTicks
     /// Must be above max possible queue data value (texture max = 16,149,999).
     /// </summary>
     public const int QUEUE_COUNT_MARKER = 16_777_000;
+
+    /// <summary>
+    /// Terminates the lower-rank half of the spellbook batch.
+    /// A count header cannot express that block: a cell tops out at 16,777,215, so
+    /// QUEUE_COUNT_MARKER + n saturates at n = 215 and a level 60+ spellbook holds more
+    /// ranks. The marker cannot be lowered to make room either - a binding encoding spans
+    /// the full 24 bits. This value is only read on the spellbook cell, so it cannot
+    /// collide with the binding queue.
+    /// </summary>
+    public const int SPELLBOOK_ALL_RANKS_END = 16_776_999;
 }

--- a/Core/Addon/SpellBookReader.cs
+++ b/Core/Addon/SpellBookReader.cs
@@ -17,14 +17,42 @@ public sealed class SpellBookReader : IReader
 
     private int expectedCount = -1;
     private int receivedCount;
+    private bool snapshotDirty;
 
     public SpellDB SpellDB { get; }
     public int Count => spells.Count;
     public int ExpectedCount => expectedCount;
     public int ReceivedCount => receivedCount;
+
+    /// <summary>
+    /// True once the highest rank of every spell has arrived. Deliberately not tied to
+    /// the lower ranks that follow: AddonReader withholds DataReady until this flips, so
+    /// waiting for the full set would pause the agent for hundreds of extra ticks after
+    /// every /dcflush and on every SPELLS_CHANGED resend.
+    /// </summary>
     public bool IsInitialized => expectedCount >= 0 && receivedCount >= expectedCount;
+
+    /// <summary>
+    /// True once every rank has arrived, not just the highest of each. Only then can
+    /// <see cref="HasExact"/> answer which rank is known.
+    /// </summary>
+    public bool AllRanksReceived { get; private set; }
+
     public int Hash { get; private set; }
-    public int[] SpellIds => spellIdsSnapshot;
+
+    public int[] SpellIds
+    {
+        get
+        {
+            if (snapshotDirty)
+            {
+                spellIdsSnapshot = [.. spells];
+                snapshotDirty = false;
+            }
+
+            return spellIdsSnapshot;
+        }
+    }
 
     public SpellBookReader(SpellDB spellDB)
     {
@@ -43,6 +71,14 @@ public sealed class SpellBookReader : IReader
         {
             expectedCount = spellId - AddonTicks.QUEUE_COUNT_MARKER;
             receivedCount = 0;
+            AllRanksReceived = false;
+            return;
+        }
+
+        // Closes the lower-rank block that follows the counted one.
+        if (spellId == AddonTicks.SPELLBOOK_ALL_RANKS_END)
+        {
+            AllRanksReceived = true;
             return;
         }
 
@@ -52,7 +88,7 @@ public sealed class SpellBookReader : IReader
             return;
 
         Hash++;
-        spellIdsSnapshot = [.. spells];
+        snapshotDirty = true;
         if (TryGetValue(spellId, out Spell spell))
         {
             spellNames.Add(spell.Name);
@@ -64,15 +100,29 @@ public sealed class SpellBookReader : IReader
         spells.Clear();
         spellNames.Clear();
         spellIdsSnapshot = [];
+        snapshotDirty = false;
         expectedCount = -1;
         receivedCount = 0;
+        AllRanksReceived = false;
         Hash++;
     }
 
+    /// <summary>
+    /// Rank-blind: true when any rank of the spell is known, because the name fallback
+    /// matches every rank of a spell against one another. This is what the Spell:
+    /// requirement wants - "can I cast this at all".
+    /// </summary>
     public bool Has(int id)
     {
         return spells.Contains(id) || (SpellDB.Spells.TryGetValue(id, out Spell spell) && spellNames.Contains(spell.Name));
     }
+
+    /// <summary>
+    /// True only for the exact rank. Meaningful once <see cref="AllRanksReceived"/> is
+    /// set - before that the lower ranks simply have not arrived yet and this reports
+    /// false for ranks the player does own.
+    /// </summary>
+    public bool HasExact(int id) => spells.Contains(id);
 
     public bool TryGetValue(int id, out Spell spell)
     {

--- a/Core/AddonComponent/AddonBits.cs
+++ b/Core/AddonComponent/AddonBits.cs
@@ -124,4 +124,13 @@ public sealed class AddonBits : IReader, IGameMenuWindowShown
     public bool SpellBookFrameOpen() => v3[Mask._14];
 
     public bool FriendsFrameOpen() => v3[Mask._15];
+
+    public bool TrainerFrameShown() => v3[Mask._16];
+
+    /// <summary>
+    /// Polled from MerchantFrame, so it says whether the window is on screen right now -
+    /// unlike the cell 73 sentinels, which latch the last event and cannot tell a window
+    /// that is currently open from one that opened and closed again.
+    /// </summary>
+    public bool MerchantFrameShown() => v3[Mask._17];
 }

--- a/Core/AddonComponent/UnitClass.cs
+++ b/Core/AddonComponent/UnitClass.cs
@@ -16,3 +16,26 @@ public enum UnitClass
     Druid,
     DemonHunter
 }
+
+public static class UnitClassExtensions
+{
+    /// <summary>
+    /// The text a class trainer carries in <c>Creature.SubName</c> - "Warrior Trainer",
+    /// "Priest Trainer" and so on. Used to keep a ClassTrainer search from walking to
+    /// another class's trainer, since NpcFlags.ClassTrainer marks all of them alike.
+    /// <para>
+    /// The enum name is the keyword. Matching is a case-insensitive substring test, so
+    /// it also picks up the hand-titled ones - "High Priest", "Master Mage",
+    /// "Grand Master Rogue" - while excluding "Portal Trainer" and "Pet Trainer", which
+    /// teach no class spells.
+    /// </para>
+    /// <para>
+    /// Covers every class trainer in som and tbc, and all but the non-spell ones in
+    /// wrath. NOT wired up for DeathKnight or DemonHunter: the data spells those two
+    /// inconsistently ("Death Knight" in wrath, "Deathknight" in MoP) and wrath does
+    /// not flag its DK trainers as ClassTrainer at all.
+    /// </para>
+    /// </summary>
+    public static string TrainerSubName(this UnitClass unitClass) =>
+        unitClass == UnitClass.None ? string.Empty : unitClass.ToString();
+}

--- a/Core/ClassConfig/ActionMask.cs
+++ b/Core/ClassConfig/ActionMask.cs
@@ -24,4 +24,6 @@ public static class ActionMask
     public const int CancelOnInterrupt = 1 << 17;
 
     public const int UseMount = 1 << 18;
+
+    public const int TrainAll = 1 << 19;
 }

--- a/Core/ClassConfig/ClassConfiguration.cs
+++ b/Core/ClassConfig/ClassConfiguration.cs
@@ -85,13 +85,13 @@ public sealed partial class ClassConfiguration
     public Dictionary<string, string> StringVariables { get; } = [];
 
     public KeyActions Pull { get; } = new();
-    public KeyActions Flee { get; } = new();
+    public KeyActions Flee { get; } = new() { KeyRequired = false };
     public KeyActions Combat { get; } = new();
     public KeyActions Adhoc { get; } = new();
     public KeyActions Parallel { get; } = new();
-    public KeyActions NPC { get; } = new();
+    public KeyActions NPC { get; } = new() { KeyRequired = false };
     public KeyActions AssistFocus { get; } = new();
-    public WaitKeyActions Wait { get; } = new();
+    public WaitKeyActions Wait { get; } = new() { KeyRequired = false };
     public FormKeyActions Form { get; } = new();
 
     /// <summary>
@@ -472,94 +472,4 @@ public sealed partial class ClassConfiguration
         Message = "Loaded mail config from {MailPath}")]
     static partial void LogLoadedMailConfig(ILogger logger, string mailPath);
 
-}
-
-/// <summary>
-/// Deserializes IntVariables where each value can be either a scalar int or an int[].
-/// Scalars are normalized to single-element arrays for uniform handling.
-/// </summary>
-public sealed class IntOrIntArrayDictionaryConverter : JsonConverter<Dictionary<string, int[]>>
-{
-    public override Dictionary<string, int[]>? ReadJson(
-        JsonReader reader, Type objectType,
-        Dictionary<string, int[]>? existingValue, bool hasExistingValue,
-        JsonSerializer serializer)
-    {
-        Dictionary<string, int[]> result = existingValue ?? [];
-
-        if (reader.TokenType == JsonToken.Null)
-            return result;
-
-        if (reader.TokenType != JsonToken.StartObject)
-            throw new JsonSerializationException(
-                $"Expected StartObject for IntVariables, got {reader.TokenType}.");
-
-        while (reader.Read())
-        {
-            if (reader.TokenType == JsonToken.EndObject)
-                return result;
-
-            if (reader.TokenType != JsonToken.PropertyName)
-                throw new JsonSerializationException(
-                    $"Expected PropertyName, got {reader.TokenType}.");
-
-            string key = (string)reader.Value!;
-            reader.Read();
-
-            int[] values = reader.TokenType switch
-            {
-                JsonToken.Integer => [(int)(long)reader.Value!],
-                JsonToken.StartArray => ReadIntArray(reader),
-                _ => throw new JsonSerializationException(
-                    $"IntVariables['{key}']: expected integer or array, got {reader.TokenType}.")
-            };
-
-            result[key] = values;
-        }
-
-        return result;
-    }
-
-    private static int[] ReadIntArray(JsonReader reader)
-    {
-        List<int> list = [];
-        while (reader.Read())
-        {
-            if (reader.TokenType == JsonToken.EndArray)
-                return [.. list];
-
-            if (reader.TokenType != JsonToken.Integer)
-                throw new JsonSerializationException(
-                    $"IntVariables array element: expected integer, got {reader.TokenType}.");
-
-            list.Add((int)(long)reader.Value!);
-        }
-
-        throw new JsonSerializationException("Unexpected end of JSON in IntVariables array.");
-    }
-
-    public override void WriteJson(
-        JsonWriter writer, Dictionary<string, int[]>? value, JsonSerializer serializer)
-    {
-        writer.WriteStartObject();
-        if (value != null)
-        {
-            foreach ((string key, int[] values) in value)
-            {
-                writer.WritePropertyName(key);
-                if (values.Length == 1)
-                {
-                    writer.WriteValue(values[0]);
-                }
-                else
-                {
-                    writer.WriteStartArray();
-                    for (int i = 0; i < values.Length; i++)
-                        writer.WriteValue(values[i]);
-                    writer.WriteEndArray();
-                }
-            }
-        }
-        writer.WriteEndObject();
-    }
 }

--- a/Core/ClassConfig/IntOrIntArrayDictionaryConverter.cs
+++ b/Core/ClassConfig/IntOrIntArrayDictionaryConverter.cs
@@ -1,0 +1,113 @@
+using Newtonsoft.Json;
+
+using System;
+using System.Collections.Generic;
+
+namespace Core;
+
+/// <summary>
+/// Deserializes IntVariables where each value can be either a scalar int or an int[].
+/// Scalars are normalized to single-element arrays for uniform handling.
+/// </summary>
+public sealed class IntOrIntArrayDictionaryConverter : JsonConverter<Dictionary<string, int[]>>
+{
+    public override Dictionary<string, int[]>? ReadJson(
+        JsonReader reader, Type objectType,
+        Dictionary<string, int[]>? existingValue, bool hasExistingValue,
+        JsonSerializer serializer)
+    {
+        Dictionary<string, int[]> result = existingValue ?? [];
+
+        if (reader.TokenType == JsonToken.Null)
+            return result;
+
+        if (reader.TokenType != JsonToken.StartObject)
+            throw new JsonSerializationException(
+                $"Expected StartObject for IntVariables, got {reader.TokenType}.");
+
+        while (ReadSkippingComments(reader))
+        {
+            if (reader.TokenType == JsonToken.EndObject)
+                return result;
+
+            if (reader.TokenType != JsonToken.PropertyName)
+                throw new JsonSerializationException(
+                    $"Expected PropertyName, got {reader.TokenType}.");
+
+            string key = (string)reader.Value!;
+            ReadSkippingComments(reader);
+
+            int[] values = reader.TokenType switch
+            {
+                JsonToken.Integer => [(int)(long)reader.Value!],
+                JsonToken.StartArray => ReadIntArray(reader),
+                _ => throw new JsonSerializationException(
+                    $"IntVariables['{key}']: expected integer or array, got {reader.TokenType}.")
+            };
+
+            result[key] = values;
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Advances past any comment tokens. Class profiles are commented heavily, and a
+    /// hand-written converter sees those tokens where the default deserializer would
+    /// have hidden them - a single // line inside IntVariables otherwise fails the
+    /// whole profile load with "Expected PropertyName, got Comment".
+    /// </summary>
+    private static bool ReadSkippingComments(JsonReader reader)
+    {
+        while (reader.Read())
+        {
+            if (reader.TokenType != JsonToken.Comment)
+                return true;
+        }
+
+        return false;
+    }
+
+    private static int[] ReadIntArray(JsonReader reader)
+    {
+        List<int> list = [];
+        while (ReadSkippingComments(reader))
+        {
+            if (reader.TokenType == JsonToken.EndArray)
+                return [.. list];
+
+            if (reader.TokenType != JsonToken.Integer)
+                throw new JsonSerializationException(
+                    $"IntVariables array element: expected integer, got {reader.TokenType}.");
+
+            list.Add((int)(long)reader.Value!);
+        }
+
+        throw new JsonSerializationException("Unexpected end of JSON in IntVariables array.");
+    }
+
+    public override void WriteJson(
+        JsonWriter writer, Dictionary<string, int[]>? value, JsonSerializer serializer)
+    {
+        writer.WriteStartObject();
+        if (value != null)
+        {
+            foreach ((string key, int[] values) in value)
+            {
+                writer.WritePropertyName(key);
+                if (values.Length == 1)
+                {
+                    writer.WriteValue(values[0]);
+                }
+                else
+                {
+                    writer.WriteStartArray();
+                    for (int i = 0; i < values.Length; i++)
+                        writer.WriteValue(values[i]);
+                    writer.WriteEndArray();
+                }
+            }
+        }
+        writer.WriteEndObject();
+    }
+}

--- a/Core/ClassConfig/KeyAction.cs
+++ b/Core/ClassConfig/KeyAction.cs
@@ -4,6 +4,8 @@ using Game;
 
 using Microsoft.Extensions.Logging;
 
+using Newtonsoft.Json;
+
 using SharedLib;
 
 using System;
@@ -166,6 +168,16 @@ public sealed partial class KeyAction
         set => features[ActionMask.UseMount] = value;
     }
 
+    /// <summary>
+    /// ClassTrainer entries only. Buys every spell the trainer offers and the player can
+    /// afford, instead of only the ones the profile whitelists under SPELL_ IntVariables.
+    /// </summary>
+    public bool TrainAll
+    {
+        get => features[ActionMask.TrainAll];
+        set => features[ActionMask.TrainAll] = value;
+    }
+
     public int AfterCastStepBack { get; set; }
 
     public string InCombat { get; set; } = "false";
@@ -198,9 +210,17 @@ public sealed partial class KeyAction
     private int canBeInterruptedTime;
     private bool canBeInterrupted;
 
+    /// <summary>
+    /// Set for entries whose goal never presses a key - the NPC, Flee and Wait sections,
+    /// which are driven entirely by their Requirements. Without it every such entry warns
+    /// about a missing key that it is not supposed to have.
+    /// </summary>
+    [JsonIgnore]
+    public bool KeyOptional { get; set; }
+
     public void InitSlot(ILogger logger)
     {
-        if (!KeyReader.ReadKey(logger, this) && !BaseAction)
+        if (!KeyReader.ReadKey(logger, this) && !BaseAction && !KeyOptional)
         {
             LogInputNoValidKey(logger, Name, Key, ConsoleKey);
         }

--- a/Core/ClassConfig/KeyActions.cs
+++ b/Core/ClassConfig/KeyActions.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 
+using Newtonsoft.Json;
+
 using System;
 
 namespace Core;
@@ -9,6 +11,14 @@ public class KeyActions
     public KeyAction[] Sequence { get; set; } =
         Array.Empty<KeyAction>();
 
+    /// <summary>
+    /// False for sections whose goals act on Requirements alone and never press the
+    /// entry's key - NPC, Flee and Wait. Propagated onto each KeyAction because
+    /// InitSlot also runs later from KeyAction.Init, which has no view of the section.
+    /// </summary>
+    [JsonIgnore]
+    public bool KeyRequired { get; init; } = true;
+
     public virtual void InitBinds(ILogger logger,
         RequirementFactory factory)
     {
@@ -16,6 +26,7 @@ public class KeyActions
         {
             KeyAction keyAction = Sequence[i];
 
+            keyAction.KeyOptional = !KeyRequired;
             keyAction.InitSlot(logger);
             factory.InitAutoBinds(keyAction);
         }

--- a/Core/ClassConfig/WaitKeyActions.cs
+++ b/Core/ClassConfig/WaitKeyActions.cs
@@ -50,7 +50,10 @@ public sealed partial class WaitKeyActions : KeyActions
         {
             Cost = FoodDrinkCost,
             Name = newActionName,
-            Requirement = requirement
+            Requirement = requirement,
+            // Appended after InitBinds has already run for this section, so it never
+            // picks the flag up from KeyRequired the way the declared entries do.
+            KeyOptional = true
         };
 
         KeyAction[] keyActions = Sequence;

--- a/Core/Database/AreaDB.cs
+++ b/Core/Database/AreaDB.cs
@@ -169,7 +169,8 @@ public sealed class AreaDB : IDisposable
         string[] allowedNames,
         Span<NpcSearchResult> destination, // caller-provided buffer
         out int written,
-        bool crossZoneSearch = false)
+        bool crossZoneSearch = false,
+        string? subNameContains = null)
     {
         written = 0;
 
@@ -183,6 +184,14 @@ public sealed class AreaDB : IDisposable
             foreach (var n in npcs)
             {
                 if (allowedNames.Length != 0 && !allowedNames.Contains(n.Name))
+                    continue;
+
+                // NpcFlags.ClassTrainer marks every class's trainer alike, so without
+                // this the nearest few are usually the wrong class - and the caller's
+                // buffer fills with them before the right one is ever considered.
+                if (subNameContains != null &&
+                    (n.SubName == null ||
+                    !n.SubName.Contains(subNameContains, StringComparison.OrdinalIgnoreCase)))
                     continue;
 
                 if (!NpcWorldLocations.TryGetValue(n.Entry, out Vector3[]? worldPos))

--- a/Core/DependencyInjection.cs
+++ b/Core/DependencyInjection.cs
@@ -54,6 +54,7 @@ public static class DependencyInjection
         s.ForwardSingleton<GossipReader, IReader>();
         s.ForwardSingleton<SpellBookReader, IReader>();
         s.ForwardSingleton<TalentReader, IReader>();
+        s.ForwardSingleton<TrainerReader, IReader>();
         s.ForwardSingleton<KeyBindingsReader, IReader>();
         s.ForwardSingleton<ActionBarTextureReader, IReader>();
         s.ForwardSingleton<ActionBarMacroReader, IReader>();
@@ -190,6 +191,7 @@ public static class DependencyInjection
         s.ForwardSingleton<GossipReader>(sp);
         s.ForwardSingleton<SpellBookReader>(sp);
         s.ForwardSingleton<TalentReader>(sp);
+        s.ForwardSingleton<TrainerReader>(sp);
 
         s.ForwardSingleton<ActionBarCostReader>(sp);
         s.ForwardSingleton<ActionBarCooldownReader>(sp);

--- a/Core/GOAP/GoapAgent.cs
+++ b/Core/GOAP/GoapAgent.cs
@@ -52,6 +52,9 @@ public sealed partial class GoapAgent : IDisposable
     // own ctor and nothing else asks for them.
     private readonly IBagChangeTracker bagChangeTracker;
     private readonly IMoneyChangeTracker moneyChangeTracker;
+    // Not behind the LogBagChanges toggle the other two share - a level-up is one line
+    // every few hours, not the per-item chatter that toggle exists to silence.
+    private readonly LevelChangeTracker levelChangeTracker;
 
     private long lastNoPlanReport;
 
@@ -135,6 +138,7 @@ public sealed partial class GoapAgent : IDisposable
         CorpseTracker corpseTracker,
         IBagChangeTracker bagChangeTracker,
         IMoneyChangeTracker moneyChangeTracker,
+        LevelChangeTracker levelChangeTracker,
         SessionStat sessionStat,
         StopMoving stopMoving,
         IGrindSessionHandler sessionHandler,
@@ -164,6 +168,7 @@ public sealed partial class GoapAgent : IDisposable
         this.corpseTracker = corpseTracker;
         this.bagChangeTracker = bagChangeTracker;
         this.moneyChangeTracker = moneyChangeTracker;
+        this.levelChangeTracker = levelChangeTracker;
 
         SessionStat = sessionStat;
 

--- a/Core/Goals/AdhocNPCGoal.cs
+++ b/Core/Goals/AdhocNPCGoal.cs
@@ -16,6 +16,7 @@ using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using System.Text;
 using System.Threading;
 
 #pragma warning disable 162
@@ -42,9 +43,17 @@ public sealed partial class AdhocNPCGoal : GoapGoal, IGoapEventListener, IRouteP
 
     private const int MAX_TIME_TO_REACH_MELEE = 10000;
     private const int TIMEOUT = 5000;
+
+    // The addon buys one service per timer tick and rescans between them, so a full
+    // whitelist takes noticeably longer than a merchant interaction.
+    private const int TRAIN_TIMEOUT = 30000;
     private const int MAX_SELL_NOTHING_RETRIES = 2;
 
-    private readonly FrozenDictionary<NpcFlags, SearchValues<string>> npcSearchPatterns;
+    // Ordered longest flag name first, so a name is matched against the most specific
+    // flag that fits it. Enum order would test Trainer (1<<4) before ClassTrainer
+    // (1<<5) and "ClassTrainer" contains "Trainer", which sent a class trainer entry
+    // searching the generic superset - and every Vendor* subtype to plain Vendor.
+    private readonly (NpcFlags Flag, SearchValues<string> Pattern)[] npcSearchPatterns;
 
     public override float Cost => key.Cost;
 
@@ -65,9 +74,15 @@ public sealed partial class AdhocNPCGoal : GoapGoal, IGoapEventListener, IRouteP
     private readonly AreaDB areaDB;
     private readonly BagReader bagReader;
     private readonly SessionStat sessionStat;
+    private readonly TrainerReader trainerReader;
+    private readonly TrainerPlanner trainerPlanner;
+    private readonly AddonConfigurator addonConfigurator;
+    private readonly ActionBarPopulator actionBarPopulator;
 
     private PathState pathState = PathState.Finished;
 
+    private readonly NpcFlags npcFlag;
+    private readonly string[] allowedNames;
     private readonly bool tryFindClosestNPC;
     private Creature npc;
     private NpcSearchResult[] searchResult = [];
@@ -106,6 +121,8 @@ public sealed partial class AdhocNPCGoal : GoapGoal, IGoapEventListener, IRouteP
         Navigation navigation, StopMoving stopMoving, AreaDB areaDB,
         NpcNameTargeting npcNameTargeting, ClassConfiguration classConfig,
         BagReader bagReader, SessionStat sessionStat,
+        TrainerReader trainerReader, TrainerPlanner trainerPlanner,
+        AddonConfigurator addonConfigurator, ActionBarPopulator actionBarPopulator,
         IMountHandler mountHandler, ExecGameCommand exec, CancellationTokenSource cts)
         : base(nameof(AdhocNPCGoal))
     {
@@ -121,6 +138,10 @@ public sealed partial class AdhocNPCGoal : GoapGoal, IGoapEventListener, IRouteP
         this.classConfig = classConfig;
         this.bagReader = bagReader;
         this.sessionStat = sessionStat;
+        this.trainerReader = trainerReader;
+        this.trainerPlanner = trainerPlanner;
+        this.addonConfigurator = addonConfigurator;
+        this.actionBarPopulator = actionBarPopulator;
         this.mountHandler = mountHandler;
         token = cts.Token;
         this.execGameCommand = exec;
@@ -141,19 +162,56 @@ public sealed partial class AdhocNPCGoal : GoapGoal, IGoapEventListener, IRouteP
 
         Keys = [key];
 
-        npcSearchPatterns = Enum.GetValues<NpcFlags>().Select(static flag =>
-        {
-            string[] strings = flag switch
+        npcSearchPatterns = Enum.GetValues<NpcFlags>()
+            .OrderByDescending(static flag => flag.ToString().Length)
+            .Select(static flag =>
             {
-                NpcFlags.Vendor => [flag.ToString(), "Sell"],
-                _ => [flag.ToString()]
-            };
+                string[] strings = flag switch
+                {
+                    NpcFlags.Vendor => [flag.ToString(), "Sell"],
+                    _ => [flag.ToString()]
+                };
 
-            return new KeyValuePair<NpcFlags, SearchValues<string>>(flag, SearchValues.Create(strings, StringComparison.OrdinalIgnoreCase));
-        })
-        .ToFrozenDictionary(pair => pair.Key, pair => pair.Value);
+                return (flag, SearchValues.Create(strings, StringComparison.OrdinalIgnoreCase));
+            })
+            .ToArray();
+
+        npcFlag = ResolveNpcFlag(key.Name);
+        allowedNames = ResolveAllowedNames(key.Name);
+
+        if (allowedNames.Length > 0 && logger.IsEnabled(LogLevel.Information))
+            logger.LogInformation("Search for {NpcFlag} like {AllowedNames}", npcFlag, string.Join(',', allowedNames));
 
         tryFindClosestNPC = key.Path.Length == 0;
+    }
+
+    /// <summary>
+    /// Resolved once from the KeyAction name rather than per search, so it is known even
+    /// for an entry that ships a PathFilename and never runs the closest-NPC search.
+    /// </summary>
+    private NpcFlags ResolveNpcFlag(ReadOnlySpan<char> name)
+    {
+        for (int i = 0; i < npcSearchPatterns.Length; i++)
+        {
+            if (name.ContainsAny(npcSearchPatterns[i].Pattern))
+                return npcSearchPatterns[i].Flag;
+        }
+
+        return NpcFlags.None;
+    }
+
+    // TODO: faction specific filter?
+    // try to detect pattern
+    // [TYPE][ ][npc1 | npc2 | npc3]
+    private static string[] ResolveAllowedNames(ReadOnlySpan<char> name)
+    {
+        int separator = name.IndexOf(' ');
+        if (separator == -1)
+            return [];
+
+        return name[(separator + 1)..]
+            .ToString()
+            .Split('|', options: StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
     }
 
     public void Dispose()
@@ -161,7 +219,16 @@ public sealed partial class AdhocNPCGoal : GoapGoal, IGoapEventListener, IRouteP
         navigation.Dispose();
     }
 
-    public override bool CanRun() => key.CanRun();
+    /// <summary>
+    /// A trainer entry additionally answers to the planner. The profile can say
+    /// HasTrainableSpell, but not "every trainer near me already turned out to teach
+    /// none of them" or "the price was more than I have" - that is session state, and
+    /// without it the goal walks back to the same trainers forever.
+    /// </summary>
+    public override bool CanRun() =>
+        key.CanRun() &&
+        (npcFlag != NpcFlags.ClassTrainer ||
+         (key.TrainAll ? trainerPlanner.CanVisitAll : trainerPlanner.CanVisit));
 
     public void OnGoapEvent(GoapEventArgs e)
     {
@@ -182,6 +249,12 @@ public sealed partial class AdhocNPCGoal : GoapGoal, IGoapEventListener, IRouteP
         {
             pathState = PathState.Finished;
             LogWarn("No NPC with the criteria!");
+
+            // Guarded on the area being loaded: a null CurrentArea is a transient
+            // startup state, not evidence that the zone has no trainer.
+            if (npcFlag == NpcFlags.ClassTrainer && areaDB.CurrentArea != null)
+                trainerPlanner.OnNoTrainerFound();
+
             return;
         }
 
@@ -396,10 +469,23 @@ public sealed partial class AdhocNPCGoal : GoapGoal, IGoapEventListener, IRouteP
         }
 
         Log($"Found Target!");
-        input.PressInteract();
-        wait.Update();
 
-        MerchantResult merchantResult = OpenMerchantWindow();
+        // Interacting again on an open window closes it. The soft-interact branch above
+        // can already have opened the merchant - and the grey items can already be sold
+        // by the time it returns - at which point this press would shut it and the wait
+        // below would time out on a visit that had in fact succeeded.
+        if (!bits.MerchantFrameShown() && !bits.TrainerFrameShown())
+        {
+            input.PressInteract();
+            wait.Update();
+        }
+
+        bool training = npcFlag == NpcFlags.ClassTrainer;
+
+        MerchantResult merchantResult = training
+            ? OpenTrainerWindow()
+            : OpenMerchantWindow();
+
         if (merchantResult == MerchantResult.TryNextNPC && tryFindClosestNPC)
         {
             input.PressClearTarget();
@@ -408,11 +494,22 @@ public sealed partial class AdhocNPCGoal : GoapGoal, IGoapEventListener, IRouteP
         }
 
         if (merchantResult != MerchantResult.Success)
+        {
+            // Only the success path used to clean up, so a failed interaction walked away
+            // still targeting the NPC. Observed: a vendor whose window had in fact opened
+            // and sold, was toggled shut by the second interact, timed out, and stayed
+            // targeted for minutes while FollowRouteGoal tab-hunted around it.
+            input.PressRandom(ConsoleKey.Escape, InputDuration.DefaultPress);
+            input.PressClearTarget();
+            wait.Update();
             return;
+        }
 
         // Signal that vendor/repair completed successfully
-        // MailGoal uses this to know it can run
-        sessionStat.VendoredOrRepairedRecently = true;
+        // MailGoal uses this to know it can run. Training moves no items and costs
+        // rather than earns, so it is not what MailGoal is waiting for.
+        if (!training)
+            sessionStat.OnVendored();
 
         input.PressRandom(ConsoleKey.Escape, InputDuration.DefaultPress);
         input.PressClearTarget();
@@ -483,14 +580,20 @@ public sealed partial class AdhocNPCGoal : GoapGoal, IGoapEventListener, IRouteP
 
     private MerchantResult OpenMerchantWindow()
     {
-        float e = wait.Until(TIMEOUT, gossipReader.GossipStartOrMerchantWindowOpened);
+        // Watches GossipEnd rather than GossipStart, for the reason spelled out in
+        // OpenTrainerWindow: the gossip cell latches its last value, so by the time this
+        // polls, the queue has already run past 69 to GOSSIP_END. Hunting the start value
+        // missed it every time and burned the whole timeout, then the second wait found
+        // the end value already sitting there - two waits, one of them always wasted.
+        float e = wait.Until(TIMEOUT,
+            () => gossipReader.GossipEnd() || gossipReader.MerchantWindowOpened());
+
         if (gossipReader.MerchantWindowOpened())
         {
             LogWarn($"Gossip no options! {e}ms");
         }
         else
         {
-            e = wait.Until(TIMEOUT, gossipReader.GossipEnd);
             if (e < 0)
             {
                 LogWarn($"Gossip - {nameof(gossipReader.GossipEnd)} not fired after {e}ms");
@@ -558,6 +661,222 @@ public sealed partial class AdhocNPCGoal : GoapGoal, IGoapEventListener, IRouteP
         return MerchantResult.Success;
     }
 
+    /// <summary>
+    /// Opens the class trainer and hands the addon the spells worth buying. The addon
+    /// owns the purchase: it is the only side that can see what this trainer actually
+    /// offers and what each service costs.
+    /// </summary>
+    private MerchantResult OpenTrainerWindow()
+    {
+        int npcId = playerReader.TargetId;
+
+        // Waits on GossipEnd rather than GossipStart: the gossip cell latches its last
+        // value, and by the time this runs the queue has usually already drained through
+        // 69 (start) and the option hashes to GOSSIP_END. Watching for the start value
+        // therefore missed it every time and burned the full timeout before the end
+        // value - which was already sitting there - was checked.
+        float e = wait.Until(TIMEOUT,
+            () => gossipReader.GossipEnd() || bits.TrainerFrameShown());
+
+        // A trainer that greets with a menu has to be told which service to open. One
+        // that opens the trainer frame outright has already answered.
+        if (!bits.TrainerFrameShown())
+        {
+            if (e < 0)
+            {
+                LogWarn($"Gossip - {nameof(gossipReader.GossipEnd)} not fired after {e}ms");
+                return MerchantResult.Failed;
+            }
+
+            if (!gossipReader.Gossips.TryGetValue(Gossip.Trainer, out int orderNum))
+            {
+                LogWarn($"Target({playerReader.TargetId}) has no {Gossip.Trainer.ToString()} option!");
+                trainerPlanner.OnNothingToTrain(npcId);
+                return MerchantResult.TryNextNPC;
+            }
+
+            Log($"Picked {orderNum}th for {Gossip.Trainer.ToString()}");
+            execGameCommand.Run($"/run SelectGossipOption({orderNum})--");
+
+            e = wait.Until(TIMEOUT, bits.TrainerFrameShown);
+            if (e < 0)
+            {
+                LogWarn($"Trainer window did not open after {e}ms");
+                return MerchantResult.Failed;
+            }
+        }
+
+        Log($"Trainer window opened after {e}ms");
+
+        Span<int> buffer = stackalloc int[trainerPlanner.MaxTrainable];
+        bool trainAll = key.TrainAll;
+        int count = 0;
+
+        if (!trainAll && !trainerPlanner.TryGetTrainable(buffer, out count))
+        {
+            // Nothing eligible any more - levelled past it, or another visit got it.
+            // Not the trainer's fault, so it is not blacklisted.
+            Log("Nothing left to train.");
+            return MerchantResult.Success;
+        }
+
+        string addonName = addonConfigurator.Config.Title;
+
+        ReadOnlySpan<int> wanted = buffer[..count];
+        int walletBefore = playerReader.Money.Value;
+
+        // Locals, not inline arguments: CA1873 does not track the guard for
+        // source-generated log methods, only local variable access.
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            string wantedNames = trainAll ? "everything offered" : trainerPlanner.Describe(wanted);
+            string wallet = Coin.Format(walletBefore);
+            LogTrainerWanted(logger, npcId, count, wantedNames, wallet);
+        }
+
+        trainerReader.Reset();
+        execGameCommand.Run($"/run {addonName}:TC()--");
+        wait.Update();
+
+        if (!trainAll)
+            SendTrainSpellIdsBatched(addonName, wanted);
+
+        // TGo(1) tells the addon to ignore the whitelist and buy whatever it can afford.
+        execGameCommand.Run($"/run {addonName}:TGo({(trainAll ? "1" : "")})--");
+
+        e = wait.Until(TRAIN_TIMEOUT, () => trainerReader.Completed);
+        if (e < 0)
+        {
+            LogWarn($"Training did not report back after {e}ms");
+            return MerchantResult.Failed;
+        }
+
+        if (trainerReader.NoMoney)
+        {
+            trainerPlanner.OnNotEnoughMoney();
+        }
+        else if (trainerReader.NoMatch)
+        {
+            LogWarn($"Target({npcId}) teaches none of the wanted spells!");
+
+            // Train-all asked for everything, so an empty answer is about the player's
+            // level, not this trainer - blacklisting it and walking to the next one
+            // would just repeat the same trip.
+            if (trainAll)
+            {
+                trainerPlanner.OnNothingTrainedAtThisLevel();
+                return MerchantResult.Success;
+            }
+
+            trainerPlanner.OnNothingToTrain(npcId);
+            return MerchantResult.TryNextNPC;
+        }
+
+        int bought = trainerReader.Bought.Count;
+
+        // The addon reports what it bought one id per addon tick. Seeing none of them
+        // while the trainer clearly sold something means the batch was not decoded, not
+        // that nothing happened - worth saying out loud rather than logging "trained 0".
+        if (bought == 0 && !trainerReader.NoMoney)
+        {
+            if (trainAll)
+            {
+                trainerPlanner.OnNothingTrainedAtThisLevel();
+            }
+            else
+            {
+                LogWarn($"Trainer reported no purchases for the {count} spell(s) offered - " +
+                    $"the report may have been missed. Check the spellbook.");
+            }
+        }
+        else
+        {
+            Span<int> boughtIds = stackalloc int[bought];
+            for (int i = 0; i < bought; i++)
+                boughtIds[i] = trainerReader.Bought[i];
+
+            sessionStat.OnTrained(bought);
+
+            if (logger.IsEnabled(LogLevel.Information))
+            {
+                int walletAfter = playerReader.Money.Value;
+
+                string boughtNames = trainerPlanner.Describe(boughtIds);
+                // Derived from the two snapshots rather than reported by the trainer, so
+                // clamped - anything else that moved the wallet mid-visit lands here too.
+                string spent = Coin.Format(Math.Max(0, walletBefore - walletAfter));
+                string wallet = Coin.Format(walletAfter);
+
+                LogTrained(logger, bought, boughtNames, spent, wallet, e);
+            }
+
+            PlaceTrainedOnActionBar(boughtIds);
+        }
+
+        return MerchantResult.Success;
+    }
+
+    /// <summary>
+    /// Puts the freshly learnt spells back on their action bar slots. Learning a rank
+    /// leaves the button pointing at the rank that was dragged onto it, so without this
+    /// the bot keeps casting the old one.
+    /// <para>
+    /// Only the slots holding a spell that was just bought are touched - re-placing the
+    /// whole bar would be a chat command per slot and would disturb entries that are
+    /// resolved from live state, such as Food, Drink and the trinkets.
+    /// </para>
+    /// </summary>
+    private void PlaceTrainedOnActionBar(ReadOnlySpan<int> boughtIds)
+    {
+        List<string> names = [];
+        trainerPlanner.CollectNames(boughtIds, names);
+
+        if (names.Count == 0)
+            return;
+
+        int placed = actionBarPopulator.PlaceByNames(names);
+        wait.Update();
+
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            string joined = string.Join(", ", names);
+            LogActionBarPlaced(logger, placed, joined);
+        }
+    }
+
+    /// <summary>
+    /// The chat box truncates past 255 characters, so the id list is paginated the same
+    /// way MailGoal paginates its excluded items.
+    /// </summary>
+    private void SendTrainSpellIdsBatched(string addonName, ReadOnlySpan<int> ids)
+    {
+        const int MAX_CMD_LENGTH = 250;  // Leave margin for safety (WoW limit is 255)
+        string prefix = $"/run {addonName}:TAdd(\"";
+        const string suffix = "\")--";
+        int overhead = prefix.Length + suffix.Length;
+
+        StringBuilder batch = new();
+        for (int i = 0; i < ids.Length; i++)
+        {
+            string idStr = ids[i].ToString();
+            if (batch.Length > 0 && batch.Length + 1 + idStr.Length + overhead > MAX_CMD_LENGTH)
+            {
+                execGameCommand.Run($"{prefix}{batch}{suffix}");
+                wait.Update();
+                batch.Clear();
+            }
+
+            if (batch.Length > 0) batch.Append(',');
+            batch.Append(idStr);
+        }
+
+        if (batch.Length > 0)
+        {
+            execGameCommand.Run($"{prefix}{batch}{suffix}");
+            wait.Update();
+        }
+    }
+
     private bool TryAutoSelectNPCAndSetPath()
     {
         if (areaDB.CurrentArea == null)
@@ -565,39 +884,21 @@ public sealed partial class AdhocNPCGoal : GoapGoal, IGoapEventListener, IRouteP
             return false;
         }
 
-        ReadOnlySpan<char> name = key.Name;
+        // Read live rather than cached in the constructor: the addon may not have
+        // reported the class yet when the goal is built. Empty for UnitClass.None,
+        // which filters nothing rather than filtering everything out.
+        string? subNameContains = npcFlag == NpcFlags.ClassTrainer
+            ? playerReader.Class.TrainerSubName()
+            : null;
 
-        NpcFlags npcFlag = NpcFlags.None;
-        foreach ((NpcFlags type, SearchValues<string> pattern) in npcSearchPatterns)
-        {
-            if (name.ContainsAny(pattern))
-            {
-                npcFlag = type;
-                break;
-            }
-        }
-
-        string[] allowedNames = [];
-
-        // TODO: faction specific filter?
-        // try to detect pattern
-        // [TYPE][ ][npc1 | npc2 | npc3]
-        int separator = name.IndexOf(' ');
-        if (separator != -1)
-        {
-            allowedNames = name[(separator + 1)..]
-                .ToString()
-                .Split('|', options: StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
-
-            if (allowedNames.Length > 0 && logger.IsEnabled(LogLevel.Information))
-                logger.LogInformation("Search for {NpcFlag} like {AllowedNames}", npcFlag, string.Join(',', allowedNames));
-        }
+        if (string.IsNullOrEmpty(subNameContains))
+            subNameContains = null;
 
         if (searchResult.Length == 0)
         {
             searchResult = new NpcSearchResult[8];
 
-            int found = areaDB.GetNearestNpcs(playerReader.Faction, npcFlag, playerReader.WorldPos, allowedNames, searchResult.AsSpan(), out searchCount, classConfig.CrossZoneSearch);
+            int found = areaDB.GetNearestNpcs(playerReader.Faction, npcFlag, playerReader.WorldPos, allowedNames, searchResult.AsSpan(), out searchCount, classConfig.CrossZoneSearch, subNameContains);
             if (found == 0 || searchCount == 0)
             {
                 return false;
@@ -607,6 +908,14 @@ public sealed partial class AdhocNPCGoal : GoapGoal, IGoapEventListener, IRouteP
             searchIndex = 0;
         }
         else
+        {
+            searchIndex++;
+        }
+
+        // A trainer that turned out to teach nothing on the whitelist is not worth
+        // walking to a second time. Empty for every other NPC type.
+        while (searchIndex < searchCount &&
+            trainerPlanner.IsUseless(searchResult[searchIndex].Creature.Entry))
         {
             searchIndex++;
         }
@@ -661,6 +970,24 @@ public sealed partial class AdhocNPCGoal : GoapGoal, IGoapEventListener, IRouteP
         Level = LogLevel.Information,
         Message = "Found {count} potential {type} NPC.")]
     static partial void LogFoundPotentialNPCByType(ILogger logger, int count, NpcFlags type);
+
+    [LoggerMessage(
+        EventId = 0302,
+        Level = LogLevel.Information,
+        Message = "Trainer({npcId}): offering {count} spell(s) to learn - {spells}. Wallet {wallet}")]
+    static partial void LogTrainerWanted(ILogger logger, int npcId, int count, string spells, string wallet);
+
+    [LoggerMessage(
+        EventId = 0303,
+        Level = LogLevel.Information,
+        Message = "Trained {count} spell(s): {spells}. Spent {spent}, wallet now {wallet}, took {elapsedMs}ms")]
+    static partial void LogTrained(ILogger logger, int count, string spells, string spent, string wallet, float elapsedMs);
+
+    [LoggerMessage(
+        EventId = 0304,
+        Level = LogLevel.Information,
+        Message = "Action bar: re-placed {placed} slot(s) for the newly trained {spells}")]
+    static partial void LogActionBarPlaced(ILogger logger, int placed, string spells);
 
 
     #endregion

--- a/Core/GoalsComponent/TrainerPlanner.cs
+++ b/Core/GoalsComponent/TrainerPlanner.cs
@@ -1,0 +1,305 @@
+using Core.Database;
+
+using Microsoft.Extensions.Logging;
+
+using SharedLib;
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Core;
+
+/// <summary>
+/// Decides whether a trip to a class trainer is worth making, and which spell ids to
+/// hand the addon once there.
+/// <para>
+/// Session scoped, so everything it remembers is dropped when a profile is reloaded -
+/// a different profile means different spells, and a trainer written off under the old
+/// one deserves another look. The eligibility rule itself is in
+/// <see cref="TrainerSpells"/>, which the HasTrainableSpell requirement also uses.
+/// </para>
+/// </summary>
+public sealed partial class TrainerPlanner
+{
+    private readonly ILogger<TrainerPlanner> logger;
+    private readonly PlayerReader playerReader;
+    private readonly SpellBookReader spellBookReader;
+    private readonly SpellDB spellDB;
+
+    private readonly int[][] whitelist;
+
+    // Nothing in the game says "this trainer was no use to me", so it has to be
+    // remembered. Without it the planner keeps reporting work, the goal keeps walking
+    // back, and the bot loops between the same trainers forever.
+    private readonly HashSet<int> uselessNpcs = [];
+
+    // Ids the era's spells.json does not carry - a profile written for a later client.
+    // Kept so the warning is emitted once rather than on every evaluation.
+    private readonly HashSet<int> unknownIds = [];
+
+    // Set to the wallet at the moment a trainer reported a service it could not afford.
+    // Suppression lifts by itself once the balance rises above it, so no timer is needed.
+    private int suppressUntilMoneyAbove = -1;
+
+    // The zone whose trainer search came up empty. Cleared by walking into a different
+    // one, which is the only thing that can change the answer: CrossZoneSearch is off by
+    // default, so a zone with no trainer of this class has none to find however long the
+    // bot waits - and HasTrainableSpell can stay true for a whole zone's worth of levels.
+    private int noTrainerInZone = -1;
+
+    // The player level at which a train-all visit came back having bought nothing. Only
+    // levelling changes what a trainer offers, so anything short of that would just walk
+    // there to be told the same thing - and train-all has no whitelist to go quiet on.
+    private int nothingToTrainAtLevel = -1;
+
+    private int lastSeenLevel = -1;
+
+    public TrainerPlanner(ILogger<TrainerPlanner> logger, ClassConfiguration classConfig,
+        PlayerReader playerReader, SpellBookReader spellBookReader, SpellDB spellDB)
+    {
+        this.logger = logger;
+        this.playerReader = playerReader;
+        this.spellBookReader = spellBookReader;
+        this.spellDB = spellDB;
+
+        whitelist = TrainerSpells.BuildWhitelist(classConfig);
+    }
+
+    /// <summary>
+    /// Levelling is the only thing that changes what a trainer will teach, so every
+    /// "there was nothing here" memory has to let go on a level-up - otherwise a trainer
+    /// written off at level 4 is never revisited at level 6. Checked on read rather than
+    /// driven off Level.Changed, so there is no subscription to unwind.
+    /// </summary>
+    private void ForgetOnLevelUp()
+    {
+        int level = playerReader.Level.Value;
+        if (level <= lastSeenLevel)
+            return;
+
+        if (lastSeenLevel >= 0)
+        {
+            uselessNpcs.Clear();
+            nothingToTrainAtLevel = -1;
+            noTrainerInZone = -1;
+        }
+
+        lastSeenLevel = level;
+    }
+
+    /// <summary>
+    /// Upper bound on what <see cref="TryGetTrainable"/> can write, so a caller can size
+    /// a stack buffer without allocating.
+    /// </summary>
+    public int MaxTrainable => TrainerSpells.MaxCount(whitelist);
+
+    /// <summary>
+    /// True when a visit could actually achieve something. The goal gates on this as
+    /// well as on its profile requirements, because the reasons a visit is pointless -
+    /// no money, every nearby trainer already tried - are session state the requirement
+    /// language cannot see.
+    /// </summary>
+    public bool CanVisit => CanVisitInternal(trainAll: false);
+
+    /// <summary>
+    /// Train-all has no whitelist to reason about - what a trainer sells is only knowable
+    /// once the window is open - so it is gated on the suppressions alone. A profile is
+    /// expected to add its own <c>Money</c> or <c>SecondsSinceTrained</c> requirement.
+    /// </summary>
+    public bool CanVisitAll => CanVisitInternal(trainAll: true);
+
+    private bool CanVisitInternal(bool trainAll)
+    {
+        ForgetOnLevelUp();
+
+        if (MoneySuppressed() || NoTrainerReachable())
+            return false;
+
+        if (!trainAll)
+            return whitelist.Length > 0 &&
+                TrainerSpells.Any(whitelist, spellBookReader, spellDB, playerReader.Level.Value);
+
+        return playerReader.Level.Value > nothingToTrainAtLevel;
+    }
+
+    /// <summary>
+    /// A train-all visit finished without buying anything. Nothing will change until the
+    /// player levels, so stop asking until then.
+    /// </summary>
+    public void OnNothingTrainedAtThisLevel()
+    {
+        int level = playerReader.Level.Value;
+        if (nothingToTrainAtLevel == level)
+            return;
+
+        nothingToTrainAtLevel = level;
+        LogNothingAtLevel(logger, level);
+    }
+
+    public bool TryGetTrainable(Span<int> destination, out int written)
+    {
+        written = TrainerSpells.Collect(whitelist,
+            spellBookReader, spellDB, playerReader.Level.Value, destination, unknownIds);
+
+        // Collect only adds to unknownIds; report each one the first time it shows up.
+        ReportUnknownIds();
+
+        return written > 0;
+    }
+
+    private void ReportUnknownIds()
+    {
+        if (unknownIds.Count == 0 || !logger.IsEnabled(LogLevel.Warning))
+            return;
+
+        foreach (int id in unknownIds)
+            LogUnknownSpell(logger, id);
+
+        // Cleared rather than kept: the set exists to rate-limit the warning, and
+        // Collect refills it on the next call if the ids are still missing.
+        unknownIds.Clear();
+    }
+
+    private bool MoneySuppressed()
+    {
+        if (suppressUntilMoneyAbove < 0)
+            return false;
+
+        if (playerReader.Money.Value > suppressUntilMoneyAbove)
+        {
+            suppressUntilMoneyAbove = -1;
+            return false;
+        }
+
+        return true;
+    }
+
+    private bool NoTrainerReachable()
+    {
+        if (noTrainerInZone < 0)
+            return false;
+
+        if (noTrainerInZone != playerReader.UIMapId.Value)
+        {
+            noTrainerInZone = -1;
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// The search turned up no trainer of this class to walk to. Without this the goal
+    /// stays runnable, gets picked for its low cost, finds nothing again and occupies the
+    /// agent doing nothing - the blacklist cannot cover it, since that only fires once a
+    /// trainer has actually been reached.
+    /// </summary>
+    public void OnNoTrainerFound()
+    {
+        int zone = playerReader.UIMapId.Value;
+        if (noTrainerInZone == zone)
+            return;
+
+        noTrainerInZone = zone;
+        LogNoTrainerInZone(logger, zone);
+    }
+
+    /// <summary>
+    /// The trainer offered something wanted but unaffordable. Stops asking until the
+    /// wallet grows past what it was worth at that moment.
+    /// </summary>
+    public void OnNotEnoughMoney()
+    {
+        suppressUntilMoneyAbove = playerReader.Money.Value;
+        LogNotEnoughMoney(logger, suppressUntilMoneyAbove);
+    }
+
+    /// <summary>
+    /// The trainer had nothing on the whitelist - the wrong class, or a profile listing
+    /// spells it does not teach. Skipped from here on so the search moves to the next.
+    /// </summary>
+    public void OnNothingToTrain(int npcId)
+    {
+        if (npcId != 0 && uselessNpcs.Add(npcId))
+            LogNothingToTrain(logger, npcId);
+    }
+
+    public bool IsUseless(int npcId) => uselessNpcs.Contains(npcId);
+
+    /// <summary>
+    /// Resolves spell ids to their names. Only ids the DB knows are added, so a caller
+    /// matching these against profile KeyAction names cannot be fooled by a stray id.
+    /// </summary>
+    public void CollectNames(ReadOnlySpan<int> ids, ICollection<string> destination)
+    {
+        for (int i = 0; i < ids.Length; i++)
+        {
+            if (spellDB.Spells.TryGetValue(ids[i], out Spell spell) &&
+                !string.IsNullOrEmpty(spell.Name) &&
+                !destination.Contains(spell.Name))
+            {
+                destination.Add(spell.Name);
+            }
+        }
+    }
+
+    /// <summary>
+    /// "Charge(100), Rend rank 2(6546)" - for logs, so a trainer visit says which spells
+    /// it meant rather than a bare count. Allocates, but runs once per visit.
+    /// </summary>
+    public string Describe(ReadOnlySpan<int> ids)
+    {
+        if (ids.Length == 0)
+            return "none";
+
+        StringBuilder sb = new();
+
+        for (int i = 0; i < ids.Length; i++)
+        {
+            if (sb.Length > 0)
+                sb.Append(", ");
+
+            if (spellDB.Spells.TryGetValue(ids[i], out Spell spell))
+                sb.Append(spell.Name).Append('(').Append(ids[i]).Append(')');
+            else
+                sb.Append(ids[i]);
+        }
+
+        return sb.ToString();
+    }
+
+    #region Logging
+
+    [LoggerMessage(
+        EventId = 0310,
+        Level = LogLevel.Warning,
+        Message = "Trainer: spell {SpellId} is not in this client's spells.json - skipped")]
+    static partial void LogUnknownSpell(ILogger logger, int spellId);
+
+    [LoggerMessage(
+        EventId = 0311,
+        Level = LogLevel.Information,
+        Message = "Trainer: cannot afford training, waiting for the purse to rise above {Copper}")]
+    static partial void LogNotEnoughMoney(ILogger logger, int copper);
+
+    [LoggerMessage(
+        EventId = 0312,
+        Level = LogLevel.Information,
+        Message = "Trainer: npc {NpcId} teaches nothing on the whitelist - skipping it from now on")]
+    static partial void LogNothingToTrain(ILogger logger, int npcId);
+
+    [LoggerMessage(
+        EventId = 0313,
+        Level = LogLevel.Information,
+        Message = "Trainer: no reachable trainer of this class in zone {UIMapId} - not asking again until the zone changes")]
+    static partial void LogNoTrainerInZone(ILogger logger, int uiMapId);
+
+    [LoggerMessage(
+        EventId = 0314,
+        Level = LogLevel.Information,
+        Message = "Trainer: nothing left to learn at level {Level} - not asking again until the next level")]
+    static partial void LogNothingAtLevel(ILogger logger, int level);
+
+    #endregion
+}

--- a/Core/GoalsFactory/GoalFactory.cs
+++ b/Core/GoalsFactory/GoalFactory.cs
@@ -39,6 +39,10 @@ public static class GoalFactory
         services.AddScoped<CancellationTokenSource<GoapAgent>>();
         services.AddScoped<IGrindSessionHandler, GrindSessionHandler>();
 
+        // Always on, unlike the bag and coin trackers below: a level-up is one line every
+        // few hours, not the per-item chatter LogBagChanges exists to silence.
+        services.AddScoped<LevelChangeTracker>();
+
         if (classConfig.LogBagChanges)
         {
             services.AddScoped<IBagChangeTracker, BagChangeTracker>();
@@ -87,6 +91,8 @@ public static class GoalFactory
         services.AddScoped<CombatTracker>();
         services.AddScoped<SafeSpotCollector>();
         services.AddScoped<ThreatFinder>();
+        services.AddScoped<TrainerPlanner>();
+        services.AddScoped<ActionBarPopulator>();
 
         var playerReader = sp.GetRequiredService<PlayerReader>();
 

--- a/Core/Level/LevelChangeTracker.cs
+++ b/Core/Level/LevelChangeTracker.cs
@@ -1,0 +1,109 @@
+using Microsoft.Extensions.Logging;
+
+using System;
+
+using static System.Diagnostics.Stopwatch;
+
+namespace Core;
+
+/// <summary>
+/// Announces level-ups the way <see cref="BagChangeTracker"/> and
+/// <see cref="MoneyChangeTracker"/> announce loot and coin, with how long the level took.
+/// <para>
+/// Distinct from <see cref="LevelTracker"/>, which predicts when the next level will
+/// arrive from the XP rate and says nothing when it actually does.
+/// </para>
+/// </summary>
+public sealed partial class LevelChangeTracker : IDisposable
+{
+    private readonly ILogger<LevelChangeTracker> logger;
+    private readonly PlayerReader playerReader;
+
+    // The addon reports the current level, so the first change is the opening value
+    // rather than a ding - announcing it would claim a level-up that never happened.
+    // Same reason MoneyChangeTracker primes before reporting a delta.
+    private bool primed;
+    private int previous;
+    private long levelStartTime;
+
+    public LevelChangeTracker(ILogger<LevelChangeTracker> logger,
+        PlayerReader playerReader)
+    {
+        this.logger = logger;
+        this.playerReader = playerReader;
+
+        levelStartTime = GetTimestamp();
+
+        playerReader.Level.Changed += Level_Changed;
+    }
+
+    public void Dispose()
+    {
+        playerReader.Level.Changed -= Level_Changed;
+    }
+
+    private void Level_Changed()
+    {
+        int current = playerReader.Level.Value;
+
+        if (!primed)
+        {
+            primed = true;
+            previous = current;
+            levelStartTime = GetTimestamp();
+            return;
+        }
+
+        int from = previous;
+        previous = current;
+
+        TimeSpan elapsed = GetElapsedTime(levelStartTime);
+        levelStartTime = GetTimestamp();
+
+        // A level can go down - a death on a Hardcore-style server, or the bot attaching
+        // to a different character - so this reports the direction rather than assuming.
+        if (current <= from)
+        {
+            LogLevelChanged(logger, from, current);
+            return;
+        }
+
+        // Local, not an inline argument: CA1873 does not track the guard for
+        // source-generated log methods, only local variable access.
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            string took = FormatElapsed(elapsed);
+            LogLevelUp(logger, from, current, took);
+        }
+    }
+
+    /// <summary>
+    /// "1h 04m 12s", trimmed to the units that carry a value.
+    /// </summary>
+    private static string FormatElapsed(TimeSpan span)
+    {
+        if (span.TotalHours >= 1)
+            return $"{(int)span.TotalHours}h {span.Minutes:00}m {span.Seconds:00}s";
+
+        if (span.TotalMinutes >= 1)
+            return $"{span.Minutes}m {span.Seconds:00}s";
+
+        return $"{span.Seconds}s";
+    }
+
+    #region Logging
+
+    [LoggerMessage(
+        EventId = 1997,
+        Level = LogLevel.Information,
+        Message = "Level {from} -> {to}, took {elapsed}")]
+    static partial void LogLevelUp(ILogger logger, int from, int to, string elapsed);
+
+    [LoggerMessage(
+        EventId = 1998,
+        Level = LogLevel.Warning,
+        Message = "Level changed {from} -> {to}")]
+    static partial void LogLevelChanged(ILogger logger, int from, int to);
+
+    #endregion
+}

--- a/Core/Money/Coin.cs
+++ b/Core/Money/Coin.cs
@@ -1,0 +1,50 @@
+using System.Text;
+
+namespace Core;
+
+/// <summary>
+/// Renders a copper amount the way the game quotes it - <c>4g 50s 10c</c>.
+/// </summary>
+public static class Coin
+{
+    public const int COPPER_PER_GOLD = 10000;
+    public const int COPPER_PER_SILVER = 100;
+
+    // The purse is capped by int copper, so the longest possible string is
+    // "214748g 36s 47c" - 15 chars. Rounded up to leave the builder room rather
+    // than have it grow on the one value that sits right on the boundary.
+    private const int MAX_FORMATTED_LENGTH = 32;
+
+    /// <summary>
+    /// Only the units that carry a value, so a clean gold drop reads "2g"
+    /// rather than "2g 0s 0c". Zero is "0c" rather than an empty string.
+    /// </summary>
+    public static string Format(int copper)
+    {
+        if (copper == 0)
+            return "0c";
+
+        StringBuilder sb = new(MAX_FORMATTED_LENGTH);
+
+        Append(sb, copper / COPPER_PER_GOLD, 'g');
+        Append(sb, copper / COPPER_PER_SILVER % COPPER_PER_SILVER, 's');
+        Append(sb, copper % COPPER_PER_SILVER, 'c');
+
+        return sb.ToString();
+
+        static void Append(StringBuilder sb, int value, char unit)
+        {
+            if (value == 0)
+            {
+                return;
+            }
+
+            if (sb.Length > 0)
+            {
+                sb.Append(' ');
+            }
+
+            sb.Append(value).Append(unit);
+        }
+    }
+}

--- a/Core/Money/MoneyChangeTracker.cs
+++ b/Core/Money/MoneyChangeTracker.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.Logging;
 
 using System;
-using System.Text;
 
 namespace Core;
 
@@ -16,14 +15,6 @@ public sealed class NoMoneyChangeTracker : IMoneyChangeTracker { }
 /// </summary>
 public sealed partial class MoneyChangeTracker : IDisposable, IMoneyChangeTracker
 {
-    private const int COPPER_PER_GOLD = 10000;
-    private const int COPPER_PER_SILVER = 100;
-
-    // The purse is capped by int copper, so the longest possible string is
-    // "214748g 36s 47c" - 15 chars. Rounded up to leave the builder room rather
-    // than have it grow on the one value that sits right on the boundary.
-    private const int MAX_FORMATTED_LENGTH = 32;
-
     private readonly ILogger<MoneyChangeTracker> logger;
     private readonly PlayerReader playerReader;
 
@@ -72,39 +63,9 @@ public sealed partial class MoneyChangeTracker : IDisposable, IMoneyChangeTracke
         // Locals, not inline arguments: CA1873 does not track the guard above
         // for source-generated log methods, only local variable access.
         char sign = delta > 0 ? '+' : '-';
-        string amount = Format(Math.Abs(delta));
+        string amount = Coin.Format(Math.Abs(delta));
 
         LogMoneyChange(logger, sign, amount);
-    }
-
-    /// <summary>
-    /// Only the units that carry a value, so a clean gold drop reads "2g"
-    /// rather than "2g 0s 0c".
-    /// </summary>
-    private static string Format(int copper)
-    {
-        StringBuilder sb = new(MAX_FORMATTED_LENGTH);
-
-        Append(sb, copper / COPPER_PER_GOLD, 'g');
-        Append(sb, copper / COPPER_PER_SILVER % COPPER_PER_SILVER, 's');
-        Append(sb, copper % COPPER_PER_SILVER, 'c');
-
-        return sb.ToString();
-
-        static void Append(StringBuilder sb, int value, char unit)
-        {
-            if (value == 0)
-            {
-                return;
-            }
-
-            if (sb.Length > 0)
-            {
-                sb.Append(' ');
-            }
-
-            sb.Append(value).Append(unit);
-        }
     }
 
     #region Logging

--- a/Core/Requirement/RequirementFactory.cs
+++ b/Core/Requirement/RequirementFactory.cs
@@ -104,6 +104,13 @@ public sealed partial class RequirementFactory
         corpseTracker = sp.GetRequiredService<CorpseTracker>();
         TotemDetector totemDetector = sp.GetRequiredService<TotemDetector>();
 
+        // Built here rather than taken from TrainerPlanner: the planner is a session
+        // scoped goal component and this factory runs from the root provider while the
+        // profile is still loading, before that scope exists. Both read the same rule
+        // out of TrainerSpells, so they cannot drift.
+        int[][] trainWhitelist = TrainerSpells.BuildWhitelist(classConfig);
+        SpellDB spellDB = sp.GetRequiredService<SpellDB>();
+
         var playerBuff = sp.GetRequiredService<AuraTimeReader<IPlayerBuffTimeReader>>();
         var playerDebuff = sp.GetRequiredService<AuraTimeReader<IPlayerDebuffTimeReader>>();
         var targetDebuff = sp.GetRequiredService<AuraTimeReader<ITargetDebuffTimeReader>>();
@@ -174,6 +181,13 @@ public sealed partial class RequirementFactory
             { "BagGreyItem", bagReader.AnyGreyItem },
             { "HasRangedWeapon", equipmentReader.RangedWeapon },
             { "HasAmmo", bits.Ammo },
+
+            // Class trainer - false once there is nothing left to learn, so a
+            // ClassTrainer NPC entry stops asking. The goal additionally declines to
+            // run when a visit would be pointless for a reason only it can see, such
+            // as not affording the price the trainer quoted.
+            { "HasTrainableSpell", () => TrainerSpells.Any(
+                trainWhitelist, spellBookReader, spellDB, playerReader.Level.Value) },
 
             { "Casting", playerReader.IsCasting },
             { "HasTarget", bits.Target },
@@ -269,9 +283,21 @@ public sealed partial class RequirementFactory
             { "SessionMinutes", sessionStat._Minutes },
             { "SessionHours", sessionStat._Hours },
 
+            // NPC visit history. Elapsed seconds rather than another "recently" flag, so
+            // a profile picks its own window and nothing has to clear anything.
+            // int.MaxValue until the event happens, so a "has it been a while" test is
+            // true from the start.
+            { "SecondsSinceVendored", sessionStat._SecondsSinceVendored },
+            { "SecondsSinceTrained", sessionStat._SecondsSinceTrained },
+            { "SpellsTrained", sessionStat._SpellsTrained },
+
             { "Level", playerReader.Level._Value },
             { "ExpPerc", playerReader._PlayerXpPercent },
             { "UIMapId", playerReader.UIMapId._Value },
+
+            // Copper, the unit every cost in the game is quoted in.
+            { "Money", playerReader.Money._Value },
+            { "Gold", () => playerReader.Money.Value / 10000 },
 
             { "SpellQueueWindow", playerReader._SpellQueueTimeMs },
             { "-SpellQueueWindow", playerReader._SpellQueueTimeMsNegative },

--- a/Core/Session/SessionStats/SessionStat.cs
+++ b/Core/Session/SessionStats/SessionStat.cs
@@ -19,6 +19,23 @@ public sealed class SessionStat
     /// </summary>
     public bool VendoredOrRepairedRecently { get; set; }
 
+    /// <summary>
+    /// When the last successful vendor/repair and class trainer visit happened, and how
+    /// many spells have been learnt this session.
+    /// <para>
+    /// Exposed as elapsed seconds rather than as another "recently" flag on purpose: a
+    /// flag needs someone to clear it - <see cref="VendoredOrRepairedRecently"/> latches
+    /// true until MailGoal happens to run - whereas elapsed time answers both "did this
+    /// just happen" and "has it been a while" without any handshake, and needs no reset.
+    /// A profile composes whatever window it wants.
+    /// </para>
+    /// </summary>
+    public long LastVendoredTime { get; set; }
+
+    public long LastTrainedTime { get; set; }
+
+    public int SpellsTrained { get; set; }
+
     public int _Deaths() => Deaths;
 
     public int _Kills() => Kills;
@@ -37,11 +54,45 @@ public sealed class SessionStat
 
     public bool _VendoredOrRepairedRecently() => VendoredOrRepairedRecently;
 
+    /// <summary>
+    /// Seconds since the event, or <see cref="int.MaxValue"/> when it has not happened
+    /// this session - so "it has been a while" reads true before the first one, which is
+    /// what a profile gating on a cooldown wants.
+    /// </summary>
+    private static int SecondsSince(long timestamp) =>
+        timestamp == 0 ? int.MaxValue : (int)GetElapsedTime(timestamp).TotalSeconds;
+
+    public int SecondsSinceVendored => SecondsSince(LastVendoredTime);
+
+    public int _SecondsSinceVendored() => SecondsSinceVendored;
+
+    public int SecondsSinceTrained => SecondsSince(LastTrainedTime);
+
+    public int _SecondsSinceTrained() => SecondsSinceTrained;
+
+    public int _SpellsTrained() => SpellsTrained;
+
+    public void OnVendored()
+    {
+        VendoredOrRepairedRecently = true;
+        LastVendoredTime = GetTimestamp();
+    }
+
+    public void OnTrained(int spellCount)
+    {
+        SpellsTrained += spellCount;
+        LastTrainedTime = GetTimestamp();
+    }
+
     public void Reset()
     {
         Deaths = 0;
         Kills = 0;
         VendoredOrRepairedRecently = false;
+
+        LastVendoredTime = 0;
+        LastTrainedTime = 0;
+        SpellsTrained = 0;
     }
 
     public void Start()

--- a/Core/Trainer/TrainerReader.cs
+++ b/Core/Trainer/TrainerReader.cs
@@ -1,0 +1,119 @@
+using System.Collections.Generic;
+
+namespace Core;
+
+/// <summary>
+/// Decodes what the addon's Trainer.lua reports after a class trainer visit.
+/// <para>
+/// A visit always ends with a batch header and the ids that were bought, even when that
+/// is none - the header is the only completion signal, so a goal waiting on it cannot
+/// hang on a trainer that had nothing to sell. The reason sentinels arrive first and say
+/// why the batch is empty.
+/// </para>
+/// </summary>
+public sealed class TrainerReader : IReader
+{
+    private const int cTrainer = 115;
+
+    // Both sit above any spell id and below QUEUE_COUNT_MARKER, and are only ever read
+    // on this cell - the binding queue's encoding does span this range, on its own cell.
+    private const int TRAINER_NO_MATCH = 16_776_001;
+    private const int TRAINER_NO_MONEY = 16_776_002;
+
+    private readonly List<int> pending = [];
+    private readonly List<int> bought = [];
+
+    private int expectedCount = -1;
+    private int receivedCount;
+
+    /// <summary>Spell ids bought during the last completed visit.</summary>
+    public IReadOnlyList<int> Bought => bought;
+
+    /// <summary>The trainer offered nothing on the whitelist.</summary>
+    public bool NoMatch { get; private set; }
+
+    /// <summary>A whitelisted service was offered but could not be afforded.</summary>
+    public bool NoMoney { get; private set; }
+
+    /// <summary>A batch arrived, so the visit is over however it went.</summary>
+    public bool Completed { get; private set; }
+
+    public void Update(IAddonDataProvider reader)
+    {
+        int value = reader.GetInt(cTrainer);
+        if (value == 0)
+            return;
+
+        if (value == TRAINER_NO_MATCH)
+        {
+            NoMatch = true;
+            return;
+        }
+
+        if (value == TRAINER_NO_MONEY)
+        {
+            NoMoney = true;
+            return;
+        }
+
+        if (value >= AddonTicks.QUEUE_COUNT_MARKER)
+        {
+            expectedCount = value - AddonTicks.QUEUE_COUNT_MARKER;
+            receivedCount = 0;
+            pending.Clear();
+
+            // Bought nothing: the header is the whole batch.
+            if (expectedCount == 0)
+                Commit();
+
+            return;
+        }
+
+        // A stray id with no header in front of it - a value left over from before a
+        // Reset, or the tail of a batch whose header was missed. Either way it belongs
+        // to no visit.
+        if (expectedCount < 0)
+            return;
+
+        // The same value can be captured on two consecutive frames; counting it twice
+        // would satisfy the header early and drop the ids that had not arrived yet.
+        if (pending.Contains(value))
+            return;
+
+        receivedCount++;
+        pending.Add(value);
+
+        if (receivedCount >= expectedCount)
+            Commit();
+    }
+
+    /// <summary>
+    /// Swaps the staged batch in. An incomplete one - a dropped frame, a reload
+    /// mid-visit - simply never commits and <see cref="Completed"/> stays false.
+    /// </summary>
+    private void Commit()
+    {
+        bought.Clear();
+        bought.AddRange(pending);
+
+        expectedCount = -1;
+        receivedCount = 0;
+        Completed = true;
+    }
+
+    /// <summary>
+    /// Called before a visit so the previous one's verdict cannot be mistaken for it.
+    /// </summary>
+    public void Reset()
+    {
+        pending.Clear();
+        bought.Clear();
+
+        expectedCount = -1;
+        receivedCount = 0;
+
+        NoMatch = false;
+        NoMoney = false;
+        Completed = false;
+    }
+}

--- a/Core/Trainer/TrainerSpells.cs
+++ b/Core/Trainer/TrainerSpells.cs
@@ -1,0 +1,153 @@
+using Core.Database;
+
+using SharedLib;
+
+using System;
+using System.Collections.Generic;
+
+namespace Core;
+
+/// <summary>
+/// Which whitelisted spells the player is eligible to learn. Pure - no session state.
+/// <para>
+/// Lives apart from <see cref="TrainerPlanner"/> because the two callers cannot share an
+/// instance: <see cref="RequirementFactory"/> is built from the root provider while the
+/// profile is still loading, and the planner is a session-scoped goal component that
+/// does not exist yet at that point.
+/// </para>
+/// </summary>
+public static class TrainerSpells
+{
+    /// <summary>
+    /// Every <c>IntVariables</c> key with this prefix is a training whitelist, its array
+    /// being that spell's ranks in ascending order.
+    /// </summary>
+    public const string VAR_PREFIX = "SPELL_";
+
+    public static int[][] BuildWhitelist(ClassConfiguration classConfig)
+    {
+        List<int[]> lists = [];
+
+        foreach ((string key, int[] ids) in classConfig.IntVariables)
+        {
+            if (key.StartsWith(VAR_PREFIX, StringComparison.OrdinalIgnoreCase))
+                lists.Add(ids);
+        }
+
+        return [.. lists];
+    }
+
+    public static int MaxCount(int[][] whitelist)
+    {
+        int total = 0;
+        for (int i = 0; i < whitelist.Length; i++)
+            total += whitelist[i].Length;
+
+        return total;
+    }
+
+    /// <summary>
+    /// Never true before <see cref="SpellBookReader.AllRanksReceived"/>: until the lower
+    /// ranks land the spellbook cannot say which rank is owned, and every rank below the
+    /// highest known one would look unlearnt.
+    /// </summary>
+    public static bool Any(int[][] whitelist,
+        SpellBookReader spellBookReader, SpellDB spellDB, int playerLevel)
+    {
+        if (!spellBookReader.AllRanksReceived)
+            return false;
+
+        for (int i = 0; i < whitelist.Length; i++)
+        {
+            int[] ids = whitelist[i];
+            for (int j = 0; j < ids.Length; j++)
+            {
+                if (IsTrainable(ids[j], spellBookReader, spellDB, playerLevel, out _))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static int Collect(int[][] whitelist,
+        SpellBookReader spellBookReader, SpellDB spellDB, int playerLevel,
+        Span<int> destination, ICollection<int>? unknownIds = null)
+    {
+        int written = 0;
+
+        if (!spellBookReader.AllRanksReceived)
+            return written;
+
+        for (int i = 0; i < whitelist.Length; i++)
+        {
+            int[] ids = whitelist[i];
+            for (int j = 0; j < ids.Length; j++)
+            {
+                if (written >= destination.Length)
+                    return written;
+
+                if (IsTrainable(ids[j], spellBookReader, spellDB, playerLevel, out bool missing))
+                    destination[written++] = ids[j];
+                else if (missing)
+                    unknownIds?.Add(ids[j]);
+            }
+        }
+
+        return written;
+    }
+
+    /// <summary>
+    /// Where one whitelisted rank stands. Shared by the bot and the UI so the page
+    /// cannot disagree with what the bot will actually do.
+    /// </summary>
+    public static TrainableState GetState(int id,
+        SpellBookReader spellBookReader, SpellDB spellDB, int playerLevel,
+        out Spell spell)
+    {
+        // Rank exact, not the name-matching Has(): every rank of a spell shares a name,
+        // so Has() answers true for rank 1 the moment rank 7 is known.
+        bool known = spellBookReader.HasExact(id);
+
+        if (!spellDB.Spells.TryGetValue(id, out spell))
+        {
+            // A profile written for a later client than the one running.
+            return known ? TrainableState.Known : TrainableState.NotInThisClient;
+        }
+
+        if (known)
+            return TrainableState.Known;
+
+        // A level of 0 means the DBC carries no requirement on that row - several
+        // duplicate rows per spell name look like this - so it cannot gate anything.
+        return spell.Level == 0 || spell.Level <= playerLevel
+            ? TrainableState.Trainable
+            : TrainableState.LevelLocked;
+    }
+
+    private static bool IsTrainable(int id,
+        SpellBookReader spellBookReader, SpellDB spellDB, int playerLevel,
+        out bool missingFromDB)
+    {
+        TrainableState state = GetState(id, spellBookReader, spellDB, playerLevel, out _);
+
+        missingFromDB = state == TrainableState.NotInThisClient;
+
+        return state == TrainableState.Trainable;
+    }
+}
+
+public enum TrainableState
+{
+    /// <summary>Already in the spellbook at this exact rank.</summary>
+    Known,
+
+    /// <summary>Not known, and the player is high enough level to learn it.</summary>
+    Trainable,
+
+    /// <summary>Not known, but the player is below the level the spell requires.</summary>
+    LevelLocked,
+
+    /// <summary>The running client's spells.json has no such id.</summary>
+    NotInThisClient
+}

--- a/Frontend/Pages/SpellBookComponent.razor
+++ b/Frontend/Pages/SpellBookComponent.razor
@@ -8,6 +8,9 @@
 @inject IconDB iconDB
 @inject WApi api
 @inject IAddonReader addonReader
+@inject IBotController botController
+@inject PlayerReader playerReader
+@inject SpellDB spellDB
 
 @implements IDisposable
 
@@ -172,6 +175,125 @@
     </div>
 </div>
 
+@* ===================== Class Trainer (whitelist progress) ===================== *@
+<div class="card mt-3">
+    <div class="card-header d-flex justify-content-between align-items-center">
+        <span>Class Trainer (@trainableCount ready to learn)</span>
+        <div class="d-flex align-items-center">
+            <div class="form-check form-switch me-3 mb-0">
+                <input class="form-check-input" type="checkbox" role="switch"
+                       id="trainerShowAll" @bind="showAllRanks" />
+                <label class="form-check-label" for="trainerShowAll" style="font-size: 0.85rem;">
+                    Show all ranks
+                </label>
+            </div>
+            <span class="badge bg-success me-1">@trainableCount Trainable</span>
+            <span class="badge bg-secondary me-1">@knownCount Known</span>
+            <span class="badge bg-dark me-1">@lockedCount Level locked</span>
+        </div>
+    </div>
+    <div class="card-body p-0">
+        @if (trainerGroups.Count == 0)
+        {
+            <div class="p-3 text-muted">
+                No <code>SPELL_</code> prefixed entries in the loaded profile's <code>IntVariables</code>,
+                so there is no class trainer whitelist.
+                <br />
+                <small>Every <code>IntVariables</code> key starting with <code>SPELL_</code> is treated as a
+                whitelist, its array being that spell's ranks in ascending order.</small>
+            </div>
+        }
+        else
+        {
+            @if (!spellBookReader.AllRanksReceived)
+            {
+                <div class="p-2 text-muted border-bottom">
+                    <small>Waiting for the addon to send the lower spell ranks — until then a rank you
+                    already own can still show as trainable.</small>
+                </div>
+            }
+            @if (visibleGroups.Count == 0)
+            {
+                <div class="p-3 text-muted">
+                    Nothing to learn right now — every whitelisted rank is either already known or
+                    above your level. Flip <em>Show all ranks</em> to see the full whitelist.
+                </div>
+            }
+            else
+            {
+            <div class="table-responsive">
+                <table class="table table-sm table-striped table-hover mb-0">
+                    <thead class="sticky-top bg-dark">
+                        <tr>
+                            <th style="width: 40px;"></th>
+                            <th>Spell</th>
+                            <th style="width: 200px;">Variable</th>
+                            <th style="width: 80px;">Req. Level</th>
+                            <th style="width: 80px;">Spell ID</th>
+                            <th style="width: 130px;">Status</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (TrainerGroup group in visibleGroups)
+                        {
+                            @foreach (TrainerEntry entry in VisibleEntries(group))
+                            {
+                                <tr>
+                                    <td class="align-middle">
+                                        @if (!string.IsNullOrEmpty(entry.IconUrl))
+                                        {
+                                            <img src="@entry.IconUrl" alt="@entry.Name"
+                                                 style="width: 24px; height: 24px; border-radius: 4px;" />
+                                        }
+                                        else
+                                        {
+                                            <div style="width: 24px; height: 24px; background: #333; border-radius: 4px;"></div>
+                                        }
+                                    </td>
+                                    <td class="align-middle">
+                                        <a href="@($"{api.SpellId}{entry.SpellId}")"
+                                           target="_blank"
+                                           data-wowhead="spell=@entry.SpellId"
+                                           style="text-decoration: none;">
+                                            @entry.Name
+                                        </a>
+                                    </td>
+                                    <td class="align-middle text-muted" style="font-size: 0.8rem;">@group.Variable</td>
+                                    <td class="align-middle text-muted">
+                                        @(entry.RequiredLevel > 0 ? entry.RequiredLevel.ToString() : "—")
+                                    </td>
+                                    <td class="align-middle text-muted">@entry.SpellId</td>
+                                    <td class="align-middle">
+                                        @switch (entry.State)
+                                        {
+                                            case TrainableState.Trainable:
+                                                <span class="badge bg-success">Trainable</span>
+                                                break;
+                                            case TrainableState.Known:
+                                                <span class="badge bg-secondary">Known</span>
+                                                break;
+                                            case TrainableState.LevelLocked:
+                                                <span class="badge bg-dark">Level @entry.RequiredLevel</span>
+                                                break;
+                                            default:
+                                                <span class="badge bg-warning text-dark"
+                                                      title="This id is not in the running client's spells.json">
+                                                    Not in client
+                                                </span>
+                                                break;
+                                        }
+                                    </td>
+                                </tr>
+                            }
+                        }
+                    </tbody>
+                </table>
+            </div>
+            }
+        }
+    </div>
+</div>
+
 @code {
     private const int totalSlots = ActionBar.CELL_COUNT * ActionBar.BIT_PER_CELL;
 
@@ -189,6 +311,32 @@
     private List<SpellDisplayEntry> cachedSpells = [];
     private int lastSpellbookHash;
 
+    // ---------- Class trainer ----------
+    private record TrainerEntry(int SpellId, string Name, int RequiredLevel,
+        TrainableState State, string? IconUrl);
+
+    private record TrainerGroup(string Variable, List<TrainerEntry> Entries);
+
+    private List<TrainerGroup> trainerGroups = [];
+    private int trainableCount;
+    private int knownCount;
+    private int lockedCount;
+    private int lastTrainerLevel = -1;
+
+    // Default to the actionable view - the whole whitelist is mostly ranks that are
+    // already known or many levels away. The badges still report the full totals.
+    private bool showAllRanks;
+
+    private IEnumerable<TrainerEntry> VisibleEntries(TrainerGroup group) =>
+        showAllRanks
+            ? group.Entries
+            : group.Entries.Where(e => e.State == TrainableState.Trainable);
+
+    private List<TrainerGroup> visibleGroups =>
+        showAllRanks
+            ? trainerGroups
+            : trainerGroups.Where(g => VisibleEntries(g).Any()).ToList();
+
     protected override void OnInitialized()
     {
         addonReader.AddonDataChanged += OnAddonDataChanged;
@@ -196,6 +344,7 @@
 
         RebuildActionBar();
         RebuildSpellbook();
+        RebuildTrainer();
     }
 
     public void Dispose()
@@ -211,13 +360,22 @@
             int beforePopulated = populatedCount;
             int beforeCastbar = castbarCount;
             int beforeSpellHash = lastSpellbookHash;
+            int beforeTrainable = trainableCount;
 
             RebuildActionBar();
             RebuildSpellbook();
 
+            // Levelling changes what is trainable without touching the spellbook hash.
+            if (beforeSpellHash != lastSpellbookHash
+                || lastTrainerLevel != playerReader.Level.Value)
+            {
+                RebuildTrainer();
+            }
+
             if (beforePopulated != populatedCount
                 || beforeCastbar != castbarCount
-                || beforeSpellHash != lastSpellbookHash)
+                || beforeSpellHash != lastSpellbookHash
+                || beforeTrainable != trainableCount)
             {
                 StateHasChanged();
             }
@@ -351,6 +509,62 @@
         }
 
         return lookup;
+    }
+
+    // -------------------------------------------------------------
+    //  Class trainer: one row per whitelisted rank, with the same
+    //  verdict the bot uses - both go through TrainerSpells, so the
+    //  page cannot claim something the trainer goal disagrees with.
+    // -------------------------------------------------------------
+    private void RebuildTrainer()
+    {
+        trainerGroups = [];
+        trainableCount = 0;
+        knownCount = 0;
+        lockedCount = 0;
+
+        int playerLevel = playerReader.Level.Value;
+        lastTrainerLevel = playerLevel;
+
+        ClassConfiguration? classConfig = botController.ClassConfig;
+        if (classConfig is null)
+            return;
+
+        foreach ((string variable, int[] ids) in classConfig.IntVariables)
+        {
+            if (!variable.StartsWith(TrainerSpells.VAR_PREFIX, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            List<TrainerEntry> entries = new(ids.Length);
+
+            foreach (int id in ids)
+            {
+                TrainableState state = TrainerSpells.GetState(
+                    id, spellBookReader, spellDB, playerLevel, out Spell spell);
+
+                switch (state)
+                {
+                    case TrainableState.Trainable: trainableCount++; break;
+                    case TrainableState.Known: knownCount++; break;
+                    case TrainableState.LevelLocked: lockedCount++; break;
+                }
+
+                string name = string.IsNullOrEmpty(spell.Name) ? $"#{id}" : spell.Name;
+
+                entries.Add(new TrainerEntry(
+                    id, name, spell.Level, state, iconDB.GetIconUrlForSpell(id, 18)));
+            }
+
+            if (entries.Count > 0)
+                trainerGroups.Add(new TrainerGroup(variable, entries));
+        }
+
+        // Anything with something to learn first, then alphabetically, so the
+        // actionable rows are at the top rather than buried among learnt ranks.
+        trainerGroups = trainerGroups
+            .OrderByDescending(g => g.Entries.Any(e => e.State == TrainableState.Trainable))
+            .ThenBy(g => g.Variable)
+            .ToList();
     }
 
     private static string GetBaseSpellName(string name)

--- a/README.md
+++ b/README.md
@@ -1256,6 +1256,7 @@ Can specify conditions with [Requirement(s)](#requirement) in order to create a 
 | `"ResetOnNewTarget"` | Reset the Cooldown if the target changes | `false` |
 | `"Log"` | Related events should appear in the logs | `true` |
 | `"UseMount"` | Should use mount ? <br/>Limited to [AdhocNpcGoals](#npc-goals) such as `Repair`, `Sell`, `Vendor` routes. | `false` |
+| `"TrainAll"` | Buy every spell the trainer offers and can be afforded, instead of only the ones whitelisted via `SPELL_` variables. <br/>Limited to [`ClassTrainer`](#class-trainer) NPC entries. **Do not pair with the `HasTrainableSpell` requirement** - see [Class Trainer](#class-trainer). | `false` |
 | --- | Before keypress cast, ... | --- |
 | `"BeforeCastFaceTarget"` | Attempt to look directly at target.<br>**Note**: it may not work for every scenario. | `false` |
 | `"BeforeCastDelay"` | Delay in milliseconds. | `0` |
@@ -1994,6 +1995,139 @@ examples of full automatic npc detection or multiple whitelisted names:
 }
 ```
 
+#### Class Trainer
+
+A `ClassTrainer` entry walks to the trainer and **learns spells**, instead of opening a
+merchant window.
+
+There is no new syntax for saying which spells to learn. Every `IntVariables` key whose
+name starts with `SPELL_` is the whitelist, and its array is that spell's **ranks in
+ascending order** - the same arrays a profile already writes for `Spell:` requirements:
+
+```json
+"IntVariables": {
+    "SPELL_CHARGE": [100, 6178, 11578],       // Charge rank 1, 2, 3
+    "SPELL_REND":   [772, 6546, 6547],        // Rend rank 1, 2, 3
+    "SPELL_BLOODRAGE": 2687,                  // a single rank is fine too
+    "WAIT_CHARGE_MS": 4000                    // ignored, no SPELL_ prefix
+},
+"NPC": {
+    "Sequence": [
+        {
+            "Cost": 5,
+            "Name": "ClassTrainer",
+            "Requirements": [
+                "HasTrainableSpell",
+                "Money > 100"
+            ]
+        }
+    ]
+}
+```
+
+##### Two modes: whitelist, or `TrainAll`
+
+The whitelist above is the default. `"TrainAll": true` on the entry instead buys
+**everything the trainer offers that you can afford**, ignoring `SPELL_` entirely:
+
+```json
+{ "Cost": 5, "Name": "ClassTrainer", "TrainAll": true, "Requirements": ["Money > 5000"] }
+```
+
+|  | whitelist *(default)* | `"TrainAll": true` |
+| --- | --- | --- |
+| What it buys | only ids listed in `SPELL_*` `IntVariables` | everything offered and affordable |
+| Who decides | the bot, before setting off | the trainer's own list, on arrival |
+| Gate to use | `HasTrainableSpell` | `Money` and/or `SecondsSinceTrained` |
+| Goes quiet when | nothing whitelisted is learnable | a visit buys nothing, until you next level |
+| Best for | a curated levelling profile | "just teach me everything" |
+
+> **Do not combine `TrainAll` with `HasTrainableSpell`.** That requirement only reads the
+> `SPELL_` whitelist, so both gates have to pass and the trip stays locked to whitelist
+> eligibility. Once those spells are all known it turns false permanently and the trainer
+> is never visited again - even though `TrainAll` would happily have bought everything
+> else. Gate `TrainAll` on `Money` and a cooldown instead.
+
+`TrainAll` cannot use `HasTrainableSpell` because what a trainer sells is only knowable
+once its window is open - there is nothing to check beforehand. That is also why it needs
+its own stopping rule: after a visit that buys nothing it goes quiet until your next
+level-up, since levelling is the only thing that changes what is on offer.
+
+In the log a `TrainAll` visit reads `offering 0 spell(s) to learn - everything offered`.
+The zero is expected: no id list is sent, the addon does the choosing. It reports back
+what it actually bought, so `Trained N spell(s)` and the action bar placement still name
+real spells.
+
+One limitation: to report a purchase the addon has to resolve the service to a spell id,
+which it does through the tooltip. A service whose id will not resolve is **skipped
+rather than bought**, so the bot never claims a purchase it cannot account for. If a
+trainer visibly has spells but nothing is bought, that is the case to suspect.
+
+How it decides *(whitelist mode)*:
+* Only **your own class's** trainer is considered. `ClassTrainer` is a single NPC flag
+  shared by every class, so the search additionally requires the NPC's subtitle to name
+  your class - a Warrior goes to a "Warrior Trainer" and never to the Mage one standing
+  next to it. *(Death Knight and Demon Hunter are not wired up for this yet.)*
+* A spell is **trainable** when the player does not know that exact rank and is at or
+  above the level the spell requires. Both come from data the bot already has - the
+  in-game spellbook and `Json/dbc/<client>/spells.json`.
+* At the trainer, the addon matches the whitelist against what that trainer actually
+  offers, checks each price against your purse, and buys what it can afford - cheapest
+  rank first, since lower ranks are prerequisites for higher ones.
+* `HasTrainableSpell` turns false once there is nothing left to learn, which is what
+  stops the bot walking back. **Include it in the requirements** or the entry will keep
+  firing.
+
+**Gating it further.** `HasTrainableSpell` on its own is usually enough - it is true
+exactly while something is learnable, goes false once it is learnt, and becomes true
+again on the level-up that unlocks the next rank. The bot also stops asking by itself
+when a trainer quotes a price it cannot pay, and when no trainer of your class is
+reachable in the zone.
+
+If you want more control, prefer facts that **do not decay while the bot walks**:
+
+```json
+// only bother when there is plausibly enough coin
+{ "Name": "ClassTrainer", "Requirements": ["HasTrainableSpell", "Money > 1000"] }
+
+// at most one trainer trip every ten minutes
+{ "Name": "ClassTrainer", "Requirements": ["HasTrainableSpell", "SecondsSinceTrained > 600"] }
+```
+
+> **A requirement is re-checked while the goal runs, not just when it starts.** A
+> narrowing window such as `SecondsSinceVendored < 120` therefore expires *during* the
+> walk to the trainer: the goal is dropped part-way and, since that number only grows,
+> it never re-opens until the next vendor trip. Use a widening test
+> (`SecondsSinceTrained > 600`) or a state one (`Money > 1000`) for anything the bot has
+> to travel for. `SecondsSinceVendored` is fine for a check made on the spot.
+
+Likewise `SpellsTrained == 0` means "once per bot run", which is not what a levelling
+profile wants - a 1-10 profile trains repeatedly as it levels. It is there for
+reporting, not for gating.
+
+`VendoredOrRepairedRecently` is a different thing again: a flag latched by a vendor
+visit and cleared only by a successful **mail** run, so without mail enabled it stays
+true forever after the first sale.
+
+Notes:
+* Ids the running client does not have are skipped with a warning, so a profile shared
+  between expansions does not break - e.g. `Victory Rush` does not exist in Classic Era.
+* If the trainer teaches nothing on the whitelist (wrong class, or a profile listing
+  spells it does not sell) that NPC is skipped from then on and the search moves to the
+  next one.
+* If a wanted spell is offered but unaffordable, the entry goes quiet until the wallet
+  grows, rather than walking back and forth.
+* The NPC search obeys [`CrossZoneSearch`](#classconfiguration) like every other NPC
+  entry, so by default only trainers in the **current zone** are considered. If none is
+  found there, the entry goes quiet until you move to another zone - otherwise it would
+  keep being chosen and keep finding nothing, since `HasTrainableSpell` can stay true
+  for a whole zone's worth of levels.
+* **Mists of Pandaria (5.4.8) grants class spells on level up** and its trainers do not
+  sell them, so a `ClassTrainer` entry has nothing to do there. It reports "teaches
+  nothing" and stops rather than failing.
+
+---
+
 #### Safe Path Transitions
 
 **Problem:** When bags are full or repairs are needed, the bot immediately abandons the grind path and uses pathfinding to navigate directly to the vendor path start. This direct route may pass through dangerous mob-dense areas, which is especially risky for Hardcore players.
@@ -2267,6 +2401,11 @@ Arithmetic operators can be used to build complex expressions:
 | `SessionMinutes` | Returns with the elapsed time in Minutes since the Session started.<br>The Session starts when the `Start Bot` button is pressed! |
 | `SessionHours` | Returns with the elapsed time in Hours since the Session started.<br>The Session starts when the `Start Bot` button is pressed! |
 | `ExpPerc` | Returns with the player experience as percentage to hit next level. |
+| `SecondsSinceVendored` | Seconds since the last successful vendor/repair visit. A very large number until the first one, so "it has been a while" reads true from the start. **Only grows** - see the warning under [Class Trainer](#class-trainer) before using it as an upper bound on a goal that has to travel. |
+| `SecondsSinceTrained` | Seconds since the last successful [class trainer](#class-trainer) visit, same convention. Safe as a cooldown (`> N`). |
+| `SpellsTrained` | How many spells have been learnt from a trainer this session. Intended for reporting - as a gate it only expresses "once per bot run". |
+| `Money` | Returns the player's purse in **copper** - the unit every price in the game is quoted in. e.g. `Money > 5000` is "more than 50 silver". |
+| `Gold` | Returns the player's purse in whole **gold**, the copper and silver remainder dropped. e.g. `Gold >= 10`. |
 | `UIMapId` | Returns with the player current [UIMapId](https://github.com/Xian55/WowClassicGrindBot/blob/9bea201760babc0f6670df2bd5c071c9c3f1220d/Json/dbc/som/WorldMapArea.json#L3C6-L3C11) |
 | `PathDist` | Returns the context [PathSettings](#pathsettings) of closest distance (in yards) from the player location to the Path. |
 | `PathDist_{PathSettings.Id}` | Returns the closest distance (in yards) from the player location to the Path. |
@@ -2837,6 +2976,7 @@ Allow requirements about what buffs/debuffs you have or the target has or in gen
 | `"Items Broken"` | Has any broken(red) worn item |
 | `"HasRangedWeapon"` | Has equipped ranged weapon (wand/crossbow/bow/gun) |
 | `"HasAmmo"` | AmmoSlot has equipped ammo and count is greater than zero |
+| `"HasTrainableSpell"` | There is at least one spell on the [class trainer whitelist](#class-trainer) the player does not know yet and is high enough level to learn. Also false while the spellbook is still loading. Note the bot applies two further checks of its own that this variable does not expose - see the [Class Trainer](#class-trainer) notes. |
 | `"Casting"` | The player is currently casting any spell. |
 | `"HasTarget"` | The player currently has a target. |
 | `"TargetAlive"` | The player currently has an alive target. |

--- a/docs/npc-interaction-known-issues.md
+++ b/docs/npc-interaction-known-issues.md
@@ -1,0 +1,223 @@
+# Known issues: casting feedback, NPC interaction and the gossip channel
+
+Everything here was found while building class trainer support, and left unfixed on
+purpose. Each entry records the evidence, the mechanism and the intended fix, so it can
+be picked up without re-deriving it. Log excerpts are from
+`BlazorServer/out20260803*.log` (Wrath 3.4.3, addon 1.12.0).
+
+Ordered by consequence.
+
+---
+
+## 1. `CurrentActionNotDetected` re-casts spells that already landed
+
+**Symptom.** A cast reports failure and the bot presses the same key again seconds later:
+
+```
+[Rend] instant input 51ms CAST_SUCCESS -215.5411ms
+[Rend] ... Cast failed due CurrentActionNotDetected!
+```
+
+Same spell retried at 22:01:56, 22:02:04, 22:02:12, 22:02:18. Every failing line carries
+`CAST_SUCCESS`, so the spell did land. `Rend` dominates - it is the only action in the
+test profile with `Required Form: Warrior_BattleStance`, which may or may not be related.
+
+**Mechanism.** `CastingHandler.WaitCurrentAction` accepts only two things inside a
+budget of `Max(HalfSpellQueueTimeMs, RemainCastMs) + NetworkLatency` (~215 ms measured):
+
+```csharp
+bool Interrupt() =>
+    currentAction.Is(item) ||
+    playerReader.CastState == UI_ERROR.CAST_SENT ||
+    token.IsCancellationRequested;
+```
+
+* `currentAction` is the addon's `IsCurrentAction` bit, true only briefly for an instant
+  spell - the pixel pipeline can sample straight past it.
+* `CAST_SENT` is an **intermediate** state. By the time the bot samples, the addon has
+  already advanced to `CAST_SUCCESS`, so the terminal state is never matched.
+
+`CastInstant` then times out and, at `CastingHandler.cs:214-228`, already knows better:
+`CastInstantSuccessful(playerReader.CastEvent.Value)` is true. That result is used only
+to *suppress* a `UIError` return, after which it falls through to
+`return CastResult.CurrentActionNotDetected` anyway.
+
+**Why it costs more than a log line.** `Cast()` returns `false` for this result
+(`CastingHandler.cs:799-813`), so `item.SetClicked()` and `UpdateGCD()` never run. The
+cooldown and charge bookkeeping is not updated and the goal re-presses the spell.
+
+**Intended fix.** Accept the terminal state in the wait, so `elapsedMs` goes positive and
+the normal post-cast path runs rather than converting a timeout into a success:
+
+```csharp
+(item.SpellId != 0 &&
+ playerReader.CastSpellId.Value == item.SpellId &&
+ CastInstantSuccessful(playerReader.CastEvent.Value))
+```
+
+The `CastSpellId` comparison is load-bearing. `playerReader.CastEvent` is the global cell
+62 holding the most recent event for *any* spell; without the ownership check a stale
+`CAST_SUCCESS` from the previous cast would satisfy the wait instantly and mask genuine
+failures. `CastEventReader` already keeps a per-spellId log for exactly this reason
+(`CastingHandler.cs:341-356`) and may be the better source.
+
+**Risk.** This is on every cast the bot makes. Worth landing on its own so combat
+regressions are easy to attribute.
+
+---
+
+## 2. `MoveToTargetAndReached` burns 10 s on an NPC already in range
+
+**Symptom.** At a vendor, ten seconds pass between the interact and the goal noticing:
+
+```
+23:04:05.598  Interact pressed
+23:04:05.8-06.8  merchant window opens, SellJunk sells 13 stacks, +1s 8c
+23:04:15.656  "Found Target!"          <- 10s later
+```
+
+**Mechanism.** `AdhocNPCGoal.Navigation_OnDestinationReached` runs the soft-interact
+branch unconditionally when `bits.SoftInteract()` is set, and that branch calls
+`MoveToTargetAndReached()`, which waits up to `MAX_TIME_TO_REACH_MELEE` (10 000 ms) for
+`bits.NotMoving`. Standing still at the NPC, the whole budget elapses while the merchant
+window is already open and selling.
+
+**Partly mitigated.** The redundant second `PressInteract` that used to *close* that
+window is now skipped via `bits.MerchantFrameShown()` / `bits.TrainerFrameShown()`, and a
+failed interaction now clears the target instead of walking away still holding it. The
+10 s wait itself remains.
+
+**Intended fix.** Skip or shorten the approach when the frame is already up, or when
+`playerReader.MinRangeZero()` already holds before waiting.
+
+---
+
+## 3. The gossip channel cannot distinguish fresh data from stale
+
+**Background.** Cell 73 latches - the addon writes only when its queue actually pops:
+
+```lua
+local gossipNum = DataToColor.gossipQueue:shift(globalTick)
+if gossipNum then Pixel(int, gossipNum, 73) end   -- no `or 0`
+```
+
+So the cell holds the last value indefinitely. The queue runs
+`GOSSIP_START (69)` -> option hashes -> `GOSSIP_END (9999994)`, and the bot only starts
+polling after it presses interact - by which time `69` has long been overwritten.
+
+**What this caused.** `OpenMerchantWindow` and `OpenTrainerWindow` both waited on
+`GossipStart()` first. That value was never observed, so the wait always burned its full
+`TIMEOUT` (5 s), after which the second wait found `GossipEnd` already latched and
+returned instantly. Measured 5.026 s per trainer visit, 10 s for a vendor with a gossip
+menu (both 5 s waits expiring).
+
+**Fixed by** collapsing each into a single wait on `GossipEnd() || <frame shown>`.
+Trainer visits went from 5.03 s to 0.13 s; the vendor visit to 0.5 s.
+
+**Residual risk, unaddressed.** Because `GossipEnd` also latches, a wait can return
+immediately on a value left over from a *previous* NPC and then read a stale
+`GossipReader.Gossips`. `GossipReader.Update` only clears that dictionary on
+`GossipStart`, so a genuinely fresh menu does reset it - but the window between "we begin
+polling" and "the new `GOSSIP_START` arrives" is real. Waiting on `GossipStart` was the
+original attempt to guarantee freshness; it simply lost the race every time.
+
+**Intended fix.** A sequence number on the gossip channel, so the reader can tell "this
+menu is newer than the one I saw before I interacted" rather than inferring it from a
+sentinel value. `CastEventReader`'s cell 113/114 encoded-value-plus-monotonic-seq pairing
+is the pattern to copy.
+
+---
+
+## 4. `InitSlot` runs twice for every KeyAction
+
+`KeyActions.InitBinds` calls `keyAction.InitSlot(logger)` (`KeyActions.cs:19`) and
+`KeyAction.Init` calls it again (`KeyAction.cs:231`). `ClassConfiguration.Initialise`
+runs both loops in sequence, so every action is slot-resolved twice and any warning it
+emits prints twice.
+
+**Not simply removable.** `WaitKeyActions.AddNewKeyAction` appends generated Food/Drink
+wait entries *after* `InitBinds` has already run for that section, so `Init`'s call is
+their only slot resolution. Deleting it would silently skip them.
+
+**Intended fix.** Have `AddWaitKeyActionsForFoodOrDrink` initialise the entries it
+creates, then drop the call from `KeyAction.Init`. The duplicate-warning symptom is
+already gone - keyless sections are now flagged `KeyOptional` - so this is redundant work
+only, not user-visible.
+
+---
+
+## 5. Spellbook lower-rank block is terminated, not counted
+
+`InitSpellBookQueue` sends the highest rank of each spell under a
+`QUEUE_COUNT_MARKER + n` header, then the remaining ranks, then
+`SPELLBOOK_ALL_RANKS_END`. The first block is counted; the second is only terminated.
+
+A terminator proves the batch *ended*, not that every id in it *arrived*. A dropped value
+leaves a hole in `SpellBookReader.spells` while `AllRanksReceived` still flips true, and
+`HasExact` reads a hole as "not known" - which `TrainerPlanner` turns into a purchase.
+
+**No evidence this has ever happened.** It was suspected once and disproved: the repeated
+purchases in `out20260803_old.log` were a `.unlearn` test macro, not lost pixels.
+
+**Intended fix if pursued.** Send the low block as `marker`, `count`, `ids` - the count
+as its own value rather than folded into the marker, since a cell tops out at 16,777,215
+and `QUEUE_COUNT_MARKER + n` saturates at `n = 215`, which a level 60+ spellbook exceeds.
+A count of zero cannot be sent (zero is what an empty queue writes and the reader
+ignores), so the rank-less clients - Cata and MoP dropped ranks entirely - need a
+separate "no lower ranks" sentinel. Counting must also tolerate the same id arriving on
+two consecutive frames, and must still complete on a `SPELLS_CHANGED` re-send where every
+id is already in the set.
+
+---
+
+## 6. Class trainer matching skips Death Knight and Demon Hunter
+
+`UnitClass.TrainerSubName()` returns the plain enum name and the match is a
+case-sensitive-insensitive substring test against `Creature.SubName`. That covers every
+class trainer in `som` and `tbc` (201/201, 271/271) and all the spell-teaching ones in
+`wrath`, but not the two classes spelled inconsistently in the data:
+
+* Wrath writes `Death Knight`, MoP writes `Deathknight` - one keyword cannot match both
+  without ignoring spaces.
+* **Wrath does not flag its DK trainers as `ClassTrainer` at all.** The eight NPCs whose
+  `SubName` is `Death Knight` lack the bit, so no code-side keyword change reaches them;
+  it is a `creatures.json` / `Utilities/TransferTrainerFlags` gap.
+
+Unmatched rows in the other eras are `Portal Trainer`, `Pet Trainer`, `Battle Pet
+Trainer`, `Demon Trainer` and blanks - none of which teach class spells, so excluding
+them is correct.
+
+---
+
+## 7. Profession and weapon-skill training is not implemented
+
+[Issue #671](https://github.com/Xian55/WowClassicGrindBot/issues/671) is titled *Skill
+Training*, and "skill" in WoW usually reads as a profession or weapon skill. The first
+iteration covers **class trainers only**; `NpcFlags.ProfessionTrainer` is populated and
+the navigation half would work unchanged, but the filtering does not carry over - a
+profession advances through ranks (Apprentice, Journeyman, Expert...) gated on skill
+level rather than through spell ranks gated on character level, so
+`TrainerSpells.GetState` does not describe it.
+
+Deferred to a second iteration.
+
+**Weapon Masters are flagged `ProfessionTrainer`.** In som, tbc and wrath every one of
+them - `Hanashi`, `Woo Ping`, `Sayoc`, `Buliwyf Stonehand`, `Ilyenia Moonfire` and the
+rest - carries the profession bit rather than plain `Trainer`.
+`Utilities/TransferTrainerFlags` has a `WeaponTrainer->Trainer` path meant to strip
+exactly that, but the committed `creatures.json` does not reflect it (som and tbc have
+*no* plain-`Trainer` rows at all; wrath has 34). So a profession-trainer search will also
+match weapon masters until the data is regenerated or the goal filters on `SubName`.
+
+Weapon skills themselves - Vanilla/TBC/Wrath only, removed in Cata 4.0 - are a third
+shape again: no ranks, nothing to choose, learnt once and then levelled by use. Deferred
+further still.
+
+---
+
+## 8. Trainer purchase order is arbitrary
+
+`Trainer.lua` iterates `pairs(mWanted)`, which is unordered, so it may try a higher rank
+before the one it depends on. This self-corrects: a rank the trainer will not yet sell is
+simply skipped, the prerequisite is bought, and the next tick's rescan picks the higher
+one up. Worth knowing it relies on that rescan rather than on ordering.


### PR DESCRIPTION
Closes #671 — the class trainer half. Professions and weapon skills are split out to #825.

The bot walks to the nearest trainer **of its own class**, buys the spells it is eligible for and can afford, puts the new ranks back on the action bar, and stops asking once there is nothing left to learn.

---

## Usage

Whitelist mode (default) — the profile lists what it is willing to learn through `SPELL_*` `IntVariables`, ranks ascending. These are the same arrays a profile already writes for `Spell:` requirements, so declaring a trainer costs no new configuration:

```json
"IntVariables": {
    "SPELL_CHARGE": [100, 6178, 11578],
    "SPELL_REND":   [772, 6546, 6547],
    "WAIT_CHARGE_MS": 4000          // ignored, no SPELL_ prefix
},
"NPC": { "Sequence": [
    { "Cost": 6, "Name": "ClassTrainer", "Requirements": ["HasTrainableSpell", "Money > 100"] }
]}
```

Train-all mode — ignores the whitelist and buys everything offered and affordable:

```json
{ "Cost": 6, "Name": "ClassTrainer", "TrainAll": true, "Requirements": ["Money > 5000"] }
```

|  | whitelist *(default)* | `"TrainAll": true` |
| --- | --- | --- |
| What it buys | only ids listed in `SPELL_*` | everything offered and affordable |
| Who decides | the bot, before setting off | the trainer list, on arrival |
| Gate to use | `HasTrainableSpell` | `Money` and/or `SecondsSinceTrained` |
| Goes quiet when | nothing whitelisted is learnable | a visit buys nothing, until next level-up |

> `TrainAll` must **not** be paired with `HasTrainableSpell` — that requirement reads only the whitelist, so both gates would have to pass and the trip stays locked to whitelist eligibility. Documented in the README.

The NPC name also accepts the existing `[TYPE] {npc1 | npc2}` form and a `PathFilename`, exactly like `Vendor` and `Repair`.

---

## Two prerequisites

Neither of these is trainer code, but nothing works without them.

### The spellbook could not say which rank you own

`InitSpellBookQueue` transmitted only the highest rank per base name, and `SpellBookReader.Has` falls back to matching by `Spell.Name` — so `Has(6673)` is true the moment *any* Battle Shout rank is known. "Which rank should I buy next" is unanswerable against that.

The addon now sends the remaining ranks after the counted block, closed by `SPELLBOOK_ALL_RANKS_END`, and `HasExact` reads them without the name fallback. `Has` is left alone; the `Spell:` requirement depends on its rank-blind behaviour.

`IsInitialized` still flips on the **first block alone**. `AddonReader` withholds `DataReady` until it does, and ranks arrive one id per addon tick — gating readiness on the full set would stall the agent for hundreds of extra ticks after every `/dcflush` and on every `SPELLS_CHANGED` resend. `AllRanksReceived` is a second, independent flag that only the planner consults.

### ClassTrainer was searching the wrong flag

`Enum.GetValues<NpcFlags>` iterates ascending by value, so `Trainer` (`1<<4`) was tested before `ClassTrainer` (`1<<5`) — and `"ClassTrainer".Contains("Trainer")` matches first. A `ClassTrainer` entry was therefore searching the generic superset (810 NPCs in wrath rather than 303). Every `Vendor*` subtype collapsed to `Vendor` the same way.

Search patterns are now ordered longest-name-first.

---

## Shape

**`TrainerSpells`** — the pure eligibility rule, no session state. **`TrainerPlanner`** — a session-scoped goal component that adds the memory. They cannot share an instance: `RequirementFactory` is constructed from the **root** provider while the profile is still loading, and the planner lives in the child container built later by `CreateSession`, which is also the only place `ClassConfiguration` is registered. Both read the same rule, so the goal and the `HasTrainableSpell` requirement cannot drift apart.

**The addon owns the purchase.** Only it can see what a trainer actually offers and what each service costs, so `Trainer.lua` matches the whitelist against the live service list, checks `GetMoney`, buys one per tick (indices shift after each purchase) and reports back.

Matching is done on the **localized** spell name from `GetSpellInfo(id)`, which answers for spells the player does not know yet, plus the rank subtext where the client provides one. Train-all has no whitelist to match against, so it resolves each service to a spell id through `GameTooltip:SetTrainerService` + `GetSpell()`; a service whose id will not resolve is **skipped rather than bought blind**, so every reported id corresponds to a real purchase and the count the bot waits on stays honest.

### Wire format

* **New cell 115** carries the trainer result — `NUMBER_OF_FRAMES` 117 → 118. `GLOBAL_TIME_CELL` and the validation sentinel are derived (`N-2`, `N-1`) and shift automatically; nothing in C# hardcodes them. The mandatory TOC bump invalidates any cached `frame_config.json` on its own, since `FrameConfig.IsValid` compares `AddonVersion`.
* Batch of bought spell ids under `QUEUE_COUNT_MARKER + n`, sent even when `n = 0` so it is the single completion signal, preceded by `TRAINER_NO_MATCH` / `TRAINER_NO_MONEY` when they apply.
* **`TrainerFrameShown`** (v3 bit 16) and **`MerchantFrameShown`** (v3 bit 17). The merchant one is polled from `MerchantFrame` rather than event-cached, because the point is to know whether the window is on screen *right now* — the cell 73 sentinels latch the last event and cannot tell an open window from one that opened and closed.

### Knowing when not to bother

Three ways a trip can be pointless are remembered rather than rediscovered:

* the trainer teaches nothing wanted → that NPC is skipped, search moves to the next
* the price cannot be met → quiet until the wallet rises above what it was
* no trainer of this class is reachable in the zone → quiet until the zone changes

All three **forget on level-up**, since levelling is the only thing that changes what a trainer offers. Without that, a trainer written off at level 4 would never be revisited at level 6.

---

## Fixed along the way

All reachable from the same code path, all pre-existing.

* **The gossip cell latches its last value** — the addon writes only when its queue pops. Waiting on `GossipStart` (`69`) therefore missed it every time and burned the full `TIMEOUT`, after which the second wait found `GossipEnd` already sitting there. Measured **5.03 s** per trainer visit and **10 s** for a gossip-menu vendor (both waits expiring). Both paths now wait on `GossipEnd` or the frame bit: **0.13 s** and **0.5 s** after.
* **A failed NPC interaction returned without clearing the target.** Only the success path cleaned up, so a vendor stayed targeted for ~3.5 minutes while `FollowRouteGoal` tab-hunted around it.
* **The second interact was closing an already-open merchant window.** The soft-interact branch can open the merchant and sell the greys before it returns; the unconditional `PressInteract` then shut it and the wait timed out on a visit that had in fact succeeded. Now guarded on the frame bits.
* **`IntOrIntArrayDictionaryConverter` never skipped `Comment` tokens** — a single `//` inside `IntVariables` failed the *whole profile load* with `Expected PropertyName, got Comment`. A hand-written converter sees tokens the default deserializer hides. Also moved out of `ClassConfiguration.cs` into its own file.
* **`NPC`, `Flee` and `Wait` entries no longer warn** about a key they are not supposed to have.
* **The soft-interact id is read live** when the event cache is empty, so cell 102 agrees with the `UnitExists` bit that gates it. Previously the bot could interact with a unit it could not identify (`Soft Interact found NPC with id 0`).

---

## New requirement variables

`Money`, `Gold`, `HasTrainableSpell`, `SecondsSinceVendored`, `SecondsSinceTrained`, `SpellsTrained`.

Elapsed seconds rather than another `...Recently` flag: a flag needs someone to clear it, and `VendoredOrRepairedRecently` latches true until `MailGoal` happens to run — so without mail it means "ever vendored", not "just vendored". Elapsed time answers both questions with nothing to clear and no handshake.

> A requirement is re-checked **while** the goal runs. A narrowing window such as `SecondsSinceVendored < 120` therefore expires during the walk to the trainer, dropping the goal part-way; and since that number only grows it never re-opens. Use a widening test or a state one for anything the bot must travel for. Called out in the README.

`LevelChangeTracker` announces a ding the way the bag and coin trackers announce loot (`Level 5 -> 6, took 42m 18s`), deliberately **not** behind `LogBagChanges` — that toggle exists to silence per-item chatter, and this is one line every few hours.

The Spell Book page gains a **Class Trainer** card showing trainable / known / level-locked / not-in-client per whitelisted rank, with a trainable-only toggle. It reads the same `TrainerSpells` rule the bot does, so the page cannot claim something the goal disagrees with.

---

## Client coverage

Ranks exist in **som / tbc / wrath** and were removed in **cata / mop**. The rank-less clients need no special-casing — the same code produces an empty lower-rank block and the sentinel still terminates it. MoP grants class spells on level-up and its trainers sell none, so a `ClassTrainer` entry there reports "teaches nothing" and stops rather than raising.

Class matching covers every class trainer in som (201/201) and tbc (271/271), and all the spell-teaching ones in wrath; the unmatched rows are `Portal Trainer`, `Pet Trainer` and blanks, which teach no class spells. **Death Knight and Demon Hunter are not wired up** — the data spells them inconsistently (`Death Knight` in wrath, `Deathknight` in MoP) and wrath does not flag its DK trainers as `ClassTrainer` at all, which is a data gap rather than something a keyword change reaches.

---

## Verified

Live on Wrath 3.4.3, addon 1.12.0:

```
Found 5 potential ClassTrainer NPC.
Closest NPC found ClassTrainer Llane Beshere
Picked 1th for Trainer
Trainer(911): offering 3 spell(s) to learn - Charge(100), Battle Shout(6673), Rend(772). Wallet 3s 7c
Trained 3 spell(s): Charge(100), Rend(772), Battle Shout(6673). Spent 1s 99c, wallet now 1s 8c
Action bar: re-placed 3 slot(s) for the newly trained Charge, Rend, Battle Shout
```

* went to the **Warrior** trainer, not the nearest trainer of any class
* wallet arithmetic checks out (307c − 199c = 108c = `1s 8c`)
* action bar slots 75/76/77 match exactly what `ActionBarSlotValidator` expected, and were empty before
* `TrainAll` bought three spells with every id resolved through the tooltip
* vendor → trainer chain clean; vendor visit 10 s → 0.5 s with the sale observed and the target cleared
* solution builds with 0 warnings; `luac -p` clean on all touched Lua

---

## Not covered

* Professions and weapon skills — #825.
* **`CurrentActionNotDetected` makes the bot re-cast spells that already landed.** `Cast()` returns false, so `SetClicked()` and `UpdateGCD()` never run. Every failing log line carries `CAST_SUCCESS`; the wait only accepts the `currentAction` bit or the *intermediate* `CAST_SENT`, and by sampling time the addon has already advanced to the terminal state. Diagnosis and proposed fix are in `docs/npc-interaction-known-issues.md` — left out because it touches every cast in the bot and deserves its own change.

That doc also records five further known gaps: the 10 s `MoveToTargetAndReached` on an in-range NPC, the residual gossip-staleness this PR trades into, the duplicated `InitSlot` call (and why it cannot simply be deleted), the terminated-not-counted lower-rank block, and the DK/Demon Hunter matching gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
