### PR TITLE
feat: runtime route generation from spawn data, plus approach/facing/stuck fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -320,3 +320,6 @@ local/
 # Host-specific native binary; the Windows DLLs are committed, these are not.
 PPather/MPQ/libstorm.dylib
 PPather/MPQ/libstorm.so
+
+# Rendered route pictures from `run.ps1 routegen --output`. Regenerated in seconds.
+CoreTests/routegen-out/

--- a/Core/ClassConfig/ClassConfiguration.cs
+++ b/Core/ClassConfig/ClassConfiguration.cs
@@ -61,6 +61,31 @@ public sealed partial class ClassConfiguration
     public List<string> SideActivityRequirements = [];
     public PathSettings[] Paths { get; set; } = [];
 
+    /// <summary>
+    /// External <see cref="PathSettings"/> group files, relative to Json/path/. Each file is a
+    /// bare array of PathSettings, so a group can be shared across profiles instead of pasted
+    /// into each one.
+    ///
+    /// <para>Loaded in listed order and appended after any inline <see cref="Paths"/>. Order is
+    /// not cosmetic: it decides each route goal's GOAP cost through
+    /// <see cref="Core.Goals.FollowRouteGoal.COST_OFFSET"/>, so a profile keeps control of
+    /// priority by where it lists a group.</para>
+    /// </summary>
+    public string[] PathsFilenames { get; set; } = [];
+
+    /// <summary>
+    /// Seeds every randomised decision route generation makes. Null draws a fresh one per
+    /// session, which is then logged - so a run stays reproducible after the fact without
+    /// making every run identical. Set it to pin a route while testing.
+    /// </summary>
+    public int? Seed { get; set; }
+
+    /// <summary>
+    /// The seed actually in force, resolved once in <see cref="Initialise"/>.
+    /// </summary>
+    [JsonIgnore]
+    public int ResolvedSeed { get; private set; }
+
     public Mode Mode { get; set; } = Mode.Grind;
 
     public bool GatheringMode => Mode is Mode.AttendedGather or Mode.AutoGather;
@@ -133,6 +158,51 @@ public sealed partial class ClassConfiguration
     private readonly List<KeyAction> macroActions = [];
     public IReadOnlyList<KeyAction> MacroActions => macroActions;
 
+    [JsonIgnore]
+    private bool pathGroupsResolved;
+
+    /// <summary>
+    /// Appends every <see cref="PathsFilenames"/> group onto <see cref="Paths"/>, in listed
+    /// order, inline entries first.
+    ///
+    /// <para>Public and callable without <see cref="Initialise"/> on purpose: tooling that only
+    /// wants the routes reads <see cref="Paths"/> straight off a deserialized profile, and
+    /// would otherwise see the inline entries alone and silently miss every group.</para>
+    ///
+    /// <para>Runs at most once per instance - a second call is a no-op rather than a second
+    /// append.</para>
+    /// </summary>
+    /// <param name="pathRoot">Directory the group filenames are relative to (DataConfig.Path).</param>
+    /// <returns>True when at least one group file was read.</returns>
+    public bool ResolvePathGroups(string pathRoot)
+    {
+        if (pathGroupsResolved || PathsFilenames.Length == 0)
+            return false;
+
+        pathGroupsResolved = true;
+
+        List<PathSettings> combined = [.. Paths];
+
+        for (int i = 0; i < PathsFilenames.Length; i++)
+        {
+            string groupFile = PathsFilenames[i];
+            string groupPath = Path.Join(pathRoot, groupFile);
+
+            if (!File.Exists(groupPath))
+            {
+                throw new Exception(
+                    $"[{nameof(ClassConfiguration)}.{nameof(PathsFilenames)}[{i}]] " +
+                    $"`{groupFile}` file does not exists!");
+            }
+
+            combined.AddRange(
+                JsonConvert.DeserializeObject<PathSettings[]>(File.ReadAllText(groupPath)) ?? []);
+        }
+
+        Paths = [.. combined];
+        return true;
+    }
+
     public void Initialise(IServiceProvider sp, Dictionary<int, string> overridePathFile)
     {
         Approach.Key = Interact.Key;
@@ -142,6 +212,9 @@ public sealed partial class ClassConfiguration
         PlayerReader playerReader = sp.GetRequiredService<PlayerReader>();
 
         RecordInt globalTime = sp.GetRequiredService<AddonReader>().GlobalTime;
+
+        ResolvedSeed = Seed ?? Random.Shared.Next();
+        LogSeed(logger, ResolvedSeed, Seed.HasValue);
 
         if (Paths == Array.Empty<PathSettings>() &&
             !string.IsNullOrEmpty(PathFilename))
@@ -185,6 +258,12 @@ public sealed partial class ClassConfiguration
             }
         }
 
+        int inlinePathCount = Paths.Length;
+        if (ResolvePathGroups(dataConfig.Path))
+        {
+            LogLoadedPathGroups(logger, PathsFilenames.Length, inlinePathCount, Paths.Length);
+        }
+
         for (int i = 0; i < Paths.Length; i++)
         {
             PathSettings settings = Paths[i];
@@ -197,7 +276,11 @@ public sealed partial class ClassConfiguration
                 settings.PathFilename = settings.OverridePathFilename;
             }
 
-            if (!File.Exists(Path.Join(dataConfig.Path, settings.PathFilename)))
+            // A generated path has no file, by design - the whole point is that the route
+            // comes from the client's spawn data instead. Only demand a file when one was
+            // asked for.
+            if (settings.Generate == null &&
+                !File.Exists(Path.Join(dataConfig.Path, settings.PathFilename)))
             {
                 if (!string.IsNullOrEmpty(OverridePathFilename))
                     throw new Exception(
@@ -472,4 +555,15 @@ public sealed partial class ClassConfiguration
         Message = "Loaded mail config from {MailPath}")]
     static partial void LogLoadedMailConfig(ILogger logger, string mailPath);
 
+    [LoggerMessage(
+        EventId = 0013,
+        Level = LogLevel.Information,
+        Message = "Route generation seed {seed} (pinned: {pinned})")]
+    static partial void LogSeed(ILogger logger, int seed, bool pinned);
+
+    [LoggerMessage(
+        EventId = 0014,
+        Level = LogLevel.Information,
+        Message = "Loaded {groupCount} PathSettings group file(s): {inlineCount} inline + groups -> {totalCount} path(s)")]
+    static partial void LogLoadedPathGroups(ILogger logger, int groupCount, int inlineCount, int totalCount);
 }

--- a/Core/ClassConfig/PathSettings.cs
+++ b/Core/ClassConfig/PathSettings.cs
@@ -18,6 +18,41 @@ public sealed partial class PathSettings
     public bool PathReduceSteps { get; set; }
     public int UIMapId { get; set; }
 
+    /// <summary>
+    /// Describes the route as a query over spawn data instead of a file. Mutually exclusive
+    /// with <see cref="PathFilename"/>; when set, no file is read or required to exist.
+    /// </summary>
+    public RouteGenSettings? Generate { get; set; }
+
+    /// <summary>
+    /// Whether generation produced a usable route. False leaves <see cref="Path"/> empty,
+    /// where <see cref="GetDistanceXYFromPath"/> returns int.MaxValue and
+    /// <see cref="PathFinished"/> is permanently true - a silently dead goal that would
+    /// still win planning. <see cref="CanRun"/> gates on this so GOAP falls through to the
+    /// next path instead.
+    /// </summary>
+    public bool Generated { get; private set; } = true;
+
+    /// <summary>
+    /// Zone, mob selection and navmesh connectivity for <see cref="Generate"/>, resolved
+    /// once. All of it is lap-invariant, so a Wander re-sample reuses it and does no
+    /// pathfinding at all.
+    /// </summary>
+    [Newtonsoft.Json.JsonIgnore]
+    public RouteGenerator.Context? GenerateContext { get; set; }
+
+    /// <summary>Laps completed, so each regenerated route gets a distinct seed.</summary>
+    [Newtonsoft.Json.JsonIgnore]
+    public int Lap { get; set; }
+
+    /// <summary>
+    /// Whether the generated route was filled in by pathing between its stops. False means
+    /// the legs could not be pathed and the route is still bare anchors, which
+    /// <see cref="Core.Goals.FollowRouteGoal"/> has to tell Navigation about.
+    /// </summary>
+    [Newtonsoft.Json.JsonIgnore]
+    public bool RouteIsDense { get; set; }
+
     public bool WorldCoords { get; private set; }
     public Vector3[] OriginalMapPath { get; private set; } = Array.Empty<Vector3>();
 
@@ -27,6 +62,15 @@ public sealed partial class PathSettings
         !string.IsNullOrEmpty(OverridePathFilename)
         ? OverridePathFilename
         : PathFilename;
+
+    /// <summary>
+    /// Display name, for the goal title and the UI badge. A generated path has no filename,
+    /// so callers must not reach for <c>GetFileNameWithoutExtension(FileName)</c> directly.
+    /// </summary>
+    public string DisplayName =>
+        Generate != null
+        ? Generate.Name ?? Generate.Subzone ?? Generate.Zone ?? "Generated"
+        : System.IO.Path.GetFileNameWithoutExtension(FileName);
 
     private const int MaxRaceStartingZoneLevel = 20;
 
@@ -116,7 +160,12 @@ public sealed partial class PathSettings
         WorldCoords = true;
     }
 
-    private static bool TryFindRaceZone(ReadOnlySpan<char> input, WorldMapAreaDB worldMapAreaDB, out int uiMapId)
+    /// <summary>
+    /// Starting-zone map for the first race name found in <paramref name="input"/>. Public
+    /// because route generation resolves an unqualified <see cref="RouteGenSettings"/> the
+    /// same way a filename is resolved - one race-to-zone table, not two.
+    /// </summary>
+    public static bool TryFindRaceZone(ReadOnlySpan<char> input, WorldMapAreaDB worldMapAreaDB, out int uiMapId)
     {
         if (TryParseMinLevel(input, out int minLevel) && minLevel > MaxRaceStartingZoneLevel)
         {
@@ -156,12 +205,36 @@ public sealed partial class PathSettings
         return false;
     }
 
+    /// <summary>
+    /// Replaces the route with world-space points, keeping the map-space copy the UI draws
+    /// in sync. The counterpart to <see cref="ConvertToWorldCoords"/> for routes that were
+    /// never in map space to begin with.
+    /// </summary>
+    public void SetWorldPath(Vector3[] worldPath, int uiMapId, WorldMapAreaDB worldMapAreaDB,
+        bool isDense = false)
+    {
+        Path = worldPath;
+        WorldCoords = true;
+        Generated = worldPath.Length > 0;
+        RouteIsDense = isDense;
+        UIMapId = uiMapId;
+
+        Vector3[] mapPath = new Vector3[worldPath.Length];
+        Array.Copy(worldPath, mapPath, worldPath.Length);
+        worldMapAreaDB.ToMap_FlipXY(uiMapId, mapPath);
+
+        OriginalMapPath = mapPath;
+    }
+
     public bool CanRun()
     {
         if (canRunTime == globalTime.Value)
             return canRun;
 
         canRunTime = globalTime.Value;
+
+        if (!Generated)
+            return canRun = false;
 
         ReadOnlySpan<Requirement> span = RequirementsRuntime;
         for (int i = 0; i < span.Length; i++)

--- a/Core/ClassConfig/RouteGenSettings.cs
+++ b/Core/ClassConfig/RouteGenSettings.cs
@@ -1,0 +1,153 @@
+namespace Core;
+
+/// <summary>
+/// Whether a route should concentrate on where the mobs actually pack together, or try to
+/// take in everything that matched the filter.
+/// </summary>
+public enum RouteFocus
+{
+    /// <summary>
+    /// Stick to the packs. Isolated spawn clusters are dropped, and stops are drawn heavily
+    /// toward locally dense spots. Best for levelling - kills per yard walked is what
+    /// matters, and a stray mob across a lake is not worth the swim.
+    /// </summary>
+    Density,
+
+    /// <summary>Middle ground: drop only the sparsest outliers, mild density bias.</summary>
+    Balanced,
+
+    /// <summary>
+    /// Take in everything that matched, spread evenly. Use when the point is to sweep an
+    /// area - gathering, or hunting a rare that can be anywhere.
+    /// </summary>
+    Coverage
+}
+
+public enum RouteGenMode
+{
+    /// <summary>
+    /// A fresh set of anchors inside the spawn polygon every lap, so the bot never
+    /// retraces a line. <see cref="PathSettings.PathThereAndBack"/> is ignored.
+    /// </summary>
+    Wander,
+
+    /// <summary>
+    /// One closed tour over spawn-cluster centroids, ordered by a TSP solver. Generated
+    /// once at session build time and deterministic for a given seed - the drop-in
+    /// replacement for a hand-recorded route file.
+    /// </summary>
+    Loop
+}
+
+/// <summary>
+/// Describes a grind route as a query over the running client's NPC spawn data, instead
+/// of pointing at a recorded waypoint file. Set on <see cref="PathSettings.Generate"/>.
+/// See docs/generated-routes-design.md.
+/// </summary>
+public sealed class RouteGenSettings
+{
+    /// <summary>Zone name, matched against <c>WorldMapArea.AreaName</c>.</summary>
+    public string? Zone { get; set; }
+
+    /// <summary>Subzone name - narrower than <see cref="Zone"/>, e.g. "Northshire Valley".</summary>
+    public string? Subzone { get; set; }
+
+    /// <summary>Explicit override; wins over both names when &gt; 0.</summary>
+    public int UIMapId { get; set; }
+
+    /// <summary>Label for logs, the goal name and the UI badge.</summary>
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// The whole mob selector, as a requirement expression in <b>creature scope</b> - the
+    /// subject is a candidate creature row, not the player. <c>Level</c> is the creature's
+    /// level; the player's is <c>PlayerLevel</c>. Empty means the default level window.
+    /// See <see cref="CreatureRequirementFactory"/>.
+    /// </summary>
+    public string Mobs { get; set; } = string.Empty;
+
+    public RouteGenMode Mode { get; set; } = RouteGenMode.Wander;
+
+    /// <summary>Pack together, or cover the whole spread. See <see cref="RouteFocus"/>.</summary>
+    public RouteFocus Focus { get; set; } = RouteFocus.Density;
+
+    /// <summary>
+    /// A spawn cluster is kept only if it holds at least this share of the spawns the
+    /// biggest cluster holds. Derived from <see cref="Focus"/> unless set explicitly.
+    /// </summary>
+    public float? MinClusterShare { get; set; }
+
+    /// <summary>
+    /// How hard anchor selection leans toward locally dense spots. 0 is uniform, 1 is
+    /// proportional to density, 2 strongly favours packs. Derived from
+    /// <see cref="Focus"/> unless set explicitly.
+    /// </summary>
+    public float? DensityBias { get; set; }
+
+    /// <summary>Effective cluster threshold, honouring an explicit override.</summary>
+    public float ResolvedMinClusterShare => MinClusterShare ?? Focus switch
+    {
+        RouteFocus.Density => 0.25f,
+        RouteFocus.Balanced => 0.10f,
+        _ => 0f
+    };
+
+    /// <summary>Effective density bias, honouring an explicit override.</summary>
+    public float ResolvedDensityBias => DensityBias ?? Focus switch
+    {
+        RouteFocus.Density => 2f,
+        RouteFocus.Balanced => 1f,
+        _ => 0f
+    };
+
+    /// <summary>
+    /// Minimum share of the busiest cell's spawn count that a cell must hold to become a
+    /// <see cref="RouteGenMode.Loop"/> stop.
+    ///
+    /// <para><see cref="DensityBias"/> only steers the random draw a wander route makes, so
+    /// it does nothing in Loop, which picks its stops deterministically. This is the knob
+    /// that makes <see cref="Focus"/> mean something there: it is what excludes the thin
+    /// fringe cells holding one stray mob.</para>
+    /// </summary>
+    public float? MinCellShare { get; set; }
+
+    /// <summary>Effective cell-density floor, honouring an explicit override.</summary>
+    public float ResolvedMinCellShare => MinCellShare ?? Focus switch
+    {
+        RouteFocus.Density => 0.35f,
+        RouteFocus.Balanced => 0.15f,
+        _ => 0f
+    };
+
+    /// <summary>
+    /// Anchors per generated route. These are hunting spots the bot roams between, not a
+    /// traced path, so this is far smaller than a recorded route's point count.
+    /// </summary>
+    public int Stops { get; set; } = 8;
+
+    /// <summary>How far the spawn-cell mask is dilated before sampling.</summary>
+    public float PaddingYards { get; set; } = 25f;
+
+    /// <summary>
+    /// Rejects a sampled point whose z differs from its anchoring spawn by more than this.
+    /// The cheap half of the roof/canopy/ledge gate - see the design doc, §6 gate 2.
+    /// </summary>
+    public float MaxVerticalDelta { get; set; } = 5f;
+
+    /// <summary>Minimum spacing between two anchors, so a route spreads over the area.</summary>
+    public float MinSpacingYards { get; set; } = 30f;
+
+    /// <summary>
+    /// Spacing of the emitted waypoints, in yards.
+    ///
+    /// <para>The legs between stops are pathed through the navmesh, which returns points
+    /// every few yards. Handing those straight to the follower makes it brake at every one,
+    /// because each waypoint ends a spline segment - the bot visibly stutters along a
+    /// straight stretch. Recorded routes sit around 17 yd apart and that is what the
+    /// follower is tuned for, so the leg is resampled to roughly that.</para>
+    /// </summary>
+    public float WaypointSpacingYards { get; set; } = 15f;
+
+    /// <summary>Per-path override of <see cref="ClassConfiguration.Seed"/>.</summary>
+    public int? Seed { get; set; }
+}

--- a/Core/Database/AreaDB.cs
+++ b/Core/Database/AreaDB.cs
@@ -206,7 +206,7 @@ public sealed class AreaDB : IDisposable
                             continue;
                     }
 
-                    if (!FriendlyToPlayer(n, faction, factionDB))
+                    if (!FactionExt.FriendlyToPlayer(n, faction, factionDB))
                         continue;
 
                     float d = playerPosW.WorldDistanceXYTo(pos);
@@ -230,30 +230,6 @@ public sealed class AreaDB : IDisposable
         {
             pool.Return(rented, clearArray: false);
         }
-    }
-
-    static bool FriendlyToPlayer(Creature npc, PlayerFaction playerFaction, FactionTemplateDB factionDB)
-    {
-        if (!factionDB.Factions.TryGetValue(npc.Faction, out int friendGroup))
-            return false;
-
-        const int AllPlayers = 1;
-
-        const int AlliancePlayers = 2;
-        int allianceOurMask = AllPlayers | AlliancePlayers;
-
-        const int HordePlayers = 4;
-        int hordeOurMask = AllPlayers | HordePlayers;
-
-        return playerFaction switch
-        {
-            PlayerFaction.Alliance => (friendGroup & allianceOurMask) != 0,
-            PlayerFaction.Horde => (friendGroup & hordeOurMask) != 0,
-            // A Neutral player (Pandaren before the Wandering Isle is finished)
-            // only counts NPCs friendly to every player as friendly.
-            PlayerFaction.Neutral => (friendGroup & AllPlayers) != 0,
-            _ => false
-        };
     }
 
     public (Creature, Vector3) FindClosestCreatureByNpcFlag(NpcFlags npcFlag, Vector3 position)

--- a/Core/Database/FactionExt.cs
+++ b/Core/Database/FactionExt.cs
@@ -1,0 +1,46 @@
+using SharedLib;
+
+namespace Core.Database;
+
+/// <summary>
+/// Faction reaction rules shared by the NPC search (which wants friendly NPCs) and the
+/// route generator (which wants the opposite). Kept in one place so the two cannot drift:
+/// a creature the vendor search treats as friendly must never also be a grind candidate.
+/// </summary>
+public static class FactionExt
+{
+    private const int AllPlayers = 1;
+    private const int AlliancePlayers = 2;
+    private const int HordePlayers = 4;
+
+    public static bool FriendlyToPlayer(in Creature npc, PlayerFaction playerFaction,
+        FactionTemplateDB factionDB)
+    {
+        if (!factionDB.Factions.TryGetValue(npc.Faction, out int friendGroup))
+        {
+            return false;
+        }
+
+        return playerFaction switch
+        {
+            PlayerFaction.Alliance => (friendGroup & (AllPlayers | AlliancePlayers)) != 0,
+            PlayerFaction.Horde => (friendGroup & (AllPlayers | HordePlayers)) != 0,
+            // A Neutral player (Pandaren before the Wandering Isle is finished)
+            // only counts NPCs friendly to every player as friendly.
+            PlayerFaction.Neutral => (friendGroup & AllPlayers) != 0,
+            _ => false
+        };
+    }
+
+    /// <summary>
+    /// Attackable by this player. Not simply <c>!FriendlyToPlayer</c> in spirit - a faction
+    /// the template table does not know about is "not friendly" but also not a safe grind
+    /// target, so an unknown faction is excluded from both sets.
+    /// </summary>
+    public static bool HostileToPlayer(in Creature npc, PlayerFaction playerFaction,
+        FactionTemplateDB factionDB)
+    {
+        return factionDB.Factions.ContainsKey(npc.Faction) &&
+            !FriendlyToPlayer(npc, playerFaction, factionDB);
+    }
+}

--- a/Core/Database/NpcSpawnDB.cs
+++ b/Core/Database/NpcSpawnDB.cs
@@ -1,0 +1,79 @@
+using Microsoft.Extensions.Logging;
+
+using Newtonsoft.Json;
+
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Numerics;
+
+using static System.IO.File;
+using static System.IO.Path;
+
+namespace Core.Database;
+
+/// <summary>
+/// Creature entry -&gt; world spawn positions, for an arbitrary map id.
+///
+/// <para><see cref="AreaDB.NpcWorldLocations"/> holds the same data but only for the map the
+/// player is currently standing on, and refreshes it on a background thread when the zone
+/// changes. Route generation needs a specific map, deterministically, possibly before the
+/// player has ever been there - hence a separate, explicitly-keyed cache.</para>
+///
+/// <para>A missing file is a normal state, not an error: the dumps are per client and cover
+/// neither every map nor every client (<c>npcspawnlocations/som</c> has maps 0 and 1 only).</para>
+/// </summary>
+public sealed partial class NpcSpawnDB(ILogger<NpcSpawnDB> logger, DataConfig dataConfig)
+{
+    private readonly Dictionary<int, FrozenDictionary<int, Vector3[]>> byMapId = [];
+
+    public FrozenDictionary<int, Vector3[]> Get(int mapId)
+    {
+        if (byMapId.TryGetValue(mapId, out FrozenDictionary<int, Vector3[]>? cached))
+        {
+            return cached;
+        }
+
+        FrozenDictionary<int, Vector3[]> result = Load(mapId);
+        byMapId[mapId] = result;
+        return result;
+    }
+
+    private FrozenDictionary<int, Vector3[]> Load(int mapId)
+    {
+        string path = Join(dataConfig.NpcSpawnLocations, $"{mapId}.json");
+
+        if (!System.IO.File.Exists(path))
+        {
+            LogNoSpawnData(logger, mapId, path);
+            return FrozenDictionary<int, Vector3[]>.Empty;
+        }
+
+        Dictionary<int, Vector3[]>? data =
+            JsonConvert.DeserializeObject<Dictionary<int, Vector3[]>>(ReadAllText(path));
+
+        if (data == null)
+        {
+            return FrozenDictionary<int, Vector3[]>.Empty;
+        }
+
+        LogLoadedSpawns(logger, data.Count, mapId);
+
+        return data.ToFrozenDictionary();
+    }
+
+    #region Logging
+
+    [LoggerMessage(
+        EventId = 0080,
+        Level = LogLevel.Warning,
+        Message = "No NPC spawn data for map {mapId} ({path}) - routes cannot be generated there")]
+    static partial void LogNoSpawnData(ILogger logger, int mapId, string path);
+
+    [LoggerMessage(
+        EventId = 0081,
+        Level = LogLevel.Debug,
+        Message = "Loaded spawns for {count} creatures on map {mapId}")]
+    static partial void LogLoadedSpawns(ILogger logger, int count, int mapId);
+
+    #endregion
+}

--- a/Core/DependencyInjection.cs
+++ b/Core/DependencyInjection.cs
@@ -111,6 +111,15 @@ public static class DependencyInjection
         s.AddSingleton<CreatureDB>();
         s.AddSingleton<FactionTemplateDB>();
         s.AddSingleton<AreaDB>();
+        s.AddSingleton<NpcSpawnDB>();
+
+        // Root-scoped so the preview page can generate without a bot session running.
+        // RouteGenerator serialises its own creature-filter evaluation, so the page and a
+        // wander regeneration can share the instance.
+        s.AddSingleton<IRouteGenPlayer, RouteGenPlayer>();
+        s.AddSingleton<CreatureRequirementFactory>();
+        s.AddSingleton<RouteGenerator>();
+
         s.AddSingleton<SpellDB>();
         s.AddSingleton<IconDB>();
         s.AddSingleton<ItemDB>();
@@ -160,6 +169,13 @@ public static class DependencyInjection
         s.ForwardSingleton<ItemDB>(sp);
         s.ForwardSingleton<CreatureDB>(sp);
         s.ForwardSingleton<FactionTemplateDB>(sp);
+        s.ForwardSingleton<NpcSpawnDB>(sp);
+
+        // Route generation samples and floods the navmesh directly, which IPPather - a
+        // point-to-point interface - cannot express. The service is registered regardless
+        // of pathing mode, so this is available even when a remote pather is in use.
+        s.ForwardSingleton<PPatherService>(sp);
+        s.ForwardSingleton<RouteGenerator>(sp);
         s.ForwardSingleton<SpellDB>(sp);
         s.ForwardSingleton<IconDB>(sp);
         s.ForwardSingleton<TalentDB>(sp);
@@ -278,10 +294,19 @@ public static class DependencyInjection
         s.AddSingleton<ItemDB>();
         s.AddSingleton<CreatureDB>();
         s.AddSingleton<FactionTemplateDB>();
+        s.AddSingleton<NpcSpawnDB>();
         s.AddSingleton<SpellDB>();
         s.AddSingleton<IconDB>();
         s.AddSingleton<TalentDB>();
         s.AddSingleton<MailboxDB>();
+
+        // Route generation. Root-scoped so the preview page can generate with no bot
+        // session running, and so AddStartupIoC can forward one shared instance into the
+        // session container - RouteGenerator serialises its own creature-filter evaluation
+        // precisely so the page and a wander lap can share it.
+        s.AddSingleton<IRouteGenPlayer, RouteGenPlayer>();
+        s.AddSingleton<CreatureRequirementFactory>();
+        s.AddSingleton<RouteGenerator>();
 
         s.AddAddonComponents();
 

--- a/Core/Goals/AdhocNPCGoal.cs
+++ b/Core/Goals/AdhocNPCGoal.cs
@@ -294,7 +294,7 @@ public sealed partial class AdhocNPCGoal : GoapGoal, IGoapEventListener, IRouteP
     public override void Update()
     {
         if (bits.Drowning())
-            input.PressJump();
+            input.PressJumpAscend();
 
         if (pathState != PathState.Finished)
             navigation.Update();

--- a/Core/Goals/ApproachTargetGoal.cs
+++ b/Core/Goals/ApproachTargetGoal.cs
@@ -17,6 +17,44 @@ public sealed partial class ApproachTargetGoal : GoapGoal, IGoapEventListener
     private const double MAX_APPROACH_DURATION_MS = 15_000; // max time to chase to pull
     private const double MIN_TIME_TILL_IDLE = 2000;
 
+    // Spacing between tab-probes for a closer target. The TargetNearestTarget
+    // key cooldown alone let this re-tab every 400ms for the whole approach.
+    private const double NEAREST_PROBE_INTERVAL_MS = 3000;
+
+    // The addon needs a few frames after the tab lands before the range cells
+    // describe the new unit rather than the old one.
+    private const double NEAREST_PROBE_SETTLE_MS = 300;
+
+    private const double SWAP_BACK_TIMEOUT_MS = 300;
+    private const int SWAP_BACK_MAX_ATTEMPTS = 2;
+
+    /// <summary>
+    /// Yards the tab-target must beat the current one by before the swap is
+    /// worth it. A bare "closer" comparison flip-flops between two mobs at
+    /// similar distance, because MinRange is a coarse bucket that jitters and
+    /// because the baseline it is compared against is captured one settle
+    /// window before the reading. The player keeps closing on the initial
+    /// target during that window - at run speed roughly
+    /// NEAREST_PROBE_SETTLE_MS * 7yd/s - so the baseline reads too far and
+    /// every probe leans towards switching. This margin has to cover both.
+    /// </summary>
+    private const int NEAREST_PROBE_MIN_GAIN = 5;
+
+    /// <summary>
+    /// How long a mob stays "the one we just walked away from". Long enough to
+    /// outlast a whole approach so the two candidates cannot trade places every
+    /// time the goal re-enters, short enough that a genuinely new situation is
+    /// judged on its own merits.
+    /// </summary>
+    private const double ABANDONED_GUID_TTL_MS = 20_000;
+
+    private enum CloserTargetProbe
+    {
+        Idle,
+        Settling,
+        SwappingBack
+    }
+
     public override float Cost => 8f;
 
     private readonly ILogger<ApproachTargetGoal> logger;
@@ -29,6 +67,7 @@ public sealed partial class ApproachTargetGoal : GoapGoal, IGoapEventListener
     private readonly IMountHandler mountHandler;
     private readonly IBlacklist targetBlacklist;
     private readonly CombatLog combatLog;
+    private readonly ApproachThrottle approachThrottle;
 
     private long approachStart;
 
@@ -36,6 +75,23 @@ public sealed partial class ApproachTargetGoal : GoapGoal, IGoapEventListener
 
     private int initialTargetGuid;
     private float initialMinRange;
+
+    private CloserTargetProbe probe;
+
+    /// <summary>
+    /// A probe holds a different unit than the one being approached, so anything
+    /// keyed off the target's range reads the wrong mob until it resolves. The
+    /// old blocking version never exposed that window.
+    /// </summary>
+    private bool ProbeInFlight => probe != CloserTargetProbe.Idle;
+
+    private double probeDeadline;
+    private double nextNearestProbeTime;
+    private int probeInitialMinRange;
+    private int swapBackAttempts;
+
+    private int probeAbandonedGuid;
+    private long probeAbandonedAt;
 
     private double ApproachDurationMs => GetElapsedTime(approachStart).TotalMilliseconds;
 
@@ -45,7 +101,8 @@ public sealed partial class ApproachTargetGoal : GoapGoal, IGoapEventListener
         StopMoving stopMoving, CombatTracker combatTracker,
         IBlacklist blacklist,
         IMountHandler mountHandler,
-        CombatLog combatLog)
+        CombatLog combatLog,
+        ApproachThrottle approachThrottle)
         : base(nameof(ApproachTargetGoal))
     {
         this.logger = logger;
@@ -60,6 +117,7 @@ public sealed partial class ApproachTargetGoal : GoapGoal, IGoapEventListener
         this.mountHandler = mountHandler;
         this.targetBlacklist = blacklist;
         this.combatLog = combatLog;
+        this.approachThrottle = approachThrottle;
 
         AddPrecondition(GoapKey.hastarget, true);
         AddPrecondition(GoapKey.targetisalive, true);
@@ -86,7 +144,11 @@ public sealed partial class ApproachTargetGoal : GoapGoal, IGoapEventListener
         initialMinRange = playerReader.MinRange();
 
         approachStart = GetTimestamp();
+        approachThrottle.Reset();
         SetNextStuckTimeCheck();
+
+        probe = CloserTargetProbe.Idle;
+        nextNearestProbeTime = 0;
     }
 
     public override void OnExit()
@@ -112,10 +174,19 @@ public sealed partial class ApproachTargetGoal : GoapGoal, IGoapEventListener
             return;
         }
 
-        if (!input.Approach.OnCooldown() && (!bits.SoftInteract() || HasValidSoftInteract()))
+        // WithInCombatRange is the source of GoapKey.incombatrange and this
+        // goal's own effect: once it holds the goal is done and GOAP simply
+        // has not replanned yet. A press inside that lag window restarts the
+        // interact run onto a mob the player already stands on, which is what
+        // carries a melee class past it.
+        if (!ProbeInFlight &&
+            approachThrottle.ShouldPress(playerReader.WithInCombatRange()) &&
+            (!bits.SoftInteract() || HasValidSoftInteract()))
         {
             input.PressApproach();
             wait.Update();
+
+            approachThrottle.OnPressed();
         }
 
         if (!bits.Combat())
@@ -184,49 +255,14 @@ public sealed partial class ApproachTargetGoal : GoapGoal, IGoapEventListener
             return;
         }
 
-        if (playerReader.TargetGuid == initialTargetGuid &&
-            !playerReader.IsInMeleeRange() &&
-            // Tab-targeting with an auto attack running engages whatever it lands
-            // on: Auto Shot fires the moment the new target is acquired, so even
-            // switching straight back leaves a second mob pulled and inbound.
-            // Only once something is in pull range though - out of range the swap
-            // costs nothing, and that is where a closer target is worth finding.
-            !(bits.Any_AutoAttack() && playerReader.WithInPullRange()))
+        if (UpdateCloserTargetProbe())
         {
-            int initialTargetMinRange = playerReader.MinRange();
-            if (!input.TargetNearestTarget.OnCooldown())
-            {
-                //logger.LogWarning($"Attempt to find closer target IsInMeleeRange:{playerReader.IsInMeleeRange()} - min:{playerReader.MinRange()} | max:{playerReader.MaxRange()} - initialMinRange:{initialTargetMinRange}");
-
-                input.PressNearestTarget();
-                wait.Update();
-
-                if (bits.Target() && playerReader.TargetGuid != initialTargetGuid)
-                {
-                    if (targetBlacklist.Is())
-                    {
-                        logger.LogWarning("Losing the target due blacklist!");
-                        return;
-                    }
-
-                    if (playerReader.MinRange() < initialTargetMinRange)
-                    {
-                        logger.LogWarning("Found a closer target! {MinRange} < {InitialTargetMinRange}", playerReader.MinRange(), initialTargetMinRange);
-
-                        initialMinRange = playerReader.MinRange();
-                    }
-                    else
-                    {
-                        initialTargetGuid = -1;
-                        logger.LogWarning("Stick to initial target!");
-
-                        input.PressLastTargetAndWait(wait, bits.Target);
-                    }
-                }
-            }
+            return;
         }
 
-        if (ApproachDurationMs > MIN_TIME_TILL_IDLE && initialMinRange < playerReader.MinRange())
+        if (!ProbeInFlight &&
+            ApproachDurationMs > MIN_TIME_TILL_IDLE &&
+            initialMinRange < playerReader.MinRange())
         {
             Log($"Going away from the target! {initialMinRange} < {playerReader.MinRange()}");
 
@@ -238,6 +274,163 @@ public sealed partial class ApproachTargetGoal : GoapGoal, IGoapEventListener
     private void SetNextStuckTimeCheck()
     {
         nextStuckCheckTime = ApproachDurationMs + STUCK_INTERVAL_MS;
+    }
+
+    /// <summary>
+    /// Tab for a closer target, spread across ticks instead of blocking the loop.
+    /// A keypress and the addon frame that reflects it are several frames apart,
+    /// so each step arms a deadline and a later Update picks it up. Nothing here
+    /// waits.
+    /// </summary>
+    /// <returns>True when the caller should give up the rest of this tick.</returns>
+    private bool UpdateCloserTargetProbe()
+    {
+        if (probe == CloserTargetProbe.Settling)
+        {
+            return ApproachDurationMs >= probeDeadline && JudgeCloserTarget();
+        }
+
+        if (probe == CloserTargetProbe.SwappingBack)
+        {
+            if (ApproachDurationMs >= probeDeadline)
+            {
+                ResolveSwapBack();
+            }
+
+            return false;
+        }
+
+        if (!CanStartCloserTargetProbe())
+        {
+            return false;
+        }
+
+        probeInitialMinRange = playerReader.MinRange();
+
+        input.PressNearestTarget();
+
+        probe = CloserTargetProbe.Settling;
+        probeDeadline = ApproachDurationMs + NEAREST_PROBE_SETTLE_MS;
+        nextNearestProbeTime = ApproachDurationMs + NEAREST_PROBE_INTERVAL_MS;
+
+        return false;
+    }
+
+    private bool CanStartCloserTargetProbe()
+    {
+        return playerReader.TargetGuid == initialTargetGuid &&
+            !playerReader.IsInMeleeRange() &&
+            ApproachDurationMs >= nextNearestProbeTime &&
+            !input.TargetNearestTarget.OnCooldown() &&
+            // Inside pull range the chase is over and a swap is all downside.
+            // Tab-targeting with an auto attack running engages whatever it
+            // lands on: Auto Shot fires the moment the new target is acquired,
+            // so even switching straight back leaves a second mob pulled and
+            // inbound. Beyond that, a warrior reaches charge range long before
+            // melee, so the plan flips between this goal and PullTargetGoal and
+            // every re-entry re-arms the probe - trading targets there is how
+            // the bot closes on two mobs and pulls neither. Out of pull range
+            // the swap costs nothing, and that is where a closer target is
+            // worth finding.
+            !playerReader.WithInPullRange();
+    }
+
+    private bool JudgeCloserTarget()
+    {
+        probe = CloserTargetProbe.Idle;
+
+        // The tab landed back on the same unit, or on nothing at all.
+        if (!bits.Target() || playerReader.TargetGuid == initialTargetGuid)
+        {
+            return false;
+        }
+
+        if (targetBlacklist.Is())
+        {
+            logger.LogWarning("Losing the target due blacklist!");
+            return true;
+        }
+
+        // The mob we just walked away from. Without this the two candidates
+        // trade places on every re-entry: switch to B, re-enter, tab back to A,
+        // switch to A, re-enter, tab back to B - closing on both, pulling
+        // neither.
+        if (RecentlyAbandoned(playerReader.TargetGuid))
+        {
+            SwapBackToInitial();
+            return false;
+        }
+
+        if (playerReader.MinRange() + NEAREST_PROBE_MIN_GAIN <= probeInitialMinRange)
+        {
+            logger.LogWarning("Found a closer target! {MinRange} + {MinGain} <= {InitialTargetMinRange}",
+                playerReader.MinRange(), NEAREST_PROBE_MIN_GAIN, probeInitialMinRange);
+
+            Abandon(initialTargetGuid);
+
+            initialMinRange = playerReader.MinRange();
+
+            return false;
+        }
+
+        logger.LogWarning("Stick to initial target!");
+
+        Abandon(playerReader.TargetGuid);
+        SwapBackToInitial();
+
+        return false;
+    }
+
+    private void SwapBackToInitial()
+    {
+        swapBackAttempts = 0;
+        PressLastTargetAndArm();
+    }
+
+    private void Abandon(int guid)
+    {
+        probeAbandonedGuid = guid;
+        probeAbandonedAt = GetTimestamp();
+    }
+
+    private bool RecentlyAbandoned(int guid)
+    {
+        return guid == probeAbandonedGuid &&
+            GetElapsedTime(probeAbandonedAt).TotalMilliseconds < ABANDONED_GUID_TTL_MS;
+    }
+
+    private void PressLastTargetAndArm()
+    {
+        input.PressLastTarget();
+
+        swapBackAttempts++;
+
+        probe = CloserTargetProbe.SwappingBack;
+        probeDeadline = ApproachDurationMs + SWAP_BACK_TIMEOUT_MS;
+    }
+
+    private void ResolveSwapBack()
+    {
+        probe = CloserTargetProbe.Idle;
+
+        if (playerReader.TargetGuid == initialTargetGuid)
+        {
+            // Back on the original. Retire the probe for the rest of this
+            // approach - the start guard keys off initialTargetGuid, so -1
+            // stops it re-firing.
+            initialTargetGuid = -1;
+            return;
+        }
+
+        if (swapBackAttempts < SWAP_BACK_MAX_ATTEMPTS)
+        {
+            PressLastTargetAndArm();
+            return;
+        }
+
+        // Out of attempts and still holding the farther unit. Retire the probe
+        // rather than tab back and forth for the rest of the approach.
+        initialTargetGuid = -1;
     }
 
     private void RandomJump()

--- a/Core/Goals/AutoGatherGoal.cs
+++ b/Core/Goals/AutoGatherGoal.cs
@@ -135,7 +135,7 @@ public sealed class AutoGatherGoal : GoapGoal, IGoapEventListener, IRouteProvide
     public override void Update()
     {
         if (bits.Drowning())
-            input.PressJump();
+            input.PressJumpAscend();
 
         // Check if we're close to the target node
         if (key.Path.Length == 1 && key.Path[0] != default)

--- a/Core/Goals/CombatGoal.cs
+++ b/Core/Goals/CombatGoal.cs
@@ -117,7 +117,7 @@ public sealed class CombatGoal : GoapGoal, IGoapEventListener
 
         if (bits.Drowning())
         {
-            input.PressJump();
+            input.PressJumpAscend();
             return;
         }
 

--- a/Core/Goals/FollowRouteGoal.cs
+++ b/Core/Goals/FollowRouteGoal.cs
@@ -4,6 +4,7 @@ using Game;
 
 using Microsoft.Extensions.Logging;
 
+using SharedLib;
 using SharedLib.Extensions;
 using SharedLib.NpcFinder;
 
@@ -48,6 +49,8 @@ public sealed class FollowRouteGoal : GoapGoal, IGoapEventListener, IRouteProvid
     private CancellationTokenSource sideActivityCts;
 
     private readonly PathSettings pathSettings;
+    private readonly RouteGenerator routeGenerator;
+    private readonly WorldMapAreaDB worldMapAreaDB;
 
     private Vector3[] mapRoute
     {
@@ -92,10 +95,14 @@ public sealed class FollowRouteGoal : GoapGoal, IGoapEventListener, IRouteProvid
         ClassConfiguration classConfig,
         Navigation navigation,
         IMountHandler mountHandler, TargetFinder targetFinder,
-        IBlacklist targetBlacklist)
-    : base("Follow " + System.IO.Path.GetFileNameWithoutExtension(pathSettings.FileName))
+        IBlacklist targetBlacklist,
+        RouteGenerator routeGenerator,
+        WorldMapAreaDB worldMapAreaDB)
+    : base("Follow " + pathSettings.DisplayName)
     {
         this.cost = cost;
+        this.routeGenerator = routeGenerator;
+        this.worldMapAreaDB = worldMapAreaDB;
 
         this.logger = logger;
         this.input = input;
@@ -117,7 +124,7 @@ public sealed class FollowRouteGoal : GoapGoal, IGoapEventListener, IRouteProvid
             Keys = [
              new KeyAction() {
                 RequirementsRuntime = pathSettings.RequirementsRuntime,
-                Name = "Follow " + System.IO.Path.GetFileNameWithoutExtension(pathSettings.FileName)
+                Name = "Follow " + pathSettings.DisplayName
             }];
         }
 
@@ -188,6 +195,8 @@ public sealed class FollowRouteGoal : GoapGoal, IGoapEventListener, IRouteProvid
     {
         SendGoapEvent(FollowRouteChanged.Instance);
 
+        EnsureGenerated();
+
         if (sideActivityCts.IsCancellationRequested)
         {
             sideActivityCts = new();
@@ -247,7 +256,7 @@ public sealed class FollowRouteGoal : GoapGoal, IGoapEventListener, IRouteProvid
 
         if (bits.Drowning())
         {
-            input.PressJump();
+            input.PressJumpAscend();
         }
 
         if (bits.Combat() && !classConfig.GatheringMode) { return; }
@@ -372,9 +381,79 @@ public sealed class FollowRouteGoal : GoapGoal, IGoapEventListener, IRouteProvid
         MountIfPossible();
     }
 
+    /// <summary>
+    /// Builds a generated route the first time this goal actually runs, rather than at
+    /// session start.
+    ///
+    /// <para>Every path in the profile gets a goal, including ones whose requirements can
+    /// never pass in this session - a Human character still carries the Draenei entries.
+    /// Generating all of them up front cost ~1.8s of startup flooding navmesh connectivity
+    /// and pathing legs for routes that would never be walked.</para>
+    /// </summary>
+    private void EnsureGenerated()
+    {
+        if (pathSettings.Generate == null || pathSettings.GenerateContext != null)
+            return;
+
+        RouteGenerator.Context? context =
+            routeGenerator.TryBuildContext(pathSettings.Generate);
+
+        if (context == null)
+        {
+            // Leaves Generated false, so CanRun() drops this goal and GOAP falls through
+            // to the next path instead of walking an empty route.
+            pathSettings.SetWorldPath([], pathSettings.UIMapId, worldMapAreaDB);
+            return;
+        }
+
+        pathSettings.GenerateContext = context;
+
+        int seed = RouteSeed.For(
+            pathSettings.Generate.Seed ?? classConfig.ResolvedSeed, pathSettings.Id, lap: 0);
+
+        pathSettings.SetWorldPath(
+            routeGenerator.Sample(context, pathSettings.Generate, seed),
+            context.Target.UIMapId, worldMapAreaDB, routeGenerator.LastRouteIsDense);
+
+        ApplyWaypointDensity();
+    }
+
+    /// <summary>
+    /// A densified route is hundreds of points a few yards apart, so Navigation's
+    /// average-spacing heuristic works as designed. Only a route whose legs could not be
+    /// pathed stays sparse and needs every hop forced through the pathfinder.
+    /// </summary>
+    private void ApplyWaypointDensity()
+    {
+        navigation.SparseWaypoints =
+            pathSettings.Generate != null && !pathSettings.RouteIsDense;
+    }
+
     public void RefillWaypoints(bool onlyClosest)
     {
         Log($"{nameof(RefillWaypoints)} - findClosest:{onlyClosest} - ThereAndBack:{pathSettings.PathThereAndBack}");
+
+        // A Wander route is not walked twice. Re-sampling costs a cached component lookup
+        // per stop - no pathfinding - so the lap boundary is the natural place to do it,
+        // and the bot never retraces the line it just walked.
+        if (!onlyClosest &&
+            pathSettings.Generate is { Mode: RouteGenMode.Wander } gen &&
+            pathSettings.GenerateContext is { } context)
+        {
+            pathSettings.Lap++;
+
+            int seed = RouteSeed.For(
+                gen.Seed ?? classConfig.ResolvedSeed, pathSettings.Id, pathSettings.Lap);
+
+            Vector3[] fresh = routeGenerator.Sample(context, gen, seed);
+            if (fresh.Length > 0)
+            {
+                pathSettings.SetWorldPath(fresh, context.Target.UIMapId, worldMapAreaDB,
+                    routeGenerator.LastRouteIsDense);
+                ApplyWaypointDensity();
+                Log($"{nameof(RefillWaypoints)} - regenerated {fresh.Length} waypoints for lap {pathSettings.Lap}");
+            }
+        }
 
         Span<Vector3> path = stackalloc Vector3[mapRoute.Length];
         mapRoute.CopyTo(path);

--- a/Core/Goals/PullTargetGoal.cs
+++ b/Core/Goals/PullTargetGoal.cs
@@ -31,6 +31,7 @@ public sealed class PullTargetGoal : GoapGoal, IGoapEventListener
     private readonly IMountHandler mountHandler;
     private readonly CombatTracker combatTracker;
     private readonly IBlacklist targetBlacklist;
+    private readonly ApproachThrottle approachThrottle;
 
     private readonly KeyAction? approachKey;
     private readonly Action approachAction;
@@ -48,7 +49,7 @@ public sealed class PullTargetGoal : GoapGoal, IGoapEventListener
         StopMoving stopMoving, CastingHandler castingHandler,
         IMountHandler mountHandler, NpcNameTargeting npcNameTargeting,
         StuckDetector stuckDetector, CombatTracker combatTracker,
-        ClassConfiguration classConfig)
+        ClassConfiguration classConfig, ApproachThrottle approachThrottle)
         : base(nameof(PullTargetGoal))
     {
         this.logger = logger;
@@ -65,6 +66,7 @@ public sealed class PullTargetGoal : GoapGoal, IGoapEventListener
         this.combatTracker = combatTracker;
         this.targetBlacklist = targetBlacklist;
         this.classConfig = classConfig;
+        this.approachThrottle = approachThrottle;
 
         Keys = classConfig.Pull.Sequence;
 
@@ -102,6 +104,7 @@ public sealed class PullTargetGoal : GoapGoal, IGoapEventListener
     {
         wait.Update();
         stuckDetector.Reset();
+        approachThrottle.Reset();
 
         if (mountHandler.IsMounted())
         {
@@ -228,13 +231,21 @@ public sealed class PullTargetGoal : GoapGoal, IGoapEventListener
 
     private void DefaultApproach()
     {
+        // Rate limiter for the whole method, not just the press: the stuck
+        // detector below jumps on every call until its ladder opens, and
+        // PressJump does not honour a cooldown of its own.
         if (input.Approach.OnCooldown())
+        {
             return;
+        }
 
-        if (!bits.SoftInteract() || EligibleEnemySoftTargetExists())
+        if (approachThrottle.ShouldPress(playerReader.WithInCombatRange()) &&
+            (!bits.SoftInteract() || EligibleEnemySoftTargetExists()))
         {
             input.PressApproach();
             wait.Update();
+
+            approachThrottle.OnPressed();
         }
 
         if (!stuckDetector.IsMoving)

--- a/Core/GoalsComponent/ApproachThrottle.cs
+++ b/Core/GoalsComponent/ApproachThrottle.cs
@@ -1,0 +1,128 @@
+using System;
+
+namespace Core.Goals;
+
+/// <summary>
+/// Interact-with-target moves the character to the target on a single press: the
+/// client finishes the run on its own and keeps the player facing the target the
+/// whole way. Re-pressing restarts that run, and a press landing in the final
+/// yards carries a melee class straight past the mob. This narrows Approach down
+/// to the presses that do something - (re)starting a stalled run, and re-aiming
+/// at a target that moved.
+/// </summary>
+public sealed class ApproachThrottle(
+    ConfigurableInput input, PlayerReader playerReader, AddonBits bits)
+{
+    /// <summary>
+    /// A run at a stationary target keeps its heading, so re-aiming is wasted.
+    /// Still a keepalive rather than zero: something other than the interact run
+    /// can be carrying the player (the blind StartForward after
+    /// ERR_AUTOFOLLOW_TOO_FAR, knockback), and that needs re-engaging.
+    /// </summary>
+    public const int STATIONARY_TARGET_REPEAT_MS = 1000;
+
+    /// <summary>
+    /// A moving target invalidates the run's heading - re-aim at the base cadence.
+    /// </summary>
+    public const int MOVING_TARGET_REPEAT_MS = CastingHandler.SPELL_QUEUE;
+
+    /// <summary>
+    /// Bearing drift since the last press that counts as "the mob moved". Closing
+    /// straight on a fixed point leaves only convergence noise, so this is a
+    /// deadband rather than an exact compare. ~0.10 rad is ~6 degrees.
+    /// </summary>
+    public const float MOVING_TARGET_DRIFT_RAD = 0.10f;
+
+    private float directionAtPress;
+    private int minRangeAtPress;
+
+    /// <summary>
+    /// Re-seeds the reference bearing. Call from OnEnter. A stale pair costs at
+    /// most one extra press, never a decision that stays wrong.
+    /// </summary>
+    public void Reset()
+    {
+        directionAtPress = playerReader.Direction;
+        minRangeAtPress = playerReader.MinRange();
+    }
+
+    /// <summary>
+    /// Whether to re-press Interact while already engaged and standing on the target,
+    /// waiting out a swing.
+    ///
+    /// <para>There is no run left to restart at this range, so the overshoot the
+    /// approach path guards against cannot happen - the press is here to re-face a mob
+    /// that has moved around the player. Treating close melee range as "arrived" and
+    /// suppressing it outright removed the only thing that recovers from
+    /// ERR_BADATTACKFACING while auto-attacking, which is the state issue #827
+    /// describes: on top of the mob, in combat, never turning, dead.</para>
+    ///
+    /// <para>Bearing drift does the deciding. A mob that circles the player drifts it and
+    /// earns a prompt re-face; a mob standing still gets the slow keepalive.</para>
+    /// </summary>
+    public bool ShouldPressEngaged()
+    {
+        if (input.Approach.OnCooldown())
+        {
+            return false;
+        }
+
+        return input.Approach.SinceLastClickMs >
+            (TargetMoved()
+                ? MOVING_TARGET_REPEAT_MS
+                : STATIONARY_TARGET_REPEAT_MS);
+    }
+
+    /// <param name="arrived">
+    /// The reason to press is already satisfied - for the approach goals,
+    /// WithInCombatRange(). Callers already engaged with the target want
+    /// <see cref="ShouldPressEngaged"/> instead.
+    /// </param>
+    public bool ShouldPress(bool arrived)
+    {
+        if (input.Approach.OnCooldown())
+        {
+            return false;
+        }
+
+        if (arrived)
+        {
+            return false;
+        }
+
+        // Nothing is carrying the player forward - (re)start the run.
+        if (!bits.Moving())
+        {
+            return true;
+        }
+
+        return input.Approach.SinceLastClickMs >
+            (TargetMoved()
+                ? MOVING_TARGET_REPEAT_MS
+                : STATIONARY_TARGET_REPEAT_MS);
+    }
+
+    /// <summary>
+    /// Call right after a press so the next comparison is against the bearing the
+    /// run was actually started with - the press itself snaps the facing on target.
+    /// </summary>
+    public void OnPressed()
+    {
+        Reset();
+    }
+
+    /// <summary>
+    /// The interact run keeps the player facing the target, so the player's own
+    /// facing is a free bearing-to-target read. A mob that strafes drifts the
+    /// bearing; a mob fleeing straight away leaves the bearing alone and grows
+    /// the range instead.
+    /// </summary>
+    private bool TargetMoved()
+    {
+        float drift = MathF.Abs(
+            SplineFollowerCore.WrapPi(playerReader.Direction - directionAtPress));
+
+        return drift > MOVING_TARGET_DRIFT_RAD ||
+            playerReader.MinRange() > minRangeAtPress;
+    }
+}

--- a/Core/GoalsComponent/CastingHandler.cs
+++ b/Core/GoalsComponent/CastingHandler.cs
@@ -52,6 +52,8 @@ public sealed partial class CastingHandler
 
     private readonly CastingHandlerInterruptWatchdog interruptWatchdog;
 
+    private readonly ApproachThrottle approachThrottle;
+
     public bool SpellInQueue()
     {
         // Returns true while a non-base press would be wasted; CombatGoal
@@ -92,7 +94,8 @@ public sealed partial class CastingHandler
         CombatLog combatLog,
         StopMoving stopMoving,
         ReactCastError react,
-        CastingHandlerInterruptWatchdog interruptWatchdog)
+        CastingHandlerInterruptWatchdog interruptWatchdog,
+        ApproachThrottle approachThrottle)
     {
         this.logger = logger;
         this.input = input;
@@ -119,6 +122,24 @@ public sealed partial class CastingHandler
         this.react = react;
 
         this.interruptWatchdog = interruptWatchdog;
+
+        this.approachThrottle = approachThrottle;
+    }
+
+    /// <summary>
+    /// Keepalive for the melee swing wait. The point here is staying on the mob and
+    /// facing it, not reaching combat range, so this uses the engaged cadence rather
+    /// than any notion of arrival - see <see cref="ApproachThrottle.ShouldPressEngaged"/>
+    /// for why suppressing the press at close melee range was wrong.
+    /// </summary>
+    private void PressApproachThrottled()
+    {
+        if (approachThrottle.ShouldPressEngaged())
+        {
+            input.PressApproach();
+
+            approachThrottle.OnPressed();
+        }
     }
 
     private int PressKeyAction(KeyAction item, CancellationToken token)
@@ -217,14 +238,32 @@ public sealed partial class CastingHandler
                 LogInstantInput(logger, item.Name, pressMs,
                     playerReader.CastState, elapsedMs);
 
-            if (!CastInstantSuccessful(playerReader.CastEvent.Value) &&
-                playerReader.CastState is not UI_ERROR.NONE &&
-                beforeCastEventTime != playerReader.UIErrorTime.Value)
-            {
-                return CastResult.UIError;
-            }
+            // The action bar bit is the primary signal, but it is only observable while the
+            // slot is highlighted, and for some instants that never survives a frame - Rend
+            // on 3.4.3 shows no outline at all. Against a local server the window is at its
+            // shortest, so the poll missed it on ~60% of instants and reported a cast that
+            // had plainly succeeded as a failure, burning the whole spell-queue wait.
+            //
+            // The addon stamps uiErrorMessageTime alongside lastCastEvent in
+            // OnUnitSpellCastSucceeded, so a cast event newer than the one we saw before
+            // pressing, carrying a success code, is proof the spell went out. Fall through
+            // to the normal post-cast handling rather than returning - AfterCastWaitSwing
+            // and the aura/event wait below still have to run.
+            bool castConfirmed =
+                beforeCastEventTime != playerReader.UIErrorTime.Value &&
+                CastInstantSuccessful(playerReader.CastEvent.Value);
 
-            return CastResult.CurrentActionNotDetected;
+            if (!castConfirmed)
+            {
+                if (!CastInstantSuccessful(playerReader.CastEvent.Value) &&
+                    playerReader.CastState is not UI_ERROR.NONE &&
+                    beforeCastEventTime != playerReader.UIErrorTime.Value)
+                {
+                    return CastResult.UIError;
+                }
+
+                return CastResult.CurrentActionNotDetected;
+            }
         }
 
         // Melee Swing
@@ -233,7 +272,7 @@ public sealed partial class CastingHandler
             elapsedMs = AfterCastWaitSwing(
                 playerReader.MainHandSpeedMs() + playerReader.NetworkLatency,
                 wait, item, playerReader, currentAction,
-                input.PressApproachOnCooldown, token);
+                PressApproachThrottled, token);
 
             static float AfterCastWaitSwing(int duration, Wait wait,
                 KeyAction item,

--- a/Core/GoalsComponent/Navigation.cs
+++ b/Core/GoalsComponent/Navigation.cs
@@ -49,6 +49,19 @@ public sealed partial class Navigation : IDisposable
     private const float SIMPLIFY_LOOK_AHEAD = 0.25f;   // seconds
 
     private float AvgDistance;
+
+    /// <summary>
+    /// The destination has resisted every unstuck attempt for long enough that the caller
+    /// should stop trying to reach it. See <see cref="StuckDetector.IsUnreachable"/>.
+    /// </summary>
+    public bool IsUnreachable => stuckDetector.IsUnreachable;
+
+    /// <summary>
+    /// The waypoints are hunting anchors spread over an area, not a traced path, so every
+    /// leg between them must be pathfound. Set by the caller that supplies such a route -
+    /// see the note in <see cref="SetWayPoints"/>.
+    /// </summary>
+    public bool SparseWaypoints { get; set; }
     private float lastWorldDistance = float.MaxValue;
 
     private const float minAngleToTurn = PI / 35f;              // 5.14 degree
@@ -589,7 +602,17 @@ public sealed partial class Navigation : IDisposable
             wayPoints.Push(point);
         }
 
-        AvgDistance = wayPoints.Count > 1 ? Max(mapDistanceXY / wayPoints.Count, OutDoorMinDistance) : OutDoorMinDistance;
+        // The average-spacing heuristic in RefillRouteToNextWaypoint means "a hop about as
+        // long as this route's own point spacing is not worth pathfinding for". That holds
+        // for a recorded route of hundreds of points a few yards apart. It is actively wrong
+        // for sparse waypoints, where the spacing IS the long hop: an 8-anchor route across
+        // a subzone yields AvgDistance ~60yd, so a 100yd leg counted as trivial and the bot
+        // walked blind through whatever stood in the way.
+        AvgDistance = SparseWaypoints
+            ? OutDoorMinDistance
+            : wayPoints.Count > 1
+                ? Max(mapDistanceXY / wayPoints.Count, OutDoorMinDistance)
+                : OutDoorMinDistance;
 
         UpdateTotalRoute();
 

--- a/Core/GoalsComponent/ReactCastError.cs
+++ b/Core/GoalsComponent/ReactCastError.cs
@@ -11,6 +11,13 @@ namespace Core;
 
 public sealed partial class ReactCastError
 {
+    /// <summary>
+    /// How many <c>updateCount</c>-frame samples the facing gets to settle in before the
+    /// interact-turn is called failed. Needs to be &gt; 1: at exactly one sample the
+    /// timeout equals the cost of taking it, so the loop exits before it can ever compare.
+    /// </summary>
+    private const float SettleSampleBudget = 2.5f;
+
     private readonly ILogger<ReactCastError> logger;
     private readonly PlayerReader playerReader;
     private readonly ActionBarBits<IUsableAction> usableAction;
@@ -174,28 +181,39 @@ public sealed partial class ReactCastError
                 // Try fast interact if no invalid soft target exists
                 if (!bits.SoftInteract_CombatBlocker())
                 {
-                    float beforeDir = playerReader.Direction;
                     input.PressFastInteract();
 
                     const int updateCount = 4;
-                    float e = wait.AfterEquals(playerReader.SpellQueueTimeMs,
-                        updateCount, playerReader._Direction);
 
+                    // Budget the settle window off what a sample actually costs, not off
+                    // SpellQueueTimeMs. That CVar caps at 400ms while one sample is
+                    // updateCount addon frames - at ~100ms a frame the first sample eats
+                    // the whole budget, AfterEquals can only ever time out, and the turn
+                    // is reported as failed at every frame rate but the fastest.
                     float sampleTimeMs =
                         updateCount * (float)addonReader.AvgUpdateLatency;
 
-                    if (e > sampleTimeMs)
+                    int settleMs = Math.Max(playerReader.SpellQueueTimeMs,
+                        (int)(sampleTimeMs * SettleSampleBudget));
+
+                    float e = wait.AfterEquals(settleMs,
+                        updateCount, playerReader._Direction);
+
+                    // AfterEquals returns negative on timeout - the facing never held
+                    // still, so the character is mid-spin. Do NOT treat "direction
+                    // changed" as success there: it is true precisely while the turn is
+                    // unfinished, and it used to suppress the fallback below in the one
+                    // state that needs it.
+                    turnedWithInteract = e > sampleTimeMs;
+
+                    if (turnedWithInteract)
                     {
                         stopMoving.Stop();
                         LogReactFastTurnInteract(logger, value, e);
-                        turnedWithInteract = true;
                     }
                     else
                     {
                         LogUnableToReactFastTurn(logger, value, e);
-
-                        // Check if we turned at all (even if slowly)
-                        turnedWithInteract = beforeDir != playerReader.Direction;
                     }
                 }
 

--- a/Core/GoalsComponent/StuckDetector.cs
+++ b/Core/GoalsComponent/StuckDetector.cs
@@ -20,6 +20,19 @@ public sealed partial class StuckDetector
     private const double UNSTUCK_AFTER_MS = 2000;
     private const double ACTION_STUCK_TIME = 3000;
 
+    /// <summary>
+    /// How long the target may go without getting any closer than it has ever been before
+    /// the destination is written off as unreachable.
+    ///
+    /// <para>Sized against the ladder, not picked round: attempts are
+    /// <see cref="UNSTUCK_AFTER_MS"/> apart and the last rung is reached on attempt 6, so a
+    /// full pass takes ~12s and this allows roughly one and a half. Long enough that every
+    /// recovery has been tried and retried, short enough that the character is not visibly
+    /// jumping and sidestepping on the spot for a minute - which is what a passer-by
+    /// notices and reports.</para>
+    /// </summary>
+    private const double GIVE_UP_AFTER_MS = 20_000;
+
     private readonly ILogger<StuckDetector> logger;
     private readonly ConfigurableInput input;
 
@@ -30,15 +43,29 @@ public sealed partial class StuckDetector
 
     private Vector3 worldTarget;
 
-    private float prevDistance = MAX_RANGE;
     private long startTime;
     private long attemptTime;
     private int attemptCount;
+
+    // Closest the target has ever been on this attempt, and when that happened. A
+    // last-reading comparison cannot tell a yard of shuffling apart from covering ground;
+    // a best-so-far one can.
+    private float bestDistance = MAX_RANGE;
+    private long bestTime;
 
     public double ActionDurationMs => GetElapsedTime(startTime).TotalMilliseconds;
     private double UnstuckMs => GetElapsedTime(attemptTime).TotalMilliseconds;
 
     public bool IsMoving => bits.Moving();
+
+    /// <summary>
+    /// The target has not been approached in <see cref="GIVE_UP_AFTER_MS"/> despite the
+    /// unstuck attempts. The caller owns what to do about it - pick another destination,
+    /// abandon the goal - but it must do something, or it will retry forever.
+    /// </summary>
+    public bool IsUnreachable =>
+        bestDistance < MAX_RANGE &&
+        GetElapsedTime(bestTime).TotalMilliseconds > GIVE_UP_AFTER_MS;
 
     public StuckDetector(ILogger<StuckDetector> logger, ConfigurableInput input,
         AddonBits bits, PlayerReader playerReader, PlayerDirection playerDirection,
@@ -60,16 +87,30 @@ public sealed partial class StuckDetector
         if (this.worldTarget != worldTarget)
         {
             this.worldTarget = worldTarget;
+
+            // A different destination is a genuinely fresh attempt, so the unreachable
+            // verdict goes with it.
             Reset();
+
+            bestDistance = MAX_RANGE;
+            bestTime = GetTimestamp();
         }
     }
 
+    /// <summary>
+    /// Clears the escalation state.
+    ///
+    /// <para>Deliberately leaves the unreachable clock alone: every caller means "start this
+    /// attempt over" - a nudge worked, or the route is being recalculated - and none of them
+    /// means the destination changed. Clearing the clock here is what let a hopeless
+    /// approach retry indefinitely, because <see cref="Navigation"/> recalculates the route
+    /// every few seconds while stuck.</para>
+    /// </summary>
     public void Reset()
     {
         attemptTime = GetTimestamp();
         startTime = GetTimestamp();
 
-        prevDistance = MAX_RANGE;
         attemptCount = 0;
     }
 
@@ -80,7 +121,14 @@ public sealed partial class StuckDetector
 
         if (UnstuckMs < UNSTUCK_AFTER_MS)
         {
-            if (!bits.Flying())
+            // Rate limit, because this branch cannot be trusted to be entered
+            // slowly. A spline advances its lookahead every tick and re-seeds
+            // SetTargetLocation with it, which Resets attemptTime - so UnstuckMs
+            // restarts before it ever reaches UNSTUCK_AFTER_MS. The ladder then
+            // never escalates past attempt 0, never logs, and this jump fires on
+            // every single frame: the character pogo-jumps in place and the
+            // spacebar looks stuck down.
+            if (!bits.Flying() && !input.Jump.OnCooldown())
                 input.PressJump(token);
 
             return;
@@ -112,19 +160,117 @@ public sealed partial class StuckDetector
             return;
         }
 
-        // Aggressive: stop, turn, move forward, jump, reorient
+        if (attemptCount == 3)
+        {
+            // Aggressive: stop, turn, move forward, jump, reorient
+            stopMoving.Stop();
+
+            int turnDuration = Random.Shared.Next(150) + 100;
+            LogUnstuckTurn(logger, attemptCount, turnDuration);
+            input.TurnRandomDir(turnDuration, token);
+
+            int moveDuration = Random.Shared.Next(500) + 500;
+            input.PressFixed(input.ForwardKey, moveDuration, token);
+
+            if (!bits.Flying())
+                input.PressJump(token);
+
+            FaceTarget(token);
+            return;
+        }
+
+        // Everything above pushes forward, which is useless once the character is jammed
+        // against something - it just holds it there. From here on the goal is to put the
+        // body somewhere genuinely different, so the next path request starts from a spot
+        // that is not against the obstacle. Reported recovery from a real stuck on Azuremyst
+        // was exactly this: back up, then sidestep.
+        int stage = (attemptCount - 4) % 3;
+
+        switch (stage)
+        {
+            case 0:
+                StrafeOut(token);
+                break;
+
+            case 1:
+                BackOutAndAround(token);
+                break;
+
+            default:
+                BackOutAndAround(token, longer: true);
+                break;
+        }
+
+        FaceTarget(token);
+    }
+
+    /// <summary>
+    /// Slides sideways without turning. A doorway, fence post or tree the character is
+    /// pressed against is often cleared by a yard of lateral movement, which forward-only
+    /// nudging can never produce - pushing forward just holds it against the obstacle.
+    /// </summary>
+    private void StrafeOut(CancellationToken token)
+    {
+        bool left = Random.Shared.Next(2) == 0;
+        ConsoleKey strafeKey = left
+            ? input.StrafeLeft.ConsoleKey
+            : input.StrafeRight.ConsoleKey;
+
+        if (strafeKey == default)
+        {
+            LogNoStrafeBinding(logger);
+            return;
+        }
+
         stopMoving.Stop();
 
-        int turnDuration = Random.Shared.Next(150) + 100;
-        LogUnstuckTurn(logger, attemptCount, turnDuration);
-        input.TurnRandomDir(turnDuration, token);
+        int duration = Random.Shared.Next(400) + 600;
+        LogUnstuckStrafe(logger, attemptCount, left ? "left" : "right", duration);
 
-        int moveDuration = Random.Shared.Next(500) + 500;
-        input.PressFixed(input.ForwardKey, moveDuration, token);
+        input.PressFixed(strafeKey, duration, token);
 
         if (!bits.Flying())
             input.PressJump(token);
+    }
 
+    /// <summary>
+    /// Reverses out and leaves at an angle. Backing straight up tends to return to the same
+    /// spot, so the retreat is combined with a strafe - the character ends up off the line
+    /// it was jammed on, which is what lets the next path take a different approach.
+    /// </summary>
+    private void BackOutAndAround(CancellationToken token, bool longer = false)
+    {
+        stopMoving.Stop();
+
+        int backDuration = longer
+            ? Random.Shared.Next(700) + 900
+            : Random.Shared.Next(400) + 500;
+
+        LogUnstuckBackOut(logger, attemptCount, backDuration);
+
+        input.PressFixed(input.BackwardKey, backDuration, token);
+
+        bool left = Random.Shared.Next(2) == 0;
+        ConsoleKey strafeKey = left
+            ? input.StrafeLeft.ConsoleKey
+            : input.StrafeRight.ConsoleKey;
+
+        if (strafeKey != default)
+        {
+            input.PressFixed(strafeKey, Random.Shared.Next(300) + 400, token);
+        }
+        else
+        {
+            // No strafe binding - a wide turn is the next best way off the old line.
+            input.TurnRandomDir(Random.Shared.Next(300) + 400, token);
+        }
+
+        if (!bits.Flying())
+            input.PressJump(token);
+    }
+
+    private void FaceTarget(CancellationToken token)
+    {
         Vector3 targetM = WorldMapAreaDB.ToMap_FlipXY(worldTarget, playerReader.WorldMapArea);
         float heading = DirectionCalculator.CalculateMapHeading(playerReader.MapPos, targetM);
         playerDirection.SetDirection(heading, targetM, PlayerDirection.DefaultIgnoreDistance, token);
@@ -133,10 +279,20 @@ public sealed partial class StuckDetector
     public bool IsGettingCloser()
     {
         float distance = playerReader.WorldPos.WorldDistanceXYTo(worldTarget);
-        if (distance < prevDistance - MIN_RANGE_DIFF)
+
+        // Only a new closest approach counts as progress, and only it clears the ladder.
+        //
+        // This used to compare against the previous reading, which meant the yard or two an
+        // unstuck nudge produces looked like progress and reset the attempt counter. The
+        // ladder then restarted at attempt 1 every time and never reached anything stronger
+        // than a jump - 42 minutes of it in one observed session. Measuring against the best
+        // approach so far makes shuffling in place read as what it is.
+        if (distance < bestDistance - MIN_RANGE_DIFF)
         {
+            bestDistance = distance;
+            bestTime = GetTimestamp();
+
             Reset();
-            prevDistance = distance;
             return true;
         }
 
@@ -166,6 +322,24 @@ public sealed partial class StuckDetector
         Level = LogLevel.Information,
         Message = "Unstuck attempt {Attempt}: turning {TurnDuration}ms")]
     static partial void LogUnstuckTurn(ILogger logger, int attempt, int turnDuration);
+
+    [LoggerMessage(
+        EventId = 0053,
+        Level = LogLevel.Information,
+        Message = "Unstuck attempt {Attempt}: strafe {Direction} {Duration}ms")]
+    static partial void LogUnstuckStrafe(ILogger logger, int attempt, string direction, int duration);
+
+    [LoggerMessage(
+        EventId = 0054,
+        Level = LogLevel.Information,
+        Message = "Unstuck attempt {Attempt}: back out {Duration}ms + sidestep")]
+    static partial void LogUnstuckBackOut(ILogger logger, int attempt, int duration);
+
+    [LoggerMessage(
+        EventId = 0055,
+        Level = LogLevel.Warning,
+        Message = "No strafe binding available - unstuck cannot sidestep. Bind StrafeLeft/StrafeRight.")]
+    static partial void LogNoStrafeBinding(ILogger logger);
 
     #endregion
 }

--- a/Core/GoalsFactory/GoalFactory.cs
+++ b/Core/GoalsFactory/GoalFactory.cs
@@ -88,6 +88,7 @@ public static class GoalFactory
         services.AddScoped<CastingHandlerInterruptWatchdog>();
         services.AddScoped<CastingHandler>();
         services.AddScoped<StuckDetector>();
+        services.AddScoped<ApproachThrottle>();
         services.AddScoped<CombatTracker>();
         services.AddScoped<SafeSpotCollector>();
         services.AddScoped<ThreatFinder>();
@@ -377,11 +378,22 @@ public static class GoalFactory
 
             services.AddKeyedScoped<PathSettings>(i,
                 (IServiceProvider sp, object? key) =>
-                GetPathSettings(
-                    sp.GetRequiredService<ILogger>(),
-                    sp.GetRequiredService<ClassConfiguration>().Paths[(int)key!],
-                    sp.GetRequiredService<DataConfig>(),
-                    sp.GetRequiredService<WorldMapAreaDB>()));
+                {
+                    PathSettings setting =
+                        sp.GetRequiredService<ClassConfiguration>().Paths[(int)key!];
+
+                    // A generated path builds itself the first time its goal actually runs
+                    // - see FollowRouteGoal.EnsureGenerated. Doing it here built every
+                    // path in the profile at session start, including the ones whose
+                    // requirements can never pass for this character.
+                    return setting.Generate != null
+                        ? setting
+                        : GetPathSettings(
+                            sp.GetRequiredService<ILogger>(),
+                            setting,
+                            sp.GetRequiredService<DataConfig>(),
+                            sp.GetRequiredService<WorldMapAreaDB>());
+                });
 
             services.AddScoped<GoapGoal>(sp =>
                 ActivatorUtilities.CreateInstance<FollowRouteGoal>(sp,

--- a/Core/Input/ConfigurableInput.cs
+++ b/Core/Input/ConfigurableInput.cs
@@ -271,6 +271,28 @@ public sealed partial class ConfigurableInput
 
     public void PressJump(CancellationToken token = default) => PressRandom(Jump, token);
 
+    /// <summary>
+    /// How long Jump is held to swim upward while drowning.
+    /// </summary>
+    public const int DROWNING_ASCEND_MS = 800;
+
+    /// <summary>
+    /// Holds Jump so a swimming character actually ascends. A tap barely lifts
+    /// them, which is why the drowning branches used to fire on every frame and
+    /// still not surface - from the outside that reads as a stuck spacebar.
+    /// <para>Press and release happen inside this call. Cancelling only cuts the
+    /// hold short: PressFixed waits on the token handle and posts the key-up
+    /// afterwards either way, so the key cannot be left latched.</para>
+    /// </summary>
+    public void PressJumpAscend(CancellationToken token = default)
+    {
+        if (Jump.ConsoleKey == default)
+            return;
+
+        input.PressFixed(Jump.ConsoleKey, DROWNING_ASCEND_MS, token);
+        Jump.SetClicked();
+    }
+
     public void PressPetAttack(CancellationToken token = default) => PressRandom(PetAttack, token);
 
     public void PressMount(CancellationToken token = default) => PressRandom(Mount, token);

--- a/Core/PPather/LocalPathingApi.cs
+++ b/Core/PPather/LocalPathingApi.cs
@@ -28,6 +28,12 @@ public sealed class LocalPathingApi : IPPather
 
     private readonly PPatherService service;
 
+    /// <summary>
+    /// Serializes the pather's two-call search protocol. Route generation added a second
+    /// caller on a different thread; before that the single caller made this unnecessary.
+    /// </summary>
+    private readonly System.Threading.Lock searchLock = new();
+
     private DateTime lastSave;
 
     public LocalPathingApi(ILogger<LocalPathingApi> logger,
@@ -51,11 +57,21 @@ public sealed class LocalPathingApi : IPPather
     {
         long timestamp = Stopwatch.GetTimestamp();
 
-        service.SetLocations(
-            service.ToWorld(uiMap, mapFrom.X, mapFrom.Y, mapFrom.Z),
-            service.ToWorld(uiMap, mapTo.X, mapTo.Y));
+        Path path;
+        float searchFromMapId;
 
-        Path path = service.DoSearch(searchStrategy);
+        // See FindWorldRoute. SearchFrom is captured inside the lock too - it belongs to
+        // the search that just ran, and another caller's SetLocations would replace it.
+        lock (searchLock)
+        {
+            service.SetLocations(
+                service.ToWorld(uiMap, mapFrom.X, mapFrom.Y, mapFrom.Z),
+                service.ToWorld(uiMap, mapTo.X, mapTo.Y));
+
+            path = service.DoSearch(searchStrategy);
+            searchFromMapId = service.SearchFrom.W;
+        }
+
         if (path == null)
         {
             if (debug)
@@ -75,7 +91,7 @@ public sealed class LocalPathingApi : IPPather
 
         for (int i = 0; i < path.locations.Count; i++)
         {
-            path.locations[i] = service.ToLocal(path.locations[i], (int)service.SearchFrom.W, uiMap);
+            path.locations[i] = service.ToLocal(path.locations[i], (int)searchFromMapId, uiMap);
         }
         return path.locations.ToArray();
     }
@@ -84,11 +100,22 @@ public sealed class LocalPathingApi : IPPather
     {
         long timestamp = Stopwatch.GetTimestamp();
 
-        service.SetLocations(
-            service.ToWorldZ(uiMap, worldFrom.X, worldFrom.Y, worldFrom.Z, startIndoors),
-            service.ToWorldZ(uiMap, worldTo.X, worldTo.Y, worldTo.Z));
+        Path path;
 
-        Path path = service.DoSearch(searchStrategy);
+        // SetLocations/DoSearch is a stateful two-call protocol on a non-reentrant
+        // singleton (see PPather/CLAUDE.md). Until now the only caller was Navigation's
+        // PathFinderThread, so it was serialized by accident; route generation runs on the
+        // bot thread, which would interleave the two calls and search between the wrong
+        // endpoints.
+        lock (searchLock)
+        {
+            service.SetLocations(
+                service.ToWorldZ(uiMap, worldFrom.X, worldFrom.Y, worldFrom.Z, startIndoors),
+                service.ToWorldZ(uiMap, worldTo.X, worldTo.Y, worldTo.Z));
+
+            path = service.DoSearch(searchStrategy);
+        }
+
         if (path == null)
         {
             if (debug)

--- a/Core/Path/Generate/IRouteGenPlayer.cs
+++ b/Core/Path/Generate/IRouteGenPlayer.cs
@@ -1,0 +1,26 @@
+using SharedLib;
+
+namespace Core;
+
+/// <summary>
+/// The four player facts route generation actually reads. Narrower than
+/// <see cref="PlayerReader"/> on purpose: the generator has no business with combat state,
+/// and depending on the whole reader would make it impossible to exercise without a running
+/// game client and a live addon feed.
+/// </summary>
+public interface IRouteGenPlayer
+{
+    int Level { get; }
+    UnitRace Race { get; }
+    PlayerFaction Faction { get; }
+    int UIMapId { get; }
+}
+
+/// <summary>Live implementation, reading through to the addon data.</summary>
+public sealed class RouteGenPlayer(PlayerReader playerReader) : IRouteGenPlayer
+{
+    public int Level => playerReader.Level.Value;
+    public UnitRace Race => playerReader.Race;
+    public PlayerFaction Faction => playerReader.Faction;
+    public int UIMapId => playerReader.UIMapId.Value;
+}

--- a/Core/Path/Generate/RouteGenerator.cs
+++ b/Core/Path/Generate/RouteGenerator.cs
@@ -1,0 +1,769 @@
+using Core.Database;
+
+using DotRecast.Core;
+
+using Microsoft.Extensions.Logging;
+
+using PPather;
+using PPather.Navmesh;
+
+using SharedLib;
+using SharedLib.Data;
+using SharedLib.Extensions;
+
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Numerics;
+
+namespace Core;
+
+/// <summary>
+/// Builds a grind route from the running client's own NPC spawn data instead of a recorded
+/// waypoint file. See docs/generated-routes-design.md.
+/// </summary>
+public sealed partial class RouteGenerator
+{
+    /// <summary>
+    /// Applied when <see cref="RouteGenSettings.Mobs"/> is empty. Expressed in the same
+    /// language a profile would use, so there is one code path and the default is
+    /// inspectable rather than hidden in an if-chain.
+    /// </summary>
+    public const string DefaultMobFilter =
+        "Level >= PlayerLevel - 3 && Level <= PlayerLevel + 2 && !Elite";
+
+    /// <summary>
+    /// How many spawn anchors are probed to decide which navmesh component the route lives
+    /// on. The modal answer wins, so a handful of spawns stranded on a roof or inside a
+    /// building cannot drag the whole route onto their island.
+    /// </summary>
+    private const int ComponentProbeCount = 48;
+
+    /// <summary>Resample budget per stop before giving up on that stop.</summary>
+    private const int MaxAttemptsPerStop = 24;
+
+    /// <summary>
+    /// Pair budget for the Loop distance matrix. ~200 pairs is a couple of seconds; the
+    /// growth is quadratic, so 50 stops would be 1225 pairs and the better part of a minute.
+    /// </summary>
+    private const int MaxPathedMatrixPairs = 200;
+
+    private readonly ILogger logger;
+    private readonly CreatureDB creatureDb;
+    private readonly NpcSpawnDB spawnDb;
+    private readonly WorldMapAreaDB worldMapAreaDB;
+    private readonly PPatherService pather;
+    private readonly CreatureRequirementFactory creatureRequirements;
+    private readonly IRouteGenPlayer player;
+    private readonly FactionTemplateDB factionDB;
+
+    /// <summary>Point-to-point pathing, used to densify the legs between stops.</summary>
+    private readonly IPPather routePather;
+
+    /// <summary>
+    /// Whether the last <see cref="Sample"/> managed to path its legs. False means the
+    /// caller holds bare anchors, which Navigation has to be told about.
+    /// </summary>
+    public bool LastRouteIsDense { get; private set; }
+
+    /// <summary>
+    /// <see cref="CreatureRequirementFactory"/> evaluates through a single mutable cursor,
+    /// so two concurrent generations would read each other's rows. The preview page and a
+    /// wander lap regeneration are exactly that pair. Generation is rare and takes
+    /// milliseconds, so a lock is the honest fix rather than a per-caller instance.
+    /// </summary>
+    private readonly System.Threading.Lock buildLock = new();
+
+    public RouteGenerator(ILogger logger, CreatureDB creatureDb, NpcSpawnDB spawnDb,
+        WorldMapAreaDB worldMapAreaDB, PPatherService pather,
+        CreatureRequirementFactory creatureRequirements, IRouteGenPlayer player,
+        FactionTemplateDB factionDB, IPPather routePather)
+    {
+        this.logger = logger;
+        this.creatureDb = creatureDb;
+        this.spawnDb = spawnDb;
+        this.worldMapAreaDB = worldMapAreaDB;
+        this.pather = pather;
+        this.creatureRequirements = creatureRequirements;
+        this.player = player;
+        this.factionDB = factionDB;
+        this.routePather = routePather;
+    }
+
+    /// <summary>
+    /// The parts of a generated route that are worth keeping between laps: resolving the
+    /// zone, selecting creatures and flooding the navmesh are all lap-invariant, so a
+    /// wander regeneration re-samples against this and does no pathfinding at all.
+    /// </summary>
+    public sealed class Context
+    {
+        public required RouteTarget Target { get; init; }
+        public required SpawnPolygon Polygon { get; init; }
+        public required NavmeshConnectivity Connectivity { get; init; }
+        public required NavmeshPathfinder Navmesh { get; init; }
+        public required int Component { get; init; }
+        public required int MatchedCreatures { get; init; }
+    }
+
+    /// <summary>
+    /// Resolves everything a route needs except the sampling. Returns null - having logged
+    /// why - when the zone, the spawn data, the mob filter or the navmesh cannot supply it.
+    /// </summary>
+    public Context? TryBuildContext(RouteGenSettings settings)
+    {
+        lock (buildLock)
+        {
+            return BuildContext(settings);
+        }
+    }
+
+    private Context? BuildContext(RouteGenSettings settings)
+    {
+        RouteTarget? target = RouteTarget.Resolve(settings, worldMapAreaDB,
+            player.Race, player.UIMapId);
+
+        if (target == null)
+        {
+            LogNoZone(logger, settings.Zone ?? settings.Subzone ?? "<unset>");
+            return null;
+        }
+
+        string filterText = string.IsNullOrWhiteSpace(settings.Mobs)
+            ? DefaultMobFilter
+            : settings.Mobs;
+
+        Requirement filter;
+        try
+        {
+            filter = creatureRequirements.Parse(filterText);
+        }
+        catch (Exception e)
+        {
+            LogBadFilter(logger, filterText, e.Message);
+            return null;
+        }
+
+        List<Vector3> spawns = SelectSpawns(settings, target, filter, out int matched);
+
+        if (spawns.Count == 0)
+        {
+            LogNoMatches(logger, target.Name, filterText);
+            return null;
+        }
+
+        SpawnPolygon polygon = SpawnPolygon.Build(spawns, settings.PaddingYards,
+            settings.ResolvedMinClusterShare, settings.ResolvedDensityBias);
+
+        if (polygon.PrunedSpawns > 0)
+        {
+            LogPruned(logger, target.Name, polygon.PrunedSpawns, polygon.ClusterCount,
+                settings.Focus.ToString());
+        }
+
+        NavmeshPathfinder? navmesh = pather.GetQueryNavmeshForMap(target.MapId);
+        if (navmesh == null)
+        {
+            LogNoNavmesh(logger, target.Name, target.MapId);
+            return null;
+        }
+
+        NavmeshConnectivity? connectivity = pather.BuildConnectivity(target.MapId,
+            polygon.MinWorldX, polygon.MinWorldY, polygon.MaxWorldX, polygon.MaxWorldY);
+
+        if (connectivity == null || connectivity.PolyCount == 0)
+        {
+            LogNoNavmesh(logger, target.Name, target.MapId);
+            return null;
+        }
+
+        int component = ResolveComponent(polygon, navmesh, connectivity, settings);
+        if (component < 0)
+        {
+            LogNoComponent(logger, target.Name);
+            return null;
+        }
+
+        // polygon.Spawns, not the pre-prune list: pruning has already dropped the isolated
+        // stragglers, and reporting the larger number here contradicts the very next line.
+        LogContext(logger, target.Name, matched, polygon.Spawns.Length, polygon.CellCount,
+            connectivity.PolyCount, connectivity.ComponentCount);
+
+        return new Context
+        {
+            Target = target,
+            Polygon = polygon,
+            Connectivity = connectivity,
+            Navmesh = navmesh,
+            Component = component,
+            MatchedCreatures = matched
+        };
+    }
+
+    /// <summary>
+    /// Samples one route. Cheap by design - the expensive work lives in
+    /// <see cref="TryBuildContext"/> - so a wander route can be regenerated every lap.
+    /// </summary>
+    public Vector3[] Sample(Context context, RouteGenSettings settings, int seed)
+    {
+        return settings.Mode == RouteGenMode.Loop
+            ? SampleLoop(context, settings)
+            : SampleWander(context, settings, seed);
+    }
+
+    /// <summary>
+    /// One closed tour over the densest spots, ordered so a lap covers the area once.
+    ///
+    /// <para>Takes no seed: a loop is meant to be the same route every session, and every
+    /// input here - which cells are densest, how far apart the stops must be, the walking
+    /// distance between them - is already fixed by the zone and the mob filter.</para>
+    /// </summary>
+    private Vector3[] SampleLoop(Context context, RouteGenSettings settings)
+    {
+        List<Vector3> peaks = context.Polygon.DensityPeaks(
+            settings.MinSpacingYards, settings.Stops, settings.ResolvedMinCellShare,
+            out int consideredCells);
+
+        LogLoopPeaks(logger, context.Target.Name, peaks.Count, consideredCells,
+            settings.Focus.ToString(), settings.ResolvedMinCellShare);
+
+        // A centroid is an average, so it can land off-mesh, on a roof, or on the far side
+        // of a wall even when every spawn that formed it is fine. Same three gates as wander.
+        List<Vector3> stops = new(peaks.Count);
+        foreach (Vector3 peak in peaks)
+        {
+            if (TrySampleAccepted(context, settings, peak, peak, out Vector3 stop))
+            {
+                stops.Add(stop);
+            }
+        }
+
+        if (stops.Count < 2)
+        {
+            LogLoopTooFewStops(logger, context.Target.Name, stops.Count, peaks.Count);
+            return Densify(context, stops, settings);
+        }
+
+        float[,] cost = BuildCostMatrix(context, stops);
+        int[] tour = TourSolver.Solve(cost, out float greedyCost, out float tourCost);
+
+        List<Vector3> ordered = new(stops.Count + 1);
+        foreach (int index in tour)
+        {
+            ordered.Add(stops[index]);
+        }
+
+        // Close the loop explicitly so the leg home is pathed and walked like any other.
+        // PathThereAndBack should be false for this mode - the tour already returns.
+        ordered.Add(ordered[0]);
+
+        LogLoopTour(logger, context.Target.Name, stops.Count, greedyCost, tourCost);
+
+        return Densify(context, ordered, settings);
+    }
+
+    /// <summary>
+    /// Walking distance between every pair of stops, symmetric.
+    ///
+    /// <para>Straight-line distance would order two stops on opposite banks of a river as
+    /// neighbours. The pather is the only thing that knows the difference, and the legs it
+    /// returns here are the same ones <see cref="Densify"/> will walk, so the tour is
+    /// optimised against what actually happens.</para>
+    ///
+    /// <para>Falls back to euclidean for any pair the pather cannot answer, rather than
+    /// treating them as unreachable - gate 3 already established they share a navmesh
+    /// component, so a failure here is the pather giving up, not a wall.</para>
+    /// </summary>
+    private float[,] BuildCostMatrix(Context context, List<Vector3> stops)
+    {
+        int n = stops.Count;
+        float[,] cost = new float[n, n];
+        int pathed = 0;
+
+        // Pathing every pair is O(n²) calls: 12 stops is 66 and finishes instantly, 50 is
+        // 1225 and takes ~50s - unacceptable when generation happens the first time a path
+        // activates mid-session. Past the cap the ordering falls back to straight-line
+        // distance, which still removes crossings; every leg the tour actually keeps is
+        // pathed by Densify afterwards regardless, so the walked route is unaffected.
+        bool pathPairs = n * (n - 1) / 2 <= MaxPathedMatrixPairs;
+
+        if (!pathPairs)
+        {
+            LogMatrixEuclidean(logger, context.Target.Name, n, MaxPathedMatrixPairs);
+        }
+
+        for (int i = 0; i < n; i++)
+        {
+            for (int k = i + 1; k < n; k++)
+            {
+                Vector3[] leg = pathPairs
+                    ? routePather.FindWorldRoute(context.Target.UIMapId,
+                        startIndoors: false, stops[i], stops[k])
+                    : [];
+
+                float length;
+                if (leg.Length > 1)
+                {
+                    length = 0f;
+                    for (int p = 1; p < leg.Length; p++)
+                    {
+                        length += leg[p - 1].WorldDistanceXYTo(leg[p]);
+                    }
+
+                    pathed++;
+                }
+                else
+                {
+                    length = stops[i].WorldDistanceXYTo(stops[k]);
+                }
+
+                cost[i, k] = length;
+                cost[k, i] = length;
+            }
+        }
+
+        LogCostMatrix(logger, context.Target.Name, n, pathed, n * (n - 1) / 2);
+
+        return cost;
+    }
+
+    private Vector3[] SampleWander(Context context, RouteGenSettings settings, int seed)
+    {
+        Random random = new(seed);
+
+        float radius = AreaGrid.CellSize;
+        float minSpacingSq = settings.MinSpacingYards * settings.MinSpacingYards;
+
+        List<Vector3> accepted = new(settings.Stops);
+
+        for (int stop = 0; stop < settings.Stops; stop++)
+        {
+            for (int attempt = 0; attempt < MaxAttemptsPerStop; attempt++)
+            {
+                Vector3 anchor = context.Polygon.PickAnchor(random);
+
+                // The offset is drawn here rather than inside Detour so the seed actually
+                // determines the route - see TrySnapWalkable's remarks. sqrt() makes the
+                // draw uniform over the disc instead of clustering at the centre.
+                float angle = random.NextSingle() * MathF.Tau;
+                float distance = MathF.Sqrt(random.NextSingle()) * radius;
+
+                Vector3 hint = new(
+                    anchor.X + (MathF.Cos(angle) * distance),
+                    anchor.Y + (MathF.Sin(angle) * distance),
+                    anchor.Z);
+
+                if (!TrySampleAccepted(context, settings, anchor, hint,
+                    out Vector3 candidate))
+                {
+                    continue;
+                }
+
+                if (TooClose(accepted, candidate, minSpacingSq))
+                {
+                    continue;
+                }
+
+                accepted.Add(candidate);
+                break;
+            }
+        }
+
+        if (accepted.Count < settings.Stops)
+        {
+            LogShortRoute(logger, context.Target.Name, accepted.Count, settings.Stops);
+        }
+
+        return Densify(context, accepted, settings);
+    }
+
+    /// <summary>
+    /// Replaces the straight hops between stops with the ground the bot would actually
+    /// walk, by pathing each consecutive pair and emitting those points as the route.
+    ///
+    /// <para><b>Why this is not optional.</b> The bot acquires targets by cycling Tab as it
+    /// walks, so a 300yd leg between two anchors is dead travel that skips every mob beside
+    /// it. A dense route keeps the player next to mobs continuously, which is also the shape
+    /// the rest of the bot is tuned for - a recorded route is hundreds of points a few yards
+    /// apart.</para>
+    ///
+    /// <para>A leg the pather cannot answer falls back to the bare stop rather than
+    /// dropping it; <see cref="Navigation"/> will path that hop itself at walk time.</para>
+    /// </summary>
+    /// <summary>
+    /// Walks the polyline and emits a point roughly every <paramref name="spacingYards"/>,
+    /// interpolating between the navmesh points rather than picking every Nth - point
+    /// density along a navmesh path is uneven, so "every Nth" gives uneven spacing.
+    ///
+    /// <para>The first and last points are always kept, and the shape is preserved because
+    /// the emitted points lie on the original line.</para>
+    /// </summary>
+    private static Vector3[] Resample(List<Vector3> points, float spacingYards)
+    {
+        if (points.Count < 3 || spacingYards <= 0f)
+        {
+            return [.. points];
+        }
+
+        List<Vector3> result = [points[0]];
+        float carried = 0f;
+
+        for (int i = 1; i < points.Count; i++)
+        {
+            Vector3 from = points[i - 1];
+            Vector3 to = points[i];
+
+            float dx = to.X - from.X;
+            float dy = to.Y - from.Y;
+            float segment = MathF.Sqrt((dx * dx) + (dy * dy));
+
+            if (segment <= 0f)
+            {
+                continue;
+            }
+
+            float travelled = spacingYards - carried;
+
+            while (travelled <= segment)
+            {
+                float t = travelled / segment;
+                result.Add(new Vector3(
+                    from.X + (dx * t),
+                    from.Y + (dy * t),
+                    from.Z + ((to.Z - from.Z) * t)));
+
+                travelled += spacingYards;
+            }
+
+            carried = segment - (travelled - spacingYards);
+        }
+
+        // The tail is the last stop; the follower must actually arrive there.
+        if (result[^1] != points[^1])
+        {
+            result.Add(points[^1]);
+        }
+
+        return [.. result];
+    }
+
+    private Vector3[] Densify(Context context, List<Vector3> stops, RouteGenSettings settings)
+    {
+        LastRouteIsDense = false;
+
+        if (stops.Count < 2)
+        {
+            return [.. stops];
+        }
+
+        List<Vector3> dense = new(stops.Count * 16) { stops[0] };
+
+        int pathed = 0;
+
+        for (int i = 1; i < stops.Count; i++)
+        {
+            Vector3[] leg = routePather.FindWorldRoute(context.Target.UIMapId,
+                startIndoors: false, stops[i - 1], stops[i]);
+
+            if (leg.Length == 0)
+            {
+                dense.Add(stops[i]);
+                continue;
+            }
+
+            pathed++;
+
+            // Skip the leg's first point - it is the previous stop, already emitted.
+            for (int p = 1; p < leg.Length; p++)
+            {
+                dense.Add(leg[p]);
+            }
+        }
+
+        Vector3[] resampled = Resample(dense, settings.WaypointSpacingYards);
+
+        LogDensified(logger, context.Target.Name, stops.Count, dense.Count,
+            resampled.Length, pathed, stops.Count - 1);
+
+        LastRouteIsDense = pathed > 0;
+
+        return resampled;
+    }
+
+    /// <summary>
+    /// The three gates, cheapest first: Detour picks an on-poly point, the height band
+    /// rejects a roof or canopy for free, and the component id decides reachability with an
+    /// array read rather than a pathfinding query.
+    /// </summary>
+    private static bool TrySampleAccepted(Context context, RouteGenSettings settings,
+        Vector3 anchor, Vector3 hint, out Vector3 candidate)
+    {
+        candidate = default;
+
+        // Gate 1 - on the mesh by construction.
+        if (!context.Navmesh.TrySnapWalkable(hint, out Vector3 sampled, out long polyRef))
+        {
+            return false;
+        }
+
+        // Gate 2 - same floor as the spawn that anchored it. A roof, ledge or canopy poly
+        // sits meters above the ground the anchor stands on, and this costs no queries.
+        if (MathF.Abs(sampled.Z - anchor.Z) > settings.MaxVerticalDelta)
+        {
+            return false;
+        }
+
+        if (!context.Polygon.Contains(sampled.X, sampled.Y))
+        {
+            return false;
+        }
+
+        // Gate 3 - reachable. Same component means a path provably exists.
+        if (context.Connectivity.ComponentOf(polyRef) != context.Component)
+        {
+            return false;
+        }
+
+        candidate = sampled;
+        return true;
+    }
+
+    private static bool TooClose(List<Vector3> accepted, Vector3 candidate, float minSpacingSq)
+    {
+        for (int i = 0; i < accepted.Count; i++)
+        {
+            float dx = accepted[i].X - candidate.X;
+            float dy = accepted[i].Y - candidate.Y;
+            if ((dx * dx) + (dy * dy) < minSpacingSq)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Which navmesh component the route lives on: the one most of the selected spawns
+    /// stand on. Using the player's position instead would fail whenever a route is built
+    /// for a zone the player has not travelled to yet.
+    /// </summary>
+    private static int ResolveComponent(SpawnPolygon polygon, NavmeshPathfinder navmesh,
+        NavmeshConnectivity connectivity, RouteGenSettings settings)
+    {
+        Dictionary<int, int> votes = [];
+
+        // Fixed stride, not a random sample: the component a route lives on must not change
+        // between laps, or the whole route would relocate.
+        int step = Math.Max(1, polygon.Spawns.Length / ComponentProbeCount);
+
+        for (int i = 0; i < polygon.Spawns.Length; i += step)
+        {
+            if (!navmesh.TrySnapWalkable(polygon.Spawns[i],
+                out Vector3 point, out long polyRef))
+            {
+                continue;
+            }
+
+            if (MathF.Abs(point.Z - polygon.Spawns[i].Z) > settings.MaxVerticalDelta)
+            {
+                continue;
+            }
+
+            int component = connectivity.ComponentOf(polyRef);
+            if (component < 0)
+            {
+                continue;
+            }
+
+            votes.TryGetValue(component, out int count);
+            votes[component] = count + 1;
+        }
+
+        int best = -1;
+        int bestVotes = 0;
+
+        foreach ((int component, int count) in votes)
+        {
+            if (count > bestVotes)
+            {
+                bestVotes = count;
+                best = component;
+            }
+        }
+
+        return best;
+    }
+
+    private List<Vector3> SelectSpawns(RouteGenSettings settings, RouteTarget target,
+        Requirement filter, out int matchedCreatures)
+    {
+        matchedCreatures = 0;
+
+        FrozenDictionary<int, Vector3[]> byEntry = spawnDb.Get((int)target.MapId);
+        List<Vector3> result = [];
+
+        if (byEntry.Count == 0)
+        {
+            return result;
+        }
+
+        PlayerFaction faction = player.Faction;
+        List<Vector3> inZone = [];
+
+        foreach ((int entry, Vector3[] positions) in byEntry)
+        {
+            if (!creatureDb.Entries.TryGetValue(entry, out Creature creature))
+            {
+                continue;
+            }
+
+            if (!PassesBaseFilter(creature, faction))
+            {
+                continue;
+            }
+
+            inZone.Clear();
+            for (int i = 0; i < positions.Length; i++)
+            {
+                if (InZone(target, positions[i]))
+                {
+                    inZone.Add(positions[i]);
+                }
+            }
+
+            if (inZone.Count == 0)
+            {
+                continue;
+            }
+
+            // SpawnCount is the in-zone count on purpose - a profile asking for
+            // "SpawnCount > 10" means "densely present here", not "common somewhere".
+            if (!creatureRequirements.Matches(filter, creature, inZone.Count))
+            {
+                continue;
+            }
+
+            matchedCreatures++;
+            result.AddRange(inZone);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Never user-overridable. Mirrors the hostile-spawn filter in DangerZoneGenerator: a
+    /// vendor, a critter or a totem is not a grind target however the expression is written.
+    /// </summary>
+    private bool PassesBaseFilter(in Creature creature, PlayerFaction faction)
+    {
+        return creature.NpcFlag == NpcFlags.None &&
+            creature.MinLevel > 0 &&
+            creature.Type is not (CreatureType.Critter or CreatureType.Totem
+                or CreatureType.NonCombatPet) &&
+            FactionExt.HostileToPlayer(creature, faction, factionDB);
+    }
+
+    private bool InZone(RouteTarget target, Vector3 worldPos)
+    {
+        int areaId = pather.GetAreaId(target.MapId, worldPos.X, worldPos.Y);
+
+        // 0 means the point is outside the baked grid's bounds - or that no grid is baked
+        // for this era at all, which is the whole of Kalimdor on precata. Fall back to the
+        // zone's own map-coordinate bounds rather than treating it as "not in the zone".
+        return areaId != 0
+            ? target.AcceptsAreaId(areaId)
+            : target.WithinMapBounds(worldPos);
+    }
+
+    #region Logging
+
+    [LoggerMessage(
+        EventId = 0090,
+        Level = LogLevel.Error,
+        Message = "[RouteGen] cannot resolve a zone for '{zone}'")]
+    static partial void LogNoZone(ILogger logger, string zone);
+
+    [LoggerMessage(
+        EventId = 0091,
+        Level = LogLevel.Error,
+        Message = "[RouteGen] mob filter '{filter}' failed to parse: {reason}")]
+    static partial void LogBadFilter(ILogger logger, string filter, string reason);
+
+    [LoggerMessage(
+        EventId = 0092,
+        Level = LogLevel.Warning,
+        Message = "[RouteGen] {zone}: no spawns matched '{filter}'")]
+    static partial void LogNoMatches(ILogger logger, string zone, string filter);
+
+    [LoggerMessage(
+        EventId = 0093,
+        Level = LogLevel.Warning,
+        Message = "[RouteGen] {zone}: no baked navmesh for map {mapId} - bake it with --bake=<Continent>")]
+    static partial void LogNoNavmesh(ILogger logger, string zone, float mapId);
+
+    [LoggerMessage(
+        EventId = 0094,
+        Level = LogLevel.Warning,
+        Message = "[RouteGen] {zone}: no spawn stands on the navmesh - cannot pick a route component")]
+    static partial void LogNoComponent(ILogger logger, string zone);
+
+    [LoggerMessage(
+        EventId = 0095,
+        Level = LogLevel.Information,
+        Message = "[RouteGen] {zone}: {creatures} creature types, {spawns} spawns, {cells} cells, {polys} polys in {components} components")]
+    static partial void LogContext(ILogger logger, string zone, int creatures, int spawns,
+        int cells, int polys, int components);
+
+    [LoggerMessage(
+        EventId = 0096,
+        Level = LogLevel.Warning,
+        Message = "[RouteGen] {zone}: only {got} of {want} stops sampled")]
+    static partial void LogShortRoute(ILogger logger, string zone, int got, int want);
+
+    [LoggerMessage(
+        EventId = 0103,
+        Level = LogLevel.Information,
+        Message = "[RouteGen] {zone}: {stops} stops exceeds the {cap} pathed-pair budget - ordering on straight-line distance")]
+    static partial void LogMatrixEuclidean(ILogger logger, string zone, int stops, int cap);
+
+    [LoggerMessage(
+        EventId = 0102,
+        Level = LogLevel.Information,
+        Message = "[RouteGen] {zone}: {peaks} stops from {cells} occupied cells (Focus={focus}, cell floor {share:P0})")]
+    static partial void LogLoopPeaks(ILogger logger, string zone, int peaks, int cells,
+        string focus, float share);
+
+    [LoggerMessage(
+        EventId = 0099,
+        Level = LogLevel.Information,
+        Message = "[RouteGen] {zone}: loop over {stops} stops, tour {greedy:F0} -> {optimised:F0} yd (2-opt)")]
+    static partial void LogLoopTour(ILogger logger, string zone, int stops, float greedy, float optimised);
+
+    [LoggerMessage(
+        EventId = 0100,
+        Level = LogLevel.Warning,
+        Message = "[RouteGen] {zone}: only {kept} of {peaks} density peaks are reachable - loop needs at least 2")]
+    static partial void LogLoopTooFewStops(ILogger logger, string zone, int kept, int peaks);
+
+    [LoggerMessage(
+        EventId = 0101,
+        Level = LogLevel.Information,
+        Message = "[RouteGen] {zone}: cost matrix {stops}x{stops}, {pathed}/{pairs} pairs pathed")]
+    static partial void LogCostMatrix(ILogger logger, string zone, int stops, int pathed, int pairs);
+
+    [LoggerMessage(
+        EventId = 0098,
+        Level = LogLevel.Information,
+        Message = "[RouteGen] {zone}: dropped {pruned} isolated spawn(s), kept {clusters} cluster(s) (Focus={focus})")]
+    static partial void LogPruned(ILogger logger, string zone, int pruned, int clusters,
+        string focus);
+
+    [LoggerMessage(
+        EventId = 0097,
+        Level = LogLevel.Information,
+        Message = "[RouteGen] {zone}: {stops} stops -> {points} path points -> {waypoints} waypoints ({pathed}/{legs} legs pathed)")]
+    static partial void LogDensified(ILogger logger, string zone, int stops, int points,
+        int waypoints, int pathed, int legs);
+
+    #endregion
+}

--- a/Core/Path/Generate/RouteSeed.cs
+++ b/Core/Path/Generate/RouteSeed.cs
@@ -1,0 +1,33 @@
+namespace Core;
+
+/// <summary>
+/// Derives the seed for one generated route from the session seed, so laps differ from one
+/// another while the whole run still replays identically from the same
+/// <see cref="ClassConfiguration.Seed"/>.
+/// </summary>
+public static class RouteSeed
+{
+    /// <summary>
+    /// Deliberately <b>not</b> <c>HashCode.Combine</c>. That is seeded randomly per process
+    /// as a hash-flooding defence, so it returns different values for the same inputs in
+    /// every run - which made a pinned seed reproduce a route only within one session and
+    /// silently produce a different one the next time the bot started.
+    ///
+    /// <para>This is the finalizer from splitmix64, truncated: cheap, well-mixed, and fixed
+    /// for all time.</para>
+    /// </summary>
+    public static int For(int sessionSeed, int pathId, int lap)
+    {
+        ulong x = (ulong)(uint)sessionSeed;
+        x = (x * 0x9E3779B97F4A7C15UL) + (ulong)(uint)pathId;
+        x = (x * 0xBF58476D1CE4E5B9UL) + (ulong)(uint)lap;
+
+        x ^= x >> 30;
+        x *= 0xBF58476D1CE4E5B9UL;
+        x ^= x >> 27;
+        x *= 0x94D049BB133111EBUL;
+        x ^= x >> 31;
+
+        return (int)(uint)x;
+    }
+}

--- a/Core/Path/Generate/RouteTarget.cs
+++ b/Core/Path/Generate/RouteTarget.cs
@@ -1,0 +1,108 @@
+using SharedLib;
+
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+
+namespace Core;
+
+/// <summary>
+/// The zone a generated route is confined to, resolved from
+/// <see cref="RouteGenSettings"/> once and then asked "is this world point inside".
+/// </summary>
+public sealed class RouteTarget
+{
+    /// <summary>The drawable map, for world/map coordinate conversion.</summary>
+    public WorldMapArea Zone { get; }
+
+    /// <summary>Continent map id, which keys the spawn dump and the navmesh.</summary>
+    public float MapId => Zone.MapID;
+
+    public int UIMapId => Zone.UIMapId;
+
+    /// <summary>Human-readable, for logs and the goal name.</summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Area ids that count as inside. A subzone target holds exactly one; a whole-zone
+    /// target holds the zone plus each of its subzones, because the baked
+    /// <c>AreaGrid</c> stores the finest id at a point and never the parent's.
+    /// </summary>
+    private readonly HashSet<int> areaIds;
+
+    private RouteTarget(WorldMapArea zone, string name, HashSet<int> areaIds)
+    {
+        Zone = zone;
+        Name = name;
+        this.areaIds = areaIds;
+    }
+
+    public bool AcceptsAreaId(int areaId) => areaIds.Contains(areaId);
+
+    /// <summary>
+    /// Fallback containment for points the area grid cannot answer for (id 0 = outside the
+    /// baked bounds, which is the whole of Kalimdor on the precata grid). Mirrors the map
+    /// coordinate bounds check <see cref="Core.Database.AreaDB"/> uses for the same purpose.
+    /// </summary>
+    public bool WithinMapBounds(Vector3 worldPos)
+    {
+        Vector3 map = WorldMapAreaDB.ToMap_FlipXY(worldPos, Zone);
+        return map.X > 0 && map.X < 100 && map.Y > 0 && map.Y < 100;
+    }
+
+    /// <summary>
+    /// Resolution order mirrors <see cref="PathSettings.ConvertToWorldCoords"/>: explicit
+    /// UIMapId, then subzone name, then zone name, then the player's race starting zone,
+    /// then wherever the player currently is.
+    /// </summary>
+    public static RouteTarget? Resolve(RouteGenSettings settings, WorldMapAreaDB db,
+        UnitRace playerRace, int playerUIMapId)
+    {
+        if (settings.UIMapId > 0 && db.TryGet(settings.UIMapId, out WorldMapArea explicitZone))
+        {
+            return ForZone(explicitZone, db);
+        }
+
+        if (!string.IsNullOrEmpty(settings.Subzone) &&
+            db.TryFindSubzone(settings.Subzone, out WorldMapArea subzone))
+        {
+            WorldMapArea parent = db.GetByAreaId(subzone.ParentAreaId);
+            if (parent.UIMapId > 0)
+            {
+                return new RouteTarget(parent, subzone.AreaName, [subzone.AreaID]);
+            }
+        }
+
+        if (!string.IsNullOrEmpty(settings.Zone) &&
+            db.TryFindByAreaName(settings.Zone, out WorldMapArea named))
+        {
+            return ForZone(named, db);
+        }
+
+        if (PathSettings.TryFindRaceZone(playerRace.ToString(), db, out int raceUIMapId) &&
+            db.TryGet(raceUIMapId, out WorldMapArea raceZone))
+        {
+            return ForZone(raceZone, db);
+        }
+
+        return playerUIMapId > 0 && db.TryGet(playerUIMapId, out WorldMapArea current)
+            ? ForZone(current, db)
+            : null;
+    }
+
+    private static RouteTarget ForZone(WorldMapArea zone, WorldMapAreaDB db)
+    {
+        HashSet<int> ids = [zone.AreaID];
+
+        ReadOnlySpan<WorldMapArea> subzones = db.Subzones;
+        for (int i = 0; i < subzones.Length; i++)
+        {
+            if (subzones[i].ParentAreaId == zone.AreaID)
+            {
+                ids.Add(subzones[i].AreaID);
+            }
+        }
+
+        return new RouteTarget(zone, zone.AreaName, ids);
+    }
+}

--- a/Core/Path/Generate/SpawnPolygon.cs
+++ b/Core/Path/Generate/SpawnPolygon.cs
@@ -1,0 +1,446 @@
+using PPather.Navmesh;
+
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+
+// namespace Core, not Core.Path.Generate: a nested `Core.Path` namespace shadows
+// System.IO.Path for every file in `namespace Core`, which is most of the assembly.
+// The rest of Core/Path/ does the same.
+namespace Core;
+
+/// <summary>
+/// The area a generated route may roam, derived from where the selected mobs actually
+/// stand: a cell occupancy mask at <see cref="AreaGrid.CellSize"/> (33.33 yd), dilated by a
+/// configurable padding, with isolated clusters pruned.
+///
+/// <para><b>Why a mask and not a hull.</b> A bounding box is wrong for the shapes that
+/// matter - Northshire Valley's spawns form an L, and a box routes the player through the
+/// abbey. A concave hull would fit, but it is fiddly geometry to get right and to debug. A
+/// cell mask is concave for free, tests membership with an O(1) set lookup, and lands on the
+/// same grid resolution <see cref="AreaGrid"/> already buckets the world into.</para>
+/// </summary>
+public sealed class SpawnPolygon
+{
+    private readonly HashSet<long> cells;
+
+    /// <summary>
+    /// Cumulative local-density weights over <see cref="Spawns"/>, for anchor selection.
+    /// </summary>
+    private readonly float[] cumulativeWeight;
+
+    /// <summary>Spawn positions that survived zone and cluster filtering, in world space.</summary>
+    public Vector3[] Spawns { get; }
+
+    public float MinWorldX { get; }
+    public float MinWorldY { get; }
+    public float MaxWorldX { get; }
+    public float MaxWorldY { get; }
+
+    public int CellCount => cells.Count;
+    public bool IsEmpty => Spawns.Length == 0;
+
+    /// <summary>Spawns discarded as isolated stragglers, for logging.</summary>
+    public int PrunedSpawns { get; }
+
+    /// <summary>Distinct spawn clusters kept.</summary>
+    public int ClusterCount { get; }
+
+    /// <summary>
+    /// Occupied cells with their spawn count and the mean position of the spawns in them,
+    /// densest first. The raw material for <see cref="DensityPeaks"/>.
+    /// </summary>
+    private readonly (Vector3 Centre, int Count)[] cellCentres;
+
+    private SpawnPolygon(HashSet<long> cells, Vector3[] spawns, float[] cumulativeWeight,
+        (Vector3 Centre, int Count)[] cellCentres,
+        float minX, float minY, float maxX, float maxY, int prunedSpawns, int clusterCount)
+    {
+        this.cells = cells;
+        this.cumulativeWeight = cumulativeWeight;
+        this.cellCentres = cellCentres;
+        Spawns = spawns;
+        MinWorldX = minX;
+        MinWorldY = minY;
+        MaxWorldX = maxX;
+        MaxWorldY = maxY;
+        PrunedSpawns = prunedSpawns;
+        ClusterCount = clusterCount;
+    }
+
+    private static long Key(int cellX, int cellY) =>
+        ((long)cellX << 32) | (uint)cellY;
+
+    public bool Contains(float worldX, float worldY)
+    {
+        AreaGrid.WorldToCell(worldX, worldY, out int cellX, out int cellY);
+        return cells.Contains(Key(cellX, cellY));
+    }
+
+    /// <summary>
+    /// A spawn to anchor a stop on, drawn in proportion to how many other spawns sit around
+    /// it.
+    ///
+    /// <para>Uniform selection treats a lone mob on the far shore exactly like one in the
+    /// middle of a pack, so with only a handful of stops the route regularly detoured across
+    /// the zone - and across water - to reach it. Weighting by local density puts the stops
+    /// where the grinding actually is.</para>
+    /// </summary>
+    public Vector3 PickAnchor(Random random)
+    {
+        if (Spawns.Length == 1)
+        {
+            return Spawns[0];
+        }
+
+        float roll = random.NextSingle() * cumulativeWeight[^1];
+
+        int low = 0;
+        int high = cumulativeWeight.Length - 1;
+
+        while (low < high)
+        {
+            int mid = (low + high) / 2;
+            if (cumulativeWeight[mid] < roll)
+                low = mid + 1;
+            else
+                high = mid;
+        }
+
+        return Spawns[low];
+    }
+
+    /// <summary>
+    /// The densest spots in the polygon, spread at least <paramref name="minSpacingYards"/>
+    /// apart, densest first, at most <paramref name="max"/> of them.
+    ///
+    /// <para>Where <see cref="PickAnchor"/> samples randomly for a wander route, a loop wants
+    /// a fixed set of the best places to stand. Greedy selection over cells sorted by spawn
+    /// count gives that deterministically, and the spacing rule stops all the stops piling
+    /// into one camp.</para>
+    /// </summary>
+    public List<Vector3> DensityPeaks(float minSpacingYards, int max, float minCellShare,
+        out int considered)
+    {
+        considered = cellCentres.Length;
+
+        if (cellCentres.Length == 0)
+        {
+            return [];
+        }
+
+        // cellCentres is sorted densest-first, so [0] is the busiest cell in the polygon.
+        // The floor is expressed relative to it: a thin cell out on the fringe holding one
+        // stray mob is what "Density" is supposed to skip, and an absolute count could not
+        // tell a sparse zone from a dense one.
+        int busiest = cellCentres[0].Count;
+        int floor = minCellShare <= 0f
+            ? 0
+            : Math.Max(1, (int)MathF.Ceiling(busiest * minCellShare));
+
+        List<Vector3> peaks = Select(cellCentres, minSpacingYards, max, floor);
+
+        // A floor that leaves nothing to walk is worse than no floor. Sparse zones can have
+        // every cell holding one or two spawns, where any share above zero excludes the lot.
+        if (peaks.Count < 2 && floor > 0)
+        {
+            peaks = Select(cellCentres, minSpacingYards, max, 0);
+        }
+
+        return peaks;
+    }
+
+    private static List<Vector3> Select((Vector3 Centre, int Count)[] cellCentres,
+        float minSpacingYards, int max, int minCount)
+    {
+        List<Vector3> peaks = new(Math.Min(max, cellCentres.Length));
+        float minSpacingSq = minSpacingYards * minSpacingYards;
+
+        foreach ((Vector3 centre, int count) in cellCentres)
+        {
+            if (peaks.Count >= max)
+            {
+                break;
+            }
+
+            if (count < minCount)
+            {
+                // Sorted densest-first, so everything after this is thinner still.
+                break;
+            }
+
+            bool tooClose = false;
+            for (int i = 0; i < peaks.Count; i++)
+            {
+                float dx = peaks[i].X - centre.X;
+                float dy = peaks[i].Y - centre.Y;
+                if ((dx * dx) + (dy * dy) < minSpacingSq)
+                {
+                    tooClose = true;
+                    break;
+                }
+            }
+
+            if (!tooClose)
+            {
+                peaks.Add(centre);
+            }
+        }
+
+        return peaks;
+    }
+
+    /// <summary>
+    /// Marks the cell of every spawn, dilates by <paramref name="paddingYards"/> so the route
+    /// can breathe around a cluster rather than hugging its exact footprint, then drops
+    /// clusters too small to be worth walking to.
+    /// </summary>
+    public static SpawnPolygon Build(IReadOnlyList<Vector3> spawns, float paddingYards,
+        float minClusterShare, float densityBias)
+    {
+        if (spawns.Count == 0)
+        {
+            return new SpawnPolygon([], [], [], [], 0f, 0f, 0f, 0f, 0, 0);
+        }
+
+        // Sorted so the sampler's "pick spawn N" is the same spawn on every run. The callers
+        // build this list by walking dictionaries, and that order is not something to rely on
+        // when the seed is supposed to make a route reproducible.
+        Vector3[] ordered = [.. spawns];
+        Array.Sort(ordered, static (a, b) =>
+        {
+            int cmp = a.X.CompareTo(b.X);
+            if (cmp != 0) return cmp;
+            cmp = a.Y.CompareTo(b.Y);
+            return cmp != 0 ? cmp : a.Z.CompareTo(b.Z);
+        });
+
+        Dictionary<long, int> spawnsPerCell = [];
+        foreach (Vector3 p in ordered)
+        {
+            AreaGrid.WorldToCell(p.X, p.Y, out int cellX, out int cellY);
+            long key = Key(cellX, cellY);
+            spawnsPerCell.TryGetValue(key, out int count);
+            spawnsPerCell[key] = count + 1;
+        }
+
+        int radius = (int)MathF.Ceiling(paddingYards / AreaGrid.CellSize);
+        HashSet<long> dilated = radius <= 0
+            ? [.. spawnsPerCell.Keys]
+            : Dilate(spawnsPerCell.Keys, radius);
+
+        (HashSet<long> kept, int clusters) =
+            PruneIsolatedClusters(dilated, spawnsPerCell, minClusterShare);
+
+        List<Vector3> survivors = new(ordered.Length);
+        foreach (Vector3 p in ordered)
+        {
+            AreaGrid.WorldToCell(p.X, p.Y, out int cellX, out int cellY);
+            if (kept.Contains(Key(cellX, cellY)))
+            {
+                survivors.Add(p);
+            }
+        }
+
+        if (survivors.Count == 0)
+        {
+            // Every cluster fell below the bar - keep everything rather than emit nothing.
+            survivors.AddRange(ordered);
+            kept = dilated;
+        }
+
+        float minX = float.MaxValue, minY = float.MaxValue;
+        float maxX = float.MinValue, maxY = float.MinValue;
+
+        foreach (Vector3 p in survivors)
+        {
+            if (p.X < minX) minX = p.X;
+            if (p.Y < minY) minY = p.Y;
+            if (p.X > maxX) maxX = p.X;
+            if (p.Y > maxY) maxY = p.Y;
+        }
+
+        float pad = radius * AreaGrid.CellSize;
+
+        return new SpawnPolygon(kept, [.. survivors],
+            BuildWeights(survivors, spawnsPerCell, densityBias),
+            BuildCellCentres(survivors),
+            minX - pad, minY - pad, maxX + pad, maxY + pad,
+            ordered.Length - survivors.Count, clusters);
+    }
+
+    /// <summary>
+    /// Mean spawn position per occupied cell, ordered densest first. Ties break on position
+    /// so the order does not depend on how the dictionary happened to enumerate - a loop
+    /// route has to be the same one every session.
+    /// </summary>
+    private static (Vector3 Centre, int Count)[] BuildCellCentres(List<Vector3> spawns)
+    {
+        Dictionary<long, (Vector3 Sum, int Count)> byCell = [];
+
+        foreach (Vector3 p in spawns)
+        {
+            AreaGrid.WorldToCell(p.X, p.Y, out int cellX, out int cellY);
+            long key = Key(cellX, cellY);
+
+            byCell.TryGetValue(key, out (Vector3 Sum, int Count) acc);
+            byCell[key] = (acc.Sum + p, acc.Count + 1);
+        }
+
+        (Vector3 Centre, int Count)[] result = new (Vector3, int)[byCell.Count];
+
+        int i = 0;
+        foreach ((Vector3 sum, int count) in byCell.Values)
+        {
+            result[i++] = (sum / count, count);
+        }
+
+        Array.Sort(result, static (a, b) =>
+        {
+            int cmp = b.Count.CompareTo(a.Count);
+            if (cmp != 0) return cmp;
+
+            cmp = a.Centre.X.CompareTo(b.Centre.X);
+            return cmp != 0 ? cmp : a.Centre.Y.CompareTo(b.Centre.Y);
+        });
+
+        return result;
+    }
+
+    /// <summary>
+    /// Each spawn's weight is how many spawns sit in its own cell and the eight around it -
+    /// a cheap local density that needs no radius search.
+    /// </summary>
+    private static float[] BuildWeights(List<Vector3> spawns, Dictionary<long, int> spawnsPerCell,
+        float densityBias)
+    {
+        float[] cumulative = new float[spawns.Count];
+        float running = 0f;
+
+        for (int i = 0; i < spawns.Count; i++)
+        {
+            AreaGrid.WorldToCell(spawns[i].X, spawns[i].Y, out int cellX, out int cellY);
+
+            int density = 0;
+            for (int dx = -1; dx <= 1; dx++)
+            {
+                for (int dy = -1; dy <= 1; dy++)
+                {
+                    spawnsPerCell.TryGetValue(Key(cellX + dx, cellY + dy), out int count);
+                    density += count;
+                }
+            }
+
+            // bias 0 -> every spawn weighs the same (pure coverage);
+            // 1 -> proportional to density; 2 -> packs dominate.
+            running += densityBias <= 0f
+                ? 1f
+                : MathF.Pow(Math.Max(1, density), densityBias);
+            cumulative[i] = running;
+        }
+
+        return cumulative;
+    }
+
+    /// <summary>
+    /// Flood-fills the dilated mask into connected regions and keeps only those holding a
+    /// meaningful share of the spawns. Two mobs on the far side of a lake form their own
+    /// region; walking there costs more than the kills are worth.
+    /// </summary>
+    private static (HashSet<long> Cells, int Clusters) PruneIsolatedClusters(
+        HashSet<long> dilated, Dictionary<long, int> spawnsPerCell, float minClusterShare)
+    {
+        Dictionary<long, int> componentOf = [];
+        List<int> spawnCounts = [];
+        List<List<long>> componentCells = [];
+
+        Stack<long> pending = new();
+
+        foreach (long start in dilated)
+        {
+            if (componentOf.ContainsKey(start))
+                continue;
+
+            int id = spawnCounts.Count;
+            spawnCounts.Add(0);
+            componentCells.Add([]);
+
+            pending.Push(start);
+            componentOf[start] = id;
+
+            while (pending.Count > 0)
+            {
+                long current = pending.Pop();
+
+                componentCells[id].Add(current);
+                spawnsPerCell.TryGetValue(current, out int here);
+                spawnCounts[id] += here;
+
+                int cellX = (int)(current >> 32);
+                int cellY = (int)(uint)current;
+
+                for (int dx = -1; dx <= 1; dx++)
+                {
+                    for (int dy = -1; dy <= 1; dy++)
+                    {
+                        if (dx == 0 && dy == 0)
+                            continue;
+
+                        long neighbour = Key(cellX + dx, cellY + dy);
+                        if (dilated.Contains(neighbour) && !componentOf.ContainsKey(neighbour))
+                        {
+                            componentOf[neighbour] = id;
+                            pending.Push(neighbour);
+                        }
+                    }
+                }
+            }
+        }
+
+        int biggest = 0;
+        foreach (int count in spawnCounts)
+        {
+            if (count > biggest) biggest = count;
+        }
+
+        float threshold = biggest * minClusterShare;
+
+        HashSet<long> kept = [];
+        int clusters = 0;
+
+        for (int id = 0; id < spawnCounts.Count; id++)
+        {
+            if (spawnCounts[id] < threshold)
+                continue;
+
+            clusters++;
+            foreach (long cell in componentCells[id])
+            {
+                kept.Add(cell);
+            }
+        }
+
+        return (kept, clusters);
+    }
+
+    private static HashSet<long> Dilate(IEnumerable<long> seed, int radius)
+    {
+        HashSet<long> result = [];
+
+        foreach (long key in seed)
+        {
+            int cellX = (int)(key >> 32);
+            int cellY = (int)(uint)key;
+
+            for (int dx = -radius; dx <= radius; dx++)
+            {
+                for (int dy = -radius; dy <= radius; dy++)
+                {
+                    result.Add(Key(cellX + dx, cellY + dy));
+                }
+            }
+        }
+
+        return result;
+    }
+}

--- a/Core/Path/TSP/TourSolver.cs
+++ b/Core/Path/TSP/TourSolver.cs
@@ -1,0 +1,169 @@
+using System;
+
+namespace Core;
+
+/// <summary>
+/// Orders stops into a short closed tour: nearest-neighbour for a starting order, then 2-opt
+/// until no improving swap remains.
+///
+/// <para><b>Why not the genetic solver in Utilities.</b> That one derives its distances
+/// internally from <c>Vector2</c> positions and draws from a static <c>Random</c>. Route
+/// generation needs the opposite of both - the cost between two stops is the length of the
+/// walkable path between them, not the straight line, and a pinned seed has to reproduce the
+/// same tour. Reusing it would mean replacing its distance function, its randomness and its
+/// point type, which is most of it. At the handful of stops a grind route carries, 2-opt is
+/// also effectively optimal and needs no tuning.</para>
+/// </summary>
+public static class TourSolver
+{
+    /// <summary>
+    /// Guards the 2-opt loop against pathological input. Each pass is O(n²) and passes stop
+    /// as soon as one makes no improvement, so this is only ever reached if costs are
+    /// inconsistent (an asymmetric matrix can cycle).
+    /// </summary>
+    private const int MaxPasses = 64;
+
+    /// <summary>
+    /// Visit order over <paramref name="cost"/>, a square matrix where <c>cost[a,b]</c> is
+    /// the travel cost from stop a to stop b. The tour is closed: the leg from the last
+    /// index back to the first is part of what is minimised.
+    /// </summary>
+    public static int[] Solve(float[,] cost) => Solve(cost, out _, out _);
+
+    /// <summary>
+    /// As <see cref="Solve(float[,])"/>, also reporting the tour cost before and after the
+    /// 2-opt pass so callers can see whether the optimisation earned its place.
+    /// </summary>
+    public static int[] Solve(float[,] cost, out float greedyCost, out float optimisedCost)
+    {
+        int n = cost.GetLength(0);
+        if (n <= 3)
+        {
+            int[] trivial = new int[n];
+            for (int i = 0; i < n; i++)
+            {
+                trivial[i] = i;
+            }
+
+            greedyCost = optimisedCost = TourCost(trivial, cost);
+            return trivial;
+        }
+
+        int[] tour = NearestNeighbour(cost, n);
+        greedyCost = TourCost(tour, cost);
+
+        Improve(tour, cost, n);
+        optimisedCost = TourCost(tour, cost);
+
+        return tour;
+    }
+
+    /// <summary>
+    /// Always starts at stop 0 so the result is reproducible; 2-opt removes most of the
+    /// difference a start choice would make anyway.
+    /// </summary>
+    private static int[] NearestNeighbour(float[,] cost, int n)
+    {
+        int[] tour = new int[n];
+        bool[] used = new bool[n];
+
+        tour[0] = 0;
+        used[0] = true;
+
+        for (int i = 1; i < n; i++)
+        {
+            int from = tour[i - 1];
+            int best = -1;
+            float bestCost = float.MaxValue;
+
+            for (int candidate = 0; candidate < n; candidate++)
+            {
+                if (used[candidate] || cost[from, candidate] >= bestCost)
+                {
+                    continue;
+                }
+
+                bestCost = cost[from, candidate];
+                best = candidate;
+            }
+
+            // Every cost equal or unreachable - take the first unused, in index order, so
+            // the outcome stays deterministic.
+            if (best < 0)
+            {
+                for (int candidate = 0; candidate < n; candidate++)
+                {
+                    if (!used[candidate])
+                    {
+                        best = candidate;
+                        break;
+                    }
+                }
+            }
+
+            tour[i] = best;
+            used[best] = true;
+        }
+
+        return tour;
+    }
+
+    /// <summary>
+    /// Repeatedly reverses the segment between two stops when doing so shortens the tour.
+    /// This is what removes the self-crossings a nearest-neighbour order leaves behind -
+    /// a crossing is always longer than the uncrossed alternative.
+    /// </summary>
+    private static void Improve(int[] tour, float[,] cost, int n)
+    {
+        for (int pass = 0; pass < MaxPasses; pass++)
+        {
+            bool improved = false;
+
+            for (int i = 0; i < n - 1; i++)
+            {
+                for (int k = i + 2; k < n; k++)
+                {
+                    // Skip the pair that would reverse the whole tour - same cycle.
+                    if (i == 0 && k == n - 1)
+                    {
+                        continue;
+                    }
+
+                    int a = tour[i];
+                    int b = tour[i + 1];
+                    int c = tour[k];
+                    int d = tour[(k + 1) % n];
+
+                    float before = cost[a, b] + cost[c, d];
+                    float after = cost[a, c] + cost[b, d];
+
+                    if (after >= before - float.Epsilon)
+                    {
+                        continue;
+                    }
+
+                    Array.Reverse(tour, i + 1, k - i);
+                    improved = true;
+                }
+            }
+
+            if (!improved)
+            {
+                return;
+            }
+        }
+    }
+
+    /// <summary>Total closed-tour cost, for logging and comparison.</summary>
+    public static float TourCost(int[] tour, float[,] cost)
+    {
+        float total = 0f;
+
+        for (int i = 0; i < tour.Length; i++)
+        {
+            total += cost[tour[i], tour[(i + 1) % tour.Length]];
+        }
+
+        return total;
+    }
+}

--- a/Core/Requirement/CreatureRequirementFactory.cs
+++ b/Core/Requirement/CreatureRequirementFactory.cs
@@ -1,0 +1,164 @@
+using Core.Database;
+
+using Microsoft.Extensions.Logging;
+
+using SharedLib;
+
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+
+namespace Core;
+
+/// <summary>
+/// Compiles <see cref="RouteGenSettings.Mobs"/> - the same expression language the class
+/// profile uses for <c>Requirements</c>, but over a different subject.
+///
+/// <para><b>Two scopes, one syntax.</b> <see cref="RequirementFactory"/>'s variables read
+/// the <i>player</i> and decide whether a path runs. These read a <i>candidate creature
+/// row</i> and decide which mobs shape the route's polygon. <c>"Level &lt; 5"</c> is legal
+/// in both and means different things: here <c>Level</c> is the creature's level and the
+/// player's is <c>PlayerLevel</c>, so the common case reads the way you would say it -
+/// <c>Level &lt;= PlayerLevel + 2</c>. Player-only names such as <c>Health%</c> are simply
+/// absent, so a misplaced one fails at parse time rather than silently.</para>
+///
+/// <para>This is a separate <see cref="ExpressionParser"/> instance rather than new entries
+/// in the global map, which also sidesteps a live defect: <c>ParseParameterized</c>
+/// dispatches by <c>text.Contains(key)</c> over an unordered dictionary, so short keys added
+/// globally can be claimed by the wrong handler. A separate map cannot collide with
+/// player-scope keys at all.</para>
+/// </summary>
+public sealed class CreatureRequirementFactory
+{
+    private const char SEP1 = ':';
+
+    /// <summary>
+    /// The row currently under test. The compiled delegates close over this instance, so
+    /// evaluation is "assign cursor, call HasRequirement" - no per-row allocation and no
+    /// re-parsing. Not thread safe by construction; generation is single threaded.
+    /// </summary>
+    private sealed class Cursor
+    {
+        public Creature Creature;
+        public int SpawnCount;
+    }
+
+    private readonly Cursor cursor = new();
+    private readonly ExpressionParser parser;
+
+    public CreatureRequirementFactory(ILogger logger, IRouteGenPlayer player,
+        FactionTemplateDB factionDB)
+    {
+        Cursor c = cursor;
+
+        Dictionary<string, Func<int>> intVariables = new(StringComparer.OrdinalIgnoreCase)
+        {
+            // Creature scope. 'Level' deliberately shadows the player's.
+            { "Level", () => (c.Creature.MinLevel + c.Creature.MaxLevel) / 2 },
+            { "MinLevel", () => c.Creature.MinLevel },
+            { "MaxLevel", () => c.Creature.MaxLevel },
+            { "Rank", () => c.Creature.Rank },
+            { "NpcId", () => c.Creature.Entry },
+            { "SpawnCount", () => c.SpawnCount },
+
+            // The one player-scope value that belongs here, named so it cannot be mistaken.
+            { "PlayerLevel", () => player.Level },
+        };
+
+        FrozenDictionary<string, Func<bool>> boolVariables =
+            new Dictionary<string, Func<bool>>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "Elite", () => c.Creature.Rank > 0 },
+                { "Skinnable", () => c.Creature.SkinLoot != 0 },
+                { "Hostile", () => FactionExt.HostileToPlayer(
+                    c.Creature, player.Faction, factionDB) },
+            }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+        FrozenDictionary<string, Func<ReadOnlySpan<char>, Requirement>> requirementMap =
+            new Dictionary<string, Func<ReadOnlySpan<char>, Requirement>>()
+            {
+                { "Type:", CreateType },
+                { "Name:", CreateName },
+                { "Faction:", CreateFaction },
+                { "Family:", CreateFamily },
+            }.ToFrozenDictionary();
+
+        parser = new ExpressionParser(intVariables, boolVariables, requirementMap, logger);
+    }
+
+    /// <summary>
+    /// Compiles the expression once. Throws <see cref="InvalidOperationException"/> on an
+    /// unknown name - including a player-scope name used here by mistake.
+    /// </summary>
+    public Requirement Parse(ReadOnlySpan<char> expression)
+    {
+        return parser.Parse(expression);
+    }
+
+    /// <summary>Evaluates a compiled expression against one creature row.</summary>
+    public bool Matches(Requirement requirement, in Creature creature, int spawnCount)
+    {
+        cursor.Creature = creature;
+        cursor.SpawnCount = spawnCount;
+        return requirement.HasRequirement();
+    }
+
+    private Requirement CreateType(ReadOnlySpan<char> requirement)
+    {
+        // 'Type:_TYPE_' - same enum and parse as RequirementFactory's 'Target:'.
+        int sep = requirement.IndexOf(SEP1);
+        CreatureType type = Enum.Parse<CreatureType>(requirement[(sep + 1)..].Trim(), true);
+
+        Cursor c = cursor;
+
+        bool f() => c.Creature.Type == type;
+        string s() => $"Type:{type}";
+
+        return new Requirement { HasRequirement = f, LogMessage = s };
+    }
+
+    private Requirement CreateName(ReadOnlySpan<char> requirement)
+    {
+        // 'Name:_SUBSTRING_' - contains, case-insensitive. Substring rather than equals so
+        // "Name:Wolf" covers Young Wolf / Rabid Wolf / Diseased Wolf without listing them.
+        int sep = requirement.IndexOf(SEP1);
+        string needle = requirement[(sep + 1)..].Trim().ToString();
+
+        Cursor c = cursor;
+
+        bool f() => c.Creature.Name != null &&
+            c.Creature.Name.Contains(needle, StringComparison.OrdinalIgnoreCase);
+        string s() => $"Name:{needle}";
+
+        return new Requirement { HasRequirement = f, LogMessage = s };
+    }
+
+    private Requirement CreateFaction(ReadOnlySpan<char> requirement)
+    {
+        // 'Faction:_ID_' - the emulator faction template id. Selects "everything hostile
+        // around here" without naming mobs, so it survives localisation and renames.
+        int sep = requirement.IndexOf(SEP1);
+        int faction = int.Parse(requirement[(sep + 1)..].Trim());
+
+        Cursor c = cursor;
+
+        bool f() => c.Creature.Faction == faction;
+        string s() => $"Faction:{faction}";
+
+        return new Requirement { HasRequirement = f, LogMessage = s };
+    }
+
+    private Requirement CreateFamily(ReadOnlySpan<char> requirement)
+    {
+        // 'Family:_ID_' - CreatureFamily, mostly useful to separate beast subtypes.
+        int sep = requirement.IndexOf(SEP1);
+        int family = int.Parse(requirement[(sep + 1)..].Trim());
+
+        Cursor c = cursor;
+
+        bool f() => c.Creature.Family == family;
+        string s() => $"Family:{family}";
+
+        return new Requirement { HasRequirement = f, LogMessage = s };
+    }
+}

--- a/Core/Requirement/RequirementFactory.cs
+++ b/Core/Requirement/RequirementFactory.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 using SharedLib;
+using SharedLib.Data;
 using SharedLib.NpcFinder;
 
 using System;
@@ -126,6 +127,7 @@ public sealed partial class RequirementFactory
             { "Form", CreateForm },
             { "Race", CreateRace },
             { "Equipment:", CreateEquipment },
+            { "RangedWeapon:", CreateRangedWeapon },
             { "Spell:", CreateSpell },
             { "Talent", CreateTalent },
             { "Trigger:", CreateTrigger },
@@ -1155,6 +1157,48 @@ public sealed partial class RequirementFactory
                 LogMessage = s
             };
         }
+    }
+
+    /// <summary>
+    /// True when the equipped ranged weapon is of the named
+    /// <see cref="SharedLib.Data.ItemWeaponSubclass"/> - 'RangedWeapon:Bow'.
+    ///
+    /// <para>Exists so a profile can tell arrows from bullets. A hunter runs dry and has
+    /// to restock, but which ammo to buy depends on whether the ranged slot holds a bow, a
+    /// crossbow or a gun, and nothing in the expression language could see that - so an
+    /// ammo-vendor entry had to hardcode one item id and was wrong for half of them.</para>
+    /// </summary>
+    private Requirement CreateRangedWeapon(ReadOnlySpan<char> requirement)
+    {
+        // 'RangedWeapon:_SUBCLASS_'
+        int sep = requirement.IndexOf(SEP1);
+        ReadOnlySpan<char> name = requirement[(sep + 1)..].Trim();
+
+        if (!Enum.TryParse(name, true, out ItemWeaponSubclass want))
+        {
+            throw new InvalidOperationException(
+                $"'{requirement}' - '{name}' is not a known {nameof(ItemWeaponSubclass)}. " +
+                $"Expected one of: {string.Join(", ", Enum.GetNames<ItemWeaponSubclass>())}");
+        }
+
+        ItemWeaponSubclass captured = want;
+
+        bool f()
+        {
+            int id = equipmentReader.GetId((int)InventorySlotId.Ranged);
+            return id != 0 &&
+                itemDb.Items.TryGetValue(id, out Item item) &&
+                item.ClassId == ItemClass.Weapon &&
+                item.SubclassId == (int)captured;
+        }
+
+        string s() => $"RangedWeapon {captured}";
+
+        return new Requirement
+        {
+            HasRequirement = f,
+            LogMessage = s
+        };
     }
 
     private Requirement CreateEquipment(ReadOnlySpan<char> requirement)

--- a/CoreTests/CLAUDE.md
+++ b/CoreTests/CLAUDE.md
@@ -176,6 +176,69 @@ Wrath expansion:
 
 Expansion values: `SoM`, `TBC`, `Wrath`, `Cata`, `Mop`, `Retail`
 
+### routegen - Generated Grind Routes
+
+Builds routes from `Json/` + the baked navmesh, with the player stubbed - no game client.
+See `docs/generated-routes-design.md`.
+
+Args: `--exp <client>` (default `som`), `--zone`, `--subzone`, `--mobs`, `--stops`,
+`--mode Wander|Loop`, `--focus Density|Balanced|Coverage`, `--level`, `--race`, `--faction`,
+`--uimap`, `--seed <n|random>`, `--profile <class json>`, `--output <dir>`,
+`--format svg|png|webp`.
+
+`--seed` defaults to a fixed value so two runs are comparable; pass `--seed random` for a
+fresh one. `Loop` ignores it - that mode is deterministic by construction.
+
+`--output <dir>` takes any folder, absolute or relative; bare `--output` writes to
+`routegen-out`. **Relative paths resolve against the working directory, which for `run.ps1`
+is the project folder** (`dotnet run` does not use the output directory) - so a relative
+`--output out` lands in `CoreTests\out`. The resolved path is logged as `<format> output:`
+at startup.
+
+`--svg` is the old name for this flag, from when SVG was the only encoding. Still accepted,
+warns, and behaves identically.
+
+**Do not point `--output` at `routegen`.** Windows paths are case-insensitive, so that is
+the same directory as the `RouteGen/` source folder - clearing the output then deletes the
+source. The default is `routegen-out` for that reason.
+
+Ad-hoc query:
+```powershell
+.\run.ps1 routegen --exp som --subzone "Northshire Valley" --mobs "Name:Wolf || Name:Kobold"
+```
+
+Every generated path in a profile, rendered over the minimap tiles:
+```powershell
+.\run.ps1 routegen --exp wrath --profile "..\Json\class\_\Warrior_1-10.json" --race Draenei --level 2 --output routegen-out
+```
+
+```powershell
+.\run.ps1 routegen --exp wrath --profile "..\Json\class\_\Warrior_1-10--------------.json" --race Draenei --level 2 --seed random --output routegen-out --format webp
+```
+
+`--output` writes one file per path - spawns green, route blue, numbered stops - with the
+Leaflet tiles behind it, so it opens with no server running.
+
+`--format` picks the encoding, default `svg`. All three share `RouteLayout`, so they frame
+the route identically; only the encoding differs:
+
+| format | notes |
+|---|---|
+| `svg` | Tiles inlined as base64 data URIs. Sharp at any zoom, but needs a browser. |
+| `png` | Lossless raster. **Largest of the three** - the tiles re-encode worse than they arrive. |
+| `webp` | Quality 90. Smallest, and opens in any viewer - the one to attach to an issue. |
+
+On one Ammen Vale loop: svg 127 KB, png 738 KB, webp 99 KB.
+
+`--format` without `--output <dir>` writes nothing and says so. Raster text needs a system
+font (Consolas, Courier New, DejaVu Sans Mono, Segoe UI, then any); with none installed the
+route still renders and only the labels are dropped.
+
+**It reads `BlazorServer/appsettings.json` for the navmesh options.** Those feed the tile
+cache settings hash, which names the cache directory: on defaults it looks in a directory
+nothing was baked into and reports "no baked navmesh" for a continent that is in fact baked.
+`MinWorldZ.Expansion01 = -700` is exactly that case - Azeroth resolves, Outland does not.
+
 ### navmesh - Navmesh Coordinate Checks
 
 Pure math validation of the wow<->rc coordinate mapping and Detour tile

--- a/CoreTests/CoreTests.csproj
+++ b/CoreTests/CoreTests.csproj
@@ -12,6 +12,9 @@
     <PackageReference Include="Serilog.Sinks.Console" />
     <PackageReference Include="Serilog.Sinks.Debug" />
     <PackageReference Include="Serilog.Sinks.File" />
+    <!-- Raster route rendering: shapes and text for the png/webp output format. ImageSharp
+         itself already arrives transitively, but the drawing extensions do not. -->
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CoreTests/Program.cs
+++ b/CoreTests/Program.cs
@@ -44,7 +44,12 @@ internal sealed class Program
         ["find-target"] = Test_FindTargetByCursor,
         ["pather"] = Test_PPather,
         ["navmesh"] = Test_NavmeshCoords,
+        ["routegen"] = Test_RouteGeneration,
     };
+
+    /// <summary>Suites that need no WoW process - see the attach decision in Main.</summary>
+    private static readonly HashSet<string> offlineSuites =
+        new(StringComparer.OrdinalIgnoreCase) { "navmesh", "routegen" };
 
     public static void Main(string[] args)
     {
@@ -105,18 +110,27 @@ internal sealed class Program
             return;
         }
 
-        // its expected to have at least 2 DataFrame
-        DataFrame[] mockFrames =
-        [
-            new DataFrame(0, 0, 0),
-            new DataFrame(1, 0, 0),
-        ];
+        // Suites that read only from Json/ and the baked navmesh. Attaching to the game
+        // would be the only thing that could fail, so do not attach at all - otherwise
+        // every offline suite needs WoW running to say anything.
+        bool needsGame = remaining.Count == 0 ||
+            !offlineSuites.Contains(remaining[0]);
 
-        cts = new CancellationTokenSource();
-        process = new(cts, Options.Create<StartupConfigPid>(new() { Id = -1 }));
-        screen = UseDxgi
-            ? new WowScreenDXGI(loggerFactory.CreateLogger<WowScreenDXGI>(), process, mockFrames)
-            : new WowScreenWGC(loggerFactory.CreateLogger<WowScreenWGC>(), process, mockFrames);
+        if (needsGame)
+        {
+            // its expected to have at least 2 DataFrame
+            DataFrame[] mockFrames =
+            [
+                new DataFrame(0, 0, 0),
+                new DataFrame(1, 0, 0),
+            ];
+
+            cts = new CancellationTokenSource();
+            process = new(cts, Options.Create<StartupConfigPid>(new() { Id = -1 }));
+            screen = UseDxgi
+                ? new WowScreenDXGI(loggerFactory.CreateLogger<WowScreenDXGI>(), process, mockFrames)
+                : new WowScreenWGC(loggerFactory.CreateLogger<WowScreenWGC>(), process, mockFrames);
+        }
 
         if (remaining.Count > 0 && suites.TryGetValue(remaining[0], out Action<string[]> suite))
         {
@@ -535,6 +549,153 @@ internal sealed class Program
         {
             logger.LogError("CostZones: {Failures} failures", failures);
         }
+    }
+
+    /// <summary>
+    /// Route generation against the on-disk data, with the player stubbed - no game client.
+    ///
+    /// <code>
+    /// CoreTests routegen
+    /// CoreTests routegen --zone "Elwynn Forest" --mobs "Type:Humanoid &amp;&amp; !Elite"
+    /// CoreTests routegen --subzone "Northshire Valley" --mobs "Name:Wolf || Name:Kobold"
+    /// CoreTests routegen --profile "Json/class/_/Warrior_1-10.json" --output routegen-out
+    /// </code>
+    /// </summary>
+    private static void Test_RouteGeneration(string[] args)
+    {
+        string zone = "Elwynn Forest";
+        string? subzone = null;
+        string mobs = string.Empty;
+        int stops = 8;
+        int level = 5;
+        string race = "Human";
+        string faction = "Alliance";
+        int uiMapId = 0;
+        string exp = "som";
+        string focus = "Density";
+        string mode = "Wander";
+        string? profile = null;
+        string? outputDir = null;
+        string format = "svg";
+        int? seedArg = null;
+
+        // Loops to args.Length, not args.Length - 1: the old bound silently ignored any
+        // flag in the final position, so "--output" at the end of the line produced nothing
+        // and said nothing about it.
+        for (int i = 0; i < args.Length; i++)
+        {
+            string flag = args[i].ToLowerInvariant();
+
+            // Reads the value after a flag, or reports the flag as incomplete.
+            bool Value(out string value)
+            {
+                if (i + 1 < args.Length && !args[i + 1].StartsWith("--", StringComparison.Ordinal))
+                {
+                    value = args[++i];
+                    return true;
+                }
+
+                value = string.Empty;
+                return false;
+            }
+
+            switch (flag)
+            {
+                case "--zone": if (Value(out string z)) zone = z; else Missing(flag); break;
+                case "--subzone": if (Value(out string sz)) subzone = sz; else Missing(flag); break;
+                case "--mobs": if (Value(out string m)) mobs = m; else Missing(flag); break;
+                case "--race": if (Value(out string r)) race = r; else Missing(flag); break;
+                case "--faction": if (Value(out string f)) faction = f; else Missing(flag); break;
+                case "--exp": if (Value(out string e)) exp = e; else Missing(flag); break;
+                case "--focus": if (Value(out string fo)) focus = fo; else Missing(flag); break;
+                case "--mode": if (Value(out string mo)) mode = mo; else Missing(flag); break;
+                case "--profile": if (Value(out string p)) profile = p; else Missing(flag); break;
+
+                case "--stops": if (Value(out string st)) stops = int.Parse(st); else Missing(flag); break;
+                case "--level": if (Value(out string lv)) level = int.Parse(lv); else Missing(flag); break;
+                case "--uimap": if (Value(out string um)) uiMapId = int.Parse(um); else Missing(flag); break;
+
+                case "--svg":
+                    // Kept as an alias: it predates --format, when SVG was the only output.
+                    Log.Logger.Warning("--svg is now --output - still honoured");
+                    goto case "--output";
+
+                case "--output":
+                    // A bare --output still means "write them"; only the folder is optional.
+                    // Named routegen-out, not routegen: the source folder is RouteGen/, and
+                    // Windows paths are case-insensitive, so an output folder called
+                    // "routegen" is the same directory as the source. Deleting the output
+                    // then deletes the source.
+                    outputDir = Value(out string dir) && dir.Length > 0 ? dir : "routegen-out";
+                    break;
+
+                case "--format":
+                    // Output encoding for --output. SVG stays the default: it is the only one
+                    // that keeps the tiles as tiles and stays sharp at any zoom.
+                    if (!Value(out string fmt))
+                    {
+                        Missing(flag);
+                        break;
+                    }
+
+                    fmt = fmt.ToLowerInvariant();
+                    if (fmt is "svg" or "png" or "webp")
+                    {
+                        format = fmt;
+                    }
+                    else
+                    {
+                        Log.Logger.Warning(
+                            "--format {Value} is not svg|png|webp - keeping {Current}", fmt, format);
+                    }
+                    break;
+
+                case "--seed":
+                    // "random" is explicit on purpose: omitting --seed keeps the fixed
+                    // default, so a harness run stays comparable to the last one unless
+                    // asked otherwise.
+                    if (!Value(out string seedText))
+                    {
+                        Missing(flag);
+                        break;
+                    }
+
+                    seedArg = seedText.Equals("random", StringComparison.OrdinalIgnoreCase)
+                        ? Random.Shared.Next()
+                        : int.Parse(seedText);
+                    break;
+
+                default:
+                    if (flag.StartsWith("--", StringComparison.Ordinal))
+                        Log.Logger.Warning("Unknown option {Flag}", args[i]);
+                    break;
+            }
+        }
+
+        void Missing(string flag) =>
+            Log.Logger.Warning("{Flag} needs a value - ignored", flag);
+
+        if (outputDir != null)
+        {
+            outputDir = System.IO.Path.GetFullPath(outputDir);
+            Log.Logger.Information("{Format} output: {Dir}", format, outputDir);
+        }
+        else if (format != "svg")
+        {
+            Log.Logger.Warning("--format {Format} does nothing without --output <dir>", format);
+        }
+
+        using Test_RouteGen test = new(logger, loggerFactory, level, race, faction, uiMapId, exp);
+
+        if (profile != null)
+        {
+            test.TestProfile(profile, seedArg, outputDir, format);
+            return;
+        }
+
+        test.TestExpressionScope();
+        test.TestGenerate(zone, subzone, mobs, stops, Enum.Parse<RouteFocus>(focus, true),
+            Enum.Parse<RouteGenMode>(mode, true), seedArg, outputDir, format);
     }
 
     private static void Test_NavmeshCoords(string[] args)

--- a/CoreTests/routegen/LeafletTiles.cs
+++ b/CoreTests/routegen/LeafletTiles.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace CoreTests;
+
+/// <summary>
+/// Places the pre-extracted minimap tiles behind a rendered route.
+///
+/// <para>Without a map behind it a route is an abstract squiggle - you cannot tell whether it
+/// crosses a road, hugs a lake or runs through a building. These are the same tiles the
+/// Leaflet page uses, read straight off disk.</para>
+///
+/// <para>The per-continent extents live only in <c>leaflet-watch.js</c>, so they are parsed
+/// out of it rather than copied. <c>Frontend/CLAUDE.md</c> already warns that the JS mirrors
+/// <c>DataConfig</c> and the two must be kept in step; a third copy in a test harness would
+/// be one more thing to drift.</para>
+/// </summary>
+internal static partial class LeafletTiles
+{
+    // Mirrors the derivation in leaflet-watch.js: resX/resY are normalised away, so every
+    // continent ends up on the same world extent and only the offset differs.
+    private const double MapSize = 34133.33333333334;
+    private const double AdtSize = MapSize / 64.0;
+    private const double BlpSize = 512.0;
+    private const double PxPerCoord = AdtSize / BlpSize;
+    private const int TilePixels = 256;
+
+    internal readonly record struct Config(int MaxZoom, int OffsetX, int OffsetY);
+
+    internal static int TileSize => TilePixels;
+
+    /// <summary>Max-zoom pixels per world yard, for scale bars.</summary>
+    internal static double PixelsPerYard => 1.0 / PxPerCoord;
+
+    /// <summary>World position to pixel coordinates at the continent's maximum zoom.</summary>
+    internal static (double X, double Y) WorldToPixel(double worldX, double worldY, Config config)
+    {
+        double offsetX = (config.OffsetY * AdtSize) / PxPerCoord;
+        double offsetY = (config.OffsetX * AdtSize) / PxPerCoord;
+
+        double x = (((MapSize / 2) - worldY) / PxPerCoord) - offsetX;
+        double y = (((MapSize / 2) - worldX) / PxPerCoord) - offsetY;
+
+        return (x, y);
+    }
+
+    /// <summary>Scale factor from max-zoom pixels to the given zoom level.</summary>
+    internal static double ZoomScale(int zoom, Config config) =>
+        Math.Pow(2, zoom - config.MaxZoom);
+
+    /// <summary>
+    /// Reads the extent for one continent out of the Leaflet script. Returns null when the
+    /// script, the era or the continent is absent - the caller then renders without a map
+    /// rather than failing.
+    /// </summary>
+    internal static Config? ReadConfig(string repoRoot, string era, string continent)
+    {
+        string script = Path.Combine(repoRoot,
+            "Frontend", "wwwroot", "script", "leaflet-watch.js");
+
+        if (!File.Exists(script))
+        {
+            return null;
+        }
+
+        string text = File.ReadAllText(script);
+
+        // The Configs object is JS, not JSON - unquoted keys, comments, trailing commas - so
+        // it is scanned rather than parsed. Narrow to the era block first, because continent
+        // names repeat across eras with different offsets.
+        Match eraMatch = Regex.Match(text,
+            "'" + Regex.Escape(era) + @"'\s*:\s*\{",
+            RegexOptions.None, TimeSpan.FromSeconds(5));
+
+        if (!eraMatch.Success)
+        {
+            return null;
+        }
+
+        string eraBlock = ExtractBlock(text, eraMatch.Index + eraMatch.Length - 1);
+
+        Match contMatch = Regex.Match(eraBlock,
+            "'" + Regex.Escape(continent) + @"'\s*:\s*\{",
+            RegexOptions.None, TimeSpan.FromSeconds(5));
+
+        if (!contMatch.Success)
+        {
+            return null;
+        }
+
+        string block = ExtractBlock(eraBlock, contMatch.Index + contMatch.Length - 1);
+
+        Match maxZoom = MaxZoomRegex().Match(block);
+        Match min = OffsetMinRegex().Match(block);
+
+        if (!maxZoom.Success || !min.Success)
+        {
+            return null;
+        }
+
+        return new Config(
+            int.Parse(maxZoom.Groups[1].Value, CultureInfo.InvariantCulture),
+            int.Parse(min.Groups[1].Value, CultureInfo.InvariantCulture),
+            int.Parse(min.Groups[2].Value, CultureInfo.InvariantCulture));
+    }
+
+    /// <summary>Substring of one brace-balanced block starting at an opening brace.</summary>
+    private static string ExtractBlock(string text, int openBrace)
+    {
+        int depth = 0;
+
+        for (int i = openBrace; i < text.Length; i++)
+        {
+            if (text[i] == '{')
+            {
+                depth++;
+            }
+            else if (text[i] == '}')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    return text[openBrace..(i + 1)];
+                }
+            }
+        }
+
+        return text[openBrace..];
+    }
+
+    /// <summary>Tile files covering a pixel rectangle at a zoom.</summary>
+    internal static List<(int X, int Y, string Path)> Cover(string tileDir, int zoom,
+        double minPx, double minPy, double maxPx, double maxPy)
+    {
+        List<(int, int, string)> result = [];
+
+        if (!Directory.Exists(tileDir))
+        {
+            return result;
+        }
+
+        int x0 = (int)Math.Floor(minPx / TilePixels);
+        int x1 = (int)Math.Floor(maxPx / TilePixels);
+        int y0 = (int)Math.Floor(minPy / TilePixels);
+        int y1 = (int)Math.Floor(maxPy / TilePixels);
+
+        for (int x = x0; x <= x1; x++)
+        {
+            for (int y = y0; y <= y1; y++)
+            {
+                string path = Path.Combine(tileDir, $"z{zoom}x{x}y{y}.webp");
+                if (File.Exists(path))
+                {
+                    result.Add((x, y, path));
+                }
+            }
+        }
+
+        return result;
+    }
+
+    [GeneratedRegex(@"maxZoom\s*:\s*(\d+)")]
+    private static partial Regex MaxZoomRegex();
+
+    [GeneratedRegex(@"min\s*:\s*\{\s*x\s*:\s*(-?\d+)\s*,\s*y\s*:\s*(-?\d+)")]
+    private static partial Regex OffsetMinRegex();
+}

--- a/CoreTests/routegen/RouteGenLayout.cs
+++ b/CoreTests/routegen/RouteGenLayout.cs
@@ -1,0 +1,168 @@
+using Core;
+
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+
+namespace CoreTests;
+
+internal delegate void Projector(Vector3 p, out double sx, out double sy);
+
+/// <summary>
+/// Where everything lands on the canvas: image size, the world-to-pixel projection, the scale
+/// bar's ratio, and which minimap tiles sit behind it.
+///
+/// <para>Shared by the SVG and raster backends on purpose. The zoom search and the pixel
+/// flip are the fiddly part of this renderer, and a second copy in the raster path would
+/// drift from the first - two pictures of the same route that disagree is worse than
+/// having only one format.</para>
+/// </summary>
+internal sealed class RouteLayout
+{
+    public const int Margin = 24;
+
+    /// <summary>
+    /// Tile budget. In SVG each tile is inlined as a data URI, so this bounds both the file
+    /// size and the zoom that gets chosen. The raster backend keeps the same bound so the
+    /// two formats show the same level of detail.
+    /// </summary>
+    private const int MaxTiles = 120;
+
+    private const int PlainWidth = 1400;
+
+    /// <summary>Length of the scale bar drawn bottom-left, in yards.</summary>
+    public const float BarYards = 100f;
+
+    /// <summary>
+    /// Full path for an output file, creating the directory and scrubbing characters the
+    /// filesystem rejects - zone names carry apostrophes and colons.
+    /// </summary>
+    public static string OutputPath(string directory, string name, string extension)
+    {
+        System.IO.Directory.CreateDirectory(directory);
+
+        string safe = name;
+        foreach (char c in System.IO.Path.GetInvalidFileNameChars())
+        {
+            safe = safe.Replace(c, '_');
+        }
+
+        return System.IO.Path.GetFullPath(
+            System.IO.Path.Combine(directory, $"{safe}.{extension}"));
+    }
+
+    public required int Width { get; init; }
+    public required int Height { get; init; }
+    public required Projector Project { get; init; }
+    public required float YardsToPixels { get; init; }
+    public required string Title { get; init; }
+
+    /// <summary>Tiles to paint behind the route. Empty when no map was available.</summary>
+    public required IReadOnlyList<(int X, int Y, string Path)> Tiles { get; init; }
+
+    /// <summary>
+    /// Pixel offset applied to a tile's grid position, in the same space as
+    /// <see cref="Project"/>: a tile goes at <c>tile.X * TileSize + TileOffsetX</c>.
+    /// </summary>
+    public required double TileOffsetX { get; init; }
+    public required double TileOffsetY { get; init; }
+
+    public static RouteLayout Build(RouteGenerator.Context context, string title,
+        string? tileDir, LeafletTiles.Config? tileConfig)
+    {
+        return tileDir != null && tileConfig.HasValue
+            ? WithMap(context, title, tileDir, tileConfig.Value)
+            : Plain(context, title + "  [no map tiles]");
+    }
+
+    private static RouteLayout WithMap(RouteGenerator.Context context, string title,
+        string tileDir, LeafletTiles.Config cfg)
+    {
+        // Pixel space at max zoom. World X maps to pixel y and world Y to pixel x, which is
+        // the same flip the map view applies - so the picture is oriented like the in-game
+        // map instead of transposed.
+        (double ax, double ay) = LeafletTiles.WorldToPixel(
+            context.Polygon.MinWorldX, context.Polygon.MinWorldY, cfg);
+        (double bx, double by) = LeafletTiles.WorldToPixel(
+            context.Polygon.MaxWorldX, context.Polygon.MaxWorldY, cfg);
+
+        double minPxFull = Math.Min(ax, bx);
+        double maxPxFull = Math.Max(ax, bx);
+        double minPyFull = Math.Min(ay, by);
+        double maxPyFull = Math.Max(ay, by);
+
+        // Highest zoom whose tile count fits the budget - the most detail affordable.
+        int zoom = cfg.MaxZoom;
+        double scale;
+
+        while (true)
+        {
+            scale = LeafletTiles.ZoomScale(zoom, cfg);
+
+            int wide = (int)Math.Floor(maxPxFull * scale / LeafletTiles.TileSize)
+                - (int)Math.Floor(minPxFull * scale / LeafletTiles.TileSize) + 1;
+            int high = (int)Math.Floor(maxPyFull * scale / LeafletTiles.TileSize)
+                - (int)Math.Floor(minPyFull * scale / LeafletTiles.TileSize) + 1;
+
+            if (zoom <= 1 || wide * high <= MaxTiles)
+            {
+                break;
+            }
+
+            zoom--;
+        }
+
+        double minPx = minPxFull * scale;
+        double maxPx = maxPxFull * scale;
+        double minPy = minPyFull * scale;
+        double maxPy = maxPyFull * scale;
+
+        void Point(Vector3 p, out double sx, out double sy)
+        {
+            (double x, double y) = LeafletTiles.WorldToPixel(p.X, p.Y, cfg);
+            sx = (x * scale) - minPx + Margin;
+            sy = (y * scale) - minPy + Margin;
+        }
+
+        return new RouteLayout
+        {
+            Width = (int)(maxPx - minPx) + (2 * Margin),
+            Height = (int)(maxPy - minPy) + (2 * Margin),
+            Project = Point,
+            YardsToPixels = (float)(LeafletTiles.PixelsPerYard * scale),
+            Title = title,
+            Tiles = LeafletTiles.Cover(tileDir, zoom, minPx, minPy, maxPx, maxPy),
+            TileOffsetX = Margin - minPx,
+            TileOffsetY = Margin - minPy
+        };
+    }
+
+    private static RouteLayout Plain(RouteGenerator.Context context, string title)
+    {
+        float minWorldX = context.Polygon.MinWorldX;
+        float minWorldY = context.Polygon.MinWorldY;
+
+        float spanX = MathF.Max(1f, context.Polygon.MaxWorldX - minWorldX);
+        float spanY = MathF.Max(1f, context.Polygon.MaxWorldY - minWorldY);
+
+        float scale = (PlainWidth - (2 * Margin)) / spanY;
+
+        void Point(Vector3 p, out double sx, out double sy)
+        {
+            sx = Margin + ((p.Y - minWorldY) * scale);
+            sy = Margin + ((p.X - minWorldX) * scale);
+        }
+
+        return new RouteLayout
+        {
+            Width = PlainWidth,
+            Height = (int)((spanX * scale) + (2 * Margin)),
+            Project = Point,
+            YardsToPixels = scale,
+            Title = title,
+            Tiles = [],
+            TileOffsetX = 0,
+            TileOffsetY = 0
+        };
+    }
+}

--- a/CoreTests/routegen/RouteGenRaster.cs
+++ b/CoreTests/routegen/RouteGenRaster.cs
@@ -1,0 +1,201 @@
+using Core;
+
+using SixLabors.Fonts;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Drawing;
+using SixLabors.ImageSharp.Drawing.Processing;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.Formats.Webp;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Numerics;
+
+namespace CoreTests;
+
+/// <summary>
+/// The same picture <see cref="RouteGenSvg"/> draws, rasterised to PNG or WebP.
+///
+/// <para>An SVG with a hundred inlined tiles is several hundred KB of base64 and needs a
+/// browser to look at. A raster of the same view is smaller, opens in any image viewer, and
+/// can be dropped into an issue - which is what makes it worth carrying a second backend.</para>
+///
+/// <para>Geometry is not recomputed here: <see cref="RouteLayout"/> is shared with the SVG
+/// path so both formats frame the route identically.</para>
+/// </summary>
+internal static class RouteGenRaster
+{
+    private static readonly Color Background = Color.ParseHex("0d1117");
+    private static readonly Color SpawnColour = Color.ParseHex("3fb950").WithAlpha(0.7f);
+    private static readonly Color RouteHalo = Color.ParseHex("0d1117").WithAlpha(0.7f);
+    private static readonly Color RouteLine = Color.ParseHex("58a6ff");
+    private static readonly Color StopFill = Color.ParseHex("f78166");
+    private static readonly Color Ink = Color.ParseHex("e6edf3");
+
+    public static string Render(RouteGenerator.Context context, Vector3[] route,
+        IReadOnlyList<Vector3> stops, string title,
+        string? tileDir, LeafletTiles.Config? tileConfig,
+        string directory, string name, string format)
+    {
+        RouteLayout layout = RouteLayout.Build(context, title, tileDir, tileConfig);
+
+        using Image<Rgba32> image = new(layout.Width, layout.Height, Background.ToPixel<Rgba32>());
+
+        DrawTiles(image, layout);
+        DrawSpawns(image, context, layout);
+        DrawRoute(image, route, layout);
+        DrawStops(image, stops, layout);
+        DrawChrome(image, layout);
+
+        string path = RouteLayout.OutputPath(directory, name, format);
+
+        if (format == "webp")
+        {
+            image.Save(path, new WebpEncoder { Quality = 90 });
+        }
+        else
+        {
+            image.Save(path, new PngEncoder());
+        }
+
+        return path;
+    }
+
+    private static void DrawTiles(Image<Rgba32> image, RouteLayout layout)
+    {
+        foreach ((int tx, int ty, string tilePath) in layout.Tiles)
+        {
+            // A tile that fails to decode should cost that tile, not the whole render - the
+            // extracted set legitimately has gaps at the edge of a continent.
+            Image<Rgba32> tile;
+            try
+            {
+                tile = Image.Load<Rgba32>(tilePath);
+            }
+            catch (ImageFormatException)
+            {
+                continue;
+            }
+
+            using (tile)
+            {
+                int px = (int)((tx * LeafletTiles.TileSize) + layout.TileOffsetX);
+                int py = (int)((ty * LeafletTiles.TileSize) + layout.TileOffsetY);
+
+                image.Mutate(c => c.DrawImage(tile, new Point(px, py), 1f));
+            }
+        }
+    }
+
+    private static void DrawSpawns(Image<Rgba32> image, RouteGenerator.Context context,
+        RouteLayout layout)
+    {
+        image.Mutate(c =>
+        {
+            foreach (Vector3 spawn in context.Polygon.Spawns)
+            {
+                layout.Project(spawn, out double sx, out double sy);
+                c.Fill(SpawnColour, new EllipsePolygon((float)sx, (float)sy, 3f));
+            }
+        });
+    }
+
+    private static void DrawRoute(Image<Rgba32> image, Vector3[] route, RouteLayout layout)
+    {
+        if (route.Length < 2)
+        {
+            return;
+        }
+
+        PointF[] points = new PointF[route.Length];
+        for (int i = 0; i < route.Length; i++)
+        {
+            layout.Project(route[i], out double sx, out double sy);
+            points[i] = new PointF((float)sx, (float)sy);
+        }
+
+        // Dark halo under the line so it stays readable over light terrain.
+        image.Mutate(c => c
+            .DrawLine(RouteHalo, 5f, points)
+            .DrawLine(RouteLine, 2.5f, points));
+    }
+
+    private static void DrawStops(Image<Rgba32> image, IReadOnlyList<Vector3> stops,
+        RouteLayout layout)
+    {
+        Font? font = Mono(12);
+
+        image.Mutate(c =>
+        {
+            for (int i = 0; i < stops.Count; i++)
+            {
+                layout.Project(stops[i], out double sx, out double sy);
+
+                EllipsePolygon dot = new((float)sx, (float)sy, 7f);
+                c.Fill(StopFill, dot);
+                c.Draw(Background, 2f, dot);
+
+                if (font != null)
+                {
+                    c.DrawText(
+                        i.ToString(CultureInfo.InvariantCulture),
+                        font, Color.White,
+                        new PointF((float)sx + 9f, (float)sy - 6f));
+                }
+            }
+        });
+    }
+
+    private static void DrawChrome(Image<Rgba32> image, RouteLayout layout)
+    {
+        float barPixels = RouteLayout.BarYards * layout.YardsToPixels;
+        float barX = RouteLayout.Margin;
+        float barY = layout.Height - 12;
+
+        Font? bar = Mono(12);
+        Font? heading = Mono(14);
+
+        image.Mutate(c =>
+        {
+            c.Fill(Background.WithAlpha(0.65f), new RectangleF(
+                barX - 6, barY - 20, barPixels + 60, 26));
+
+            c.DrawLine(Ink, 2f,
+                new PointF(barX, barY), new PointF(barX + barPixels, barY));
+
+            if (bar != null)
+            {
+                c.DrawText($"{RouteLayout.BarYards:F0} yd", bar, Ink,
+                    new PointF(barX + barPixels + 6, barY - 8));
+            }
+
+            c.Fill(Background.WithAlpha(0.7f), new RectangleF(0, 0, layout.Width, 26));
+
+            if (heading != null)
+            {
+                c.DrawText(layout.Title, heading, Ink, new PointF(RouteLayout.Margin, 5));
+            }
+        });
+    }
+
+    /// <summary>
+    /// A monospace face, or null when the host has none of them. Text is decoration here -
+    /// a machine without Consolas should still get the route, not an exception.
+    /// </summary>
+    private static Font? Mono(float size)
+    {
+        foreach (string name in (string[])["Consolas", "Courier New", "DejaVu Sans Mono", "Segoe UI"])
+        {
+            if (SystemFonts.TryGet(name, out FontFamily family))
+            {
+                return family.CreateFont(size, FontStyle.Regular);
+            }
+        }
+
+        return SystemFonts.Families.GetEnumerator().MoveNext()
+            ? SystemFonts.Families.GetEnumerator().Current.CreateFont(size, FontStyle.Regular)
+            : null;
+    }
+}

--- a/CoreTests/routegen/RouteGenSvg.cs
+++ b/CoreTests/routegen/RouteGenSvg.cs
@@ -1,0 +1,137 @@
+using Core;
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Numerics;
+using System.Text;
+
+namespace CoreTests;
+
+/// <summary>
+/// Renders a generated route to a standalone SVG over the game's own minimap tiles - spawns,
+/// the chosen stops and the walked path.
+///
+/// <para>The Blazor page draws on the Leaflet map, which needs the bot running. This is the
+/// same picture from the offline harness, so a route can be judged while iterating on filters
+/// without launching anything - and with the map behind it, "does this cross the river" is
+/// answerable.</para>
+///
+/// <para>Layout comes from <see cref="RouteLayout"/>, shared with
+/// <see cref="RouteGenRaster"/>.</para>
+/// </summary>
+internal static class RouteGenSvg
+{
+    public static string Render(RouteGenerator.Context context, Vector3[] route,
+        IReadOnlyList<Vector3> stops, string title,
+        string? tileDir, LeafletTiles.Config? tileConfig)
+    {
+        RouteLayout layout = RouteLayout.Build(context, title, tileDir, tileConfig);
+
+        StringBuilder sb = new(1 << 20);
+
+        sb.Append("<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' ")
+          .Append(CultureInfo.InvariantCulture,
+            $"width='{layout.Width}' height='{layout.Height}' viewBox='0 0 {layout.Width} {layout.Height}'>")
+          .Append("<rect width='100%' height='100%' fill='#0d1117'/>");
+
+        if (layout.Tiles.Count > 0)
+        {
+            sb.Append("<g>");
+            foreach ((int tx, int ty, string path) in layout.Tiles)
+            {
+                double px = (tx * LeafletTiles.TileSize) + layout.TileOffsetX;
+                double py = (ty * LeafletTiles.TileSize) + layout.TileOffsetY;
+
+                sb.Append(CultureInfo.InvariantCulture,
+                    $"<image x='{px:F1}' y='{py:F1}' width='{LeafletTiles.TileSize}' height='{LeafletTiles.TileSize}' ")
+                  .Append("href='data:image/webp;base64,")
+                  .Append(Convert.ToBase64String(File.ReadAllBytes(path)))
+                  .Append("'/>");
+            }
+            sb.Append("</g>");
+        }
+
+        Body(sb, context, route, stops, layout);
+
+        sb.Append("</svg>");
+        return sb.ToString();
+    }
+
+    private static void Body(StringBuilder sb, RouteGenerator.Context context, Vector3[] route,
+        IReadOnlyList<Vector3> stops, RouteLayout layout)
+    {
+        Projector project = layout.Project;
+
+        // Spawns first, so the route draws over them.
+        sb.Append("<g fill='#3fb950' fill-opacity='0.7'>");
+        foreach (Vector3 spawn in context.Polygon.Spawns)
+        {
+            project(spawn, out double sx, out double sy);
+            sb.Append(CultureInfo.InvariantCulture, $"<circle cx='{sx:F1}' cy='{sy:F1}' r='3'/>");
+        }
+        sb.Append("</g>");
+
+        if (route.Length > 1)
+        {
+            // Dark halo under the line so it stays readable over light terrain.
+            sb.Append("<polyline fill='none' stroke='#0d1117' stroke-opacity='0.7' stroke-width='5' points='");
+            AppendPoints(sb, route, project);
+            sb.Append("'/>");
+
+            sb.Append("<polyline fill='none' stroke='#58a6ff' stroke-width='2.5' points='");
+            AppendPoints(sb, route, project);
+            sb.Append("'/>");
+        }
+
+        for (int i = 0; i < stops.Count; i++)
+        {
+            project(stops[i], out double sx, out double sy);
+
+            sb.Append(CultureInfo.InvariantCulture,
+                $"<circle cx='{sx:F1}' cy='{sy:F1}' r='7' fill='#f78166' stroke='#0d1117' stroke-width='2'/>");
+            sb.Append(CultureInfo.InvariantCulture,
+                $"<text x='{sx + 9:F1}' y='{sy + 4:F1}' fill='#ffffff' stroke='#0d1117' stroke-width='3' ")
+              .Append(CultureInfo.InvariantCulture,
+                $"paint-order='stroke' font-family='monospace' font-size='12'>{i}</text>");
+        }
+
+        double barPixels = RouteLayout.BarYards * layout.YardsToPixels;
+        double barX = RouteLayout.Margin;
+        double barY = layout.Height - 12;
+
+        sb.Append(CultureInfo.InvariantCulture,
+            $"<rect x='{barX - 6:F1}' y='{barY - 20:F1}' width='{barPixels + 60:F1}' height='26' fill='#0d1117' fill-opacity='0.65'/>");
+        sb.Append(CultureInfo.InvariantCulture,
+            $"<line x1='{barX:F1}' y1='{barY:F1}' x2='{barX + barPixels:F1}' y2='{barY:F1}' stroke='#e6edf3' stroke-width='2'/>");
+        sb.Append(CultureInfo.InvariantCulture,
+            $"<text x='{barX + barPixels + 6:F1}' y='{barY + 4:F1}' fill='#e6edf3' font-family='monospace' font-size='12'>{RouteLayout.BarYards:F0} yd</text>");
+
+        sb.Append(CultureInfo.InvariantCulture,
+            $"<rect x='0' y='0' width='{layout.Width}' height='26' fill='#0d1117' fill-opacity='0.7'/>");
+        sb.Append(CultureInfo.InvariantCulture,
+            $"<text x='{RouteLayout.Margin}' y='18' fill='#e6edf3' font-family='monospace' font-size='14'>")
+          .Append(Escape(layout.Title)).Append("</text>");
+    }
+
+    private static void AppendPoints(StringBuilder sb, Vector3[] route, Projector project)
+    {
+        foreach (Vector3 p in route)
+        {
+            project(p, out double sx, out double sy);
+            sb.Append(CultureInfo.InvariantCulture, $"{sx:F1},{sy:F1} ");
+        }
+    }
+
+    public static string Write(string directory, string name, string svg)
+    {
+        string path = RouteLayout.OutputPath(directory, name, "svg");
+        File.WriteAllText(path, svg);
+
+        return path;
+    }
+
+    private static string Escape(string s) =>
+        s.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;");
+}

--- a/CoreTests/routegen/Test_RouteGen.cs
+++ b/CoreTests/routegen/Test_RouteGen.cs
@@ -1,0 +1,561 @@
+using Core;
+using Core.Database;
+
+using Microsoft.Extensions.Logging;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+using PPather;
+
+using SharedLib;
+using SharedLib.Data;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Numerics;
+
+namespace CoreTests;
+
+/// <summary>
+/// Exercises route generation without a game client: everything but the navmesh reads from
+/// <c>Json/</c>, and the navmesh half reads baked tiles. The player is stubbed, which is the
+/// whole reason <see cref="IRouteGenPlayer"/> exists.
+/// </summary>
+internal sealed class Test_RouteGen : IDisposable
+{
+    private sealed class StubPlayer(int level, UnitRace race, PlayerFaction faction, int uiMapId)
+        : IRouteGenPlayer
+    {
+        public int Level => level;
+        public UnitRace Race => race;
+        public PlayerFaction Faction => faction;
+        public int UIMapId => uiMapId;
+    }
+
+    private readonly ILogger logger;
+    private readonly PPatherService pather;
+    private readonly RouteGenerator generator;
+    private readonly CreatureRequirementFactory creatureRequirements;
+    private readonly DataConfig dataConfig;
+
+    public Test_RouteGen(ILogger logger, ILoggerFactory loggerFactory,
+        int level, string race, string faction, int uiMapId, string exp)
+    {
+        this.logger = logger;
+
+        // Exp is normally derived from the running client's exe version. There is no client
+        // here, so the caller picks which client's data to generate against - which is also
+        // what makes "does this profile work on mop" testable at all.
+        dataConfig = DataConfig.Load();
+        dataConfig.Exp = exp;
+
+        // DataConfig.Root is relative and only resolves from the output directory, but
+        // run.ps1 uses `dotnet run`, whose working directory is the project folder - so the
+        // same command works one way and dies with "X:\json not found" the other. Anchor on
+        // the assembly location instead, as DangerZoneGenerator does.
+        if (!Directory.Exists(dataConfig.ExpDbc))
+        {
+            string? found = FindRepoJson(AppContext.BaseDirectory);
+            if (found != null)
+            {
+                dataConfig.Root = found;
+            }
+        }
+
+        logger.LogInformation("data root '{Root}' exp '{Exp}'",
+            Path.GetFullPath(dataConfig.Root), dataConfig.Exp);
+
+        WorldMapAreaDB worldMapAreaDB = new(dataConfig);
+        ContinentDB.Init(worldMapAreaDB.Values);
+
+        CreatureDB creatureDb = new(loggerFactory.CreateLogger<CreatureDB>(), dataConfig);
+        FactionTemplateDB factionDb = new(loggerFactory.CreateLogger<FactionTemplateDB>(), dataConfig);
+        NpcSpawnDB spawnDb = new(loggerFactory.CreateLogger<NpcSpawnDB>(), dataConfig);
+
+        (NavmeshBakeOptions bake, NavmeshQueryOptions query) = LoadNavmeshOptions();
+
+        pather = new PPatherService(loggerFactory.CreateLogger<PPatherService>(),
+            dataConfig, worldMapAreaDB,
+            Microsoft.Extensions.Options.Options.Create(bake),
+            Microsoft.Extensions.Options.Options.Create(query))
+        {
+            Engine = PathingEngine.Navmesh
+        };
+
+        StubPlayer player = new(level,
+            Enum.Parse<UnitRace>(race, true),
+            Enum.Parse<PlayerFaction>(faction, true),
+            uiMapId);
+
+        creatureRequirements = new CreatureRequirementFactory(logger, player, factionDb);
+
+        LocalPathingApi localPather = new(loggerFactory.CreateLogger<LocalPathingApi>(), pather);
+
+        generator = new RouteGenerator(logger, creatureDb, spawnDb, worldMapAreaDB,
+            pather, creatureRequirements, player, factionDb, localPather);
+    }
+
+    public void Dispose()
+    {
+        pather.Dispose();
+    }
+
+    /// <summary>
+    /// Nearest ancestor of <paramref name="start"/> holding a <c>Json</c> folder with dbc
+    /// data in it. Null when there is none, leaving the configured root in place.
+    /// </summary>
+    private static string? FindRepoJson(string start)
+    {
+        DirectoryInfo? dir = new(start);
+
+        while (dir != null)
+        {
+            string candidate = Path.Combine(dir.FullName, "Json");
+            if (Directory.Exists(Path.Combine(candidate, "dbc")))
+            {
+                return candidate;
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+
+    private string RepoRoot => Path.GetFullPath(Path.Combine(dataConfig.Root, ".."));
+
+    /// <summary>
+    /// Reads the host's navmesh settings rather than using the defaults.
+    ///
+    /// <para>The bake options feed the tile-cache settings hash, which names the cache
+    /// directory - so a harness running on defaults looks in a directory nothing was ever
+    /// baked into and reports "no baked navmesh" for a continent that is in fact baked. That
+    /// is exactly what happened with Outland: appsettings sets
+    /// <c>MinWorldZ.Expansion01 = -700</c>, which changes the hash for that continent alone,
+    /// so Azeroth resolved fine and Expansion01 did not.</para>
+    /// </summary>
+    private (NavmeshBakeOptions Bake, NavmeshQueryOptions Query) LoadNavmeshOptions()
+    {
+        NavmeshBakeOptions bake = new();
+        NavmeshQueryOptions query = new();
+
+        string path = Path.Combine(RepoRoot, "BlazorServer", "appsettings.json");
+
+        if (!File.Exists(path))
+        {
+            logger.LogWarning(
+                "appsettings not found at {Path} - using navmesh defaults, which may point " +
+                "at a different tile cache than the one the bot baked.", path);
+
+            return (bake, query);
+        }
+
+        try
+        {
+            JObject root = JObject.Parse(File.ReadAllText(path));
+            JToken? navmesh = root["Navmesh"];
+
+            if (navmesh?["Bake"]?.ToObject<NavmeshBakeOptions>() is { } b)
+            {
+                bake = b;
+            }
+
+            if (navmesh?["Query"]?.ToObject<NavmeshQueryOptions>() is { } q)
+            {
+                query = q;
+            }
+
+            logger.LogInformation("navmesh options from {Path}", path);
+        }
+        catch (Exception e)
+        {
+            logger.LogWarning("could not read {Path}: {Message} - using defaults",
+                path, e.Message);
+        }
+
+        return (bake, query);
+    }
+
+    /// <summary>
+    /// Asserts the creature scope parses what it should and rejects player-scope names.
+    /// The two tables sharing a syntax is this feature's sharpest edge, so it is checked
+    /// first and explicitly.
+    /// </summary>
+    public void TestExpressionScope()
+    {
+        logger.LogInformation("--- expression scope ---");
+
+        string[] shouldParse =
+        [
+            "Type:Humanoid",
+            "Type:Humanoid && Level <= PlayerLevel + 2 && !Elite",
+            "(Name:Wolf || Name:Kobold) && Level >= PlayerLevel - 3",
+            "Faction:7 && !Name:Defias",
+            "NpcId == 299 || NpcId == 6",
+            "SpawnCount > 4 && Skinnable",
+            RouteGenerator.DefaultMobFilter,
+        ];
+
+        foreach (string text in shouldParse)
+        {
+            try
+            {
+                creatureRequirements.Parse(text);
+                logger.LogInformation("  OK    {Text}", text);
+            }
+            catch (Exception e)
+            {
+                logger.LogError("  FAIL  {Text} -> {Message}", text, e.Message);
+            }
+        }
+
+        // Player-scope names must not resolve here - a misplaced one has to fail loudly
+        // rather than silently evaluate against the wrong subject.
+        string[] shouldThrow = ["Health% > 50", "Race:Human", "BagFull"];
+
+        foreach (string text in shouldThrow)
+        {
+            try
+            {
+                creatureRequirements.Parse(text);
+                logger.LogError("  LEAK  {Text} parsed in creature scope but should not", text);
+            }
+            catch (Exception)
+            {
+                logger.LogInformation("  OK    {Text} rejected, as intended", text);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Generates every <c>Generate</c> path in a class profile, in profile order.
+    ///
+    /// <para>Reads the same file the bot reads, so what is rendered is what the profile will
+    /// actually walk - no retyping filters into CLI flags and hoping they match.</para>
+    /// </summary>
+    public void TestProfile(string profilePath, int? seed, string? outputDir,
+        string format = "svg")
+    {
+        if (!File.Exists(profilePath))
+        {
+            logger.LogError("profile not found: {Path}", profilePath);
+            return;
+        }
+
+        ClassConfiguration? config =
+            JsonConvert.DeserializeObject<ClassConfiguration>(File.ReadAllText(profilePath));
+
+        // Deserializing only fills inline Paths. Groups listed in PathsFilenames are pulled in
+        // by ClassConfiguration.Initialise, which needs a live service provider - so resolve
+        // them directly here, or a profile that keeps its routes in group files reports
+        // "no Paths" and renders nothing.
+        config?.ResolvePathGroups(dataConfig.Path);
+
+        if (config == null || config.Paths.Length == 0)
+        {
+            logger.LogError("profile has no Paths: {Path}", profilePath);
+            return;
+        }
+
+        logger.LogInformation("--- profile {Path}: {Count} path(s) ---",
+            profilePath, config.Paths.Length);
+
+        int index = 0;
+        foreach (PathSettings path in config.Paths)
+        {
+            int id = index++;
+
+            if (path.Generate == null)
+            {
+                logger.LogInformation("[{Id}] {File} - recorded route, skipped",
+                    id, path.PathFilename);
+                continue;
+            }
+
+            logger.LogInformation("--- [{Id}] {Name} ---", id, path.DisplayName);
+
+            Run(path.Generate, seed ?? path.Generate.Seed ?? config.Seed, outputDir,
+                $"{id}_{path.DisplayName}", format);
+        }
+    }
+
+    /// <summary>Generates from CLI arguments and reports on the result.</summary>
+    public void TestGenerate(string zone, string? subzone, string mobs, int stops,
+        RouteFocus focus = RouteFocus.Density, RouteGenMode mode = RouteGenMode.Wander,
+        int? seed = null, string? outputDir = null, string format = "svg")
+    {
+        RouteGenSettings settings = new()
+        {
+            Zone = string.IsNullOrEmpty(zone) ? null : zone,
+            Subzone = string.IsNullOrEmpty(subzone) ? null : subzone,
+            Mobs = mobs,
+            Stops = stops,
+            Mode = mode,
+            Focus = focus
+        };
+
+        Run(settings, seed, outputDir, settings.Subzone ?? settings.Zone ?? "route", format);
+    }
+
+    /// <summary>Generates from an already-built settings object and reports on it.</summary>
+    public void Run(RouteGenSettings settings, int? seed, string? outputDir, string label,
+        string format = "svg")
+    {
+        logger.LogInformation("--- generate: zone={Zone} subzone={Subzone} mobs='{Mobs}' " +
+            "mode={Mode} focus={Focus} ---",
+            settings.Zone, settings.Subzone, settings.Mobs, settings.Mode, settings.Focus);
+
+        RouteGenerator.Context? context = generator.TryBuildContext(settings);
+        if (context == null)
+        {
+            logger.LogError("generation produced no context - see the reason above");
+            return;
+        }
+
+        logger.LogInformation(
+            "zone={Zone} uiMap={UIMap} map={Map} creatures={Creatures} spawns={Spawns} cells={Cells}",
+            context.Target.Name, context.Target.UIMapId, context.Target.MapId,
+            context.MatchedCreatures, context.Polygon.Spawns.Length, context.Polygon.CellCount);
+
+        logger.LogInformation("connectivity: {Polys} polys, {Components} components, route on #{Component}",
+            context.Connectivity.PolyCount, context.Connectivity.ComponentCount, context.Component);
+
+        // Fixed unless asked: two harness runs should be comparable by default.
+        int effectiveSeed = seed ?? 1234;
+        logger.LogInformation("seed {Seed}{Note}", effectiveSeed,
+            settings.Mode == RouteGenMode.Loop ? " (Loop is deterministic - unused)" : "");
+
+        // Two laps with the same seed must match; different seeds must not. That is the
+        // reproducibility contract the whole seed plumbing exists to provide.
+        Vector3[] first = generator.Sample(context, settings, RouteSeed.For(effectiveSeed, 0, 0));
+        Vector3[] repeat = generator.Sample(context, settings, RouteSeed.For(effectiveSeed, 0, 0));
+        Vector3[] nextLap = generator.Sample(context, settings, RouteSeed.For(effectiveSeed, 0, 1));
+
+        logger.LogInformation("sampled {Count} waypoints (repeat identical: {Same}, next lap differs: {Differs})",
+            first.Length, Same(first, repeat), !Same(first, nextLap));
+
+        // Printed so two separate processes can be diffed - in-process repeatability says
+        // nothing about whether a seed reproduces a route tomorrow.
+        logger.LogInformation("hash: spawns {Spawns:X8} route {Route:X8}",
+            Hash(context.Polygon.Spawns), Hash(first));
+
+        if (outputDir != null)
+        {
+            WriteImage(context, settings, first, effectiveSeed, outputDir, label, format);
+        }
+
+        ReportSpacing(first);
+        ReportVerticalSpread(context, first);
+        ReportAreaIds(context);
+    }
+
+    private void WriteImage(RouteGenerator.Context context, RouteGenSettings settings,
+        Vector3[] route, int seed, string outputDir, string label, string format)
+    {
+        string continent = ContinentDB.IdToName.TryGetValue(context.Target.MapId, out string c)
+            ? c
+            : string.Empty;
+
+        string tileDir = continent.Length == 0 ? string.Empty : dataConfig.LeafletFor(continent);
+
+        LeafletTiles.Config? tileConfig = continent.Length == 0
+            ? null
+            : LeafletTiles.ReadConfig(RepoRoot, DataConfig.ClientEra(dataConfig.Exp), continent);
+
+        bool haveTiles = tileConfig != null && Directory.Exists(tileDir);
+        if (!haveTiles)
+        {
+            logger.LogWarning("no minimap tiles for {Continent} at {Dir} - rendering without a map",
+                continent, tileDir);
+        }
+
+        string title =
+            $"{context.Target.Name} | {settings.Mode} | Focus={settings.Focus} | " +
+            $"{settings.Stops} stops | seed {seed} | '{settings.Mobs}'";
+
+        string name = $"{label}_{settings.Mode}";
+
+        if (format == "svg")
+        {
+            string svg = RouteGenSvg.Render(context, route, StopsOf(route), title,
+                haveTiles ? tileDir : null, haveTiles ? tileConfig : null);
+
+            logger.LogInformation("svg: {Path}", RouteGenSvg.Write(outputDir, name, svg));
+            return;
+        }
+
+        logger.LogInformation("{Format}: {Path}", format,
+            RouteGenRaster.Render(context, route, StopsOf(route), title,
+                haveTiles ? tileDir : null, haveTiles ? tileConfig : null,
+                outputDir, name, format));
+    }
+
+    /// <summary>
+    /// The emitted route is densified, so the original stops are not recoverable from it.
+    /// Sampling every Nth waypoint is enough to show the tour shape in the picture.
+    /// </summary>
+    private static List<Vector3> StopsOf(Vector3[] route)
+    {
+        List<Vector3> stops = [];
+        int step = Math.Max(1, route.Length / 24);
+
+        for (int i = 0; i < route.Length; i += step)
+        {
+            stops.Add(route[i]);
+        }
+
+        return stops;
+    }
+
+    /// <summary>
+    /// Distance between consecutive waypoints. The follower brakes at the end of every
+    /// spline segment, and a segment ends at every waypoint - so a route much denser than a
+    /// recorded one (~17 yd) makes the bot stutter along straight stretches.
+    /// </summary>
+    private void ReportSpacing(Vector3[] route)
+    {
+        if (route.Length < 2)
+        {
+            return;
+        }
+
+        float[] gaps = new float[route.Length - 1];
+        for (int i = 1; i < route.Length; i++)
+        {
+            float dx = route[i].X - route[i - 1].X;
+            float dy = route[i].Y - route[i - 1].Y;
+            gaps[i - 1] = MathF.Sqrt((dx * dx) + (dy * dy));
+        }
+
+        Array.Sort(gaps);
+
+        logger.LogInformation("spacing: n={Count} min={Min:F1} p50={Median:F1} max={Max:F1} yd",
+            gaps.Length, gaps[0], gaps[gaps.Length / 2], gaps[^1]);
+    }
+
+    /// <summary>
+    /// Looks for the signature of a rooftop stop.
+    ///
+    /// <para>This is a proxy, not the gate itself: gate 2 compares a sample against the spawn
+    /// that anchored it, which the reporter no longer knows, so this compares against the
+    /// XY-nearest spawn instead. A large dz on its own means nothing - on a hillside the
+    /// nearest spawn is simply further up the slope. What indicts a stop is a large dz at a
+    /// <i>small</i> dxy: ground that close should be at the same height.</para>
+    /// </summary>
+    private void ReportVerticalSpread(RouteGenerator.Context context, Vector3[] route)
+    {
+        if (route.Length == 0)
+        {
+            return;
+        }
+
+        const float CloseXY = 12f;
+        const float SuspectDz = 6f;
+
+        int suspects = 0;
+        float worstDz = 0f;
+        float worstAtDxy = 0f;
+
+        for (int i = 0; i < route.Length; i++)
+        {
+            Vector3 nearest = default;
+            float nearestSq = float.MaxValue;
+
+            foreach (Vector3 spawn in context.Polygon.Spawns)
+            {
+                float dx = spawn.X - route[i].X;
+                float dy = spawn.Y - route[i].Y;
+                float d = (dx * dx) + (dy * dy);
+                if (d < nearestSq)
+                {
+                    nearestSq = d;
+                    nearest = spawn;
+                }
+            }
+
+            float dxy = MathF.Sqrt(nearestSq);
+            float dz = MathF.Abs(route[i].Z - nearest.Z);
+
+            if (dz > worstDz)
+            {
+                worstDz = dz;
+                worstAtDxy = dxy;
+            }
+
+            if (dxy < CloseXY && dz > SuspectDz)
+            {
+                suspects++;
+                logger.LogWarning(
+                    "  stop [{Index}] is {Dz:F1} yd above a spawn only {Dxy:F1} yd away - possible roof",
+                    i, dz, dxy);
+            }
+        }
+
+        logger.LogInformation(
+            "vertical: worst dz {Dz:F2} yd (at dxy {Dxy:F1} yd), {Suspects} suspect stop(s)",
+            worstDz, worstAtDxy, suspects);
+    }
+
+    /// <summary>
+    /// Which area id each accepted spawn actually sits in. A subzone target should show one
+    /// id and nothing else; anything else means the zone filter leaked.
+    /// </summary>
+    private void ReportAreaIds(RouteGenerator.Context context)
+    {
+        Dictionary<int, int> histogram = [];
+
+        foreach (Vector3 spawn in context.Polygon.Spawns)
+        {
+            int areaId = pather.GetAreaId(context.Target.MapId, spawn.X, spawn.Y);
+            histogram.TryGetValue(areaId, out int count);
+            histogram[areaId] = count + 1;
+        }
+
+        foreach ((int areaId, int count) in histogram.OrderByDescending(kv => kv.Value))
+        {
+            logger.LogInformation("  areaId {AreaId}: {Count} spawn(s){Note}",
+                areaId, count, areaId == 0 ? "  <- grid had no answer, map-bounds fallback" : "");
+        }
+    }
+
+    /// <summary>Order-sensitive FNV-1a over the coordinates, for cross-process comparison.</summary>
+    private static uint Hash(IReadOnlyList<Vector3> points)
+    {
+        uint h = 2166136261u;
+
+        for (int i = 0; i < points.Count; i++)
+        {
+            foreach (float f in new[] { points[i].X, points[i].Y, points[i].Z })
+            {
+                uint bits = (uint)BitConverter.SingleToInt32Bits(f);
+                for (int b = 0; b < 4; b++)
+                {
+                    h = (h ^ ((bits >> (b * 8)) & 0xFF)) * 16777619u;
+                }
+            }
+        }
+
+        return h;
+    }
+
+    private static bool Same(IReadOnlyList<Vector3> a, IReadOnlyList<Vector3> b)
+    {
+        if (a.Count != b.Count)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < a.Count; i++)
+        {
+            if (a[i] != b[i])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -52,6 +52,7 @@
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
+    <PackageVersion Include="SixLabors.ImageSharp.Drawing" Version="2.1.7" />
     <PackageVersion Include="System.Management" Version="10.0.10" />
   </ItemGroup>
 </Project>

--- a/Frontend/Pages/Index.razor
+++ b/Frontend/Pages/Index.razor
@@ -102,7 +102,7 @@
                             </AccordionItem>
                         </Accordion>
                     }
-                    else
+                    else if (botController.ClassConfig!.Paths.Length == 1)
                     {
                         <PathSelectorComponent Hide="@(botController.IsBotActive)"
                                                Target="@(botController.ClassConfig!.Paths.First())"

--- a/Frontend/Pages/RouteComponent.razor
+++ b/Frontend/Pages/RouteComponent.razor
@@ -302,7 +302,11 @@
     {
         if (botController.ClassConfig == null) return;
 
-        PathSettings? first = botController.ClassConfig.Paths.First(x => x.CanRun());
+        // FirstOrDefault, not First: no path being runnable right now is a normal state,
+        // not an error. Every path can be conditional, and a generated one also drops out
+        // when its query yields nothing. First() threw and took the circuit down with it,
+        // which made the null check below dead code.
+        PathSettings? first = botController.ClassConfig.Paths.FirstOrDefault(x => x.CanRun());
         if (first == null) return;
 
         routeSymbol = first.PathThereAndBack ?

--- a/Frontend/Pages/RouteGeneratorPage.razor
+++ b/Frontend/Pages/RouteGeneratorPage.razor
@@ -1,0 +1,408 @@
+@page "/RouteGen"
+@implements IDisposable
+
+@using System.IO
+@using System.Numerics
+@using System.Text.Json
+@using Core.Database
+@using SharedLib
+@using static System.Text.Json.JsonSerializer
+
+@inject ILogger logger
+@inject RouteGenerator generator
+@inject WorldMapAreaDB worldMapAreaDB
+@inject DataConfig dataConfig
+@inject IBotController botController
+@inject PlayerReader PlayerReader
+@inject IJSRuntime jsRuntime
+@inject JsonSerializerOptions options
+
+<div class="row">
+    <div class="col-md-4">
+        <Card>
+            <CardHeader>Generate a route</CardHeader>
+            <CardBody>
+
+                @if (profilePaths.Count > 0)
+                {
+                    <div class="mb-2">
+                        <label class="form-label">From the loaded profile</label>
+                        <select class="form-select" @onchange="LoadFromProfile">
+                            <option value="-1">-- custom --</option>
+                            @foreach ((int id, PathSettings p) in profilePaths)
+                            {
+                                <option value="@id" selected="@(id == loadedPathId)">
+                                    [@id] @p.DisplayName
+                                </option>
+                            }
+                        </select>
+                        <small class="text-muted">
+                            Only paths with a <code>Generate</code> block are listed.
+                            Editing here does not change the profile.
+                        </small>
+                    </div>
+                    <hr />
+                }
+
+                <div class="mb-2">
+                    <label class="form-label">Zone</label>
+                    <input class="form-control" @bind="settings.Zone" placeholder="Elwynn Forest" />
+                    <small class="text-muted">Blank = the player's current zone.</small>
+                </div>
+
+                <div class="mb-2">
+                    <label class="form-label">Subzone</label>
+                    <input class="form-control" @bind="settings.Subzone" placeholder="Northshire Valley" />
+                    <small class="text-muted">Narrower than Zone; wins when both are set.</small>
+                </div>
+
+                <div class="mb-2">
+                    <label class="form-label">Mobs</label>
+                    <input class="form-control" @bind="settings.Mobs"
+                           placeholder="@RouteGenerator.DefaultMobFilter" />
+                    <small class="text-muted">
+                        Creature scope, not player scope: <code>Level</code> is the mob's level,
+                        the player's is <code>PlayerLevel</code>.
+                        Keys: <code>Type:</code> <code>Name:</code> <code>Faction:</code>
+                        <code>Family:</code> <code>NpcId</code> <code>Rank</code>
+                        <code>SpawnCount</code> <code>Elite</code> <code>Skinnable</code>
+                        <code>Hostile</code>.
+                    </small>
+                </div>
+
+                <div class="row">
+                    <div class="col mb-2">
+                        <label class="form-label">Mode</label>
+                        <select class="form-select" @bind="settings.Mode">
+                            <option value="@RouteGenMode.Wander">Wander</option>
+                            <option value="@RouteGenMode.Loop">Loop</option>
+                        </select>
+                    </div>
+                    <div class="col mb-2">
+                        <label class="form-label">Stops</label>
+                        <input type="number" class="form-control" @bind="settings.Stops" />
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col mb-2">
+                        <label class="form-label">Focus</label>
+                        <select class="form-select" @bind="settings.Focus">
+                            <option value="@RouteFocus.Density">Density</option>
+                            <option value="@RouteFocus.Balanced">Balanced</option>
+                            <option value="@RouteFocus.Coverage">Coverage</option>
+                        </select>
+                        <small class="text-muted">
+                            Density sticks to the packs and drops isolated spawns;
+                            Coverage takes in everything that matched.
+                        </small>
+                    </div>
+                    <div class="col mb-2">
+                        <label class="form-label">Waypoint spacing (yd)</label>
+                        <input type="number" class="form-control" @bind="settings.WaypointSpacingYards" />
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col mb-2">
+                        <label class="form-label">Padding (yd)</label>
+                        <input type="number" class="form-control" @bind="settings.PaddingYards" />
+                    </div>
+                    <div class="col mb-2">
+                        <label class="form-label">Max &Delta;z (yd)</label>
+                        <input type="number" class="form-control" @bind="settings.MaxVerticalDelta" />
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col mb-2">
+                        <label class="form-label">Min spacing (yd)</label>
+                        <input type="number" class="form-control" @bind="settings.MinSpacingYards" />
+                    </div>
+                    <div class="col mb-2">
+                        <label class="form-label">Seed</label>
+                        <input type="number" class="form-control" @bind="seed"
+                               placeholder="blank = random" />
+                        <small class="text-muted">
+                            @(settings.Mode == RouteGenMode.Loop
+                                ? "Loop ignores the seed - it is the same route every time."
+                                : "Blank draws a fresh one each Generate.")
+                        </small>
+                    </div>
+                </div>
+
+                <hr />
+
+                <button class="btn btn-primary" @onclick="Generate" disabled="@busy">
+                    Generate
+                </button>
+                <button class="btn btn-secondary" @onclick="Reroll"
+                        disabled="@(busy || context == null)">
+                    Re-roll
+                </button>
+
+                <hr />
+
+                <div class="mb-2">
+                    <label class="form-label">Save as</label>
+                    <input class="form-control" @bind="saveName" placeholder="@DefaultSaveName()" />
+                </div>
+                <button class="btn btn-success" @onclick="Save" disabled="@(route.Length == 0)">
+                    Save to Json/path
+                </button>
+
+                @if (!string.IsNullOrEmpty(message))
+                {
+                    <div class="alert alert-info mt-2 mb-0 py-2">@message</div>
+                }
+                @if (!string.IsNullOrEmpty(error))
+                {
+                    <div class="alert alert-danger mt-2 mb-0 py-2">@error</div>
+                }
+
+            </CardBody>
+        </Card>
+
+        @if (context != null)
+        {
+            <Card class="mt-2">
+                <CardHeader>@context.Target.Name</CardHeader>
+                <CardBody>
+                    <table class="table table-sm mb-0">
+                        <tbody>
+                            <tr><td>UIMapId / MapId</td><td>@context.Target.UIMapId / @context.Target.MapId</td></tr>
+                            <tr><td>Creature types matched</td><td>@context.MatchedCreatures</td></tr>
+                            <tr><td>Spawns kept</td><td>@context.Polygon.Spawns.Length (dropped @context.Polygon.PrunedSpawns)</td></tr>
+                            <tr><td>Clusters</td><td>@context.Polygon.ClusterCount</td></tr>
+                            <tr><td>Polygon cells</td><td>@context.Polygon.CellCount</td></tr>
+                            <tr><td>Navmesh polys</td><td>@context.Connectivity.PolyCount</td></tr>
+                            <tr><td>Components (route on)</td><td>@context.Connectivity.ComponentCount (#@context.Component)</td></tr>
+                            <tr><td>Stops sampled</td><td>@route.Length</td></tr>
+                        </tbody>
+                    </table>
+                </CardBody>
+            </Card>
+        }
+    </div>
+
+    <div class="col-md-8">
+        <LeafletComponent Size="80vh" Edit="true" />
+    </div>
+</div>
+
+@code {
+    private RouteGenSettings settings = new();
+
+    private RouteGenerator.Context? context;
+    private Vector3[] route = [];
+    private Vector3[] mapRoute = [];
+
+    private int? seed;
+    private int lap;
+    private int effectiveSeed;
+    private bool busy;
+    private int loadedPathId = -1;
+
+    private List<(int Id, PathSettings Path)> profilePaths = [];
+
+    private string saveName = string.Empty;
+    private string message = string.Empty;
+    private string error = string.Empty;
+
+    protected override void OnInitialized()
+    {
+        settings.Zone = PlayerReader.WorldMapArea.AreaName;
+
+        RefreshProfilePaths();
+        botController.ProfileLoaded += OnProfileLoaded;
+    }
+
+    public void Dispose()
+    {
+        botController.ProfileLoaded -= OnProfileLoaded;
+    }
+
+    private void OnProfileLoaded()
+    {
+        InvokeAsync(() =>
+        {
+            RefreshProfilePaths();
+            StateHasChanged();
+        });
+    }
+
+    private void RefreshProfilePaths()
+    {
+        profilePaths = botController.ClassConfig == null
+            ? []
+            : [.. botController.ClassConfig.Paths
+                    .Where(static p => p.Generate != null)
+                    .Select(static p => (p.Id, p))];
+    }
+
+    /// <summary>
+    /// Copies a profile entry's settings into the form. A copy on purpose - previewing must
+    /// not mutate the running profile's own <see cref="RouteGenSettings"/>.
+    /// </summary>
+    private void LoadFromProfile(ChangeEventArgs e)
+    {
+        if (!int.TryParse(e.Value?.ToString(), out int id) || id < 0)
+        {
+            loadedPathId = -1;
+            return;
+        }
+
+        PathSettings? source = profilePaths.FirstOrDefault(x => x.Id == id).Path;
+        if (source?.Generate == null) return;
+
+        loadedPathId = id;
+
+        RouteGenSettings g = source.Generate;
+        settings = new RouteGenSettings
+        {
+            Zone = g.Zone,
+            Subzone = g.Subzone,
+            UIMapId = g.UIMapId,
+            Name = g.Name,
+            Mobs = g.Mobs,
+            Mode = g.Mode,
+            Focus = g.Focus,
+            MinClusterShare = g.MinClusterShare,
+            DensityBias = g.DensityBias,
+            WaypointSpacingYards = g.WaypointSpacingYards,
+            Stops = g.Stops,
+            PaddingYards = g.PaddingYards,
+            MaxVerticalDelta = g.MaxVerticalDelta,
+            MinSpacingYards = g.MinSpacingYards,
+            Seed = g.Seed
+        };
+
+        seed = g.Seed;
+
+        message = $"Loaded path [{id}] {source.DisplayName}";
+    }
+
+    private string DefaultSaveName() =>
+        context == null
+            ? "generated"
+            : $"{context.Target.Name}_{settings.Mode}_{effectiveSeed}";
+
+    private async Task Generate()
+    {
+        busy = true;
+        message = error = string.Empty;
+        lap = 0;
+
+        try
+        {
+            // Null out blanks so RouteTarget's resolution order behaves the same as it
+            // does for a profile, where an unset field is absent rather than empty.
+            settings.Zone = Blank(settings.Zone);
+            settings.Subzone = Blank(settings.Subzone);
+
+            context = generator.TryBuildContext(settings);
+
+            if (context == null)
+            {
+                error = "Generation failed - check the log for the reason " +
+                    "(unknown zone, no spawn data, bad filter, or no baked navmesh).";
+                route = mapRoute = [];
+                await Draw();
+                return;
+            }
+
+            await SampleAndDraw();
+        }
+        catch (Exception e)
+        {
+            error = e.Message;
+            logger.LogError(e, "Route generation failed");
+        }
+        finally
+        {
+            busy = false;
+        }
+    }
+
+    /// <summary>
+    /// Re-samples from the cached context - the same path a Wander lap takes, so this is
+    /// also how you eyeball whether consecutive laps actually differ.
+    /// </summary>
+    private async Task Reroll()
+    {
+        if (context == null) return;
+
+        busy = true;
+        try
+        {
+            lap++;
+            await SampleAndDraw();
+        }
+        finally
+        {
+            busy = false;
+        }
+    }
+
+    private async Task SampleAndDraw()
+    {
+        // Blank means "surprise me": draw once per Generate so a re-roll still varies, and
+        // report it, because a route worth keeping needs a seed you can put in the profile.
+        effectiveSeed = seed ?? Random.Shared.Next();
+
+        route = generator.Sample(context!, settings, RouteSeed.For(effectiveSeed, 0, lap));
+
+        mapRoute = new Vector3[route.Length];
+        Array.Copy(route, mapRoute, route.Length);
+        worldMapAreaDB.ToMap_FlipXY(context!.Target.UIMapId, mapRoute);
+
+        message = settings.Mode == RouteGenMode.Loop
+            ? $"{route.Length} waypoints (Loop - deterministic, seed not used)"
+            : $"{route.Length} waypoints (lap {lap}, seed {effectiveSeed})";
+
+        await Draw();
+    }
+
+    private async Task Draw()
+    {
+        if (route.Length == 0)
+        {
+            await jsRuntime.InvokeVoidAsync("clearPolyPath", "Generated");
+            return;
+        }
+
+        // setPolyPath accepts world coordinates directly - its isMap() check only treats
+        // 0..100 values as map space, and world coords are far outside that.
+        //
+        // force: true because a re-roll keeps the same stop count, and setPolyPath's default
+        // skips any update that does not change the point count - which left the previous
+        // route drawn and made it look like the query had been ignored.
+        await jsRuntime.InvokeVoidAsync("setPolyPath", "Generated",
+            Serialize(route, options), true);
+    }
+
+    private void Save()
+    {
+        error = string.Empty;
+
+        try
+        {
+            string name = Blank(saveName) ?? DefaultSaveName();
+            string path = Path.Join(dataConfig.Path, $"{name}.json");
+
+            // Recorded routes on disk are map coordinates, so a generated one has to be
+            // written that way too or it will not load as a PathFilename.
+            File.WriteAllText(path,
+                Newtonsoft.Json.JsonConvert.SerializeObject(mapRoute));
+
+            message = $"Saved {mapRoute.Length} points to {path}";
+        }
+        catch (Exception e)
+        {
+            error = e.Message;
+        }
+    }
+
+    private static string? Blank(string? s) =>
+        string.IsNullOrWhiteSpace(s) ? null : s;
+}

--- a/Frontend/Shared/MainLayout.razor
+++ b/Frontend/Shared/MainLayout.razor
@@ -159,6 +159,10 @@
         if (DataConfig.HasLeaflet(client.Version.ToString()))
         {
             navItems.Insert(5, new() { Id = "6", Href = "/Leaflet", Text = "Leaflet" });
+
+            // Route generation previews on the leaflet map, so it is only reachable where
+            // that map exists.
+            navItems.Insert(6, new() { Id = "21", Href = "/RouteGen", Text = "Route Gen" });
         }
 
         if (!HideClassConfig)

--- a/Frontend/wwwroot/script/leaflet-watch.js
+++ b/Frontend/wwwroot/script/leaflet-watch.js
@@ -1300,7 +1300,7 @@ function isMap(p) {
     return p.x > 0 && p.x < 100;
 }
 
-function setPolyPath(name, path) {
+function setPolyPath(name, path, force = false) {
     if (!LeafletMap) return;
 
     let polyline = layerNames[name];
@@ -1329,12 +1329,30 @@ function setPolyPath(name, path) {
         scheduleGroupedLayerControlUpdate();
     }
     else {
-        if (polyline.getLatLngs().length != latlngs.length) {
+        // The length comparison is an optimization for the live route, which only ever
+        // shrinks as waypoints are consumed. It silently drops any update that happens to
+        // keep the same point count - so re-rolling a generated route of N stops never
+        // redrew, and switching to a different query with the same N left the old line on
+        // the map. Callers that replace a path wholesale pass force.
+        if (force || polyline.getLatLngs().length != latlngs.length) {
             polyline.setLatLngs(latlngs);
 
             polyline.bringToFront();
         }
     }
+}
+
+/// Removes a polyline previously added by setPolyPath, so a page can clear what it drew
+/// instead of leaving a stale line behind.
+function clearPolyPath(name) {
+    const polyline = layerNames[name];
+    if (!polyline) return;
+
+    editableLayers.removeLayer(polyline);
+    delete layerNames[name];
+
+    schedulePixiRedraw();
+    scheduleGroupedLayerControlUpdate();
 }
 
 function atlasImg(p) {

--- a/Json/class/Druid_1-10.json
+++ b/Json/class/Druid_1-10.json
@@ -1,0 +1,292 @@
+{
+  // Druid 1-10, starting-zone grind. Amalgamated from Druid_1 / Druid_4 / Druid_6 /
+  // Druid_10_bear.
+  //
+  // Caster first: Wrath and Moonfire carry the whole range. Bear Form is not trained
+  // until 10, so every bear entry carries "WhenUsable": true and stays dormant until
+  // then - at which point the pull switches to Moonfire-then-Bear on its own.
+  //
+  // Key 2 and key 3 are deliberately double-booked: WoW swaps the action bar with the
+  // form, so 2 is Wrath in caster and Maul in bear, 3 is Healing Touch in caster and
+  // Demoralizing Roar in bear. That is how Druid_10_bear binds them too.
+  //
+  // Bars (caster): 2 Wrath | 3 Healing Touch | 4 Mark of the Wild | 5 Moonfire
+  //                6 Rejuvenation | 7 Thorns | = Food | - Drink
+  // Bars (bear):   2 Maul | 3 Demoralizing Roar
+  // Forms:         F1 /cancelform macro | F2 Bear Form
+  "Loot": true,
+  "CheckTargetGivesExp": true,
+  "PathsFilenames": [
+    "1-8_Human_Northshire.json",
+    "1-8_Draenei_AmmenVale.json",
+    "1-8_NightElf_Teldrassil.json",
+    "1-8_DwarfGnome_Coldridge.json",
+    "1-8_OrcTroll_ValleyOfTrials.json",
+    "1-8_Undead_Deathknell.json",
+    "1-8_Tauren_RedCloudMesa.json",
+    "1-8_BloodElf_SunstriderIsle.json"
+  ],
+  "Paths": [],
+  "IntVariables": {
+    "MIN_HP_EAT%": 40,
+    "MIN_MANA_DRINK%": 30,
+
+    // Not SPELL_ prefixed on purpose - that prefix marks a trainer whitelist.
+    "TRAIN_COOLDOWN_SEC": 600,
+
+    "FLEE_MOB_COUNT": 1,
+    "FLEE_HP_LOW%": 60,
+
+    // Rank chains, verified against Json/dbc/wrath/spells.json. IDs rather than names:
+    // names drift between expansions, ids do not.
+    "SPELL_WRATH": [5176, 5177, 5178, 5179, 5180, 6780],
+    "SPELL_MOONFIRE": [8921, 8924, 8925, 8926, 8927, 8928, 8929],
+    "SPELL_HEALING_TOUCH": [5185, 5186, 5187, 5189, 6778, 8903],
+    "SPELL_REJUVENATION": [774, 1058, 1430, 2090, 2091, 3627, 8910],
+    "SPELL_MARK_OF_THE_WILD": [1126, 5232, 5234, 8907],
+    "SPELL_THORNS": [467, 782, 1075, 8914],
+    "SPELL_BEAR_FORM": [5487],
+    "SPELL_MAUL": [6807, 6808, 6809, 8972, 9745],
+    "SPELL_DEMORALIZING_ROAR": [99, 9490, 9747, 10968]
+  },
+  "Form": {
+    "Sequence": [
+      {
+        //macro: /cancelform
+        "Name": "cancelform",
+        "BaseAction": true,
+        "Key": "F1",
+        "Form": "None"
+      },
+      {
+        "Name": "Bear Form",
+        "Key": "F2",
+        "Form": "Druid_Bear"
+      }
+    ]
+  },
+  "Flee": {
+    "Sequence": [
+      {
+        "Name": "Flee",
+        "Requirement": "(MobCount > FLEE_MOB_COUNT && Health% < FLEE_HP_LOW%) || TargetElite"
+      }
+    ]
+  },
+  "Wait": {
+    "Sequence": [
+      {
+        "Cost": 0.9,
+        "Name": "User",
+        "Requirement": "MenuOpen || ChatInputVisible"
+      }
+    ]
+  },
+  "Pull": {
+    "Sequence": [
+      {
+        "Name": "Moonfire",
+        "Key": "5",
+        "Form": "None",
+        "WhenUsable": true,
+        "BeforeCastStop": true,
+        "AfterCastWaitBuff": true,
+        "AfterCastWaitGCD": true,
+        "Requirements": [
+          "Spell:SPELL_MOONFIRE",
+          "!Moonfire",
+          "SpellInRange:0",
+          "MinRange > 10"
+        ]
+      },
+      {
+        // From 10 on: open at range, then close as a bear.
+        "Name": "Bear Form",
+        "Key": "F2",
+        "WhenUsable": true,
+        "AfterCastWaitMeleeRange": true,
+        "Requirements": [
+          "Spell:SPELL_BEAR_FORM",
+          "Moonfire",
+          "!Form:Druid_Bear"
+        ]
+      },
+      {
+        "Name": "Wrath",
+        "Key": "2",
+        "Form": "None",
+        "HasCastBar": true,
+        "Requirements": [
+          "Spell:SPELL_WRATH",
+          "!Spell:SPELL_BEAR_FORM",
+          "SpellInRange:0"
+        ]
+      },
+      {
+        "Name": "Approach",
+        "Requirements": [
+          "!Casting",
+          "!SoftTargetDead"
+        ]
+      }
+    ]
+  },
+  "Combat": {
+    "Sequence": [
+      {
+        "Name": "Healing Touch",
+        "Key": "3",
+        "HasCastBar": true,
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_HEALING_TOUCH",
+          "Health% < 25"
+        ],
+        "Form": "None"
+      },
+      {
+        "Name": "Rejuvenation",
+        "Key": "6",
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_REJUVENATION",
+          "Health% < 55",
+          "!Rejuvenation"
+        ],
+        "Form": "None"
+      },
+      {
+        // Learned at 10 - dormant below that, so the caster rotation below runs instead.
+        "Name": "Demoralizing Roar",
+        "Key": "3",
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_DEMORALIZING_ROAR",
+          "InMeleeRange",
+          "!Demoralizing Roar",
+          "Form:Druid_Bear"
+        ],
+        "Form": "Druid_Bear"
+      },
+      {
+        "Name": "Maul",
+        "Key": "2",
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_MAUL",
+          "InMeleeRange",
+          "LastMainHandMs > 2100", // bear swing speed fixed at 2.5
+          "Form:Druid_Bear"
+        ],
+        "AfterCastWaitSwing": true,
+        "Form": "Druid_Bear"
+      },
+      {
+        "Name": "Moonfire",
+        "Key": "5",
+        "Form": "None",
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_MOONFIRE",
+          "!Spell:SPELL_BEAR_FORM",
+          "!Moonfire",
+          "TargetHealth% > 25"
+        ]
+      },
+      {
+        "Name": "Wrath",
+        "Key": "2",
+        "Form": "None",
+        "HasCastBar": true,
+        "Requirements": [
+          "Spell:SPELL_WRATH",
+          "!Spell:SPELL_BEAR_FORM",
+          "TargetHealth% > 50"
+        ]
+      },
+      {
+        "Name": "AutoAttack",
+        "Requirements": [
+          "!Casting"
+        ]
+      },
+      {
+        "Name": "Approach",
+        "Requirements": [
+          "!Casting",
+          "!MeleeSwinging && !SoftTargetDead"
+        ],
+        "Log": false
+      }
+    ]
+  },
+  "Adhoc": {
+    "Sequence": [
+      {
+        "Name": "Mark of the Wild",
+        "Key": "4",
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_MARK_OF_THE_WILD",
+          "!Mark of the Wild"
+        ],
+        "Form": "None"
+      },
+      {
+        // Learned at 6.
+        "Name": "Thorns",
+        "Key": "7",
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_THORNS",
+          "!Thorns"
+        ],
+        "Form": "None"
+      },
+      {
+        "Name": "Food",
+        "Key": "=",
+        "Requirement": "Health% < MIN_HP_EAT%",
+        "Form": "None",
+        "Cost": 3
+      },
+      {
+        "Name": "Drink",
+        "Key": "-",
+        "Requirement": "Mana% < MIN_MANA_DRINK%",
+        "Form": "None",
+        "Cost": 3
+      }
+    ]
+  },
+  "NPC": {
+    "Sequence": [
+      {
+        "Cost": 6,
+        "Name": "Repair",
+        "Form": "None",
+        "Requirement": "Items Broken"
+      },
+      {
+        "Cost": 6,
+        "Name": "Sell",
+        "Form": "None",
+        "Requirements": [
+          "BagFull",
+          "BagGreyItem"
+        ]
+      },
+      {
+        "Name": "ClassTrainer",
+        "Form": "None",
+        "Requirements": [
+          "HasTrainableSpell",
+          "VendoredOrRepairedRecently",
+          "Money > 100", // 1 silver
+          "SecondsSinceTrained > TRAIN_COOLDOWN_SEC"
+        ],
+        "Cost": 6.1
+      }
+    ]
+  }
+}

--- a/Json/class/Hunter_1-10.json
+++ b/Json/class/Hunter_1-10.json
@@ -1,0 +1,333 @@
+{
+  // Hunter 1-10, starting-zone grind. Amalgamated from Hunter_1 / Hunter_10.
+  //
+  // Everything learned after level 1 is gated on "Spell:SPELL_x" - do I know it - NOT on
+  // "WhenUsable" alone. WhenUsable only reads the usable bit of the slot the key maps to;
+  // it cannot tell that the slot holds a different spell, so a racial or any other usable
+  // ability sitting on that key makes the gate pass and the bot casts the wrong thing,
+  // forever. WhenUsable is kept as a second check for genuinely empty slots.
+  //
+  // This cannot save an ability known at level 1 from a wrong binding - bind the bars to
+  // match, see the Sync Actionbar button and the ActionBarSlotValidator lines at startup. A hunter has no pet until
+  // Tame Beast at 10, so the pet entries sit idle for most of this range - they are
+  // gated on "Has Pet" rather than removed.
+  //
+  // Bars: 2 Serpent Sting | 3 Auto Shot | 4 Raptor Strike | 5 Aspect of the Hawk
+  //       6 Aspect of the Monkey | 8 Arcane Shot | 9 Gift of the Naaru
+  //       N5 Feed Pet | N6 Call Pet | N7 Mend Pet | = Food | - Drink
+  "Loot": true,
+  "PathsFilenames": [
+    "1-8_Human_Northshire.json",
+    "1-8_Draenei_AmmenVale.json",
+    "1-8_NightElf_Teldrassil.json",
+    "1-8_DwarfGnome_Coldridge.json",
+    "1-8_OrcTroll_ValleyOfTrials.json",
+    "1-8_Undead_Deathknell.json",
+    "1-8_Tauren_RedCloudMesa.json",
+    "1-8_BloodElf_SunstriderIsle.json"
+  ],
+  "Paths": [],
+  "IntVariables": {
+    "MIN_HP_EAT%": 40,
+    "MIN_MANA_DRINK%": 30,
+
+    // Not SPELL_ prefixed on purpose - that prefix marks a trainer whitelist.
+    "TRAIN_COOLDOWN_SEC": 600,
+
+    "FLEE_MOB_COUNT": 1,
+    "FLEE_HP_LOW%": 60,
+
+    // Rank chains, verified against Json/dbc/wrath/spells.json. IDs rather than names:
+    // names drift between expansions, ids do not.
+    "SPELL_SERPENT_STING": [1978, 13549, 13550, 13551, 13552, 13553],
+    "SPELL_ARCANE_SHOT": [3044, 14281, 14283, 14284],
+    "SPELL_RAPTOR_STRIKE": [2973, 14260, 14261, 14262, 14263, 14264],
+    "SPELL_AUTO_SHOT": [75],
+    "SPELL_ASPECT_HAWK": [13165, 14318, 14319, 14320],
+    "SPELL_ASPECT_MONKEY": [13163],
+    "SPELL_CALL_PET": [883],
+    "SPELL_MEND_PET": [136, 3661, 3662],
+    "SPELL_FEED_PET": [6991],
+
+    // Ammo. Which one is needed depends on the ranged slot, not on the class - a bow or
+    // crossbow eats arrows, a gun eats bullets - so both are declared and the vendor
+    // entries below pick between them with "RangedWeapon:".
+    //
+    // 2512 Rough Arrow / 2516 Light Shot are the level-1 vendor stock. Beware the item DB:
+    // it also holds "Deprecated Iron Shot" (2513) and "Depricated Sharp Arrow" (2514),
+    // which are not buyable.
+    "ITEM_ARROW": 2512,
+    "ITEM_BULLET": 2516,
+    "MIN_COUNT_AMMO": 200,
+    "AMMO_BUY_STACKS": 5,
+
+    // Copper for one BuyMerchantItem call - a 200 stack of first-tier ammo. The macro
+    // makes AMMO_BUY_STACKS of those calls, so the run costs the product of the two, and
+    // the money gate below is what stops the bot walking to a vendor it cannot pay.
+    // Raise this when moving to better ammo.
+    "AMMO_COST_COPPER": 9
+  },
+  "StringVariables": {
+    "$ITEM_NAME_ARROW": "ITEM_ARROW",
+    "$ITEM_NAME_BULLET": "ITEM_BULLET",
+    "$AMMO_BUY_STACKS": "AMMO_BUY_STACKS"
+  },
+  "Flee": {
+    "Sequence": [
+      {
+        "Name": "Flee",
+        "Requirement": "(MobCount > FLEE_MOB_COUNT && Health% < FLEE_HP_LOW%) || TargetElite"
+      }
+    ]
+  },
+  "Wait": {
+    "Sequence": [
+      {
+        "Cost": 0.9,
+        "Name": "User",
+        "Requirement": "MenuOpen || ChatInputVisible"
+      }
+    ]
+  },
+  "Pull": {
+    "Sequence": [
+      {
+        // Learned at 4. Before that the pull is just Auto Shot.
+        "Name": "Serpent Sting",
+        "Key": "2",
+        "WhenUsable": true,
+        "BeforeCastStop": true,
+        "AfterCastWaitCombat": true,
+        "Requirements": [
+          "Spell:SPELL_SERPENT_STING",
+          "HasRangedWeapon",
+          "HasAmmo",
+          "!InMeleeRange"
+        ]
+      },
+      {
+        "Name": "Auto Shot",
+        "Key": "3",
+        "Item": true,
+        "BeforeCastStop": true,
+        "Requirements": [
+          "Spell:SPELL_AUTO_SHOT",
+          "HasRangedWeapon",
+          "HasAmmo",
+          "!InMeleeRange",
+          "!AutoShot"
+        ]
+      },
+      {
+        // No bow/gun or no ammo - walk in and melee it.
+        "Name": "Approach",
+        "Requirements": [
+          "!HasRangedWeapon || !HasAmmo",
+          "!SoftTargetDead"
+        ]
+      }
+    ]
+  },
+  "Combat": {
+    "Sequence": [
+      {
+        "Name": "Gift of the Naaru",
+        "Key": "9",
+        "HasCastBar": true,
+        "WhenUsable": true,
+        "Requirements": [
+          "Race:Draenei",
+          "Health% < 45"
+        ]
+      },
+      {
+        "Name": "Mend Pet",
+        "Key": "N7",
+        "Cooldown": 15000,
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_MEND_PET",
+          "Has Pet",
+          "PetHealth% < 40"
+        ]
+      },
+      {
+        "Name": "Serpent Sting",
+        "Key": "2",
+        "WhenUsable": true,
+        "BeforeCastStop": true,
+        "Requirements": [
+          "Spell:SPELL_SERPENT_STING",
+          "HasRangedWeapon",
+          "HasAmmo",
+          "!InMeleeRange",
+          "!Serpent Sting",
+          "TargetHealth% > 40"
+        ]
+      },
+      {
+        "Name": "Auto Shot",
+        "Key": "3",
+        "Item": true,
+        "BeforeCastStop": true,
+        "Requirements": [
+          "Spell:SPELL_AUTO_SHOT",
+          "HasRangedWeapon",
+          "HasAmmo",
+          "!InMeleeRange",
+          "!AutoShot"
+        ]
+      },
+      {
+        // Learned at 6.
+        "Name": "Arcane Shot",
+        "Key": "8",
+        "Cooldown": 6000,
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_ARCANE_SHOT",
+          "HasRangedWeapon",
+          "HasAmmo",
+          "!InMeleeRange",
+          "!Rapid Fire",
+          "!Quick Shots"
+        ]
+      },
+      {
+        "Name": "Raptor Strike",
+        "Key": "4",
+        "WhenUsable": true,
+        "AfterCastWaitSwing": true,
+        "Requirements": [
+          "Spell:SPELL_RAPTOR_STRIKE",
+          "MainHandSwing > -400",
+          "InMeleeRange",
+          "!AutoShot"
+        ]
+      },
+      {
+        "Name": "AutoAttack",
+        "Requirements": [
+          "InMeleeRange",
+          "!AutoShot"
+        ]
+      },
+      {
+        // Only closes when it cannot shoot - otherwise a hunter should stay at range.
+        "Name": "Approach",
+        "Requirements": [
+          "!HasRangedWeapon || !HasAmmo",
+          "!MeleeSwinging && !SoftTargetDead"
+        ],
+        "Log": false
+      }
+    ]
+  },
+  "Adhoc": {
+    "Sequence": [
+      {
+        // Learned at 10; Monkey at 4 covers the gap below.
+        "Name": "Aspect of the Hawk",
+        "Key": "5",
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_ASPECT_HAWK",
+          "!Aspect of the Hawk"
+        ]
+      },
+      {
+        "Name": "Aspect of the Monkey",
+        "Key": "6",
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_ASPECT_MONKEY",
+          "!Spell:SPELL_ASPECT_HAWK",
+          "!Aspect of the Monkey"
+        ]
+      },
+      {
+        "Name": "Feed Pet",
+        "Key": "N5",
+        "WhenUsable": true,
+        "Cooldown": 20000,
+        "Requirements": [
+          "Spell:SPELL_FEED_PET",
+          "Has Pet",
+          "!Pet Happy"
+        ]
+      },
+      {
+        "Name": "Call Pet",
+        "Key": "N6",
+        "HasCastBar": true,
+        "WhenUsable": true,
+        "Cooldown": 4000,
+        "Requirements": [
+          "Spell:SPELL_CALL_PET",
+          "!Has Pet"
+        ]
+      },
+      {
+        "Name": "Food",
+        "Key": "=",
+        "Requirement": "Health% < MIN_HP_EAT%",
+        "Cost": 3
+      },
+      {
+        "Name": "Drink",
+        "Key": "-",
+        "Requirement": "Mana% < MIN_MANA_DRINK%",
+        "Cost": 3
+      }
+    ]
+  },
+  "NPC": {
+    "Sequence": [
+      {
+        "Cost": 6,
+        "Name": "Repair",
+        "Requirement": "Items Broken"
+      },
+      {
+        "Cost": 6,
+        "Name": "Sell",
+        "Requirements": [
+          "BagFull",
+          "BagGreyItem"
+        ]
+      },
+      {
+        // Restock arrows - only when the ranged slot actually takes them.
+        "Cost": 6,
+        "Name": "VendorAmmo",
+        "Requirements": [
+          "RangedWeapon:Bow || RangedWeapon:Crossbow",
+          "!BagItem:ITEM_ARROW:MIN_COUNT_AMMO",
+          "Money > AMMO_BUY_STACKS * AMMO_COST_COPPER"
+        ],
+        "MacroText": "/run local a={'$ITEM_NAME_ARROW',$AMMO_BUY_STACKS} for i=1,GetMerchantNumItems() do if GetMerchantItemInfo(i)==a[1] then for j=1,a[2] do BuyMerchantItem(i,200) end end end"
+      },
+      {
+        // Same, for a gun.
+        "Cost": 6,
+        "Name": "VendorAmmo",
+        "Requirements": [
+          "RangedWeapon:Gun",
+          "!BagItem:ITEM_BULLET:MIN_COUNT_AMMO",
+          "Money > AMMO_BUY_STACKS * AMMO_COST_COPPER"
+        ],
+        "MacroText": "/run local a={'$ITEM_NAME_BULLET',$AMMO_BUY_STACKS} for i=1,GetMerchantNumItems() do if GetMerchantItemInfo(i)==a[1] then for j=1,a[2] do BuyMerchantItem(i,200) end end end"
+      },
+      {
+        "Name": "ClassTrainer",
+        "Requirements": [
+          "HasTrainableSpell",
+          "VendoredOrRepairedRecently",
+          "Money > 100", // 1 silver
+          "SecondsSinceTrained > TRAIN_COOLDOWN_SEC"
+        ],
+        "Cost": 6.1
+      }
+    ]
+  }
+}

--- a/Json/class/Mage_1-10.json
+++ b/Json/class/Mage_1-10.json
@@ -1,0 +1,274 @@
+{
+  // Mage 1-10, starting-zone grind. Amalgamated from Mage_1 / Mage_6 / Mage_10.
+  //
+  // Everything learned after level 1 carries "WhenUsable": true, so an ability the
+  // character has not trained yet has an empty action bar slot, reads as unusable and is
+  // skipped. That is what lets one profile span the whole range - ActionBarSlotValidator
+  // will log the empty slots at startup, which is expected until they are trained.
+  //
+  // Bars: 1 Frostbolt | 2 Fireball | 3 Frost Armor | 4 Arcane Intellect | 5 Fire Blast
+  //       6 Frost Nova | 8 Conjure Food | 9 Conjure Water | 0 Shoot (wand)
+  //       = Food | - Drink
+  "Loot": true,
+  "PathsFilenames": [
+    "1-8_Human_Northshire.json",
+    "1-8_Draenei_AmmenVale.json",
+    "1-8_NightElf_Teldrassil.json",
+    "1-8_DwarfGnome_Coldridge.json",
+    "1-8_OrcTroll_ValleyOfTrials.json",
+    "1-8_Undead_Deathknell.json",
+    "1-8_Tauren_RedCloudMesa.json",
+    "1-8_BloodElf_SunstriderIsle.json"
+  ],
+  "Paths": [],
+  "IntVariables": {
+    "Item_Conjure_Drink": 5350,
+    "Item_Conjure_Food": 5349,
+    "MIN_FOOD%": 50,
+    "MIN_WATER%": 40,
+    "MIN_MANA_SPELL%": 30,
+
+    // Not SPELL_ prefixed on purpose - that prefix marks a trainer whitelist.
+    "TRAIN_COOLDOWN_SEC": 600,
+
+    "FLEE_MOB_COUNT": 1,
+    "FLEE_HP_LOW%": 60,
+
+    // Rank chains, verified against Json/dbc/wrath/spells.json. IDs rather than names:
+    // names drift between expansions, ids do not.
+    "SPELL_FIREBALL": [133, 143, 145, 3140, 8400, 8401, 8402, 10148],
+    "SPELL_FROSTBOLT": [116, 205, 837, 7322, 8406, 8407, 8408],
+    "SPELL_FIRE_BLAST": [2136, 2137, 2138, 8412, 8413],
+    "SPELL_FROST_NOVA": [122, 865, 6131],
+    "SPELL_FROST_ARMOR": [168, 7300, 7301],
+    "SPELL_ARCANE_INTELLECT": [1459, 1460, 1461, 10156],
+    "SPELL_CONJURE_WATER": [5504, 5505, 5506, 6127, 10138],
+    "SPELL_CONJURE_FOOD": [587, 597, 990, 6129, 10144]
+  },
+  "Flee": {
+    "Sequence": [
+      {
+        "Name": "Flee",
+        "Requirement": "(MobCount > FLEE_MOB_COUNT && Health% < FLEE_HP_LOW%) || TargetElite"
+      }
+    ]
+  },
+  "Wait": {
+    "Sequence": [
+      {
+        "Cost": 0.9,
+        "Name": "User",
+        "Requirement": "MenuOpen || ChatInputVisible"
+      }
+    ]
+  },
+  "Pull": {
+    "Sequence": [
+      {
+        // Learned at 4 - before that this is unusable and Fireball opens instead.
+        "Name": "Frostbolt",
+        "Key": "1",
+        "WhenUsable": true,
+        "HasCastBar": true,
+        "Requirements": [
+          "Spell:SPELL_FROSTBOLT",
+          "SpellInRange:3",
+          "Mana% > MIN_MANA_SPELL%"
+        ]
+      },
+      {
+        "Name": "Fireball",
+        "Key": "2",
+        "HasCastBar": true,
+        "Requirements": [
+          "Spell:SPELL_FIREBALL",
+          "SpellInRange:2",
+          "Mana% > MIN_MANA_SPELL%"
+        ]
+      },
+      {
+        "Name": "Shoot",
+        "Key": "0",
+        "Item": true,
+        "Requirements": [
+          "HasRangedWeapon",
+          "!Shooting",
+          "SpellInRange:1",
+          "Mana% < MIN_MANA_SPELL%"
+        ]
+      },
+      {
+        "Name": "Approach",
+        "Requirements": [
+          "!Casting",
+          "!Shooting"
+        ]
+      }
+    ]
+  },
+  "Combat": {
+    "Sequence": [
+      {
+        // Learned at 10. Steps back so the freeze buys distance rather than being wasted.
+        "Name": "Frost Nova",
+        "Key": "6",
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_FROST_NOVA",
+          "InMeleeRange"
+        ],
+        "AfterCastStepBack": 1000
+      },
+      {
+        // Learned at 6.
+        "Name": "Fire Blast",
+        "Key": "5",
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_FIRE_BLAST",
+          "TargetAlive && TargetHealth% < 40",
+          "SpellInRange:4"
+        ]
+      },
+      {
+        "Name": "Frostbolt",
+        "Key": "1",
+        "WhenUsable": true,
+        "HasCastBar": true,
+        "AfterCastWaitCastbar": true,
+        "Requirements": [
+          "Spell:SPELL_FROSTBOLT",
+          "Mana% > MIN_MANA_SPELL%",
+          "TargetHealth% > 35"
+        ],
+        "Interrupt": "CanRun:Fire Blast",
+        "CancelOnInterrupt": true
+      },
+      {
+        "Name": "Fireball",
+        "Key": "2",
+        "HasCastBar": true,
+        "AfterCastWaitCastbar": true,
+        "Requirements": [
+          "Spell:SPELL_FIREBALL",
+          "Mana% > MIN_MANA_SPELL%",
+          "TargetHealth% > 35"
+        ],
+        "Interrupt": "CanRun:Fire Blast",
+        "CancelOnInterrupt": true
+      },
+      {
+        "Name": "Shoot",
+        "Key": "0",
+        "Item": true,
+        "Requirements": [
+          "HasRangedWeapon",
+          "!Shooting",
+          "SpellInRange:1"
+        ]
+      },
+      {
+        "Name": "AutoAttack",
+        "Requirements": [
+          "!HasRangedWeapon",
+          "!Casting && !Shooting"
+        ]
+      },
+      {
+        "Name": "Approach",
+        "Requirements": [
+          "!Casting",
+          "AutoAttacking && !MeleeSwinging",
+          "!SoftTargetDead"
+        ]
+      }
+    ]
+  },
+  "Adhoc": {
+    "Sequence": [
+      {
+        "Name": "Frost Armor",
+        "Key": "3",
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_FROST_ARMOR",
+          "!Frost Armor"
+        ]
+      },
+      {
+        "Name": "Arcane Intellect",
+        "Key": "4",
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_ARCANE_INTELLECT",
+          "!Arcane Intellect"
+        ],
+        "Log": false
+      },
+      {
+        // Learned at 5 / 1 respectively; both self-gate on the bar slot.
+        "Name": "Conjure Water",
+        "Key": "9",
+        "WhenUsable": true,
+        "HasCastBar": true,
+        "Requirements": [
+          "Spell:SPELL_CONJURE_WATER",
+          "!BagItem:Item_Conjure_Drink:4"
+        ],
+        "AfterCastWaitCastbar": true,
+        "AfterCastWaitBag": true
+      },
+      {
+        "Name": "Conjure Food",
+        "Key": "8",
+        "WhenUsable": true,
+        "HasCastBar": true,
+        "Requirements": [
+          "Spell:SPELL_CONJURE_FOOD",
+          "!BagItem:Item_Conjure_Food:4"
+        ],
+        "AfterCastWaitCastbar": true,
+        "AfterCastWaitBag": true
+      },
+      {
+        "Name": "Food",
+        "Key": "=",
+        "Requirement": "Health% < MIN_FOOD%",
+        "Cost": 3
+      },
+      {
+        "Name": "Drink",
+        "Key": "-",
+        "Requirement": "Mana% < MIN_WATER%",
+        "Cost": 3
+      }
+    ]
+  },
+  "NPC": {
+    "Sequence": [
+      {
+        "Cost": 6,
+        "Name": "Repair",
+        "Requirement": "Items Broken"
+      },
+      {
+        "Cost": 6,
+        "Name": "Sell",
+        "Requirements": [
+          "BagFull",
+          "BagGreyItem"
+        ]
+      },
+      {
+        "Name": "ClassTrainer",
+        "Requirements": [
+          "HasTrainableSpell",
+          "VendoredOrRepairedRecently",
+          "Money > 100", // 1 silver
+          "SecondsSinceTrained > TRAIN_COOLDOWN_SEC"
+        ],
+        "Cost": 6.1
+      }
+    ]
+  }
+}

--- a/Json/class/Paladin_1-10.json
+++ b/Json/class/Paladin_1-10.json
@@ -1,0 +1,284 @@
+{
+  // Paladin 1-10, starting-zone grind. Amalgamated from Paladin_1 / Paladin_8 / Paladin_10.
+  //
+  // Paladin_10 is built around Seal of the Crusader, which is not trained until 22. Here
+  // the rotation is Seal of Righteousness plus Judgement, and the Crusader entries are
+  // gated on knowing that seal so they stay dormant until it exists - at which point the
+  // judge-Crusader-then-Righteousness order takes over on its own.
+  //
+  // Gating is "Spell:<name>" - do I know it - NOT "WhenUsable" alone. WhenUsable only
+  // reads the usable bit of the slot the key maps to; it cannot tell that the slot holds
+  // a different spell. A Blood Elf has Arcane Torrent on slot 5 by default, which is
+  // always usable, so a WhenUsable-only gate fires, casts the racial, never satisfies
+  // "!Blessing of Might" and retries forever.
+  //
+  // That fixes abilities trained after level 1. It CANNOT fix a wrong binding for one
+  // known at level 1 - Devotion Aura and Seal of Righteousness are known immediately, so
+  // if their slots hold something else the bot still casts the wrong thing. Those carry a
+  // Cooldown so a mis-bound bar degrades to a slow retry instead of a hard loop, but the
+  // real fix is to bind the bars to match this profile - see the Sync Actionbar button,
+  // and the ActionBarSlotValidator "Mismatch" lines at startup.
+  //
+  // Bars: 1 Judgement | 2 Seal of Righteousness | 3 Holy Light | 4 Blessing of Might
+  //       5 Devotion Aura | 6 Seal of the Crusader | 7 Hammer of Justice
+  //       9 Gift of the Naaru | N1 Divine Protection | N2 Blessing of Protection
+  //       N3 Lay on Hands | = Food | - Drink
+  "Loot": true,
+  "PathsFilenames": [
+    "1-8_Human_Northshire.json",
+    "1-8_Draenei_AmmenVale.json",
+    "1-8_NightElf_Teldrassil.json",
+    "1-8_DwarfGnome_Coldridge.json",
+    "1-8_OrcTroll_ValleyOfTrials.json",
+    "1-8_Undead_Deathknell.json",
+    "1-8_Tauren_RedCloudMesa.json",
+    "1-8_BloodElf_SunstriderIsle.json"
+  ],
+  "Paths": [],
+  "IntVariables": {
+    "MIN_HP_EAT%": 40,
+    "MIN_MANA_DRINK%": 30,
+    "EMERGENCY_HP%": 20,
+
+    // Not SPELL_ prefixed on purpose - that prefix marks a trainer whitelist.
+    "TRAIN_COOLDOWN_SEC": 600,
+
+    "FLEE_MOB_COUNT": 1,
+    "FLEE_HP_LOW%": 60,
+
+    // Rank chains, verified against Json/dbc/wrath/spells.json. IDs rather than names on
+    // purpose: Blizzard renamed Blessing of Protection to Hand of Protection and dropped
+    // Seal of the Crusader outright, so a name gate breaks across clients where the id
+    // does not.
+    "SPELL_SEAL_OF_RIGHTEOUSNESS": [21084, 20154],
+    "SPELL_JUDGEMENT": [20271],
+    "SPELL_HOLY_LIGHT": [635, 639, 647, 1026, 1042, 3472],
+    "SPELL_DEVOTION_AURA": [465, 10290, 643, 10291, 1032],
+    "SPELL_BLESSING_OF_MIGHT": [19740, 19834, 19835, 19836],
+    "SPELL_DIVINE_PROTECTION": [498, 13007],
+    "SPELL_HAMMER_OF_JUSTICE": [853, 5588, 5589],
+    "SPELL_LAY_ON_HANDS": [633, 2800, 9257],
+    "SPELL_HAND_OF_PROTECTION": [1022, 5599, 10278]
+  },
+  "Flee": {
+    "Sequence": [
+      {
+        "Name": "Flee",
+        "Requirement": "(MobCount > FLEE_MOB_COUNT && Health% < FLEE_HP_LOW%) || TargetElite"
+      }
+    ]
+  },
+  "Wait": {
+    "Sequence": [
+      {
+        "Cost": 0.9,
+        "Name": "User",
+        "Requirement": "MenuOpen || ChatInputVisible"
+      }
+    ]
+  },
+  "Pull": {
+    "Sequence": [
+      {
+        "Name": "Seal of Righteousness",
+        "Key": "2",
+        "WhenUsable": true,
+        "Cooldown": 1500,
+        "Requirements": [
+          "Spell:SPELL_SEAL_OF_RIGHTEOUSNESS",
+          "!Seal of Righteousness"
+        ]
+      },
+      {
+        // Learned at 4.
+        "Name": "Judgement",
+        "Key": "1",
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_JUDGEMENT",
+          "SpellInRange:0",
+          "Seal of Righteousness"
+        ]
+      },
+      {
+        "Name": "Approach",
+        "Requirements": [
+          "!SoftTargetDead"
+        ]
+      }
+    ]
+  },
+  "Combat": {
+    "Sequence": [
+      {
+        // Learned at 6.
+        "Name": "Divine Protection",
+        "Key": "N1",
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_DIVINE_PROTECTION",
+          "Health% < EMERGENCY_HP%",
+          "!Blessing of Protection"
+        ]
+      },
+      {
+        // Learned at 10. Named Hand of Protection from Wrath on - gated on the id chain,
+        // which spans both names.
+        "Name": "Blessing of Protection",
+        "Key": "N2",
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_HAND_OF_PROTECTION",
+          "Health% < EMERGENCY_HP%",
+          "!Divine Protection"
+        ]
+      },
+      {
+        // Learned at 10.
+        "Name": "Lay on Hands",
+        "Key": "N3",
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_LAY_ON_HANDS",
+          "Health% < EMERGENCY_HP%",
+          "!Blessing of Protection && CD_Blessing of Protection > 0",
+          "!Divine Protection && CD_Divine Protection > 0"
+        ]
+      },
+      {
+        "Name": "Gift of the Naaru",
+        "Key": "9",
+        "HasCastBar": true,
+        "WhenUsable": true,
+        "Requirements": [
+          "Race:Draenei",
+          "Health% < 45"
+        ]
+      },
+      {
+        "Name": "Holy Light",
+        "Key": "3",
+        "HasCastBar": true,
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_HOLY_LIGHT",
+          "(Blessing of Protection || Divine Protection && Health% < 60) || (!Blessing of Protection && CD_Blessing of Protection > 0 && !Divine Protection && CD_Divine Protection > 0 && Health% < 50 && TargetHealth% > 20 && LastMainHandMs <= 1000)"
+        ]
+      },
+      {
+        // Learned at 4.
+        "Name": "Judgement",
+        "Key": "1",
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_JUDGEMENT",
+          "Seal of Righteousness"
+        ]
+      },
+      {
+        // Learned at 8.
+        "Name": "Hammer of Justice",
+        "Key": "7",
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_HAMMER_OF_JUSTICE",
+          "TargetCastingSpell || TargetHealth% < 50"
+        ]
+      },
+      {
+        "Name": "Seal of Righteousness",
+        "Key": "2",
+        "WhenUsable": true,
+        "Cooldown": 1500,
+        "Requirements": [
+          "Spell:SPELL_SEAL_OF_RIGHTEOUSNESS",
+          "!Seal of Righteousness",
+          "TargetHealth% > 20"
+        ]
+      },
+      {
+        "Name": "AutoAttack",
+        "Requirements": [
+          "!Divine Protection",
+          "!Blessing of Protection"
+        ]
+      },
+      {
+        "Name": "Approach",
+        "Requirements": [
+          "!MeleeSwinging && !SoftTargetDead"
+        ],
+        "Log": false
+      }
+    ]
+  },
+  "Adhoc": {
+    "Sequence": [
+      {
+        // Known from level 1, so no Spell: gate can stop this one firing on a wrong
+        // binding - a Blood Elf has Arcane Torrent on slot 5 by default, and casting that
+        // never satisfies the aura check. The Cooldown caps the damage at one wasted
+        // press every 10s instead of a hard loop; fix the binding to actually fix it.
+        "Name": "Devotion Aura",
+        "Key": "5",
+        "WhenUsable": true,
+        "Cooldown": 10000,
+        "Requirements": [
+          "Spell:SPELL_DEVOTION_AURA",
+          "!Form:Paladin_Devotion_Aura"
+        ],
+        "AfterCastAuraExpected": true
+      },
+      {
+        // Learned at 4.
+        "Name": "Blessing of Might",
+        "Key": "4",
+        "WhenUsable": true,
+        "Cooldown": 10000,
+        "Requirements": [
+          "Spell:SPELL_BLESSING_OF_MIGHT",
+          "!Blessing of Might"
+        ]
+      },
+      {
+        "Name": "Food",
+        "Key": "=",
+        "Requirement": "Health% < MIN_HP_EAT%",
+        "Cost": 3
+      },
+      {
+        "Name": "Drink",
+        "Key": "-",
+        "Requirement": "Mana% < MIN_MANA_DRINK%",
+        "Cost": 3
+      }
+    ]
+  },
+  "NPC": {
+    "Sequence": [
+      {
+        "Cost": 6,
+        "Name": "Repair",
+        "Requirement": "Items Broken"
+      },
+      {
+        "Cost": 6,
+        "Name": "Sell",
+        "Requirements": [
+          "BagFull",
+          "BagGreyItem"
+        ]
+      },
+      {
+        "Name": "ClassTrainer",
+        "Requirements": [
+          "HasTrainableSpell",
+          "VendoredOrRepairedRecently",
+          "Money > 100", // 1 silver
+          "SecondsSinceTrained > TRAIN_COOLDOWN_SEC"
+        ],
+        "Cost": 6.1
+      }
+    ]
+  }
+}

--- a/Json/class/Priest_1-10.json
+++ b/Json/class/Priest_1-10.json
@@ -1,0 +1,283 @@
+{
+  // Priest 1-10, starting-zone grind. Amalgamated from Priest_1 / Priest_10.
+  //
+  // Level spanning is done two ways: "Spell:SPELL_RANK_x" skips an ability until it is
+  // actually trained, and "WhenUsable": true skips one whose bar slot is empty.
+  //
+  // Bars: 2 Smite | 3 Lesser Heal | 4 Renew | 5 Shadow Word: Pain | 6 Power Word: Shield
+  //       7 Flash Heal | 8 Inner Fire | 9 Power Word: Fortitude | 0 Shoot (wand)
+  //       = Food | - Drink
+  "Loot": true,
+  "PathsFilenames": [
+    "1-8_Human_Northshire.json",
+    "1-8_Draenei_AmmenVale.json",
+    "1-8_NightElf_Teldrassil.json",
+    "1-8_DwarfGnome_Coldridge.json",
+    "1-8_OrcTroll_ValleyOfTrials.json",
+    "1-8_Undead_Deathknell.json",
+    "1-8_Tauren_RedCloudMesa.json",
+    "1-8_BloodElf_SunstriderIsle.json"
+  ],
+  "Paths": [],
+  "IntVariables": {
+    "MIN_TARGET_HP%": 20,
+    "MIN_HP_BEFORE_HEAL%": 45,
+    "MIN_MANA_OFFENSIVE%": 30,
+    "MIN_MANA_DRINK%": 25,
+    "MIN_HP_EAT%": 40,
+
+    // Not SPELL_ prefixed on purpose - that prefix marks a trainer whitelist.
+    "TRAIN_COOLDOWN_SEC": 600,
+
+    "FLEE_MOB_COUNT": 1,
+    "FLEE_HP_LOW%": 60,
+
+    "SPELL_RANK_SHIELD": 17,
+    "SPELL_RANK_PAIN": 594,
+    "SPELL_RANK_RENEW": 139,
+    "SPELL_RANK_FLASH": 2061,
+    "SPELL_RANK_FORTITUDE": 1243,
+    "SPELL_RANK_INNER_FIRE": 588,
+    "Debuff_Weakened_Soul": 135871
+  },
+  "Flee": {
+    "Sequence": [
+      {
+        "Name": "Flee",
+        "Requirement": "(MobCount > FLEE_MOB_COUNT && Health% < FLEE_HP_LOW%) || TargetElite"
+      }
+    ]
+  },
+  "Wait": {
+    "Sequence": [
+      {
+        "Cost": 0.9,
+        "Name": "User",
+        "Requirement": "MenuOpen || ChatInputVisible"
+      }
+    ]
+  },
+  "Pull": {
+    "Sequence": [
+      {
+        "Name": "Power Word: Shield",
+        "Key": "6",
+        "WhenUsable": true,
+        "AfterCastWaitBuff": true,
+        "AfterCastWaitGCD": true,
+        "Requirements": [
+          "Spell:SPELL_RANK_SHIELD",
+          "Debuff_Weakened_Soul == 0",
+          "!Shield"
+        ]
+      },
+      {
+        "Name": "Shadow Word: Pain",
+        "Key": "5",
+        "WhenUsable": true,
+        "BeforeCastStop": true,
+        "BeforeCastFaceTarget": true,
+        "AfterCastAuraExpected": true,
+        "AfterCastWaitBuff": true,
+        "Requirements": [
+          "Spell:SPELL_RANK_PAIN",
+          "Mana% > MIN_MANA_OFFENSIVE%"
+        ]
+      },
+      {
+        "Name": "Smite",
+        "Key": "2",
+        "HasCastBar": true,
+        "Requirements": [
+          "Mana% > MIN_MANA_OFFENSIVE%"
+        ]
+      },
+      {
+        "Name": "Shoot",
+        "Key": "0",
+        "Item": true,
+        "AfterCastDelay": 500,
+        "Requirements": [
+          "HasRangedWeapon",
+          "!Shooting"
+        ]
+      },
+      {
+        "Name": "Approach",
+        "Requirements": [
+          "InMeleeRange || MIN_MANA_OFFENSIVE% < Mana%",
+          "!Casting",
+          "!Shooting"
+        ]
+      }
+    ]
+  },
+  "Combat": {
+    "Sequence": [
+      {
+        // Gated on the shield spell and on low HEALTH. Priest_10 gated this on
+        // SPELL_RANK_PAIN and on low mana, which shielded at the wrong moment and
+        // required an unrelated spell to be trained first.
+        "Name": "Power Word: Shield",
+        "Key": "6",
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_RANK_SHIELD",
+          "Health% < MIN_HP_BEFORE_HEAL%",
+          "Debuff_Weakened_Soul == 0",
+          "!Shield"
+        ]
+      },
+      {
+        "Name": "Renew",
+        "Key": "4",
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_RANK_RENEW",
+          "Health% < MIN_HP_BEFORE_HEAL%",
+          "!Renew",
+          "Mana% > MIN_HP_BEFORE_HEAL%"
+        ]
+      },
+      {
+        "Name": "Flash Heal",
+        "Key": "7",
+        "WhenUsable": true,
+        "HasCastBar": true,
+        "Requirements": [
+          "Spell:SPELL_RANK_FLASH",
+          "Health% < MIN_HP_BEFORE_HEAL%",
+          "Mana% > MIN_HP_BEFORE_HEAL%"
+        ]
+      },
+      {
+        // The pre-20 heal. Drops out once Flash Heal is trained.
+        "Name": "Lesser Heal",
+        "Key": "3",
+        "HasCastBar": true,
+        "Requirements": [
+          "!Spell:SPELL_RANK_FLASH",
+          "Health% < MIN_HP_BEFORE_HEAL%",
+          "Mana% > MIN_HP_BEFORE_HEAL%"
+        ]
+      },
+      {
+        "Name": "Shadow Word: Pain",
+        "Key": "5",
+        "WhenUsable": true,
+        "AfterCastAuraExpected": true,
+        "Requirements": [
+          "Spell:SPELL_RANK_PAIN",
+          "!Shadow Word: Pain",
+          "TargetHealth% > 40",
+          "Mana% > MIN_MANA_OFFENSIVE%"
+        ]
+      },
+      {
+        "Name": "Smite",
+        "Key": "2",
+        "HasCastBar": true,
+        "Requirements": [
+          "Mana% > MIN_MANA_OFFENSIVE%",
+          "!InMeleeRange || Shield",
+          "TargetHealth% > MIN_TARGET_HP%"
+        ]
+      },
+      {
+        "Name": "Shoot",
+        "Key": "0",
+        "Item": true,
+        "AfterCastDelay": 500,
+        "Requirements": [
+          "HasRangedWeapon",
+          "!Shooting"
+        ]
+      },
+      {
+        "Name": "AutoAttack",
+        "Requirements": [
+          "!HasRangedWeapon",
+          "!Casting",
+          "!Shooting"
+        ]
+      },
+      {
+        "Name": "Approach",
+        "Requirements": [
+          "InMeleeRange || Mana% < MIN_MANA_OFFENSIVE%",
+          "!Casting",
+          "!Shooting",
+          "AutoAttacking && !MeleeSwinging",
+          "!SoftTargetDead"
+        ]
+      }
+    ]
+  },
+  "Adhoc": {
+    "Sequence": [
+      {
+        "Cost": 3,
+        "Name": "Power Word: Fortitude",
+        "Key": "9",
+        "WhenUsable": true,
+        "InCombat": "i dont care",
+        "Requirements": [
+          "Spell:SPELL_RANK_FORTITUDE",
+          "!Fortitude"
+        ]
+      },
+      {
+        "Cost": 3,
+        "Name": "Inner Fire",
+        "Key": "8",
+        "WhenUsable": true,
+        "InCombat": "i dont care",
+        "Requirements": [
+          "Spell:SPELL_RANK_INNER_FIRE",
+          "!Inner Fire"
+        ]
+      }
+    ]
+  },
+  "Parallel": {
+    "Sequence": [
+      {
+        "Name": "Food",
+        "Key": "=",
+        "Requirement": "Health% < MIN_HP_EAT%"
+      },
+      {
+        "Name": "Drink",
+        "Key": "-",
+        "Requirement": "Mana% < MIN_MANA_DRINK%"
+      }
+    ]
+  },
+  "NPC": {
+    "Sequence": [
+      {
+        "Cost": 6,
+        "Name": "Repair",
+        "Requirement": "Items Broken"
+      },
+      {
+        "Cost": 6,
+        "Name": "Sell",
+        "Requirements": [
+          "BagFull",
+          "BagGreyItem"
+        ]
+      },
+      {
+        "Name": "ClassTrainer",
+        "Requirements": [
+          "HasTrainableSpell",
+          "VendoredOrRepairedRecently",
+          "Money > 100", // 1 silver
+          "SecondsSinceTrained > TRAIN_COOLDOWN_SEC"
+        ],
+        "Cost": 6.1
+      }
+    ]
+  }
+}

--- a/Json/class/Rogue_1-10.json
+++ b/Json/class/Rogue_1-10.json
@@ -1,0 +1,208 @@
+{
+  // Rogue 1-10, starting-zone grind. Amalgamated from Rogue_1 / Rogue_10.
+  //
+  // Everything learned after level 1 is gated on "Spell:SPELL_x" - do I know it - NOT on
+  // "WhenUsable" alone. WhenUsable only reads the usable bit of the slot the key maps to;
+  // it cannot tell that the slot holds a different spell, so a racial or any other usable
+  // ability sitting on that key makes the gate pass and the bot casts the wrong thing,
+  // forever. WhenUsable is kept as a second check for genuinely empty slots.
+  //
+  // This cannot save an ability known at level 1 from a wrong binding - bind the bars to
+  // match, see the Sync Actionbar button and the ActionBarSlotValidator lines at startup.
+  //
+  // Rogue_1 bound Throw to 4 and Rogue_10 bound Slice and Dice to 4 - they cannot both
+  // have it. Throw moved to 7 here.
+  //
+  // Bars: 1 Backstab | 2 Sinister Strike | 3 Eviscerate | 4 Slice and Dice | 5 Evasion
+  //       7 Throw | N2 Stealth | = Food
+  "Loot": true,
+  "KeyboardOnly": true,
+  "PathsFilenames": [
+    "1-8_Human_Northshire.json",
+    "1-8_Draenei_AmmenVale.json",
+    "1-8_NightElf_Teldrassil.json",
+    "1-8_DwarfGnome_Coldridge.json",
+    "1-8_OrcTroll_ValleyOfTrials.json",
+    "1-8_Undead_Deathknell.json",
+    "1-8_Tauren_RedCloudMesa.json",
+    "1-8_BloodElf_SunstriderIsle.json"
+  ],
+  "Paths": [],
+  "IntVariables": {
+    "MIN_HP_EAT%": 40,
+
+    // Not SPELL_ prefixed on purpose - that prefix marks a trainer whitelist.
+    "TRAIN_COOLDOWN_SEC": 600,
+
+    "FLEE_MOB_COUNT": 1,
+    "FLEE_HP_LOW%": 60,
+
+    // Rank chains, verified against Json/dbc/wrath/spells.json. IDs rather than names:
+    // names drift between expansions, ids do not.
+    "SPELL_SINISTER_STRIKE": [1752, 1757, 1758, 1759, 1760, 8621],
+    "SPELL_EVISCERATE": [2098, 6760, 6761, 6762, 8623, 8624],
+    "SPELL_BACKSTAB": [53, 2589, 2590, 2591, 8721],
+    "SPELL_SLICE_AND_DICE": [5171, 6774],
+    "SPELL_EVASION": [5277],
+    "SPELL_STEALTH": [1784, 1785, 1786],
+    "SPELL_THROW": [2764]
+  },
+  "Flee": {
+    "Sequence": [
+      {
+        "Name": "Flee",
+        "Requirement": "(MobCount > FLEE_MOB_COUNT && Health% < FLEE_HP_LOW%) || TargetElite"
+      }
+    ]
+  },
+  "Wait": {
+    "Sequence": [
+      {
+        "Cost": 0.9,
+        "Name": "User",
+        "Requirement": "MenuOpen || ChatInputVisible"
+      }
+    ]
+  },
+  "Pull": {
+    "Sequence": [
+      {
+        "Name": "Stealth",
+        "Key": "N2",
+        "WhenUsable": true,
+        "AfterCastWaitBuff": true,
+        "Requirements": [
+          "Spell:SPELL_STEALTH",
+          "!Stealth",
+          "!InMeleeRange"
+        ]
+      },
+      {
+        // Opener from stealth - only lands from behind, so it is worth the attempt only
+        // while the buff is up.
+        "Name": "Backstab",
+        "Key": "1",
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_BACKSTAB",
+          "Stealth && InMeleeRange"
+        ]
+      },
+      {
+        "Name": "Throw",
+        "Key": "7",
+        "Item": true,
+        "WhenUsable": true,
+        "BeforeCastStop": true,
+        "AfterCastWaitMeleeRange": true,
+        "Requirements": [
+          "Spell:SPELL_THROW",
+          "AddVisible", // Uses NpcNameFinder to detect danger
+          "HasRangedWeapon && !Items Broken",
+          "!InMeleeRange && SpellInRange:1"
+        ]
+      },
+      {
+        "Name": "Approach",
+        "Requirements": [
+          "!MeleeSwinging && !SoftTargetDead"
+        ],
+        "Log": false
+      }
+    ]
+  },
+  "Combat": {
+    "Sequence": [
+      {
+        // Learned at 8.
+        "Name": "Evasion",
+        "Key": "5",
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_EVASION",
+          "Health% < 40"
+        ]
+      },
+      {
+        // Learned at 10.
+        "Name": "Slice and Dice",
+        "Key": "4",
+        "WhenUsable": true,
+        "AfterCastAuraExpected": true,
+        "Requirements": [
+          "Spell:SPELL_SLICE_AND_DICE",
+          "!Slice and Dice",
+          "Combo Point > 1"
+        ]
+      },
+      {
+        "Name": "Eviscerate",
+        "Key": "3",
+        "Requirements": [
+          "Spell:SPELL_EVISCERATE",
+          "TargetHealth% > 20",
+          "LastMainHandMs < 500",
+          "Combo Point > 1"
+        ]
+      },
+      {
+        "Name": "Sinister Strike",
+        "Key": "2",
+        "Requirements": [
+          "Spell:SPELL_SINISTER_STRIKE",
+          "LastMainHandMs < 500"
+        ]
+      },
+      {
+        "Name": "AutoAttack",
+        "Requirements": [
+          "InMeleeRange"
+        ]
+      },
+      {
+        "Name": "Approach",
+        "Requirements": [
+          "!MeleeSwinging && !SoftTargetDead"
+        ],
+        "Log": false
+      }
+    ]
+  },
+  "Adhoc": {
+    "Sequence": [
+      {
+        "Name": "Food",
+        "Key": "=",
+        "Requirement": "Health% < MIN_HP_EAT%",
+        "Cost": 3
+      }
+    ]
+  },
+  "NPC": {
+    "Sequence": [
+      {
+        "Cost": 6,
+        "Name": "Repair",
+        "Requirement": "Items Broken"
+      },
+      {
+        "Cost": 6,
+        "Name": "Sell",
+        "Requirements": [
+          "BagFull",
+          "BagGreyItem"
+        ]
+      },
+      {
+        "Name": "ClassTrainer",
+        "Requirements": [
+          "HasTrainableSpell",
+          "VendoredOrRepairedRecently",
+          "Money > 100", // 1 silver
+          "SecondsSinceTrained > TRAIN_COOLDOWN_SEC"
+        ],
+        "Cost": 6.1
+      }
+    ]
+  }
+}

--- a/Json/class/Shaman_1-10.json
+++ b/Json/class/Shaman_1-10.json
@@ -1,0 +1,226 @@
+{
+  // Shaman 1-10, starting-zone grind. Amalgamated from Shaman_1 / Shaman_4 / Shaman_8.
+  //
+  // Everything learned after level 1 is gated on "Spell:SPELL_x" - do I know it - NOT on
+  // "WhenUsable" alone. WhenUsable only reads the usable bit of the slot the key maps to;
+  // it cannot tell that the slot holds a different spell, so a racial or any other usable
+  // ability sitting on that key makes the gate pass and the bot casts the wrong thing,
+  // forever. WhenUsable is kept as a second check for genuinely empty slots.
+  //
+  // This cannot save an ability known at level 1 from a wrong binding - bind the bars to
+  // match, see the Sync Actionbar button and the ActionBarSlotValidator lines at startup.
+  //
+  // Shaman_8 pulled with Lightning Bolt above 60-70% mana. That is a fine opener but it
+  // drains a level-1 mana pool fast, so the thresholds are lower here and melee is the
+  // default once mana runs out.
+  //
+  // Bars: 2 Lightning Bolt | 3 Healing Wave | 4 Gift of the Naaru | 5 Rockbiter Weapon
+  //       6 Earth Shock | 7 Lightning Shield | F2 Stoneskin Totem | = Food | - Drink
+  "Loot": true,
+  "PathsFilenames": [
+    "1-8_Human_Northshire.json",
+    "1-8_Draenei_AmmenVale.json",
+    "1-8_NightElf_Teldrassil.json",
+    "1-8_DwarfGnome_Coldridge.json",
+    "1-8_OrcTroll_ValleyOfTrials.json",
+    "1-8_Undead_Deathknell.json",
+    "1-8_Tauren_RedCloudMesa.json",
+    "1-8_BloodElf_SunstriderIsle.json"
+  ],
+  "Paths": [],
+  "IntVariables": {
+    "Item_Earth_Totem": 5175,
+    "MIN_HP_EAT%": 40,
+    "MIN_MANA_DRINK%": 30,
+    "MIN_MANA_SPELL%": 35,
+
+    // Not SPELL_ prefixed on purpose - that prefix marks a trainer whitelist.
+    "TRAIN_COOLDOWN_SEC": 600,
+
+    "FLEE_MOB_COUNT": 1,
+    "FLEE_HP_LOW%": 60,
+
+    // Rank chains, verified against Json/dbc/wrath/spells.json. IDs rather than names:
+    // names drift between expansions, ids do not.
+    "SPELL_LIGHTNING_BOLT": [403, 529, 548, 943, 6041, 10391],
+    "SPELL_HEALING_WAVE": [331, 332, 547, 913, 939, 959, 8005],
+    "SPELL_EARTH_SHOCK": [8042, 8044, 8045, 8046, 10412],
+    "SPELL_STONESKIN_TOTEM": [8071, 8154, 8155, 10406],
+    "SPELL_ROCKBITER_WEAPON": [8017, 8018, 8019, 10399],
+    "SPELL_LIGHTNING_SHIELD": [324, 325, 905, 945, 8134]
+  },
+  "Flee": {
+    "Sequence": [
+      {
+        "Name": "Flee",
+        "Requirement": "(MobCount > FLEE_MOB_COUNT && Health% < FLEE_HP_LOW%) || TargetElite"
+      }
+    ]
+  },
+  "Wait": {
+    "Sequence": [
+      {
+        "Cost": 0.9,
+        "Name": "User",
+        "Requirement": "MenuOpen || ChatInputVisible"
+      }
+    ]
+  },
+  "Pull": {
+    "Sequence": [
+      {
+        "Name": "Lightning Bolt",
+        "Key": "2",
+        "HasCastBar": true,
+        "AfterCastWaitMeleeRange": true,
+        "Requirements": [
+          "Spell:SPELL_LIGHTNING_BOLT",
+          "!InMeleeRange",
+          "SpellInRange:0",
+          "Mana% > MIN_MANA_SPELL%"
+        ]
+      },
+      {
+        // Out of mana - walk in and melee it rather than stand still.
+        "Name": "Approach",
+        "Requirements": [
+          "!Casting",
+          "!SoftTargetDead"
+        ]
+      }
+    ]
+  },
+  "Combat": {
+    "Sequence": [
+      {
+        "Name": "Gift of the Naaru",
+        "Key": "4",
+        "HasCastBar": true,
+        "WhenUsable": true,
+        "Requirements": [
+          "Race:Draenei",
+          "Health% < 50"
+        ]
+      },
+      {
+        "Name": "Healing Wave",
+        "Key": "3",
+        "HasCastBar": true,
+        "WhenUsable": true,
+        "Cooldown": 5000,
+        "Requirements": [
+          "Spell:SPELL_HEALING_WAVE",
+          "Health% < 40",
+          "Mana% > MIN_MANA_SPELL%"
+        ]
+      },
+      {
+        // Learned at 4.
+        "Name": "Earth Shock",
+        "Key": "6",
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_EARTH_SHOCK",
+          "SpellInRange:1",
+          "Mana% > MIN_MANA_SPELL%",
+          "TargetHealth% > 20"
+        ]
+      },
+      {
+        // Learned at 4. Needs the totem item in the bags.
+        "Name": "Stoneskin Totem",
+        "Key": "F2",
+        "WhenUsable": true,
+        "Cooldown": 30000,
+        "Requirements": [
+          "Spell:SPELL_STONESKIN_TOTEM",
+          "InMeleeRange",
+          "TargetHealth% > 50",
+          "Mana% > MIN_MANA_SPELL%",
+          "BagItem:Item_Earth_Totem",
+          "!Stoneskin"
+        ]
+      },
+      {
+        "Name": "AutoAttack",
+        "Requirements": [
+          "InMeleeRange",
+          "!Casting"
+        ]
+      },
+      {
+        "Name": "Approach",
+        "Requirements": [
+          "!Casting",
+          "AutoAttacking && !MeleeSwinging",
+          "!SoftTargetDead"
+        ]
+      }
+    ]
+  },
+  "Adhoc": {
+    "Sequence": [
+      {
+        "Name": "Rockbiter Weapon",
+        "Key": "5",
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_ROCKBITER_WEAPON",
+          "!HasMainHandEnchant"
+        ],
+        "AfterCastAuraExpected": true
+      },
+      {
+        // Learned at 8.
+        "Name": "Lightning Shield",
+        "Key": "7",
+        "WhenUsable": true,
+        "Cooldown": 10000,
+        "Requirements": [
+          "Spell:SPELL_LIGHTNING_SHIELD",
+          "!Lightning Shield",
+          "Mana% > 50"
+        ]
+      },
+      {
+        "Name": "Food",
+        "Key": "=",
+        "Requirement": "Health% < MIN_HP_EAT%",
+        "Cost": 3
+      },
+      {
+        "Name": "Drink",
+        "Key": "-",
+        "Requirement": "Mana% < MIN_MANA_DRINK%",
+        "Cost": 3
+      }
+    ]
+  },
+  "NPC": {
+    "Sequence": [
+      {
+        "Cost": 6,
+        "Name": "Repair",
+        "Requirement": "Items Broken"
+      },
+      {
+        "Cost": 6,
+        "Name": "Sell",
+        "Requirements": [
+          "BagFull",
+          "BagGreyItem"
+        ]
+      },
+      {
+        "Name": "ClassTrainer",
+        "Requirements": [
+          "HasTrainableSpell",
+          "VendoredOrRepairedRecently",
+          "Money > 100", // 1 silver
+          "SecondsSinceTrained > TRAIN_COOLDOWN_SEC"
+        ],
+        "Cost": 6.1
+      }
+    ]
+  }
+}

--- a/Json/class/Warlock_1_10.json
+++ b/Json/class/Warlock_1_10.json
@@ -1,9 +1,17 @@
 {
   //"Mode": "AttendedGrind",
   "Loot": true,
-  "PathFilename": "1_Gnome.json",
-  "PathThereAndBack": true,
-  "PathReduceSteps": false,
+  "PathsFilenames": [
+    "1-8_Human_Northshire.json",
+    "1-8_Draenei_AmmenVale.json",
+    "1-8_NightElf_Teldrassil.json",
+    "1-8_DwarfGnome_Coldridge.json",
+    "1-8_OrcTroll_ValleyOfTrials.json",
+    "1-8_Undead_Deathknell.json",
+    "1-8_Tauren_RedCloudMesa.json",
+    "1-8_BloodElf_SunstriderIsle.json"
+  ],
+  "Paths": [],
   "IntVariables": {
     "MIN_WATER%": 20,
     "MIN_MANA_SHADOWBOLT%": 40,
@@ -12,9 +20,23 @@
     "MIN_HEALTH_CAST%": 40,
     "DOT_MIN_HEALTH": 50,
 
+    // Not SPELL_ prefixed on purpose - that prefix marks a trainer whitelist.
+    "TRAIN_COOLDOWN_SEC": 600,
+
+    "FLEE_MOB_COUNT": 1,
+    "FLEE_HP_LOW%": 60,
+
     "SPELL_IMMOLATE": [348, 707, 1094, 2941, 11665, 11667, 11668, 25309],
     "SPELL_CORRUPTION": [172, 6222, 6223, 7648, 11671, 11672, 25311],
     "SPELL_SUMMON_IMP": [688]
+  },
+  "Flee": {
+    "Sequence": [
+      {
+        "Name": "Flee",
+        "Requirement": "(MobCount > FLEE_MOB_COUNT && Health% < FLEE_HP_LOW%) || TargetElite" 
+      }
+    ]
   },
   "Wait": {
     "Sequence": [
@@ -168,6 +190,16 @@
           "BagFull",
           "BagGreyItem"
         ]
+      },
+      {
+        "Name": "ClassTrainer",
+        "Requirements": [
+          "HasTrainableSpell",
+          "VendoredOrRepairedRecently",
+          "Money > 100", // 1 silver
+          "SecondsSinceTrained > TRAIN_COOLDOWN_SEC"
+        ],
+        "Cost": 6.1
       }
     ]
   }

--- a/Json/class/Warrior_1-10.json
+++ b/Json/class/Warrior_1-10.json
@@ -1,0 +1,290 @@
+{
+  //"Mode": "AttendedGrind", //Grind //AttendedGrind //CorpseRun //AutoGather
+  "KeyboardOnly": true,
+  "NPCMaxLevels_Below": 10,
+  "IntVariables": {
+    "MIN_TARGET_HP%": 20,
+    "MIN_HP_BEFORE_HEAL%": 25,
+    "MIN_HP_EAT%": 40,
+    "FLEE_MOB_COUNT": 1,
+    "FLEE_HP_LOW%": 60,
+
+    "WAIT_CHARGE_MS": 4000,
+
+    // Not SPELL_ prefixed on purpose - that prefix marks a trainer whitelist.
+    "TRAIN_COOLDOWN_SEC": 600,
+
+    "SPELL_CHARGE": [100, 6178, 11578],
+    "SPELL_BATTLE_SHOUT": [6673, 5242, 6192, 11549, 11550, 11551, 25289],
+    "SPELL_THUNDER_CLAP": [6343, 8198, 8204, 8205, 11580, 11581],
+    "SPELL_REND": [772, 6546, 6547, 6548, 11572, 11573],
+    "SPELL_OVERPOWER": [7384, 7887, 11584, 11585],
+    "SPELL_SUNDER_ARMOR": [7386, 7405, 8380, 11596, 11597],
+    "SPELL_BLOODRAGE": 2687,
+
+    "SPELL_VICTORY_RUSH": 34428
+  },
+  // PathSettings groups, relative to Json/path/. Appended after any inline "Paths"
+  // below, in this order - which is what sets each route goal's GOAP cost.
+  "PathsFilenames": [
+    "1-8_Human_Northshire.json",
+    "1-8_Draenei_AmmenVale.json",
+    "1-8_NightElf_Teldrassil.json",
+    "1-8_DwarfGnome_Coldridge.json",
+    "1-8_OrcTroll_ValleyOfTrials.json",
+    "1-8_Undead_Deathknell.json",
+    "1-8_Tauren_RedCloudMesa.json",
+    "1-8_BloodElf_SunstriderIsle.json"
+  ],
+  "Paths": [],
+  "Flee": {
+    "Sequence": [
+      {
+        "Name": "Flee",
+        "Requirement": "(MobCount > FLEE_MOB_COUNT && Health% < FLEE_HP_LOW%) || TargetElite" 
+      }
+    ]
+  },
+  "Form": {
+    "Sequence": [
+      {
+        "Name": "Battle Stance",
+        "Key": "F1",
+        "Form": "Warrior_BattleStance"
+      },
+      {
+        "Name": "Defensive Stance",
+        "Key": "F2",
+        "Form": "Warrior_DefensiveStance"
+      },
+      {
+        "Name": "Berserker Stance",
+        "Key": "F3",
+        "Form": "Warrior_BerserkerStance"
+      }
+    ]
+  },
+  "Wait": {
+    "Sequence": [
+      {
+        "Cost": 0.9,
+        "Name": "User",
+        "Requirement": "MenuOpen || ChatInputVisible"
+      },
+      {
+        "Cost": 19,
+        "Name": "HP regen",
+        "Requirements": [
+          "FoodCount == 0 || !Usable:Food",
+          "Health% < 50"
+        ]
+      }
+    ]
+  },
+  "Pull": {
+    "Sequence": [
+      /*
+      {
+        "Name": "Throw",
+        "Key": "9",
+        "Item": true,
+        "WhenUsable": true,
+        "BeforeCastStop": true,
+        "AfterCastWaitMeleeRange": true,
+        "Requirements": [
+          "AddVisible",
+          "HasRangedWeapon",
+          "SpellInRange:3",
+          "!Items Broken"
+        ]
+      },
+      */
+      {
+        "Name": "Charge",
+        "Key": "3",
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_CHARGE",
+          "SpellInRange:0"
+        ]
+      },
+
+      {
+        "Name": "StopAttack",
+        "BeforeCastDelay": 30,
+        "Requirements": [
+          "Spell:SPELL_CHARGE",
+          "AutoAttacking",
+          "Usable:Approach"
+        ],
+        "AfterCastDelay": 50
+      },
+      {
+        "Name": "Approach",
+        "Requirements": [
+          "!Spell:SPELL_CHARGE || (Spell:SPELL_CHARGE && (CD_Charge >= WAIT_CHARGE_MS || Rage >= Cost_Heroic Strike)) || InMeleeRange"
+        ],
+        "Log": false
+      }
+    ]
+  },
+  "Combat": {
+    "Sequence": [
+      {
+        "Name": "Victory Rush",
+        "Key": "8",
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_VICTORY_RUSH"
+        ]
+      },
+      {
+        "Name": "Bloodrage",
+        "Key": "9",
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_BLOODRAGE",
+          "Rage < 10",
+          "Health% > 50"
+        ]
+      },
+      {
+        "Name": "Thunder Clap",
+        "Key": "6",
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_THUNDER_CLAP",
+          "!Thunder Clap",
+          "MobCount > 1"
+        ]
+      },
+      {
+        "Name": "Overpower",
+        "Key": "0",
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_OVERPOWER"
+        ]
+      },
+      {
+        "Name": "Rend",
+        "Key": "5",
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_REND",
+          "!Charge Stun && TargetHealth% > 50",
+          "!Rend"
+        ],
+        "Form": "Warrior_BattleStance"
+      },
+      {
+        "Name": "Sunder Armor",
+        "Key": "1",
+        "WhenUsable": true,
+        "Cooldown": 28000,
+        "Charge": 5,
+        "ResetOnNewTarget": true,
+        "Requirements": [
+          "Spell:SPELL_SUNDER_ARMOR",
+          "TargetHealth% > 30"
+        ]
+      },
+      {
+        "Name": "Heroic Strike",
+        "Key": "2",
+        "WhenUsable": true,
+        "Requirements": [
+          "!Spell:SPELL_REND || Rage >= 50",
+          "!Charge Stun && MainHandSwing > -400"
+        ],
+        "AfterCastWaitSwing": true
+      },
+      {
+        "Name": "AutoAttack",
+        "Requirements": [
+          "InMeleeRange",
+          "!Charge Stun"
+        ]
+      },
+      {
+        "Name": "Approach",
+        "Requirements": [
+          "!Charge Stun && !MeleeSwinging && !SoftTargetDead"
+        ],
+        "Log": false
+      }
+    ]
+  },
+  "Adhoc": {
+    "Sequence": [
+      {
+        "Cost": 3.1,
+        "Name": "Battle Shout",
+        "Key": "4",
+        "InCombat": "i dont care",
+        "WhenUsable": true,
+        "Requirements": [
+          "Spell:SPELL_BATTLE_SHOUT",
+          "!Battle Shout"
+        ] 
+      },
+      {
+        "Name": "Gift of the Naaru",
+        "Key": 9,
+        "WhenUsable": true,
+        "Requirements": [
+          "Race:Draenei",
+          "FoodCount == 0 || !Usable:Food",
+          "Health% < 50"
+        ]
+      },
+      {
+        "Name": "Cannibalize",
+        "Key": 9,
+        "WhenUsable": true,
+        "HasCastBar": true,
+        "AfterCastWaitCastbar": true,
+        "Requirements": [
+          "Race:Undead",
+          "Health% < 80",
+          "CannibalizeCorpse"
+        ],
+        "Interrupt": "Health% > 98"
+      },
+      {
+        "Name": "Food",
+        "Key": "=",
+        "Requirement": "Health% < MIN_HP_EAT%",
+        "Cost": 3
+      }
+    ]
+  },
+  "NPC": {
+    "Sequence": [
+      {
+        "Name": "Repair",
+        "Requirement": "Items Broken",
+        "Cost": 6
+      },
+      {
+        "Name": "Sell",
+        "Requirements": [
+          "BagFull",
+          "BagGreyItem"
+        ],
+        "Cost": 6
+      },
+      {
+        "Name": "ClassTrainer",
+        //"TrainAll": true,
+        "Requirements": [
+          "HasTrainableSpell",
+          "VendoredOrRepairedRecently",
+          "Money > 100", // 1 silver
+          "SecondsSinceTrained > TRAIN_COOLDOWN_SEC"
+        ],
+        "Cost": 6.1
+      }
+    ]
+  }
+}

--- a/Json/path/1-8_BloodElf_SunstriderIsle.json
+++ b/Json/path/1-8_BloodElf_SunstriderIsle.json
@@ -1,0 +1,49 @@
+// PathSettings group - Blood Elf starting zone (Eversong Woods), level 1-8.
+// Referenced from a class profile via "PathsFilenames".
+//
+// Sunstrider Isle sits on map 530 (Expansion01), not Eastern Kingdoms - it needs that
+// continent's navmesh baked, same as Ammen Vale.
+[
+  {
+    "Requirements": [
+      "Level < 3",
+      "Race:BloodElf"
+    ],
+    "Generate": {
+      "Subzone": "Sunstrider Isle",
+      "Mobs": "(Name:Mana Wyrm || Name:Springpaw Cub) && Level <= PlayerLevel + 2 && !Elite",
+      "Mode": "Wander"
+    },
+    "SideActivityRequirements": [
+      "PathDist <= 40"
+    ]
+  },
+  {
+    "Requirements": [
+      "Level < 5",
+      "Race:BloodElf"
+    ],
+    "Generate": {
+      "Subzone": "Sunstrider Isle",
+      "Mobs": "(Name:Springpaw Lynx || Name:Feral Tender) && Level <= PlayerLevel + 2 && !Elite",
+      "Mode": "Wander"
+    },
+    "SideActivityRequirements": [
+      "PathDist <= 40"
+    ]
+  },
+  {
+    "Requirements": [
+      "Level < 8",
+      "Race:BloodElf"
+    ],
+    "Generate": {
+      "Subzone": "Sunstrider Isle",
+      "Mobs": "Level <= PlayerLevel + 3 && !Elite",
+      "Mode": "Wander"
+    },
+    "SideActivityRequirements": [
+      "PathDist <= 40"
+    ]
+  }
+]

--- a/Json/path/1-8_Draenei_AmmenVale.json
+++ b/Json/path/1-8_Draenei_AmmenVale.json
@@ -1,0 +1,50 @@
+// PathSettings group - Draenei starting zone, level 1-8.
+// Referenced from a class profile via "PathsFilenames".
+[
+  {
+    "Requirements": [
+      "Level < 3",
+      "Race:Draenei"
+    ],
+    "Generate": {
+      "Subzone": "Ammen Vale",
+      "Mobs": "Name:Vale Moth || Name:Volatile Mutation",
+      "Focus": "Balanced",
+      "Stops": 100,
+      //"Mode": "Wander"
+      "Mode": "Loop"
+    },
+    "SideActivityRequirements": [
+      "PathDist <= 40"
+    ]
+  },
+  {
+    "Requirements": [
+      "Level < 5",
+      "Race:Draenei"
+    ],
+    "Generate": {
+      "Subzone": "Ammen Vale",
+      "Mobs": "Name:Volatile Mutation || Name:Mutated Root Lasher",
+      "Focus": "Balanced",
+      "Mode": "Wander"
+    },
+    "SideActivityRequirements": [
+      "PathDist <= 40"
+    ]
+  },
+  {
+    "Requirements": [
+      "Level < 8",
+      "Race:Draenei"
+    ],
+    "Generate": {
+      "Subzone": "Ammen Vale",
+      "Mobs": "Level <= PlayerLevel + 3 && !Elite",
+      "Mode": "Wander"
+    },
+    "SideActivityRequirements": [
+      "PathDist <= 40"
+    ]
+  }
+]

--- a/Json/path/1-8_DwarfGnome_Coldridge.json
+++ b/Json/path/1-8_DwarfGnome_Coldridge.json
@@ -1,0 +1,46 @@
+// PathSettings group - Dwarf and Gnome starting zone (Dun Morogh), level 1-8.
+// Referenced from a class profile via "PathsFilenames".
+[
+  {
+    "Requirements": [
+      "Level < 3",
+      "Race:Dwarf || Race:Gnome"
+    ],
+    "Generate": {
+      "Subzone": "Coldridge Valley",
+      "Mobs": "(Name:Ragged Young Wolf || Name:Rockjaw Trogg) && Level <= PlayerLevel + 2 && !Elite",
+      "Mode": "Wander"
+    },
+    "SideActivityRequirements": [
+      "PathDist <= 40"
+    ]
+  },
+  {
+    "Requirements": [
+      "Level < 5",
+      "Race:Dwarf || Race:Gnome"
+    ],
+    "Generate": {
+      "Subzone": "Coldridge Valley",
+      "Mobs": "(Name:Small Crag Boar || Name:Burly Rockjaw Trogg) && Level <= PlayerLevel + 2 && !Elite",
+      "Mode": "Wander"
+    },
+    "SideActivityRequirements": [
+      "PathDist <= 40"
+    ]
+  },
+  {
+    "Requirements": [
+      "Level < 8",
+      "Race:Dwarf || Race:Gnome"
+    ],
+    "Generate": {
+      "Subzone": "Coldridge Valley",
+      "Mobs": "Level <= PlayerLevel + 3 && !Elite",
+      "Mode": "Wander"
+    },
+    "SideActivityRequirements": [
+      "PathDist <= 40"
+    ]
+  }
+]

--- a/Json/path/1-8_Human_Northshire.json
+++ b/Json/path/1-8_Human_Northshire.json
@@ -1,0 +1,46 @@
+// PathSettings group - Human starting zone, level 1-8.
+// Referenced from a class profile via "PathsFilenames".
+[
+  {
+    "Requirements": [
+      "Level < 3",
+      "Race:Human"
+    ],
+    "Generate": {
+      "Subzone": "Northshire Valley",
+      "Mobs": "Name:Young Wolf || Name:Kobold Vermin",
+      "Mode": "Wander"
+    },
+    "SideActivityRequirements": [
+      "PathDist <= 40"
+    ]
+  },
+  {
+    "Requirements": [
+      "Level < 5",
+      "Race:Human"
+    ],
+    "Generate": {
+      "Subzone": "Northshire Valley",
+      "Mobs": "Name:Young Wolf || Name:Timber Wolf || Name:Kobold Vermin || Name:Kobold Vermin",
+      "Mode": "Wander"
+    },
+    "SideActivityRequirements": [
+      "PathDist <= 40"
+    ]
+  },
+  {
+    "Requirements": [
+      "Level < 8",
+      "Race:Human"
+    ],
+    "Generate": {
+      "Subzone": "Northshire Vineyards",
+      //"Mobs": "Name:Young Wolf || Name:Timber Wolf || Name:Kobold Vermin || Name:Kobold Vermin",
+      "Mode": "Wander"
+    },
+    "SideActivityRequirements": [
+      "PathDist <= 40"
+    ]
+  }
+]

--- a/Json/path/1-8_NightElf_Teldrassil.json
+++ b/Json/path/1-8_NightElf_Teldrassil.json
@@ -1,0 +1,46 @@
+// PathSettings group - Human starting zone, level 1-8.
+// Referenced from a class profile via "PathsFilenames".
+[
+  {
+    "Requirements": [
+      "Level < 3",
+      "Race:NightElf"
+    ],
+    "Generate": {
+      "Subzone": "Shadowglen",
+      "Mobs": "Name:Young Nightsaber",
+      "Mode": "Wander"
+    },
+    "SideActivityRequirements": [
+      "PathDist <= 40"
+    ]
+  },
+  {
+    "Requirements": [
+      "Level < 5",
+      "Race:NightElf"
+    ],
+    "Generate": {
+      "Subzone": "Shadowglen",
+      "Mobs": "Name:Young Nightsaber || Name:Young Thistle Boar",
+      "Mode": "Wander"
+    },
+    "SideActivityRequirements": [
+      "PathDist <= 40"
+    ]
+  },
+  {
+    "Requirements": [
+      "Level < 6",
+      "Race:NightElf"
+    ],
+    "Generate": {
+      "Subzone": "Shadowglen",
+      "Mobs": "Name:Webwood Spider || Name:Mangy Nightsaber || Name:Thistle Boar",
+      "Mode": "Wander"
+    },
+    "SideActivityRequirements": [
+      "PathDist <= 40"
+    ]
+  }
+]

--- a/Json/path/1-8_OrcTroll_ValleyOfTrials.json
+++ b/Json/path/1-8_OrcTroll_ValleyOfTrials.json
@@ -1,0 +1,49 @@
+// PathSettings group - Orc and Troll starting zone (Durotar), level 1-8.
+// Referenced from a class profile via "PathsFilenames".
+//
+// "Name:" is a substring match, so the level guards are load-bearing here:
+// "Name:Mottled Boar" also matches Dire Mottled Boar (6-7) and Elder Mottled Boar (8-9).
+[
+  {
+    "Requirements": [
+      "Level < 3",
+      "Race:Orc || Race:Troll"
+    ],
+    "Generate": {
+      "Subzone": "Valley of Trials",
+      "Mobs": "Name:Mottled Boar && Level <= PlayerLevel + 2 && !Elite",
+      "Mode": "Wander"
+    },
+    "SideActivityRequirements": [
+      "PathDist <= 40"
+    ]
+  },
+  {
+    "Requirements": [
+      "Level < 5",
+      "Race:Orc || Race:Troll"
+    ],
+    "Generate": {
+      "Subzone": "Valley of Trials",
+      "Mobs": "(Name:Scorpid Worker || Name:Vile Familiar) && Level <= PlayerLevel + 2 && !Elite",
+      "Mode": "Wander"
+    },
+    "SideActivityRequirements": [
+      "PathDist <= 40"
+    ]
+  },
+  {
+    "Requirements": [
+      "Level < 8",
+      "Race:Orc || Race:Troll"
+    ],
+    "Generate": {
+      "Subzone": "Valley of Trials",
+      "Mobs": "Level <= PlayerLevel + 3 && !Elite",
+      "Mode": "Wander"
+    },
+    "SideActivityRequirements": [
+      "PathDist <= 40"
+    ]
+  }
+]

--- a/Json/path/1-8_Tauren_RedCloudMesa.json
+++ b/Json/path/1-8_Tauren_RedCloudMesa.json
@@ -1,0 +1,50 @@
+// PathSettings group - Tauren starting zone (Mulgore), level 1-8.
+// Referenced from a class profile via "PathsFilenames".
+//
+// Red Cloud Mesa, not Camp Narache: the camp is the village and holds a single spawn, while
+// the mesa around it holds 216. "Name:" is a substring match, so the level guards matter -
+// "Name:Bristleback" also matches Bristleback Thornweaver (18-19).
+[
+  {
+    "Requirements": [
+      "Level < 3",
+      "Race:Tauren"
+    ],
+    "Generate": {
+      "Subzone": "Red Cloud Mesa",
+      "Mobs": "Name:Plainstrider && Level <= PlayerLevel + 2 && !Elite",
+      "Mode": "Wander"
+    },
+    "SideActivityRequirements": [
+      "PathDist <= 40"
+    ]
+  },
+  {
+    "Requirements": [
+      "Level < 5",
+      "Race:Tauren"
+    ],
+    "Generate": {
+      "Subzone": "Red Cloud Mesa",
+      "Mobs": "(Name:Battleboar || Name:Mountain Cougar || Name:Bristleback Quilboar) && Level <= PlayerLevel + 2 && !Elite",
+      "Mode": "Wander"
+    },
+    "SideActivityRequirements": [
+      "PathDist <= 40"
+    ]
+  },
+  {
+    "Requirements": [
+      "Level < 8",
+      "Race:Tauren"
+    ],
+    "Generate": {
+      "Subzone": "Red Cloud Mesa",
+      "Mobs": "Level <= PlayerLevel + 3 && !Elite",
+      "Mode": "Wander"
+    },
+    "SideActivityRequirements": [
+      "PathDist <= 40"
+    ]
+  }
+]

--- a/Json/path/1-8_Undead_Deathknell.json
+++ b/Json/path/1-8_Undead_Deathknell.json
@@ -1,0 +1,49 @@
+// PathSettings group - Undead starting zone (Tirisfal Glades), level 1-8.
+// Referenced from a class profile via "PathsFilenames".
+//
+// Deathknell has buildings, and route generation flags several stops as "possible roof".
+// If the bot ends up on the chapel or a cottage, tighten MaxVerticalDelta on that entry.
+[
+  {
+    "Requirements": [
+      "Level < 3",
+      "Race:Undead"
+    ],
+    "Generate": {
+      "Subzone": "Deathknell",
+      "Mobs": "(Name:Young Scavenger || Name:Duskbat) && Level <= PlayerLevel + 2 && !Elite",
+      "Mode": "Wander"
+    },
+    "SideActivityRequirements": [
+      "PathDist <= 40"
+    ]
+  },
+  {
+    "Requirements": [
+      "Level < 5",
+      "Race:Undead"
+    ],
+    "Generate": {
+      "Subzone": "Deathknell",
+      "Mobs": "(Name:Rattlecage Skeleton || Name:Ragged Scavenger) && Level <= PlayerLevel + 2 && !Elite",
+      "Mode": "Wander"
+    },
+    "SideActivityRequirements": [
+      "PathDist <= 40"
+    ]
+  },
+  {
+    "Requirements": [
+      "Level < 8",
+      "Race:Undead"
+    ],
+    "Generate": {
+      "Subzone": "Deathknell",
+      "Mobs": "Level <= PlayerLevel + 3 && !Elite",
+      "Mode": "Wander"
+    },
+    "SideActivityRequirements": [
+      "PathDist <= 40"
+    ]
+  }
+]

--- a/PPather/Navmesh/AreaGrid.cs
+++ b/PPather/Navmesh/AreaGrid.cs
@@ -27,6 +27,13 @@ public sealed class AreaGrid
     /// <summary>MCNK cells per world side: 64 ADTs * 16 MCNK.</summary>
     public const int CellsPerSide = WDT.SIZE * MapTile.SIZE;
 
+    /// <summary>
+    /// World-space size of one cell, in yards. Surfaced because <c>ChunkReader</c> is
+    /// internal and callers outside PPather (route generation) need to reason about the
+    /// same grid resolution this class buckets into.
+    /// </summary>
+    public const float CellSize = ChunkReader.CHUNKSIZE;
+
     private readonly int minCellX;
     private readonly int minCellY;
     private readonly int width;

--- a/PPather/Navmesh/NavmeshConnectivity.cs
+++ b/PPather/Navmesh/NavmeshConnectivity.cs
@@ -1,0 +1,207 @@
+#nullable enable
+using System.Collections.Frozen;
+using System.Collections.Generic;
+
+using DotRecast.Detour;
+
+using Microsoft.Extensions.Logging;
+
+using static DotRecast.Detour.DtDetour;
+
+namespace PPather.Navmesh;
+
+/// <summary>
+/// Connected components of the navmesh polygon graph, so "can I walk from here to there"
+/// is an O(1) lookup instead of a pathfinding query.
+///
+/// <para><b>Why this exists.</b> On-mesh is not the same as reachable: a rooftop, a ledge
+/// and a tree canopy are all walkable polys, merely disconnected from the floor a route
+/// lives on. As <see cref="NavmeshEndpointResolver"/> puts it, "only connectivity can tell
+/// those apart". Answering that with <c>FindPath</c> would run a full A* plus straight-path,
+/// smoothing and edge-margin passes to produce a yes/no - hundreds of times the work of an
+/// array read, and unaffordable in a sampler loop that runs every lap.</para>
+///
+/// <para>Same component means a path provably exists, so this is not an approximation of
+/// the reachability test - it is the reachability test. It says nothing about how
+/// <i>long</i> that path is.</para>
+/// </summary>
+public sealed class NavmeshConnectivity
+{
+    private readonly FrozenDictionary<long, int> componentOf;
+    private readonly NavmeshTileCache tiles;
+
+    /// <summary>Number of distinct components found in the scanned tiles.</summary>
+    public int ComponentCount { get; }
+
+    /// <summary>Polygons scanned. Zero means nothing was baked for the requested range.</summary>
+    public int PolyCount => componentOf.Count;
+
+    private NavmeshConnectivity(FrozenDictionary<long, int> componentOf, int componentCount,
+        NavmeshTileCache tiles)
+    {
+        this.componentOf = componentOf;
+        ComponentCount = componentCount;
+        this.tiles = tiles;
+    }
+
+    /// <summary>
+    /// Stable identity for a polygon: its tile's world coordinates plus its index inside
+    /// that tile.
+    ///
+    /// <para>A raw <c>polyRef</c> cannot be used as a key. It encodes a tile <i>slot</i>
+    /// index and a salt, both of which change when the LRU evicts a tile and later reloads
+    /// it - which happens routinely during sampling. Keying on the ref made lookups start
+    /// missing mid-run, which read as "unreachable" and silently changed the route; two runs
+    /// with the same seed then disagreed.</para>
+    /// </summary>
+    private static long Key(int tileX, int tileZ, int polyIndex) =>
+        ((long)(tileX & 0xFFFF) << 48) |
+        ((long)(tileZ & 0xFFFF) << 32) |
+        (uint)polyIndex;
+
+    /// <summary>Component id, or -1 when the poly was not in the scanned range.</summary>
+    public int ComponentOf(long polyRef)
+    {
+        if (polyRef == 0)
+        {
+            return -1;
+        }
+
+        tiles.Lock.EnterReadLock();
+        try
+        {
+            if (!tiles.NavMesh.GetTileAndPolyByRef(polyRef, out DtMeshTile tile, out _)
+                .Succeeded() || tile?.data?.header == null)
+            {
+                return -1;
+            }
+
+            long key = Key(tile.data.header.x, tile.data.header.y,
+                DtDetour.DecodePolyIdPoly(polyRef));
+
+            return componentOf.TryGetValue(key, out int c) ? c : -1;
+        }
+        finally
+        {
+            tiles.Lock.ExitReadLock();
+        }
+    }
+
+    /// <summary>True only when both polys are known and share a component.</summary>
+    public bool SameComponent(long a, long b)
+    {
+        int ca = ComponentOf(a);
+        return ca >= 0 && ca == ComponentOf(b);
+    }
+
+    /// <summary>
+    /// Floods every polygon in the currently resident tiles whose tile coordinates fall in
+    /// the given inclusive range.
+    ///
+    /// <para>Scoped to a tile range rather than the whole continent because a route only
+    /// ever cares about one zone: a ~1000 yd zone is ~60 tiles at
+    /// <see cref="NavmeshSettings.TileWorldSize"/>, a few tens of thousands of polys.</para>
+    ///
+    /// <para>Runs under the cache's read lock. The caller must have ensured the tiles it
+    /// cares about are resident first - a tile that is not loaded contributes nothing, and
+    /// its absence would read as "unreachable" rather than as an error.</para>
+    /// </summary>
+    public static NavmeshConnectivity Build(ILogger logger, NavmeshTileCache tiles,
+        int minTileX, int minTileZ, int maxTileX, int maxTileZ)
+    {
+        Dictionary<long, int> component = [];
+        Dictionary<long, List<long>> adjacency = [];
+
+        tiles.Lock.EnterReadLock();
+        try
+        {
+            DtNavMesh navMesh = tiles.NavMesh;
+
+            for (int i = 0; i < navMesh.GetMaxTiles(); i++)
+            {
+                DtMeshTile tile = navMesh.GetTile(i);
+                if (tile?.data?.header == null)
+                    continue;
+
+                int tx = tile.data.header.x;
+                int tz = tile.data.header.y;
+
+                if (tx < minTileX || tx > maxTileX || tz < minTileZ || tz > maxTileZ)
+                    continue;
+
+                for (int p = 0; p < tile.data.header.polyCount; p++)
+                {
+                    long polyKey = Key(tx, tz, p);
+
+                    List<long> neighbours = [];
+
+                    for (int link = tile.data.polys[p].firstLink;
+                        link != DT_NULL_LINK;
+                        link = tile.links[link].next)
+                    {
+                        long neighbourRef = tile.links[link].refs;
+                        if (neighbourRef == 0)
+                        {
+                            continue;
+                        }
+
+                        // Translate the neighbour into the same stable identity. Links
+                        // cross tiles, so this cannot assume the neighbour lives here.
+                        if (navMesh.GetTileAndPolyByRef(neighbourRef,
+                                out DtMeshTile nTile, out _).Succeeded() &&
+                            nTile?.data?.header != null)
+                        {
+                            neighbours.Add(Key(nTile.data.header.x, nTile.data.header.y,
+                                DtDetour.DecodePolyIdPoly(neighbourRef)));
+                        }
+                    }
+
+                    adjacency[polyKey] = neighbours;
+                    component[polyKey] = -1;
+                }
+            }
+        }
+        finally
+        {
+            tiles.Lock.ExitReadLock();
+        }
+
+        // Iterative flood fill - the poly graph is wide and shallow, but a recursive walk
+        // over tens of thousands of polys is a stack overflow waiting to happen.
+        int next = 0;
+        Stack<long> pending = new();
+
+        foreach (long start in adjacency.Keys)
+        {
+            if (component[start] >= 0)
+                continue;
+
+            int id = next++;
+            pending.Push(start);
+            component[start] = id;
+
+            while (pending.Count > 0)
+            {
+                long current = pending.Pop();
+
+                foreach (long neighbour in adjacency[current])
+                {
+                    // A link can point outside the scanned range (into a tile we did not
+                    // flood). Skipping it is correct: the route stays inside the range.
+                    if (!component.TryGetValue(neighbour, out int seen) || seen >= 0)
+                        continue;
+
+                    component[neighbour] = id;
+                    pending.Push(neighbour);
+                }
+            }
+        }
+
+        if (logger.IsEnabled(LogLevel.Debug))
+            logger.LogDebug(
+                "NavmeshConnectivity: {Polys} polys in tiles [{MinX},{MinZ}]-[{MaxX},{MaxZ}] -> {Components} components",
+                component.Count, minTileX, minTileZ, maxTileX, maxTileZ, next);
+
+        return new NavmeshConnectivity(component.ToFrozenDictionary(), next, tiles);
+    }
+}

--- a/PPather/Navmesh/NavmeshPathfinder.cs
+++ b/PPather/Navmesh/NavmeshPathfinder.cs
@@ -94,6 +94,13 @@ public sealed class NavmeshPathfinder : IDisposable
 
     private static readonly Vector3 ValidateExtents = new(2f, 4f, 2f);
 
+    /// <summary>
+    /// Search box for <see cref="TrySampleWalkable"/>'s anchor. Deliberately short in y:
+    /// the anchor carries a trustworthy height, and a tall box would let the probe climb to
+    /// a roof or canopy poly - the exact failure the sampler exists to avoid.
+    /// </summary>
+    private static readonly Vector3 SampleAnchorExtents = new(4f, 8f, 4f);
+
     private readonly ILogger logger;
     private readonly NavmeshTileCache tiles;
     private readonly DtNavMeshQuery query;
@@ -261,6 +268,62 @@ public sealed class NavmeshPathfinder : IDisposable
         }
 
         z = NavmeshCoords.ToWow(closest).Z;
+        return true;
+    }
+
+    /// <summary>
+    /// Snaps a caller-chosen point onto the nearest walkable polygon, returning both the
+    /// on-mesh position and the poly it landed on.
+    ///
+    /// <para><b>Why not <c>FindRandomPointWithinCircle</c>.</b> Letting Detour pick the
+    /// point is the obvious approach and it was the first one here, but it is <i>not
+    /// reproducible across processes</i>: the search walks polygons whose refs encode tile
+    /// slot indices, and slot assignment depends on the order tiles happened to become
+    /// resident. Two runs with the same seed produced different routes. Snapping a point the
+    /// caller derived from its own seeded RNG keeps the whole decision on the caller's side,
+    /// where the seed actually controls it, while still ending up on the mesh by
+    /// construction rather than by a test applied afterwards.</para>
+    ///
+    /// <para>On-mesh is <b>not</b> the same as reachable - a rooftop, a ledge and a tree
+    /// canopy are all walkable polys, merely disconnected from the floor the caller means.
+    /// Callers must still check connectivity (and their own height band) against
+    /// <paramref name="polyRef"/>.</para>
+    /// </summary>
+    public bool TrySnapWalkable(Vector3 wowPointHint, out Vector3 wowPoint, out long polyRef)
+    {
+        wowPoint = wowPointHint;
+        polyRef = 0;
+
+        NavmeshCoords.GetTileIndex(wowPointHint.X, wowPointHint.Y, out int tx, out int tz);
+        if (!tiles.IsTileOnDisk(tx, tz))
+        {
+            return false;
+        }
+
+        tiles.EnsureTilesForSegment(wowPointHint, wowPointHint);
+
+        Vector3 rc = NavmeshCoords.ToRc(wowPointHint);
+
+        filter.BeginQuery();
+
+        // Tight box on purpose. The caller supplies a hint whose height it trusts (it is
+        // offset from a real spawn position), and a tall box is exactly what lets a probe
+        // climb onto a roof or canopy above the floor that was meant.
+        DtStatus status = query.FindNearestPoly(rc, SampleAnchorExtents, filter,
+            out long refs, out Vector3 nearest, out _);
+
+        if (!status.Succeeded() || refs == 0)
+        {
+            return false;
+        }
+
+        if (!query.ClosestPointOnPoly(refs, rc, out Vector3 closest, out _).Succeeded())
+        {
+            closest = nearest;
+        }
+
+        wowPoint = NavmeshCoords.ToWow(closest);
+        polyRef = refs;
         return true;
     }
 

--- a/PPather/Search/PPatherService.cs
+++ b/PPather/Search/PPatherService.cs
@@ -1089,6 +1089,81 @@ public sealed class PPatherService : IDisposable
     }
 
     /// <summary>
+    /// Area id at a world (x, y) from the pre-baked grid alone. The cheap half of
+    /// <see cref="GetAreaIdAndZ"/> - route generation tests thousands of points for zone
+    /// membership and has no use for the height query that goes with it.
+    /// </summary>
+    public int GetAreaId(float mapId, float worldX, float worldY)
+    {
+        return ContinentDB.IdToName.TryGetValue(mapId, out string continent)
+            ? GetAreaGrid(continent)?.GetAreaId(worldX, worldY) ?? 0
+            : 0;
+    }
+
+    /// <summary>
+    /// The disk-only navmesh for a map, for callers that want to sample or query it
+    /// directly (route generation). Null when nothing is baked for the continent.
+    ///
+    /// <para>Deliberately the query mesh rather than <see cref="NavmeshPathfinder"/>: it
+    /// never bakes and never touches the live search state, so a generator can run without
+    /// disturbing - or being disturbed by - the follower's own requests.</para>
+    /// </summary>
+    public NavmeshPathfinder? GetQueryNavmeshForMap(float mapId)
+    {
+        return ContinentDB.IdToName.TryGetValue(mapId, out string continent)
+            ? GetQueryNavmesh(continent, mapId)
+            : null;
+    }
+
+    /// <summary>
+    /// Connected components of the navmesh polygons covering a world-space AABB, so a
+    /// caller can answer "is this point reachable from that one" with an array read instead
+    /// of a pathfinding query. See <see cref="NavmeshConnectivity"/>.
+    ///
+    /// <para>Loads the covering tiles first - a tile that is not resident contributes no
+    /// polygons, and its absence would read as "unreachable" rather than as missing data.</para>
+    /// </summary>
+    public NavmeshConnectivity? BuildConnectivity(float mapId,
+        float minWorldX, float minWorldY, float maxWorldX, float maxWorldY)
+    {
+        NavmeshPathfinder? nav = GetQueryNavmeshForMap(mapId);
+        if (nav == null)
+            return null;
+
+        NavmeshCoords.GetTileIndex(minWorldX, minWorldY, out int tx0, out int tz0);
+        NavmeshCoords.GetTileIndex(maxWorldX, maxWorldY, out int tx1, out int tz1);
+
+        // World x/y descend as detour tile indices ascend, so the corners can arrive in
+        // either order; normalise rather than assume. One tile of skirt keeps a component
+        // that only connects through the fringe from looking severed.
+        int minTileX = System.Math.Min(tx0, tx1) - 1;
+        int maxTileX = System.Math.Max(tx0, tx1) + 1;
+        int minTileZ = System.Math.Min(tz0, tz1) - 1;
+        int maxTileZ = System.Math.Max(tz0, tz1) + 1;
+
+        for (int tx = minTileX; tx <= maxTileX; tx++)
+        {
+            for (int tz = minTileZ; tz <= maxTileZ; tz++)
+            {
+                if (!NavmeshCoords.IsValidTile(tx, tz) || !nav.Tiles.IsTileOnDisk(tx, tz))
+                    continue;
+
+                NavmeshCoords.GetTileWowBounds(tx, tz,
+                    out float bMinX, out float bMinY, out float bMaxX, out float bMaxY);
+
+                // Guarded by IsTileOnDisk above, so this only stitches in what is already
+                // baked - it never triggers a bake, which would need the game archives and
+                // would be wildly out of budget here.
+                Vector3 centre = new((bMinX + bMaxX) / 2f, (bMinY + bMaxY) / 2f, 0f);
+                nav.Tiles.EnsureTilesForSegment(centre, centre);
+            }
+        }
+
+        return NavmeshConnectivity.Build(logger, nav.Tiles,
+            minTileX, minTileZ, maxTileX, maxTileZ);
+    }
+
+    /// <summary>
     /// Disk-only navmesh for a continent, used purely to answer height queries
     /// without the game files. Reuses the live pathfinding mesh when it already
     /// covers the continent; otherwise builds a world-less (never-baking) one

--- a/README.md
+++ b/README.md
@@ -932,6 +932,7 @@ The class configuration controls all aspects of bot behavior. Here's why each se
 | `"SideActivityRequirements"` | List of [Requirements](#requirement) to limit when the player should search for target<br/>Great for enforcing how closely should follow the path. | true | `true` |
 | --- | --- | --- | --- |
 | `"Paths"` | Array of [PathSettings](#pathsettings).<br>Either define this array or use the above properties | true | `[]` |
+| `"Seed"` | Pins the randomness of [generated routes](#generated-routes) so a session replays identically.<br>Unset draws a fresh seed per session and logs it. | true | `null` |
 | `"Mode"` | What kind of [behaviour](#modes) should the bot operate | true | `Mode.Grind` |
 | `"NPCMaxLevels_Above"` | Maximum allowed level above difference to the player | true | `1` |
 | `"NPCMaxLevels_Below"` | Maximum allowed level below difference to the player | true | `7` |
@@ -1125,7 +1126,8 @@ The path that the player follows during [Follow Route Goal](#follow-route-goal),
 
 | Property Name | Description | Optional | Default value |
 | --- | --- | --- | --- |
-| `"PathFilename"` | [Path](#path) to use while alive | **false** | `""` |
+| `"PathFilename"` | [Path](#path) to use while alive | **false**, unless `"Generate"` is set | `""` |
+| `"Generate"` | [Generate the route](#generated-routes) from spawn data instead of a file | true | `null` |
 | `"Id"` | <b>Must be a Unique Integer value</b> to identify PathSettings. | true | `"Auto incremented from zero"` or `"Unless specified by user."` |
 | `"PathThereAndBack"` | While using the path, [should go start to and reverse](#there-and-back) | true | `true` |
 | `"PathReduceSteps"` | Reduce the number of path points | true | `false` |
@@ -1188,6 +1190,121 @@ Let's look at the following example
 ```
 
 The previously mentioned example can be found under [Hunter_1.json](./Json/class/Hunter_1.json).
+
+### Generated Routes
+
+Instead of pointing at a recorded file, a path can describe **what to grind** and let the bot
+build the route from the running client's own NPC spawn data and the baked navmesh.
+
+This exists because a recorded route is tied to one race, one level band and one client - and
+the Cataclysm/Mists zone revamps moved the world, so routes recorded on Classic/TBC/Wrath do
+not survive there. The spawn data is already partitioned per client, so the same profile entry
+produces a valid route on every one.
+
+```json
+"Paths": [
+{
+    "Generate": {
+        "Subzone": "Northshire Valley",
+        "Mobs": "Name:Wolf || Name:Kobold",
+        "Mode": "Wander"
+    },
+    "Requirements": [ "Level < 5", "Race:Human" ]
+},
+{
+    "Generate": {
+        "Zone": "Elwynn Forest",
+        "Mobs": "Type:Humanoid && Level <= PlayerLevel + 2 && !Elite"
+    },
+    "Requirements": [ "Level < 10" ]
+}
+],
+```
+
+| Property Name | Description | Optional | Default value |
+| --- | --- | --- | --- |
+| `"Zone"` | Zone name, e.g. `"Elwynn Forest"` | true | player's current zone |
+| `"Subzone"` | Subzone name, e.g. `"Northshire Valley"`. Narrower than `Zone`; wins when both are set | true | `null` |
+| `"UIMapId"` | Explicit map id; wins over both names | true | `0` |
+| `"Name"` | Label shown as the goal name and in logs | true | derived from `Subzone`/`Zone` |
+| `"Mobs"` | Which mobs shape the route - see [Mob filter](#mob-filter-creature-scope) | true | mobs within `PlayerLevel - 3 .. + 2`, non-elite |
+| `"Mode"` | `"Wander"` regenerates a fresh set of spots every lap. `"Loop"` builds one fixed closed tour, ordered shortest-first | true | `"Wander"` |
+| `"Focus"` | `"Density"` sticks to where mobs pack together and drops isolated spawns. `"Balanced"` drops only the sparsest. `"Coverage"` takes in everything that matched | true | `"Density"` |
+| `"MinClusterShare"` | Override: a spawn cluster is kept only if it holds this share of what the biggest cluster holds | true | from `Focus` |
+| `"DensityBias"` | Override: how hard **Wander** spots are drawn to dense areas. `0` uniform, `1` proportional, `2` packs dominate. Not used by `Loop` | true | from `Focus` |
+| `"MinCellShare"` | Override: share of the busiest spot's mob count a place must hold to become a **Loop** stop. This is what `Focus` uses to skip thin outlying spots | true | from `Focus` |
+| `"WaypointSpacingYards"` | Spacing of the emitted waypoints. Recorded routes sit near 17; much denser makes the follower brake constantly | true | `15` |
+| `"Stops"` | How many hunting spots to pick. The route is then filled in by pathing between them, so the waypoint count is much higher than this | true | `8` |
+| `"PaddingYards"` | How far the roaming area is grown beyond the spawn footprint | true | `25` |
+| `"MaxVerticalDelta"` | Rejects a spot this far above the mob that anchored it - keeps routes off rooftops and ledges | true | `5` |
+| `"MinSpacingYards"` | Minimum gap between two spots | true | `30` |
+
+The generated route is **dense**: after picking the spots, each consecutive pair is pathed
+through the navmesh and those points become the waypoints. Target acquisition happens while
+walking, so a long straight hop between two spots would skip every mob beside it.
+
+#### Wander vs Loop
+
+`"Wander"` picks its spots at random - weighted toward dense areas - and picks a **fresh set
+every lap**, so the bot never retraces the same line. Good for staying unpredictable.
+
+`"Loop"` takes the densest spots in the area, measures the real walking distance between every
+pair, and orders them into the shortest closed tour. The result is the same route every
+session for a given zone and mob filter, and a lap covers the area once instead of
+criss-crossing it. It is the drop-in replacement for a recorded route.
+
+Set `"PathThereAndBack": false` with `"Loop"` - the tour already returns to its start, so
+walking it backwards afterwards just repeats it in reverse.
+| `"Seed"` | Pins this path's randomness. Overrides the profile-level `"Seed"`. `Loop` ignores it - that mode is deterministic already | true | `null` |
+
+`"Seed"` at the [Class Configuration](#class-configuration) level pins every generated route in
+the session. Left unset, a fresh seed is drawn per session **and written to the log**, so a run
+can still be reproduced afterwards.
+
+Generation needs a **baked navmesh** for the continent. Without one it fails, logs the reason,
+and that path simply drops out of planning so the next one in the profile takes over - so keep
+a fallback path with no requirements, exactly as with recorded routes.
+
+Preview and tune these in the browser under **Route Gen**, which draws the result on the
+Leaflet map and can save it to `Json/path` as an ordinary recorded route.
+
+#### Mob filter (creature scope)
+
+`"Mobs"` uses the same expression language as [Requirement](#requirement) - `&&`, `||`, `!`,
+parentheses, arithmetic and comparisons all work.
+
+> **The subject is a creature, not the player.** `Level` here is the *mob's* level; the
+> player's is `PlayerLevel`. So `"Level <= PlayerLevel + 2"` reads exactly as you'd say it.
+> Player-only names such as `Health%` or `Race:` are not available here and will fail to
+> parse, which is intentional - a filter must not silently test the wrong thing.
+
+| Name | Meaning |
+| --- | --- |
+| `Level` | Average of the mob's min/max level |
+| `MinLevel` / `MaxLevel` | The mob's level range |
+| `Rank` | 0 normal, higher for elite/rare |
+| `NpcId` | Creature entry id |
+| `SpawnCount` | How many of this mob spawn inside the target zone |
+| `PlayerLevel` | The player's level |
+| `Elite` | `Rank > 0` |
+| `Skinnable` | The mob can be skinned |
+| `Hostile` | Attackable by the player's faction |
+| `Type:[type]` | Creature type - same values as [Target requirements](#target-requirements), e.g. `Type:Humanoid` |
+| `Name:[text]` | Mob name contains `text`, case-insensitive. `Name:Wolf` covers Young Wolf, Rabid Wolf, ... |
+| `Faction:[id]` | Faction template id |
+| `Family:[id]` | Creature family id |
+
+e.g.
+```json
+"Mobs": "Type:Humanoid && !Elite"                              // any non-elite humanoid
+"Mobs": "(Name:Wolf || Name:Kobold) && Level >= PlayerLevel - 3"
+"Mobs": "Faction:7 && !Name:Defias"                            // a faction, minus one family of mobs
+"Mobs": "NpcId == 299 || NpcId == 6"                           // exactly these two
+"Mobs": "SpawnCount > 8 && Skinnable"                          // dense skinning spots only
+```
+
+Regardless of the expression, service NPCs, critters, totems, pets and anything not hostile to
+your faction are never picked.
 
 #### Time-based Path Cycling
 
@@ -2713,6 +2830,37 @@ e.g.
 ```
 
 ---
+### **RangedWeapon requirements**
+
+Check what **kind** of weapon occupies the ranged slot. `Equipment:Ranged` only says
+something is there; this says whether it is a bow, a gun, a crossbow, a wand or a thrown
+weapon.
+
+The motivating case is ammunition: a bow and a crossbow consume arrows, a gun consumes
+bullets, and a wand consumes neither. Without this a restocking entry has to hardcode one
+ammo item and is wrong for the other half of the weapons.
+
+Formula: `RangedWeapon:[subclass]`
+
+| subclass |
+| --- |
+| Bow |
+| Gun |
+| Crossbow |
+| Thrown |
+| Wand |
+
+Any other [`ItemWeaponSubclass`](SharedLib/Data/ItemWeaponSubclass.cs) name is accepted
+too. An unknown name throws at profile load rather than silently never matching.
+
+e.g.
+```json
+"Requirement": "RangedWeapon:Gun"                          // Gun equipped - needs bullets
+"Requirement": "RangedWeapon:Bow || RangedWeapon:Crossbow" // Either - needs arrows
+"Requirement": "!RangedWeapon:Wand"                        // Anything but a wand
+```
+
+---
 ### **Spell requirements**
 
 If a given Spell `name` or `id` must be known by the player then you can use this requirement. 
@@ -2974,7 +3122,7 @@ Allow requirements about what buffs/debuffs you have or the target has or in gen
 | `"BagFull"` | Inventory is full |
 | `"BagGreyItem"` | Indicates that there are at least one Grey Quality level item. |
 | `"Items Broken"` | Has any broken(red) worn item |
-| `"HasRangedWeapon"` | Has equipped ranged weapon (wand/crossbow/bow/gun) |
+| `"HasRangedWeapon"` | Has equipped ranged weapon (wand/crossbow/bow/gun). To tell *which*, see [RangedWeapon requirements](#rangedweapon-requirements). |
 | `"HasAmmo"` | AmmoSlot has equipped ammo and count is greater than zero |
 | `"HasTrainableSpell"` | There is at least one spell on the [class trainer whitelist](#class-trainer) the player does not know yet and is high enough level to learn. Also false while the spellbook is still loading. Note the bot applies two further checks of its own that this variable does not expose - see the [Class Trainer](#class-trainer) notes. |
 | `"Casting"` | The player is currently casting any spell. |

--- a/SharedLib/Data/WorldMapAreaDB.cs
+++ b/SharedLib/Data/WorldMapAreaDB.cs
@@ -19,6 +19,14 @@ public sealed class WorldMapAreaDB
 
     public IEnumerable<WorldMapArea> Values => wmas.Values;
 
+    /// <summary>
+    /// Entries with a parent zone and no map of their own. Not part of <see cref="Values"/>,
+    /// which only carries drawable maps - but a caller filtering world positions to a zone
+    /// needs them, because the baked area grid stores the finest (subzone) id, never the
+    /// parent's.
+    /// </summary>
+    public ReadOnlySpan<WorldMapArea> Subzones => subzonesByNameLengthDesc;
+
     public FrozenDictionary<int, WorldMapArea> AreaHitbox;
 
     public WorldMapAreaDB(DataConfig dataConfig)
@@ -172,6 +180,27 @@ public sealed class WorldMapAreaDB
         }
 
         result = default;
+        return false;
+    }
+
+    /// <summary>
+    /// The subzone entry itself, rather than its parent zone. <see cref="TryFindBySubzoneName"/>
+    /// answers "which map do I draw this on", which is what a route file name needs; this
+    /// answers "which area id is this", which is what filtering spawns to a subzone needs.
+    /// </summary>
+    public bool TryFindSubzone(ReadOnlySpan<char> input, out WorldMapArea subzone)
+    {
+        ReadOnlySpan<WorldMapArea> subzones = subzonesByNameLengthDesc;
+        for (int i = 0; i < subzones.Length; i++)
+        {
+            if (input.Contains(subzones[i].AreaName, StringComparison.OrdinalIgnoreCase))
+            {
+                subzone = subzones[i];
+                return true;
+            }
+        }
+
+        subzone = default;
         return false;
     }
 

--- a/docs/generated-routes-design.md
+++ b/docs/generated-routes-design.md
@@ -1,0 +1,669 @@
+# Generated Grind Routes — Design Doc
+
+**Status:** Phase 1 and Phase 2 implemented and verified offline — 2026-08-04.
+See §15 for the defects implementation turned up.
+**Scope:** Let a class profile describe a grind route as a *query* over the client's own NPC
+spawn data instead of pointing at a hand-recorded waypoint file. Two generation modes
+(`Wander`, `Loop`), both producing world-space waypoints that `FollowRouteGoal` walks
+unchanged. Recorded routes keep working exactly as they do today; this is additive.
+
+---
+
+## 1. Motivation
+
+Grind routes today are hand-recorded waypoint files. `ClassConfiguration.Paths[]` holds
+`PathSettings` entries, each a `PathFilename` plus `Requirements[]`;
+`GoalFactory.GetPathSettings` reads the file into `PathSettings.Path`, and one
+`FollowRouteGoal` per entry walks it, GOAP picking the cheapest whose `CanRun()` passes.
+
+Two costs:
+
+1. **One file per race × level band × zone.** `Json/class/_/Warrior_1-10--------------.json`
+   is Human-only because `1_Human.json` is a recorded Elwynn loop. Covering the other nine
+   starting zones means nine more recordings.
+2. **Cataclysm and Mists moved the world.** Routes recorded on som/tbc/wrath do not survive
+   the zone revamps, so every profile needs re-recording per client. This is the dominant
+   cost and the reason the feature exists — generation is the only fix that scales, because
+   the spawn data is already partitioned per client.
+
+Everything needed already ships:
+
+| data | path / API | shape |
+|---|---|---|
+| mob spawns | `Json/npcspawnlocations/<Exp>/<mapId>.json` | `entry -> Vector3[]`, **world** coords with real z |
+| creature metadata | `Json/dbc/<Exp>/creatures.json` → `SharedLib/Data/Creature.cs` | `Entry, Name, SubName, MinLevel, MaxLevel, Rank, Faction, NpcFlag, Type` |
+| hostility | `Core/Database/FactionTemplateDB.cs` | faction → friend-group mask |
+| zone/subzone names + world bounds | `SharedLib/Data/WorldMapAreaDB.cs` | `TryFindByAreaName`, `TryFindBySubzoneName`, `GetByAreaId` |
+| world (x,y) → subzone id | `PPather/Navmesh/AreaGrid.cs:61` `GetAreaId` | baked `Json/area_grid/<era>/<continent>.grid` |
+| walkable z without game files | `PPatherService.GetAreaIdAndZ` (`PPather/Search/PPatherService.cs:1072`) | `(areaId, z)` |
+
+`Utilities/DangerZoneGenerator/Program.cs:142-172` is working prior art for the
+spawns × creatures × subzone join.
+
+---
+
+## 2. Selector design
+
+The selector is expressed as a **single requirement expression** rather than a bag of typed
+fields. Grind-area configuration is conventionally a fixed set of knobs — a faction list, a
+mob-id list, min/max target level, an elites flag, a blacklist — every one of which is
+implicitly ANDed together.
+
+That shape has two problems here. It cannot express `||` or `!`, so "wolves or kobolds, but
+not the diseased ones" needs new syntax each time. And it duplicates a language this codebase
+already has: `Core/RPN/ExpressionParser.cs` parses `&&`, `||`, `!`, parens, arithmetic and
+comparisons for the profile's own `Requirements`.
+
+So all of it collapses into `Mobs`:
+
+| conventional knob | here |
+|---|---|
+| faction list | `"Mobs": "Faction:7"` |
+| mob id list | `"Mobs": "NpcId == 299 \|\| NpcId == 6"` |
+| min/max target level | `"Mobs": "Level >= 3 && Level <= 6"` |
+| "no elites" flag | `"Mobs": "!Elite"` |
+| blacklist | `"Mobs": "... && NpcId != 1234"` |
+| creature type | `"Mobs": "Type:Humanoid"` |
+
+Two consequences worth stating:
+
+* **Faction and creature type are the primary selectors, not mob names.** A faction id means
+  "everything hostile around here" — language-independent, immune to renames, and needing no
+  per-zone authoring. `Creature.Faction` and `Creature.Type` are both already in the DBC rows
+  we load.
+* **Loot radius, targeting distance, mount use and level tolerances are out of scope.** They
+  are already global class-config concerns (`classConfig.Loot`, `NPCMaxLevels_*`, the mount
+  handler), and duplicating them per path would create two places to set the same thing.
+
+---
+
+## 3. Config surface
+
+```json
+"Paths": [
+  {
+    "Generate": {
+      "Subzone": "Northshire Valley",
+      "Mobs": "Name:Wolf || Name:Kobold",
+      "Mode": "Wander"
+    },
+    "Requirements": [ "Level < 5", "Race:Human" ]
+  },
+  {
+    "Generate": {
+      "Zone": "Elwynn Forest",
+      "Mobs": "Type:Humanoid && Level <= PlayerLevel + 2 && !Elite",
+      "Mode": "Loop",
+      "Stops": 10
+    },
+    "PathThereAndBack": false,
+    "Requirements": [ "Level < 10" ]
+  }
+]
+```
+
+```csharp
+public sealed class RouteGenSettings
+{
+    public string? Zone { get; set; }          // "Elwynn Forest"
+    public string? Subzone { get; set; }       // "Northshire Valley" — narrower than Zone
+    public int UIMapId { get; set; }           // explicit override, wins over names
+    public string? Name { get; set; }          // label for logs / goal name / UI badge
+
+    public string Mobs { get; set; } = string.Empty;   // the whole selector, creature scope
+
+    public RouteGenMode Mode { get; set; } = RouteGenMode.Wander;
+    public int Stops { get; set; } = 8;                  // control points; route is densified
+    public float PaddingYards { get; set; } = 25f;       // polygon dilation
+    public float MaxVerticalDelta { get; set; } = 5f;    // sample vs anchor z, roof gate
+    public int? Seed { get; set; }                       // per-path override of global seed
+}
+
+public enum RouteGenMode { Wander, Loop }
+```
+
+`Race:Human` needs no work — `Race:` already exists (`RequirementFactory.cs:127`, handler
+`:1092-1110`) and `PathSettings.Requirements` goes through the same parser
+(`RequirementFactory.Init(PathSettings)` at `:420-431`). The new surface is `Generate` only.
+
+### Reuse what `PathSettings.cs` already carries
+
+Do not invent parallel machinery:
+
+* **`RaceStartingZones`** (`PathSettings.cs:33-45`) — race name → starting `AreaId`.
+  `Generate` with no `Zone`/`Subzone` resolves through it.
+* **`TryFindRaceZone` / `TryParseMinLevel`** (`:119-157`) — reuse verbatim.
+* **The 4-step UIMapId fallback** in `ConvertToWorldCoords` (`:76-110`) — `Generate` resolves
+  its target the same way and in the same order: explicit `UIMapId` → `Zone`/`Subzone` name →
+  race starting zone → player's current `UIMapId`.
+* **`WorldCoords` + `OriginalMapPath`** (`:21-22`) — the world/map split already exists;
+  generation produces world coords and back-fills `OriginalMapPath` so the Blazor/Leaflet
+  route view (`FollowRouteGoal.MapRoute()`, `:65-67`) keeps working unchanged.
+* **`CanRun()` / `CanRunSideActivity()`** (`:159-191`) tick memoization and the `Finished`
+  hook — untouched.
+
+---
+
+## 4. The creature-scope expression
+
+**Build the selector on the expression language, not on typed fields.** The profile DSL
+already parses `&&`, `||`, `!`, parens, arithmetic and comparisons
+(`Core/RPN/ExpressionParser.cs`, binding powers at `:324-336`). Duplicating a slice of it as
+`Mobs[] + NpcIds[] + Factions[] + Types[] + MinLevel + MaxLevel + MinLevelOffset +
+MaxLevelOffset + IncludeElite + Blacklist[]` gives users a second, worse language that can
+only ever express AND. One expression subsumes all ten:
+
+```json
+"Mobs": "Type:Humanoid && Level <= PlayerLevel + 2 && !Elite"
+"Mobs": "(Name:Wolf || Name:Kobold) && Level >= PlayerLevel - 3"
+"Mobs": "Faction:7 && !Name:Defias"
+"Mobs": "NpcId == 299 || NpcId == 6"
+```
+
+### It is a second scope, not the same variable table
+
+This is the feature's sharpest edge, because the syntax is identical and the subject is not:
+
+| | subject | decides | example |
+|---|---|---|---|
+| `PathSettings.Requirements` | the **player** | *whether* this path runs | `"Level < 5"`, `"Race:Human"` |
+| `Generate.Mobs` | a **candidate creature row** | *which* mobs shape the polygon | `"Type:Humanoid"`, `"Level < 5"` |
+
+`"Level < 5"` is legal in both and means different things. In creature scope `Level` shadows
+to the creature's level and the player's is `PlayerLevel`, which makes the common case read
+the way you would say it out loud: `Level <= PlayerLevel + 2`. `Health%` and friends are
+absent from the creature table and produce a parse error, which is the desired failure.
+
+### Implementation — a second `ExpressionParser` instance
+
+`ExpressionParser`'s constructor already takes its maps (`RequirementFactory.cs:307-308`), so
+a creature-scoped parser is a matter of supplying different ones. Keeping it a separate
+instance also sidesteps a live defect: `requirementMap` keys are bare prefixes and
+`ParseParameterized` re-dispatches by `text.Contains(key)` over an *unordered*
+`FrozenDictionary` (`ExpressionParser.cs:307-322`), so adding short keys to the global map
+risks `Trigger:0:Form change` dispatching to `CreateForm`. A separate map cannot collide with
+player-scope keys at all. New keys are colon-terminated regardless.
+
+| kind | keys |
+|---|---|
+| int | `Level` (avg of `MinLevel`/`MaxLevel`), `MinLevel`, `MaxLevel`, `Rank`, `NpcId`, `SpawnCount`, `PlayerLevel` |
+| bool | `Elite` (`Rank > 0`), `Hostile`, `Skinnable` |
+| parameterized | `Type:` (`CreatureType`, `SharedLib/Data/Creature.cs:23-39`), `Name:` (substring), `Faction:`, `Family:` |
+
+`Type:` copies `CreateTargetType` (`RequirementFactory.cs:1112-1134`) verbatim — same
+`Enum.Parse<CreatureType>(..., true)`, same enum — so `Target:Humanoid` in a combat
+requirement and `Type:Humanoid` in a mob filter stay consistent. Each `Requirement` still
+supplies `HasRequirement` + `LogMessage` (`Core/Requirement/Requirement.cs`); the delegates
+close over a mutable cursor holding the candidate `Creature`, and the generator sets the
+cursor and evaluates per row. ~3k creatures per map, once — free.
+
+### Base filter and default
+
+A base filter applies underneath *every* expression and is not user-overridable, mirroring
+`DangerZoneGenerator/Program.cs:157-172`: `NpcFlag == None`, `MinLevel > 0`, `Type` not
+`Critter`/`Totem`/`NonCombatPet`, plus a hostility check against the player faction (the
+inverse of `AreaDB.FriendlyToPlayer`, `Core/Database/AreaDB.cs:234-256`).
+
+With `Mobs` empty the default is every hostile, non-elite creature whose
+`[MinLevel, MaxLevel]` overlaps `[PlayerLevel - 3, PlayerLevel + 2]`, matching the spirit of
+`ClassConfiguration.NPCMaxLevels_Below/Above`.
+
+---
+
+## 5. Spawn polygon
+
+Not a convex hull — a **cell occupancy mask** at `ChunkReader.CHUNKSIZE` (33.33 yd), the same
+resolution `AreaGrid` already uses:
+
+1. Take every spawn point of every selected creature that lies inside the target zone
+   (`AreaGrid.GetAreaId(x,y) == areaId` when the grid is baked; otherwise
+   `SubZoneArea.Contains` from `Json/subzones/<Exp>/<mapId>.json`, which is populated for all
+   seven clients — `area_grid/precata` only has Azeroth + Expansion01).
+2. Mark its cell; dilate the mask by `ceil(PaddingYards / CHUNKSIZE)` cells.
+3. Drop connected components below a spawn-count floor, which kills lone stragglers across
+   the map.
+
+That gives a naturally concave region, O(1) containment, and no hull geometry to debug. It
+also handles "bounding box" better than a box would: Northshire Valley's spawns form an L, and
+a box routes the player through the abbey.
+
+---
+
+## 6. Mode `Wander`
+
+Per lap, produce `Stops` waypoints. **Every point must be on the navmesh by construction, not
+by after-the-fact testing** — let Detour pick it.
+
+Add `NavmeshPathfinder.TrySnapWalkable(Vector3 wowPointHint, out Vector3 wowPoint, out long polyRef)`
+— a small addition over the already-present private `query` + `filter`
+(`PPather/Navmesh/NavmeshPathfinder.cs:99`), reachable via the existing public
+`PPatherService.NavmeshPathfinder` property (`:87`). It runs `FindNearestPoly` with a
+deliberately short vertical extent, then `ClosestPointOnPoly`.
+
+The caller draws the offset from its own seeded RNG and asks for that point to be snapped.
+**This is not the original design.** The first implementation used
+`FindRandomPointWithinCircle`, letting Detour choose — which is the obvious approach and is
+what `ApplyJitter` (`:865-888`) does. It had to be replaced; see §15.
+
+**On-mesh is not enough — a rooftop, a ledge and a tree canopy are all walkable polys.** They
+are simply not *connected* to the floor the route lives on. The codebase already states the
+rule at `NavmeshEndpointResolver.cs:69-73`: "a position with no trustworthy height can land on
+a roof or ledge above the floor the caller meant, **and only connectivity can tell those
+apart**." `PPatherService.cs:580-586` carries the same warning for raw `z=0` callers.
+
+So each candidate passes three gates, cheapest first:
+
+* **Anchor.** Pick a random occupied cell from the mask; anchor on a real spawn point inside
+  it. Its z comes from the emulator dump, so unlike a raw `z=0` query it is a *trustworthy*
+  height — which is what lets the two gates below work at all.
+* **Gate 1 — on-poly.** Draw a uniform offset within one cell radius of the anchor
+  (`sqrt(u)` on the radius so the draw is uniform over the disc, not clustered at the
+  centre), then `TrySnapWalkable` that point. The result is on the mesh by construction,
+  and unlike letting Detour pick, the seed genuinely determines it.
+* **Gate 2 — vertical band (free).** Reject when `|sample.Z - anchor.Z| > MaxVerticalDelta`.
+  A roof, canopy or ledge poly sits meters above the ground spawn that anchored it, so this
+  costs zero queries and kills the common cases before spending anything. Default from the
+  existing `NavmeshEndpointResolver.PreferZToleranceYd = 5f` (`:55`), which encodes exactly
+  this "same floor as the surface I trust" notion. Also re-check the mask and
+  `AreaGrid.GetAreaId` here.
+* **Gate 3 — connectivity, as an O(1) lookup.** No pathfinding in the sampler loop:
+
+  ```csharp
+  accept = connectivity.ComponentOf(candidateRef) == routeComponent;   // array read
+  ```
+
+  `TrySampleWalkable` already has the `polyRef` in hand
+  (`FindRandomPointWithinCircle`'s `out long randomRef`). Same component means a path provably
+  exists — that is what "connected component" means — so this is not an approximation of the
+  reachability test, it *is* the reachability test, and it is exactly what separates a
+  disconnected porch roof or bridge deck from the ground the route lives on.
+
+* Reject candidates closer than a min-spacing to an already-chosen stop, so the route spreads.
+* Bounded resample attempts. If the budget runs out, emit the shorter route rather than a
+  broken one, and log the shortfall.
+
+**No unbaked fallback.** If the continent has no baked navmesh, `TrySampleWalkable` cannot
+guarantee anything — generation fails, logs the missing cache dir (`GetQueryNavmesh` already
+emits "No baked navmesh for {Continent}", `PPatherService.cs:1116-1120`), and sets
+`Generated = false` so the path drops out of GOAP. Snapping to raw spawn coordinates was
+considered and rejected: an emulator spawn is standable in-game but carries no guarantee it is
+on *our* baked mesh, which is precisely the guarantee being asked for.
+
+`FollowRouteGoal.RefillWaypoints` (`Core/Goals/FollowRouteGoal.cs:375`) asks the generator for
+a fresh route each lap instead of reversing the old one, so the bot never retraces a line.
+`PathThereAndBack` is ignored in this mode.
+
+---
+
+## 7. Mode `Loop`
+
+Deterministic and a drop-in replacement for a recorded file. Unlike `Wander` it takes no
+seed at all: which cells are densest, how far apart stops must be, and the walking distance
+between them are all fixed by the zone and the mob filter, so there is nothing left to
+randomise.
+
+* `SpawnPolygon.DensityPeaks` returns the densest occupied cells, at least
+  `MinSpacingYards` apart, densest first - the mean spawn position per cell, greedily
+  selected. Deterministic by construction; ties break on position so dictionary enumeration
+  order cannot leak in.
+* Each peak passes **the same gates 1-3** as `Wander`. A centroid is an average, so it can
+  land off-mesh, on a roof, or across a wall even when every spawn that formed it is fine.
+* `BuildCostMatrix` measures the **walking** distance between every surviving pair through
+  `IPPather.FindWorldRoute` - the same call `Densify` will make later, so the tour is
+  optimised against the route that actually gets walked. A pair the pather cannot answer
+  falls back to euclidean rather than being treated as unreachable; gate 3 already
+  established they share a component, so a failure there is the pather giving up, not a wall.
+* `TourSolver` orders them: nearest-neighbour, then 2-opt until no improving segment
+  reversal remains. Measured: Northshire 918 → 800 yd, Elwynn over 12 stops 6367 → 4613 yd.
+  A self-crossing is always longer than the uncrossed alternative, so removing them is
+  exactly what 2-opt does.
+* The tour is closed explicitly - the first stop is appended again - so the leg home is
+  pathed and walked like any other. `PathThereAndBack: false` is the correct pairing.
+
+**Deviation from the original plan.** This does not reuse
+`Utilities/WowheadDB_Extractor/TSP/GeneticTSPSolver.cs`. That solver derives its distances
+internally from `Vector2` positions via Euclidean and draws from a `static readonly Random`.
+Route generation needs the opposite of both - cost is a navigable path length, and a tour
+must reproduce exactly - so reusing it would have meant replacing its distance function, its
+randomness and its point type, which is most of it. At the handful of stops a grind route
+carries, 2-opt is effectively optimal and needs no tuning.
+
+## 8. Connectivity
+
+### 8a. `NavmeshConnectivity` — the gate-3 primitive
+
+**Build.** One BFS/union-find over polygon adjacency, walking `DtLink`s through
+`NavmeshTileCache.NavMesh` (public at `:113`, with its `ReaderWriterLockSlim` at `:114` —
+build under the read lock). Every poly gets a component id.
+
+**Key on `(tileX, tileZ, polyIndex)`, never on the raw `polyRef`.** A ref encodes a tile
+*slot* index and a salt, both of which change when the LRU evicts a tile and later reloads
+it — which happens routinely mid-sampling. Keying on the ref made lookups start missing
+partway through a run, which reads as "unreachable" and silently shortens or reshapes the
+route. `DtDetour.DecodePolyIdPoly` plus the tile header's `x`/`y` give the stable identity;
+links are translated the same way, since a link can cross into another tile.
+
+**Scope it to the route, not the continent.** The spawn polygon's world AABB converts to a
+tile range via `NavmeshCoords.GetTileIndex` (`:40`); flood only those tiles plus a one-tile
+skirt. `NavmeshSettings.TileWorldSize = 133.33f`, so a ~1000 yd zone is ~60 tiles — a few tens
+of thousands of polys, single-digit milliseconds, once.
+
+**Cache and invalidate.** Key by continent + tile range. Tiles bake on demand and a newly
+baked tile can join two components, so stamp the cache with
+`NavmeshTileCache.TilesBakedThisSession` (`:131`) and rebuild when it moves.
+
+```csharp
+public int ComponentOf(long polyRef);              // O(1)
+public bool SameComponent(long a, long b);
+```
+
+**Why not `FindWorldRoute` per candidate:** it runs full A* plus `FindStraightPath`,
+smoothing, jitter and edge-margin passes (`NavmeshPathfinder.FindPath`, `:267`) — hundreds of
+times the work, to answer a yes/no the component map answers with an array read. Reserve the
+real pathfinder for `Loop`'s distance matrix, where the *length* is what is wanted.
+
+**`Wander` regeneration therefore does no pathfinding at all.** It runs from
+`RefillWaypoints` on the bot thread, so its whole budget is the cached component map plus
+`Stops` array reads — no A*, no contention with `Navigation`'s requests on `PathFinderThread`.
+The component build is paid once and survives across laps.
+
+### 8b. `RouteValidator` — `Loop`'s distance matrix
+
+`Loop` runs at session build time with the pather to itself, so it can afford real navigable
+lengths where `Wander` cannot. `GetPathSettings` resolves lazily inside `CreateSession`
+(`Core/BotController.cs:463-500`), before the bot loop starts — and `PPatherService` is a
+non-reentrant singleton with a two-call `SetLocations`/`DoSearch` protocol that `Reset()`s on
+continent change (`PPather/Search/PPatherService.cs:305-307`), which is exactly why this must
+not be spread across threads.
+
+* Filter every candidate stop through gates 1-3 first, so no unreachable stop reaches the
+  matrix.
+* `pather.FindWorldRoute(uiMapId, startIndoors: false, from, to)`
+  (`Core/PPather/IPPather.cs:20`) for the surviving pairs; leg length feeds the TSP.
+* Validate the chosen tour including **the closing leg, last → first** — the one a euclidean
+  tour most often gets wrong and the one `PathThereAndBack: false` walks every lap. An empty
+  result here should be impossible after gate 3; if it happens the component map and the live
+  pather disagree, which is a bug to chase, not a case to silently drop.
+* **Log any stop that was dropped**, with coordinates. A silently 40%-culled route reads as
+  "the generator works" when it does not. If drops exceed `Stops / 3`, set `Generated = false`.
+* The dense leg points are discarded — `Navigation` re-requests during the walk anyway, and
+  `PathSettings.Path` stays a waypoint list exactly like a recorded file.
+
+**Gate on the local pather.** `RemotePathingAPI` (V1) turns a 429 rate-limit into an *empty
+route* (`PathingAPI/CLAUDE.md:34-38`), indistinguishable from "unreachable" — a batch
+validation loop through it would cull a perfectly good route. Validate only when `IPPather` is
+`LocalPathingApi`; otherwise skip and log that it was skipped.
+
+---
+
+## 9. Seed
+
+* `ClassConfiguration.Seed` (`int?`, default `null` → `Random.Shared.Next()` drawn once at
+  session start and **logged**, so a run can be reproduced after the fact).
+* `RouteGenSettings.Seed` overrides per path.
+* Derive each generation's `Random` from `RouteSeed.For(globalSeed, path.Id, lap)` so laps
+  differ but the whole run replays identically. **That mix must not be `HashCode.Combine`** —
+  see §15.
+* The same seed fills `PPatherService.PathJitterSeed` (`:97`), which is currently declared but
+  never set from config — closing that makes jittered legs reproducible too.
+
+---
+
+## 10. `PathEnd_{Id}` / `PathDist_{Id}`
+
+`RequirementFactory` binds both families per path **id**, in its constructor
+(`ClassConfiguration.Initialise:220`), which runs *before* `GoalFactory.GetPathSettings` ever
+loads a route:
+
+```csharp
+private void BindPathSettingsIntVariables(PathSettings[] paths)
+{
+    ...
+    intVariables.TryAdd($"{prefixKey}_{suffix}", settings.GetDistanceXYFromPath);
+    InitPerKeyAction(prefixKey, suffix);
+    Init(settings);
+}
+```
+(`RequirementFactory.cs:720-735`; the bool twin `PathEnd_{Id}` / `PathEnd_Any` at `:633-662`)
+
+Both bind **delegates over the instance**, not values — `GetDistanceXYFromPath`
+(`PathSettings.cs:193`) reads `Path` at call time, and `PathFinished` calls the `Finished` func
+that `FollowRouteGoal` overwrites at `:124`. A `Path` assigned later, or replaced every lap by
+the wander generator, is therefore picked up with no rebinding. **Nothing here needs
+reordering, and it should not be "fixed" to bind eagerly.**
+
+Two consequences that do need handling:
+
+* **`Id` must stay stable.** `settings.Init(globalTime, playerReader, i)` assigns
+  `Id = Id == default ? i : Id` (`PathSettings.cs:69`) and `ClassConfiguration.cs:215` enforces
+  uniqueness. Generated entries go through the same loop, so `PathEnd_2` / `PathDist_2` mean
+  the same thing whether path 2 is a file or a query. A profile can therefore already use
+  `"PathEnd_0"` to react to a generated wander lap completing — the same signal
+  `Navigation_OnDestinationReached` uses to trigger regeneration.
+* **Generation failure must not leave a live goal with an empty route.** With
+  `Path.Length == 0`, `GetDistanceXYFromPath` returns `int.MaxValue` (`PathSettings.cs:195`)
+  and `PathFinished` is permanently true — a silently dead path that still passes `CanRun()`.
+  A `Generated` flag on `PathSettings`, ANDed into `CanRun()` (`:159`), makes a path whose
+  query yielded nothing drop out so GOAP falls through to the next entry. That reuses the
+  existing priority ladder instead of adding a new requirement keyword.
+
+---
+
+## 11. Failure modes & known gaps
+
+* **Two scopes, one syntax.** `"Level < 5"` is valid in both `Requirements` (player) and
+  `Generate.Mobs` (creature) and means different things. Mitigations: the creature table has no
+  player-only names except the explicit `PlayerLevel`, so a misplaced `Health%` fails at parse
+  time rather than silently; and the log line for a generated path prints the resolved filter
+  and the matched creature count, so "0 mobs matched" is visible immediately.
+* **Same component ≠ nearby.** Connectivity proves a path exists, not that it is short — a
+  candidate across a river with a bridge 600 yd away passes gate 3. The z-band and min-spacing
+  cover the common cases; `Loop` additionally reorders by real walking distance. If wander
+  routes still show long detours in practice, add a max-spacing reject before adding anything
+  cleverer.
+* **Navmesh coverage is a hard prerequisite.** Both the on-mesh guarantee and leg validation
+  need baked tiles for the target continent; without them generation fails loudly instead of
+  degrading. This is a behaviour change for users on an unbaked install — the log line must
+  point at `--bake=<Continent>`.
+* **`area_grid/precata` has only Azeroth + Expansion01.** Kalimdor/Northrend on
+  vanilla/tbc/wrath fall back to `SubZoneArea` AABBs, which overlap heavily — expect a looser
+  zone boundary there. Cata/MoP, the clients that motivate this, are fully baked.
+* **Spawn dumps are emulator data.** Coverage varies per client dir; `npcspawnlocations/som`
+  has only maps 0 and 1. Generation must degrade to a clear log line, not an exception, when
+  the file is missing (`AreaDB.ReadJsonOrNull`, `:87-100`, is the precedent).
+* **Fileless paths break two assumptions**: the `File.Exists` guard at
+  `ClassConfiguration.cs:199`, and `Path.GetFileNameWithoutExtension(pathSettings.FileName)`
+  used for the goal name and the synthetic `KeyAction` label (`FollowRouteGoal.cs:93, 115-121`).
+  `Generate.Name` covers the latter.
+
+---
+
+## 12. What we explicitly do NOT do
+
+* **No new requirement keywords in the global player-scope map.** The creature scope is a
+  separate `ExpressionParser` instance with its own tables.
+* **No convex/concave hull geometry.** A cell mask is concave for free and O(1) to test.
+* **No offline generator utility in v1.** Runtime generation is needed anyway for per-lap
+  wander; a CLI that dumps the same generator's output is a later convenience, not a
+  prerequisite.
+* **No changes to recorded-route behaviour.** `PathFilename` entries take exactly the path they
+  take today.
+* **No dry-spot timer in v1** - no per-stop time cap before moving on.
+
+---
+
+## 13. Phasing
+
+1. `CreatureRequirementFactory` (the creature scope) + `NavmeshConnectivity` +
+   `NavmeshPathfinder.TrySampleWalkable` + `NpcSpawnDB` + `SpawnPolygon` + `Wander` + `Seed`,
+   with the config plumbing and the `File.Exists` fix. Connectivity is in phase 1, not
+   deferred — gate 3 is what makes `Wander` correct, so shipping the sampler without it ships
+   rooftop routes.
+2. `Loop`: `RouteValidator`, the `GeneticTSPSolver` move, clustering, the navigable-length
+   distance matrix, tour validation including the closing leg, and the drop/repair policy.
+3. **Done for README**; `CoreTests routegen` renders every generated path in a profile to an
+   SVG over the minimap tiles (`--profile`, `--output`), which is how a route is judged while
+   iterating. It reports rather than asserts - it prints
+   spacing, vertical spread, area-id histogram and route hashes, and is driven by hand
+   (`CoreTests routegen --mode Loop ...`). Turning those reports into assertions is the
+   remaining gap.
+
+---
+
+## 14. Verification
+
+1. `dotnet build MasterOfPuppets.sln`.
+2. **Expression scope.** Parse `"Type:Humanoid && Level <= PlayerLevel + 2 && !Elite"` and
+   assert the matched creature set against a known zone. Then assert `"Health% > 50"` in
+   `Generate.Mobs` throws at parse time (`ExpressionParser.cs:176-178`), and that
+   `"Type:Humanoid"` in `PathSettings.Requirements` does the same — the two tables must not
+   leak into each other.
+3. Add a `Generate` entry to a scratch copy of `Json/class/_/Warrior_1-10--------------.json`
+   and run `dotnet run --project BlazorServer`. The Blazor route view renders `MapRoute()` →
+   `OriginalMapPath`, so the generated loop is visible on the Leaflet map with no UI change.
+   Confirm it sits on the Northshire wolf/kobold spawns and not inside the abbey.
+4. Fix `Seed`, run twice, diff the logged waypoint arrays — byte-identical in `Loop` mode,
+   identical per-lap in `Wander`.
+5. Repeat against a `mop` install pointed at Elwynn: same profile entry, different client,
+   valid route. This is the acceptance test for the re-recording problem.
+6. **Rooftop test.** Generate in a zone with stacked geometry — Goldshire (inn roofs, bridge)
+   or Northshire (abbey) — and assert no waypoint lands on a roof. Force the failure first by
+   disabling gate 2, confirm roof points appear, then re-enable and confirm they do not. A gate
+   never observed rejecting anything is a gate that may not be wired up.
+7. **Time the regeneration.** Log elapsed ms for a `Wander` lap regeneration; it should be
+   dominated by nothing (array reads), with the one-off `NavmeshConnectivity` build reported
+   separately. If a lap boundary shows an A*-shaped cost, gate 3 is falling through to the
+   pathfinder.
+8. `PathEnd_0` / `PathDist_0` against a generated path: distance falls as the player walks it,
+   `PathEnd` flips at lap end. Then break the query on purpose (`"Mobs": "Name:NoSuchMob"`) and
+   confirm the path drops out of GOAP instead of running empty.
+9. Drive it live for several laps. `Navigation` failing to path between two generated waypoints
+   should now be impossible — if it happens, the component map and the live pather disagree.
+10. `dotnet test`.
+
+---
+
+## 15. Defects found while implementing phase 1
+
+Both were caught by the offline harness (`CoreTests routegen`) comparing a route hash across
+separate processes, and both had produced plausible-looking output that was quietly wrong.
+
+### 15.1 `HashCode.Combine` is randomized per process
+
+`RouteSeed.For` originally used `HashCode.Combine(sessionSeed, pathId, lap)`. `System.HashCode`
+seeds itself randomly at process start as a hash-flooding defence, so the same
+`ClassConfiguration.Seed` produced a different route in every session. Within one process it
+looked perfect — the "sample twice, compare" check passed — which is exactly why the harness
+has to compare across processes.
+
+Replaced with an explicit splitmix64 finalizer. Any future "combine some ints into a seed"
+must avoid `HashCode.Combine` for the same reason.
+
+### 15.2 Poly refs are not stable identities
+
+Gate 3 looked the candidate's `polyRef` up in the component map. Refs embed a tile slot and
+salt, so once the tile cache evicted and reloaded a tile, every lookup for it missed and
+returned "unreachable". The route then depended on which tiles happened to be resident.
+Fixed by keying the map on `(tileX, tileZ, polyIndex)`.
+
+### 15.3 Sparse waypoints defeat Navigation's trivial-hop heuristic
+
+`Navigation.RefillRouteToNextWaypoint` pathfinds only when
+`distance > MaxDistance || distance > AvgDistance * 2`, and `AvgDistance` is the route's own
+mean point spacing (`SetWayPoints`). The intent is "a hop no longer than the gaps in this
+route is not worth a pathfinder call" — sound for a recorded route of hundreds of points a
+few yards apart, where the threshold lands around 15 yd.
+
+A generated route is 8 anchors across a subzone, so `AvgDistance` is ~60 yd and the threshold
+~120 yd, under `MaxDistance`. Every leg therefore counted as trivial: the bot turned toward
+the next anchor and walked blind. Observed after a class-trainer visit — it set off straight
+through the abbey and ended in `StuckDetector`, with no `Pathfinder`/`Spline loaded` line in
+the log at all.
+
+Fixed with `Navigation.SparseWaypoints`, set by `FollowRouteGoal` when `Generate != null`,
+which pins `AvgDistance` to `OutDoorMinDistance` so every leg is pathfound.
+
+Deliberately **not** changed: the heuristic itself. Any short hand-authored route has the same
+exposure, and an absolute ceiling on the trivial-hop test would be the general fix — but that
+alters pathing for every existing profile, so it is a separate decision.
+
+### 15.4 Sparse anchors starve target acquisition
+
+The first implementation emitted the stops themselves as the route - a handful of anchors
+across the zone. That is how hotspot-style grind engines work, because they hunt *around* an
+anchor. This bot does not: it acquires targets by cycling Tab **while walking the path**, so a
+300 yd leg between two anchors is dead travel past every mob beside it.
+
+Observed on Ammen Vale with legs of 291, 191, 170, 511 and 277 yd. `Stops` now means control
+points, and `Densify` paths each consecutive pair and emits those points, so a route is
+hundreds of waypoints a few yards apart - the shape the rest of the bot is tuned for. In
+Northshire, 8 stops becomes 365 waypoints.
+
+That required serialising the pather: `SetLocations`/`DoSearch` is a stateful two-call
+protocol on a non-reentrant singleton, and until now the only caller was Navigation's
+`PathFinderThread`, so it was serialized by accident. Generation runs on the bot thread.
+`LocalPathingApi` now locks around both calls - including `SearchFrom`, which
+`FindMapRoute` read after the search and which belongs to whichever search ran last.
+
+### 15.5 What the vertical check actually proves
+
+The harness reports `|z - nearest spawn z|`, which is a *proxy* for gate 2, not gate 2
+itself: gate 2 compares against the spawn that anchored the sample, which the reporter no
+longer knows. A large dz alone means nothing on a hillside. The signal is a large dz at a
+**small** dxy — ground that close should be the same height. Elwynn produced one such stop
+(21.9 yd up, 3.0 yd away) before 15.1/15.2 were fixed; none after.
+
+## 16. Verified so far
+
+`dotnet build MasterOfPuppets.sln` clean. The solution contains no test projects, so
+`dotnet test` is a no-op; `CoreTests` is the harness.
+
+```
+CoreTests routegen --exp som --subzone "Northshire Valley" --mobs "Name:Wolf || Name:Kobold" --level 4
+CoreTests routegen --exp <som|tbc|wrath|cata|mop> --zone "Elwynn Forest" --mobs "Type:Humanoid && !Elite" --level 8
+```
+
+* **Expression scope** — 7 creature expressions parse; `Health% > 50`, `Race:Human` and
+  `BagFull` are all rejected. The two tables do not leak into each other.
+* **Northshire Valley** (som) — 5 creature types, 100 spawns, 120 cells, 10368 polys in 176
+  components. The 8 generated stops land within ~15 yd of the positions a human picked when
+  hand-recording the same area, which is independent confirmation that the spawn data lands
+  on the same ground.
+* **Determinism** — identical route hash across separate processes, per zone and per client.
+  Consecutive laps differ.
+* **Every client** — the same profile entry generates a valid route on som, tbc, wrath, cata
+  and mop, over each client's own spawn set and geometry. This is the acceptance test for the
+  re-recording problem.
+* **Vertical** — 0 suspect stops in Elwynn, Northshire and Goldshire.
+
+Still unverified: anything requiring the live bot — the GOAP fallthrough when `Generated` is
+false, per-lap regeneration through `FollowRouteGoal.RefillWaypoints`, and the Blazor preview
+page rendering on the Leaflet map.
+
+## Appendix — relevant existing code
+
+| concern | file:line |
+|---|---|
+| Path config model | `Core/ClassConfig/PathSettings.cs:12-30, 33-45, 47-63, 72-117, 159-191` |
+| Class config model / init | `Core/ClassConfig/ClassConfiguration.cs:55-62, 136-317` (`File.Exists` guard at `:199`) |
+| Path file → `Vector3[]` | `Core/GoalsFactory/GoalFactory.cs:401-452` |
+| Goal registration / cost ladder | `Core/GoalsFactory/GoalFactory.cs:368-391` |
+| Route goal | `Core/Goals/FollowRouteGoal.cs:50-56, 115-124, 375-485` |
+| Waypoint consumption | `Core/GoalsComponent/Navigation.cs:177-313, 566-642` |
+| Requirement compilation | `Core/Requirement/RequirementFactory.cs:371-443, 633-662, 720-735` |
+| Requirement keyword map | `Core/Requirement/RequirementFactory.cs:120-137`; `Race` handler `:1092-1110`; `Target:` handler `:1112-1134` |
+| Expression parser / tokenizer | `Core/RPN/ExpressionParser.cs:31-78, 183-336`; `Core/RPN/ExpressionTokenizer.cs:66-196` |
+| Goal selection / switching | `Core/GOAP/GoapPlanner.cs:36-77`, `Core/GOAP/GoapAgent.cs:189-198, 236-293` |
+| Creature metadata | `SharedLib/Data/Creature.cs:5-39`; `Core/Database/CreatureDB.cs:17-19` |
+| Spawn data + hostility | `Core/Database/AreaDB.cs:44-150, 165-233, 234-256` |
+| Coordinate conversion | `SharedLib/Data/WorldMapAreaDB.cs:79-124, 162-201`; `PPather/Navmesh/NavmeshCoords.cs:21-63` |
+| Subzone AABB | `SharedLib/Data/SubZoneArea.cs:6-24` |
+| Area grid | `PPather/Navmesh/AreaGrid.cs:28, 54-119` |
+| Navmesh query surface | `PPather/Navmesh/NavmeshPathfinder.cs:99, 234, 267, 855-888`; `NavmeshTileCache.cs:113-131` |
+| Endpoint resolver / roof rule | `PPather/Navmesh/NavmeshEndpointResolver.cs:55, 69-113` |
+| Pather facade | `PPather/Search/PPatherService.cs:87, 94-97, 305-307, 556, 996, 1072, 1130-1150` |
+| Bot-side pather interface | `Core/PPather/IPPather.cs:9-23` |
+| TSP prior art | `Utilities/WowheadDB_Extractor/TSP/GeneticTSPSolver.cs:17, 45, 60` |
+| Spawn/creature/subzone join prior art | `Utilities/DangerZoneGenerator/Program.cs:142-172` |
+| Data paths | `DataConfig/DataConfig.cs:25, 33, 35, 47, 145, 148` |
+| Docs mandate | `CLAUDE.md:29`; `Core/CLAUDE.md:31-33` |


### PR DESCRIPTION
## Runtime route generation, and the combat fixes found while testing it

Two things in one pack. The headline feature is routes built at runtime from spawn data
instead of hand-recorded waypoint files. The rest are movement and combat fixes that
surfaced while grinding on those routes — several of them are their own bug, so they are
separate commits.

### The problem the feature solves

A class profile had to name a recorded waypoint file. That file went stale the moment the
character outlevelled the zone it was drawn for, so profiles were rewritten every couple of
levels — usually just because the trainer had new spells and the old route no longer
matched where the character should be.

`PathSettings.Generate` replaces the filename with a query:

```json
"Generate": {
  "Subzone": "Ammen Vale",
  "Mobs": "Name:Vale Moth || Name:Volatile Mutation",
  "Focus": "Balanced",
  "Mode": "Wander"
}
```

The route is built from where those mobs actually stand, in the running client's own spawn
data. `Wander` re-samples anchors every lap, so movement no longer traces the same line —
which also makes it look far less mechanical.

Combined with `PathsFilenames`, one profile now covers levels 1–10 for every race of a
class: eight starting-zone groups, each keyed on `Race`, and the character matches the one
it belongs in.

Full design writeup: [`docs/generated-routes-design.md`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/docs/generated-routes-design.md).

### Commits

| commit | what it brings | main files |
|---|---|---|
| `feat(Path)` | route generation core — spawn polygon, sampling, connectivity, seeding | [`RouteGenerator`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Core/Path/Generate/RouteGenerator.cs) · [`SpawnPolygon`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Core/Path/Generate/SpawnPolygon.cs) · [`RouteSeed`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Core/Path/Generate/RouteSeed.cs) · [`NavmeshConnectivity`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/PPather/Navmesh/NavmeshConnectivity.cs) · [`RouteGenSettings`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Core/ClassConfig/RouteGenSettings.cs) |
| `feat(Frontend)` | route generator page, preview a query on the Leaflet map | [`RouteGeneratorPage.razor`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Frontend/Pages/RouteGeneratorPage.razor) |
| `feat(CoreTests)` | `routegen` harness — render a whole profile with no game running | [`Test_RouteGen`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/CoreTests/routegen/Test_RouteGen.cs) · [`CoreTests/CLAUDE.md`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/CoreTests/CLAUDE.md) |
| `feat(ClassConfig)` | `PathsFilenames` groups + the eight starting zones | [`PathSettings`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Core/ClassConfig/PathSettings.cs) · [`Json/path/`](https://github.com/Xian55/WowClassicGrindBot/tree/dev/Json/path) |
| `feat(Json)` | nine 1–10 class profiles | [`Json/class/`](https://github.com/Xian55/WowClassicGrindBot/tree/dev/Json/class) |
| `feat(Navigation)` | `SparseWaypoints` so generated legs get pathfound | [`Navigation`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Core/GoalsComponent/Navigation.cs) |
| `fix(Approach)` | melee overshoot, probe blocking, target zig-zag | [`ApproachThrottle`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Core/GoalsComponent/ApproachThrottle.cs) · [`ApproachTargetGoal`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Core/Goals/ApproachTargetGoal.cs) · [`PullTargetGoal`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Core/Goals/PullTargetGoal.cs) |
| `fix(Combat)` | recover from `ERR_BADATTACKFACING` instead of giving up | [`ReactCastError`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Core/GoalsComponent/ReactCastError.cs) |
| `fix(StuckDetector)` | rate limit the pre-ladder jump | [`StuckDetector`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Core/GoalsComponent/StuckDetector.cs) |
| `fix(Input)` | hold jump to surface while drowning | [`ConfigurableInput`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Core/Input/ConfigurableInput.cs) |
| `feat(Requirement)` | `RangedWeapon:` — tells arrows from bullets | [`RequirementFactory`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Core/Requirement/RequirementFactory.cs) · [`README`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/README.md#rangedweapon-requirements) |

### New starting-zone PathSettings groups

Eight group files under `Json/path/`, each a bare `PathSettings` array pulled in by name
rather than pasted into every profile that levels there:

| group | zone | subzone |
|---|---|---|
| [`1-8_Human_Northshire.json`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Json/path/1-8_Human_Northshire.json) | Elwynn Forest | Northshire Valley / Vineyards |
| [`1-8_Draenei_AmmenVale.json`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Json/path/1-8_Draenei_AmmenVale.json) | Azuremyst Isle | Ammen Vale |
| [`1-8_NightElf_Teldrassil.json`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Json/path/1-8_NightElf_Teldrassil.json) | Teldrassil | Shadowglen |
| [`1-8_DwarfGnome_Coldridge.json`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Json/path/1-8_DwarfGnome_Coldridge.json) | Dun Morogh | Coldridge Valley |
| [`1-8_OrcTroll_ValleyOfTrials.json`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Json/path/1-8_OrcTroll_ValleyOfTrials.json) | Durotar | Valley of Trials |
| [`1-8_Undead_Deathknell.json`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Json/path/1-8_Undead_Deathknell.json) | Tirisfal Glades | Deathknell |
| [`1-8_Tauren_RedCloudMesa.json`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Json/path/1-8_Tauren_RedCloudMesa.json) | Mulgore | Red Cloud Mesa |
| [`1-8_BloodElf_SunstriderIsle.json`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Json/path/1-8_BloodElf_SunstriderIsle.json) | Eversong Woods | Sunstrider Isle |

Each has three tiers — `Level < 3`, `< 5`, `< 8` — with the mob filter narrowing as the
character grows, and every entry keyed on `Race`. A profile lists all eight and the
character simply never matches the seven it does not belong in, so one file serves every
race of a class.

Mob names were checked against `creatures.json` and the map spawn tables rather than typed
from memory. That caught real errors: `Wretched Zombie` has zero spawns on its map,
`Burning Blade Neophyte` is level 9-10, `Bristleback Thornweaver` is level 18-19. It also
caught **Camp Narache**, the obvious choice for Tauren, holding exactly **one** spawn — the
camp is the village, the mobs are on **Red Cloud Mesa** around it, which holds 216. That
one would have looked fine in a log and been useless in game.

`Name:` is a substring match, which matters more than it looks: `Name:Mottled Boar` also
catches *Dire* (6-7) and *Elder* (8-9), and `Name:Bristleback` catches Thornweaver at 18.
The level guards on those entries are load-bearing, not decoration.

### New 1-10 class profiles

Nine profiles, one per class, replacing the per-level ladder — this is what removes the
rewrite-every-two-levels problem:

[`Warrior`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Json/class/Warrior_1-10.json) ·
[`Warlock`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Json/class/Warlock_1_10.json) ·
[`Mage`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Json/class/Mage_1-10.json) ·
[`Priest`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Json/class/Priest_1-10.json) ·
[`Rogue`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Json/class/Rogue_1-10.json) ·
[`Hunter`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Json/class/Hunter_1-10.json) ·
[`Paladin`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Json/class/Paladin_1-10.json) ·
[`Shaman`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Json/class/Shaman_1-10.json) ·
[`Druid`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Json/class/Druid_1-10.json)

Death Knight is out of scope; it starts at 55.

Each amalgamates the existing low-level profiles for that class and gates every ability
trained after level 1 on a `Spell:SPELL_*` id array, so an untrained spell is skipped and
the same file works at level 1 and level 10. Each carries a header comment listing the key
bindings it expects.

Building them surfaced two things worth calling out:

- **Paladin** — `Paladin_10.json` builds its whole rotation on Seal of the Crusader, which
  is not trained until **22**. Copied as-is, a level 1 paladin would have had no seal at
  all. Rebuilt around Seal of Righteousness.
- **Priest** — combat Power Word: Shield was gated on `SPELL_RANK_PAIN` and on low *mana*.
  Shielding keyed to mana and gated on an unrelated spell looks like a copy-paste slip;
  changed to the shield spell and low health. Flag it if that was deliberate.

Hunter additionally restocks ammunition, which needed the new `RangedWeapon:` requirement —
a bow and a crossbow eat arrows, a gun eats bullets, and nothing in the expression language
could previously tell them apart. There is a money gate on the vendor trip so the bot does
not walk to a merchant it cannot pay.

### Relates to #827

Two independent faults, both reproduced from the reporter's own log.

**The warlock half is the real bug in that report.** `ReactCastError` was firing and
failing:

```
Unable to react to ERR_BADATTACKFACING - Fast turn with Interact -422.4484ms
React to ERR_BADATTACKFACING - Fast turn with Interact 358.9413ms
Unable to react to ERR_BADATTACKFACING - Fast turn with Interact -565.7295ms
```

Same code, three outcomes. The settle window was `SpellQueueTimeMs` — capped at 400 ms by
the CVar — while one sample costs 4 addon frames. At ~100 ms a frame the first sample eats
the whole budget, so the method can only ever time out. Success was decided by frame
latency, not by anything the player did. On failure it then inferred success from *"the
direction changed"*, which is true precisely while a turn is unfinished, and so skipped the
180° fallback in the one state that needs it. `CombatGoal` logging `Turning too fast!`
straight after each error confirms it: mid-spin, not stuck.

**The warrior half** — on top of the mob, in combat, never turning — is the approach
overshoot, fixed separately.

Worth being explicit for the reporter: the addon version in that issue is the template
default, so it is not evidence of anything, and "lag" was their inference rather than an
observation. The mechanism turned out to be addon frame latency against a fixed sample
budget, which is why it felt like lag.

### Measured

Same 9-minute grind, before and after:

| | before | after |
|---|---|---|
| Approach presses | flat ~400 ms | min 412 ms, median 1037 ms, none under 200 ms |
| Jump presses | ~70 ms for 45 s straight | 71 total, min gap 768 ms, median 7.1 s |
| Target zig-zag | A→B→A across re-entries | 24 probes, min spacing 7.9 s, none |
| Facing errors | 3, two unrecovered | 0 |

122 kills, no `Too long time`, no blacklist losses.

### Verification

- Solution builds clean in Release.
- All nine class profiles load through `HeadlessServer --loadonly`, which exercises the real
  `ClassConfiguration.Initialise` — requirement expressions compiled, `Usable:`/`CanRun:`
  resolved to named KeyActions (that one *throws*, so it would be a startup crash), and
  `PathsFilenames` groups read off disk.
- Route generation verified against the baked navmesh for all eight starting zones — every
  tier resolves with real spawns, from 39 up to 293.
- Spell id chains read out of [`Json/dbc/wrath/spells.json`](https://github.com/Xian55/WowClassicGrindBot/blob/dev/Json/dbc/wrath/spells.json), not from memory. That table
  repeats player spell names on mob abilities, so the noise clusters were filtered rather
  than taken wholesale.

### Known limits, deliberately not fixed here

- **Bar bindings still have to match the profile.** `Spell:` gating fixes anything trained
  after level 1, but nothing can stop a wrongly-bound key for an ability known *at* level 1
  — the bot presses the key and casts whatever is actually there. Those entries carry a
  `Cooldown` so it degrades to a slow retry instead of a hard loop. `ActionBarSlotValidator`
  already detects the mismatch and only logs it; turning that into a gate is a separate
  change.
- **`Food`/`Drink` on `=` and `-`.** A hunter session shows 42 × `Cast failed due
  CurrentActionNotDetected` and no successful eat. README already warns that main-bar slots
  11/12 are keyboard-layout dependent. The profiles inherit the existing convention;
  rebinding them is a follow-up.
- **`NO PLAN - nothing runnable`**, 19× in one session — in combat with no target, right
  after a loot and ClearTarget. Recovers on its own. Possibly a remaining hole from
  `d96e1121`.
- Loot reports failure when a fully-looted corpse stops being targetable, even though the
  loot succeeded. Cosmetic in the log, but the early return skips `CheckForCanGather`, so a
  skinnable corpse can be missed.

### Generated paths 
<img width="814" height="552" alt="23_Sunstrider_Isle_Wander" src="https://github.com/user-attachments/assets/73b3ea2a-7b58-40d5-bf9e-b60e083e16a9" />
<img width="725" height="717" alt="3_Ammen_Vale_Loop" src="https://github.com/user-attachments/assets/f2dcebaa-6683-4799-9f1d-69b0c715485a" />
<img width="537" height="657" alt="4_Ammen_Vale_Wander" src="https://github.com/user-attachments/assets/71316f66-8354-4c84-91f7-8b97a71921dd" />
<img width="725" height="747" alt="5_Ammen_Vale_Wander" src="https://github.com/user-attachments/assets/88ce8332-ff37-45d2-a4f2-6825ea53f359" />
<img width="490" height="354" alt="6_Shadowglen_Wander" src="https://github.com/user-attachments/assets/f9d80161-14b3-4796-892e-e119511f8230" />
<img width="566" height="365" alt="7_Shadowglen_Wander" src="https://github.com/user-attachments/assets/adabfe5f-20fa-4c88-87f5-2482b0d6b9ec" />
<img width="521" height="786" alt="8_Shadowglen_Wander" src="https://github.com/user-attachments/assets/53dfbbff-419b-497b-80b9-3a76e7f2c475" />
<img width="770" height="444" alt="9_Coldridge_Valley_Wander" src="https://github.com/user-attachments/assets/8483e027-5c8a-4be8-acc5-a242fead64ce" />
<img width="724" height="474" alt="10_Coldridge_Valley_Wander" src="https://github.com/user-attachments/assets/28785029-da81-4752-a646-d47b9e5c7777" />
<img width="770" height="567" alt="11_Coldridge_Valley_Wander" src="https://github.com/user-attachments/assets/ab8d76f7-dff1-45d1-8555-93cd8753df5e" />
<img width="409" height="566" alt="12_Valley_of_Trials_Wander" src="https://github.com/user-attachments/assets/2dd8b27c-c0aa-4f83-b785-1716158e7fab" />
<img width="535" height="795" alt="13_Valley_of_Trials_Wander" src="https://github.com/user-attachments/assets/0f3d0d4e-21f5-496c-9aac-a7e95bfcebc0" />
<img width="563" height="795" alt="14_Valley_of_Trials_Wander" src="https://github.com/user-attachments/assets/75a805e4-2a94-4e71-8f33-72a185ac2d9b" />
<img width="548" height="601" alt="15_Deathknell_Wander" src="https://github.com/user-attachments/assets/7a150625-d220-44b4-a1f4-7133bbe944c3" />
<img width="424" height="395" alt="16_Deathknell_Wander" src="https://github.com/user-attachments/assets/0294a0eb-22df-4012-9a89-341092a86a96" />
<img width="730" height="614" alt="17_Deathknell_Wander" src="https://github.com/user-attachments/assets/1a95d26f-af6e-496b-81a1-a47a4d8c231b" />
<img width="720" height="624" alt="18_Red_Cloud_Mesa_Wander" src="https://github.com/user-attachments/assets/e93cce16-cc7f-42a8-b166-48b03c7e987d" />
<img width="1139" height="757" alt="19_Red_Cloud_Mesa_Wander" src="https://github.com/user-attachments/assets/39b0a44b-b6ae-4bfa-a14e-1e23199d2041" />
<img width="1139" height="815" alt="20_Red_Cloud_Mesa_Wander" src="https://github.com/user-attachments/assets/ee866d40-b078-49f1-94da-66cc161c2d92" />
<img width="482" height="402" alt="21_Sunstrider_Isle_Wander" src="https://github.com/user-attachments/assets/6d8400fa-f0bb-4464-a802-ee4978a1110a" />
<img width="632" height="526" alt="22_Sunstrider_Isle_Wander" src="https://github.com/user-attachments/assets/2e6c8936-a338-4277-ae29-d1d408e7da23" />



---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


