### PR TITLE
Addon: [1.12.1] - Pet pull: register the pet's opener and detect a pet that cannot pull

### DIFF
--- a/Addons/DataToColor/BitCache.lua
+++ b/Addons/DataToColor/BitCache.lua
@@ -119,7 +119,17 @@ local bits3Cache = {
     friendsFrameOpen = false,       -- bit 15 (hooked)
     trainerFrameShown = false,      -- bit 16 (event-driven: TRAINER_SHOW/TRAINER_CLOSED)
     merchantFrameShown = false,     -- bit 17 (polled)
+    petCanPull = false,             -- bit 18 (polled)
 }
+
+-- { cost, type } for every pet action slot the pet spends power to cast.
+-- Rescanned on PET_BAR_UPDATE only: resolving a cost can cost a tooltip build on
+-- the oldest clients, and the poll below then needs one UnitPower read per entry
+-- rather than a full bar sweep every frame.
+local petSpellSlots = {}
+local petSpellSlotCount = 0
+
+local NUM_PET_ACTION_SLOTS = 10
 
 -- Track if cache has been initialized
 local cacheInitialized = false
@@ -240,6 +250,17 @@ local function UpdateFocusCache()
 end
 
 -- Update pet-related bits
+-- Cheap path into DataToColor:PetCanPull: the slot list below was scanned on the
+-- last PET_BAR_UPDATE, so this costs one API call per pet spell rather than the
+-- twenty a full bar sweep would cost on every poll.
+local function ComputePetCanPull()
+    if not bits1Cache.petIsAlive then
+        return false
+    end
+
+    return DataToColor:PetCanPull(petSpellSlots, petSpellSlotCount)
+end
+
 local function UpdatePetCache()
     local pet = DataToColor.C.unitPet
     local petVisible = UnitIsVisible(pet)
@@ -260,7 +281,7 @@ local function UpdatePetCache()
     -- Pet defensive mode
     if HasPetUI() then
         bits2Cache.petIsDefensive = false
-        for i = 1, 10 do
+        for i = 1, NUM_PET_ACTION_SLOTS do
             local name, _, _, isActive = GetPetActionInfo(i)
             if isActive and name == DataToColor.C.PET_MODE_DEFENSIVE then
                 bits2Cache.petIsDefensive = true
@@ -270,6 +291,29 @@ local function UpdatePetCache()
     else
         bits2Cache.petIsDefensive = false
     end
+
+    petSpellSlotCount = 0
+    if HasPetUI() then
+        for i = 1, NUM_PET_ACTION_SLOTS do
+            local cost, powerType = DataToColor:GetPetActionSpellCost(i)
+            if cost then
+                petSpellSlotCount = petSpellSlotCount + 1
+
+                -- Reused across rescans: the table is only ever read inside
+                -- PetCanPull, which never holds on to an entry.
+                local entry = petSpellSlots[petSpellSlotCount]
+                if not entry then
+                    entry = {}
+                    petSpellSlots[petSpellSlotCount] = entry
+                end
+
+                entry.cost = cost
+                entry.type = powerType
+            end
+        end
+    end
+
+    bits3Cache.petCanPull = ComputePetCanPull()
 end
 
 -- Update player combat state
@@ -406,6 +450,11 @@ local function UpdatePolledValues()
     -- Spell states - must be polled because bot checks these immediately after
     -- sending key presses, faster than START/STOP_AUTOREPEAT_SPELL events fire
     UpdateSpellStateCache()
+
+    -- Pet power drains and refills continuously and no event tracks slot
+    -- usability, so this is polled. Costs one call per pet spell, and none at
+    -- all without a pet.
+    bits3Cache.petCanPull = ComputePetCanPull()
 end
 
 --------------------------------------------------------------------------------
@@ -538,7 +587,8 @@ function DataToColor:Bits3Cached()
         (bits3Cache.spellBookFrameOpen and 2 or 0) ^ 14 +
         (bits3Cache.friendsFrameOpen and 2 or 0) ^ 15 +
         (bits3Cache.trainerFrameShown and 2 or 0) ^ 16 +
-        (bits3Cache.merchantFrameShown and 2 or 0) ^ 17
+        (bits3Cache.merchantFrameShown and 2 or 0) ^ 17 +
+        (bits3Cache.petCanPull and 2 or 0) ^ 18
 end
 
 --------------------------------------------------------------------------------

--- a/Addons/DataToColor/DataToColor.toc
+++ b/Addons/DataToColor/DataToColor.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Legacy Cataclysm 4.3.0)
-## Version: 1.12.0
+## Version: 1.12.1
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, cTimerBackport
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor_Classic.toc
+++ b/Addons/DataToColor/DataToColor_Classic.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic)
-## Version: 1.12.0
+## Version: 1.12.1
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor_TBC.toc
+++ b/Addons/DataToColor/DataToColor_TBC.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic TBC)
-## Version: 1.12.0
+## Version: 1.12.1
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/DataToColor_Wrath.toc
+++ b/Addons/DataToColor/DataToColor_Wrath.toc
@@ -2,7 +2,7 @@
 ## Title: DataToColor
 ## Author: FreeHongKongMMO
 ## Notes: Displays data as colors (Classic Wrath)
-## Version: 1.12.0
+## Version: 1.12.1
 ## RequiredDeps:
 ## OptionalDeps: Ace3, LibRangeCheck, LibClassicCasterino
 ## SavedVariables:

--- a/Addons/DataToColor/EventHandlers.lua
+++ b/Addons/DataToColor/EventHandlers.lua
@@ -575,8 +575,23 @@ function DataToColor:OnCombatEvent(...)
         end
     end
 
-    if DataToColor.playerPetSummons[sourceGUID] then
+    -- petGUID first, the way the damage taken branch above already does it.
+    -- playerPetSummons is only ever filled by a SPELL_SUMMON row seen live, and it
+    -- is emptied on every reinit, so a pet that was already out when the addon
+    -- loaded - login, /reload, a loading screen - is not in it and every point of
+    -- its damage used to be dropped here.
+    if sourceGUID == DataToColor.petGUID or
+        DataToColor.playerPetSummons[sourceGUID] then
         if playerDamageDone[subEvent] then
+            -- Same kill credit rule as the player's own damage above. Without it a
+            -- mob the pet killed on its own is never queued by unitDied, so the
+            -- corpse is never reported as lootable.
+            local targetGuid = UnitGUID(DataToColor.C.unitTarget)
+            if targetGuid == destGUID and not DataToColor:UnitIsTapDenied(DataToColor.C.unitTarget) and DataToColor.eligibleKillCredit[destGUID] == nil then
+                DataToColor.eligibleKillCredit[destGUID] = true
+                --DataToColor:Print("Kill Credit added(pet): ", destGUID)
+            end
+
             DataToColor.CombatDamageDoneQueue:push(DataToColor:getGuidFromUUID(destGUID))
         end
     end

--- a/Addons/DataToColor/Query.lua
+++ b/Addons/DataToColor/Query.lua
@@ -61,6 +61,8 @@ local SpellBookFrame = SpellBookFrame
 local FriendsFrame = FriendsFrame
 
 local HasPetUI = HasPetUI
+local GetPetActionInfo = GetPetActionInfo
+local UnitPower = UnitPower
 
 -- bits
 
@@ -201,7 +203,111 @@ function DataToColor:Bits3()
         (DataToColor:SpellBookFrameOpen() and 2 or 0) ^ 14 +
         (DataToColor:FriendsFrameOpen() and 2 or 0) ^ 15 +
         (DataToColor:TrainerFrameShown() and 2 or 0) ^ 16 +
-        (MerchantFrame:IsShown() and 2 or 0) ^ 17
+        (MerchantFrame:IsShown() and 2 or 0) ^ 17 +
+        (DataToColor:PetCanPull() and 2 or 0) ^ 18
+end
+
+-- Mode and command buttons are PET_MODE_* / PET_ACTION_* tokens. The name is the
+-- only GetPetActionInfo field at the same position on both layouts.
+local PET_TOKEN_PATTERN = "^PET_"
+local NUM_PET_ACTION_SLOTS = 10
+
+------------------------------------------------------------
+-- GetPetActionInfo return layout - both shapes are seven values, so the count
+-- cannot tell them apart and the client generation has to.
+--   Legacy 4.3.4 / 5.4.8:
+--     name, subtext, texture, isToken, isActive, autoCastAllowed, autoCastEnabled
+--   Modern Classic:
+--     name, texture, isToken, isActive, autoCastAllowed, autoCastEnabled, spellID
+------------------------------------------------------------
+-- Legacy has no spellID return at all, so its cost is looked up by name instead.
+local PET_SPELL_ID_INDEX = DataToColor.IsLegacy() and 0 or 7
+
+--- Power cost of the spell in a pet action slot, or nil when the slot holds
+--- nothing the pet spends power to cast.
+---
+--- Cost is the discriminator. Both obvious alternatives were measured on 3.4.x
+--- and both are dead: GetPetActionSlotUsable answers true for every slot,
+--- PET_ACTION_FOLLOW included, and stays true for Firebolt while the Imp is far
+--- too dry to cast it, so it says nothing about power. autoCastAllowed does not
+--- separate them either - Blood Pact (6307) reports it exactly like Firebolt
+--- (3110) does. What actually differs is that Blood Pact is free.
+---
+--- @return number|nil cost, number powerType
+function DataToColor:GetPetActionSpellCost(index)
+    local name, _, _, _, _, _, spellID = GetPetActionInfo(index)
+    if not name or find(name, PET_TOKEN_PATTERN) then
+        return nil
+    end
+
+    local costs
+    if PET_SPELL_ID_INDEX ~= 0 and spellID then
+        costs = DataToColor.GetSpellPowerCost(spellID)
+    else
+        -- name, rank, icon, cost, isFunnel, powerType, ... - the long layout,
+        -- which is the only one a client without a spellID return has.
+        local cost, _, powerType = select(4, GetSpellInfo(name))
+        if cost then
+            costs = { { cost = cost, type = powerType or 0 } }
+        end
+    end
+
+    if not costs then
+        return nil
+    end
+
+    for i = 1, #costs do
+        local entry = costs[i]
+        if entry.cost and entry.cost > 0 then
+            return entry.cost, entry.type or 0
+        end
+    end
+
+    return nil
+end
+
+--- Whether the pet can start a fight on its own right now.
+---
+--- The case this exists for is the pet running out of power: an Imp with no mana
+--- left for Firebolt just stands where it is, it does not close to melee, so the
+--- pull silently never happens and the bot waits out its pull timer.
+--- See GetPetActionSpellCost for why the answer is built from power and cost
+--- rather than from anything the client offers about slot usability.
+---
+--- @param slots table|nil BitCache's pre-scanned { cost, type } entries
+--- @param count number|nil how many of them are valid
+function DataToColor:PetCanPull(slots, count)
+    local pet = DataToColor.C.unitPet
+
+    if not UnitIsVisible(pet) or UnitIsDead(pet) then
+        return false
+    end
+
+    if slots then
+        for i = 1, count do
+            local entry = slots[i]
+            if UnitPower(pet, entry.type) >= entry.cost then
+                return true
+            end
+        end
+
+        -- A pet with nothing costed to cast pulls by running in and meleeing.
+        return count == 0
+    end
+
+    local sawCosted = false
+
+    for i = 1, NUM_PET_ACTION_SLOTS do
+        local cost, powerType = DataToColor:GetPetActionSpellCost(i)
+        if cost then
+            sawCosted = true
+            if UnitPower(pet, powerType) >= cost then
+                return true
+            end
+        end
+    end
+
+    return not sawCosted
 end
 
 -- Blizzard_TrainerUI is loaded on demand, so the frame does not exist until the player

--- a/Core/Addon/PlayerReader.cs
+++ b/Core/Addon/PlayerReader.cs
@@ -181,8 +181,10 @@ public sealed partial class PlayerReader : IMouseOverReader, IReader
     public UI_ERROR CastState => (UI_ERROR)CastEvent.Value;
     public RecordInt CastSpellId { get; } = new(63);
 
+    public const int PetTargetGuidCell = 69;
+
     public int PetGuid => reader.GetInt(68);
-    public int PetTargetGuid => reader.GetInt(69);
+    public int PetTargetGuid => reader.GetInt(PetTargetGuidCell);
     public bool PetTarget() => PetTargetGuid != 0;
 
     public int CastCount => reader.GetInt(70);

--- a/Core/AddonComponent/AddonBits.cs
+++ b/Core/AddonComponent/AddonBits.cs
@@ -133,4 +133,14 @@ public sealed class AddonBits : IReader, IGameMenuWindowShown
     /// that is currently open from one that opened and closed again.
     /// </summary>
     public bool MerchantFrameShown() => v3[Mask._17];
+
+    /// <summary>
+    /// The pet can start a fight on its own right now - it is alive and at least
+    /// one of its spells is castable.
+    ///
+    /// <para>False is the out of power case: an Imp with no mana left for Firebolt
+    /// stands where it is rather than closing to melee, so a profile that hands the
+    /// pull to the pet waits out the whole pull timer for nothing.</para>
+    /// </summary>
+    public bool Pet_CanPull() => v3[Mask._18];
 }

--- a/Core/AddonComponent/CombatLog.cs
+++ b/Core/AddonComponent/CombatLog.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace Core;
@@ -10,6 +10,8 @@ public sealed class CombatLog : IReader
     private readonly AddonBits bits;
 
     private bool wasInCombat;
+
+    private int petTargetGuid;
 
     public event Action? KillCredit;
     public event Action? PlayerDeath;
@@ -38,6 +40,40 @@ public sealed class CombatLog : IReader
     public RecordInt LastDamageDoneTime { get; }
     public RecordInt EnemySummonGuid { get; }
 
+    /// <summary>
+    /// The pet is holding a live mob that blows have already been traded with.
+    ///
+    /// <para>A pet opener does not flag the player as being in combat - from Wrath on,
+    /// <c>UnitAffectingCombat("player")</c> only turns true once the mob reaches the
+    /// player and swings, which can be many seconds after the pull connected. Until
+    /// then <see cref="AddonBits.Combat"/> is the wrong question to ask about whether
+    /// the bot is fighting.</para>
+    ///
+    /// <para>Landed damage is the earliest honest proof. Pet target alone is not:
+    /// PetAttack sets it while the pet is still running, and
+    /// <see cref="ToPull"/> is filled the moment PullTargetGoal has a target, both
+    /// before anything has been hit. <see cref="DamageTaken"/> carries the mirror
+    /// case - the addon reports blows landed on the pet as taken - so a mob that
+    /// aggroes the pet before the pet swings counts too.</para>
+    ///
+    /// <para>The mob's own <see cref="AddonBits.Target_Combat"/> flag looks like it
+    /// should work here and does not: it stayed false for the whole of a live pet
+    /// pull, so it never once beat the combat log to the answer.</para>
+    /// </summary>
+    public bool PetEngaged =>
+        bits.Pet() &&
+        petTargetGuid != 0 &&
+        !bits.PetTarget_Dead() &&
+        (DamageDone.Contains(petTargetGuid) ||
+        DamageTaken.Contains(petTargetGuid));
+
+    /// <summary>
+    /// Whether the bot is fighting, by the player's own combat flag or by its pet
+    /// already being in the fight. Not the same thing as the user facing
+    /// <c>InCombat</c> requirement, which stays bound to the raw player flag.
+    /// </summary>
+    public bool PlayerOrPetCombat() => bits.Combat() || PetEngaged;
+
     public CombatLog(AddonBits bits)
     {
         this.bits = bits;
@@ -56,6 +92,7 @@ public sealed class CombatLog : IReader
     public void Reset()
     {
         wasInCombat = false;
+        petTargetGuid = 0;
 
         DamageDone.Clear();
         DamageTaken.Clear();
@@ -76,20 +113,27 @@ public sealed class CombatLog : IReader
     public void Update(IAddonDataProvider reader)
     {
         bool combat = bits.Combat();
+        petTargetGuid = reader.GetInt(PlayerReader.PetTargetGuidCell);
+
+        // A pet fights before the player is flagged, so gating on the player's own
+        // combat flag alone drops the whole opener. Widening it to "a pet is out"
+        // is not a floodgate: the addon only pushes rows whose combat log source or
+        // destination is the player or one of its summons.
+        bool record = combat || bits.Pet();
 
         LastDamageDoneTime.Update(reader);
 
-        if (combat && DamageTakenGuid.Updated(reader) && DamageTakenGuid.Value > 0)
+        if (record && DamageTakenGuid.Updated(reader) && DamageTakenGuid.Value > 0)
         {
             DamageTaken.Add(DamageTakenGuid.Value);
         }
 
-        if (combat && DamageDoneGuid.Updated(reader) && DamageDoneGuid.Value > 0)
+        if (record && DamageDoneGuid.Updated(reader) && DamageDoneGuid.Value > 0)
         {
             DamageDone.Add(DamageDoneGuid.Value);
         }
 
-        if (combat && EnemySummonGuid.Updated(reader) && EnemySummonGuid.Value > 0)
+        if (record && EnemySummonGuid.Updated(reader) && EnemySummonGuid.Value > 0)
         {
             EnemySummons.Add(EnemySummonGuid.Value);
         }
@@ -129,7 +173,11 @@ public sealed class CombatLog : IReader
             }
         }
 
-        if (wasInCombat && !combat)
+        // Evaluated after the dead handling above, which is what takes a killed mob
+        // back out of DamageDone / DamageTaken and so ends a pet only fight.
+        bool engaged = combat || PetEngaged;
+
+        if (wasInCombat && !engaged)
         {
             // left combat
             DamageTaken.Clear();
@@ -139,6 +187,6 @@ public sealed class CombatLog : IReader
             RecentlyDead.Clear();
         }
 
-        wasInCombat = combat;
+        wasInCombat = engaged;
     }
 }

--- a/Core/GOAP/GoapAgent.cs
+++ b/Core/GOAP/GoapAgent.cs
@@ -323,7 +323,11 @@ public sealed partial class GoapAgent : IDisposable
         bool dmgTaken = combatLog.DamageTakenCount() > 0;
         bool dmgDone = combatLog.DamageDoneCount() > 0;
         bool hasTarget = b.Target();
-        bool playerCombat = b.Combat();
+
+        // Not b.Combat(): a pet opener leaves the player unflagged until the mob
+        // walks over and swings, so every combat gated goal would sit out the first
+        // seconds of a pull the pet already won. See CombatLog.PetEngaged.
+        bool playerCombat = combatLog.PlayerOrPetCombat();
 
         int data =
             (B(hasTarget) << (int)GoapKey.hastarget) |
@@ -344,7 +348,7 @@ public sealed partial class GoapAgent : IDisposable
             (B(mountHandler.IsMounted()) << (int)GoapKey.ismounted) |
             (B(playerReader.WithInPullRange()) << (int)GoapKey.withinpullrange) |
             (B(playerReader.WithInCombatRange()) << (int)GoapKey.incombatrange) |
-            (B(bits.Combat() && bits.Target_Combat() && combatLog.ToPullCount() > 0) << (int)GoapKey.pulled) |
+            (B(playerCombat && bits.Target_Combat() && combatLog.ToPullCount() > 0) << (int)GoapKey.pulled) |
             (B(b.Dead()) << (int)GoapKey.isdead) |
             (B(State.LootableCorpseCount > 0) << (int)GoapKey.shouldloot) |
             (B(State.GatherableCorpseCount > 0) << (int)GoapKey.shouldgather) |

--- a/Core/GOAP/NoPlanReport.cs
+++ b/Core/GOAP/NoPlanReport.cs
@@ -78,7 +78,8 @@ public static class NoPlanReport
             .Append(" defensive=").Append(bits.Pet_Defensive())
             .Append(" petTarget=");
         AppendGuid(sb, playerReader.PetTargetGuid);
-        sb.Append(" petTargetDead=").Append(bits.PetTarget_Dead());
+        sb.Append(" petTargetDead=").Append(bits.PetTarget_Dead())
+            .Append(" engaged=").Append(combatLog.PetEngaged);
 
         sb.Append("\n State : kills=").Append(state.LastCombatKillCount)
             .Append(" lootable=").Append(state.LootableCorpseCount)

--- a/Core/Path/Generate/RouteGenerator.cs
+++ b/Core/Path/Generate/RouteGenerator.cs
@@ -157,7 +157,7 @@ public sealed partial class RouteGenerator
         if (polygon.PrunedSpawns > 0)
         {
             LogPruned(logger, target.Name, polygon.PrunedSpawns, polygon.ClusterCount,
-                settings.Focus.ToString());
+                settings.Focus);
         }
 
         NavmeshPathfinder? navmesh = pather.GetQueryNavmeshForMap(target.MapId);
@@ -224,7 +224,7 @@ public sealed partial class RouteGenerator
             out int consideredCells);
 
         LogLoopPeaks(logger, context.Target.Name, peaks.Count, consideredCells,
-            settings.Focus.ToString(), settings.ResolvedMinCellShare);
+            settings.Focus, settings.ResolvedMinCellShare);
 
         // A centroid is an average, so it can land off-mesh, on a roof, or on the far side
         // of a wall even when every spawn that formed it is fine. Same three gates as wander.
@@ -731,7 +731,7 @@ public sealed partial class RouteGenerator
         Level = LogLevel.Information,
         Message = "[RouteGen] {zone}: {peaks} stops from {cells} occupied cells (Focus={focus}, cell floor {share:P0})")]
     static partial void LogLoopPeaks(ILogger logger, string zone, int peaks, int cells,
-        string focus, float share);
+        RouteFocus focus, float share);
 
     [LoggerMessage(
         EventId = 0099,
@@ -756,7 +756,7 @@ public sealed partial class RouteGenerator
         Level = LogLevel.Information,
         Message = "[RouteGen] {zone}: dropped {pruned} isolated spawn(s), kept {clusters} cluster(s) (Focus={focus})")]
     static partial void LogPruned(ILogger logger, string zone, int pruned, int clusters,
-        string focus);
+        RouteFocus focus);
 
     [LoggerMessage(
         EventId = 0097,

--- a/Core/Requirement/RequirementFactory.cs
+++ b/Core/Requirement/RequirementFactory.cs
@@ -165,6 +165,7 @@ public sealed partial class RequirementFactory
             { "Has Pet", bits.Pet },
             { "Pet Happy", bits.Pet_Happy },
             { "Pet HasTarget", playerReader.PetTarget },
+            { "PetCanPull", bits.Pet_CanPull },
             { "Mounted", bits.Mounted },
             
             // Auto Spell

--- a/Json/class/Hunter_1-10.json
+++ b/Json/class/Hunter_1-10.json
@@ -12,9 +12,16 @@
   // Tame Beast at 10, so the pet entries sit idle for most of this range - they are
   // gated on "Has Pet" rather than removed.
   //
+  // From 10 the pet makes the pull and the hunter holds its shots, the way
+  // Hunter_66_farm_pet_pull does. "PetCanPull" is what keeps that honest: it goes
+  // false when the pet has no focus left for a costed attack, and a pet in that
+  // state stands where it is instead of closing to melee, so the pull would
+  // otherwise stall until the pull timer gave up.
+  //
   // Bars: 2 Serpent Sting | 3 Auto Shot | 4 Raptor Strike | 5 Aspect of the Hawk
   //       6 Aspect of the Monkey | 8 Arcane Shot | 9 Gift of the Naaru
   //       N5 Feed Pet | N6 Call Pet | N7 Mend Pet | = Food | - Drink
+  //       S backpedal (the movement binding, not an action bar slot)
   "Loot": true,
   "PathsFilenames": [
     "1-8_Human_Northshire.json",
@@ -93,6 +100,10 @@
     "Sequence": [
       {
         // Learned at 4. Before that the pull is just Auto Shot.
+        //
+        // Held back once the pet can make the pull: opening from range puts the mob
+        // on the hunter instead of on the pet, and mana is the scarce resource in
+        // this bracket. Combat takes over the moment the pet's first hit lands.
         "Name": "Serpent Sting",
         "Key": "2",
         "WhenUsable": true,
@@ -100,6 +111,7 @@
         "AfterCastWaitCombat": true,
         "Requirements": [
           "Spell:SPELL_SERPENT_STING",
+          "!Has Pet",
           "HasRangedWeapon",
           "HasAmmo",
           "!InMeleeRange"
@@ -111,6 +123,7 @@
         "Item": true,
         "BeforeCastStop": true,
         "Requirements": [
+          "!Has Pet",
           "Spell:SPELL_AUTO_SHOT",
           "HasRangedWeapon",
           "HasAmmo",
@@ -119,10 +132,19 @@
         ]
       },
       {
-        // No bow/gun or no ammo - walk in and melee it.
+        // Two jobs in one entry, because PullTargetGoal keeps a single Approach key
+        // per sequence - a second entry named Approach silently shadows the first.
+        //
+        // Either the pet is making the pull and the hunter closes to 20 so it is in
+        // shooting range when Combat starts, or there is no bow/gun/ammo and this is
+        // a melee pull. PetCanPull drops to false when the pet is out of focus, which
+        // hands the opener back to Serpent Sting and Auto Shot above - a focus-less
+        // pet stands still rather than closing, so without this the pull would stall
+        // until the pull timer gave up. No pet at all before Tame Beast at 10, so for
+        // most of this range only the second half of the condition can fire.
         "Name": "Approach",
         "Requirements": [
-          "!HasRangedWeapon || !HasAmmo",
+          "(Has Pet && MinRange > 20) || !HasRangedWeapon || !HasAmmo",
           "!SoftTargetDead"
         ]
       }
@@ -152,6 +174,28 @@
         ]
       },
       {
+        // The pet has the mob, so nothing is gained by standing in its reach - back
+        // out and the hunter stops eating swings and can shoot again. Held to the
+        // pet-tanking case on purpose: retreating from a mob that is chasing the
+        // hunter only drags it along.
+        //
+        // Interrupt is a keep-going condition, not a stop one, so the 3s press is cut
+        // short the moment melee range is left or the mob dies. BeforeCastFaceTarget
+        // aims first - backpedalling is relative to facing, so without it the retreat
+        // can walk sideways or straight back into the mob.
+        "Name": "Stepback",
+        "Key": "S",
+        "PressDuration": 3000,
+        "BaseAction": true,
+        "BeforeCastFaceTarget": true,
+        "Requirements": [
+          "Has Pet",
+          "TargetsPet",
+          "InMeleeRange"
+        ],
+        "Interrupt": "InMeleeRange && TargetAlive"
+      },
+      {
         "Name": "Serpent Sting",
         "Key": "2",
         "WhenUsable": true,
@@ -179,6 +223,29 @@
         ]
       },
       {
+        // No pet to hand the mob to, so the hunter kites it itself: shoot, give
+        // ground while the weapon reloads, shoot again.
+        //
+        // Sits directly after Auto Shot because it needs the shot already away -
+        // "LastAutoShotMs < 400" is the window just after one lands. RangedSwing
+        // counts up to 0 as the next shot comes due, so "< -500" keeps the retreat
+        // to the slack before the reload animation needs the character standing.
+        // No BeforeCastFaceTarget here: the mob is chasing the hunter, so it is
+        // already being faced, and a turn mid-kite would throw the shot away.
+        "Name": "Stepback",
+        "Key": "S",
+        "PressDuration": 3000,
+        "BaseAction": true,
+        "Requirements": [
+          "!Has Pet",
+          "TargetsMe",
+          "LastAutoShotMs < 400",
+          "!InMeleeRange",
+          "AutoShot"
+        ],
+        "Interrupt": "RangedSwing < -500 && TargetAlive"
+      },
+      {
         // Learned at 6.
         "Name": "Arcane Shot",
         "Key": "8",
@@ -202,6 +269,7 @@
           "Spell:SPELL_RAPTOR_STRIKE",
           "MainHandSwing > -400",
           "InMeleeRange",
+          "(Has Pet && !TargetsMe) || !Has Pet",
           "!AutoShot"
         ]
       },

--- a/Json/class/Hunter_1-10.json
+++ b/Json/class/Hunter_1-10.json
@@ -111,7 +111,7 @@
         "AfterCastWaitCombat": true,
         "Requirements": [
           "Spell:SPELL_SERPENT_STING",
-          "!Has Pet",
+          "!Has Pet || !PetCanPull",
           "HasRangedWeapon",
           "HasAmmo",
           "!InMeleeRange"
@@ -123,7 +123,7 @@
         "Item": true,
         "BeforeCastStop": true,
         "Requirements": [
-          "!Has Pet",
+          "!Has Pet || !PetCanPull",
           "Spell:SPELL_AUTO_SHOT",
           "HasRangedWeapon",
           "HasAmmo",
@@ -144,7 +144,7 @@
         // most of this range only the second half of the condition can fire.
         "Name": "Approach",
         "Requirements": [
-          "(Has Pet && MinRange > 20) || !HasRangedWeapon || !HasAmmo",
+          "(Has Pet && PetCanPull && MinRange > 20) || !HasRangedWeapon || !HasAmmo",
           "!SoftTargetDead"
         ]
       }

--- a/Json/class/Warlock_1_10.json
+++ b/Json/class/Warlock_1_10.json
@@ -50,10 +50,12 @@
   "Pull": {
     "Sequence": [
       {
-        // let the pet pull
+        // let the pet pull - PetCanPull goes false once the pet is out of power,
+        // and a pet with nothing to cast stands still instead of closing to melee
         "Name": "Approach",
         "Requirements": [
           "Has Pet",
+          "PetCanPull",
           "MinRange > 20"
         ]
       },
@@ -62,7 +64,7 @@
         "Key": "4",
         "AfterCastAuraExpected": true,
         "Requirements": [
-          "!Has Pet",
+          "!Has Pet || !PetCanPull",
           "!Immolate",
           "Spell:SPELL_IMMOLATE",
           "Mana% > MIN_MANA_IMMOLATE%"
@@ -72,7 +74,7 @@
         "Name": "Shadow Bolt",
         "Key": "2",
         "Requirements": [
-          "!Has Pet",
+          "!Has Pet || !PetCanPull",
           "!Spell:SPELL_IMMOLATE",
           "Mana% > MIN_MANA_SHADOWBOLT%"
         ]

--- a/Json/path/1-8_NightElf_Teldrassil.json
+++ b/Json/path/1-8_NightElf_Teldrassil.json
@@ -42,5 +42,19 @@
     "SideActivityRequirements": [
       "PathDist <= 40"
     ]
+  },
+  {
+    "Requirements": [
+      "Level < 11",
+      "Race:NightElf"
+    ],
+    "Generate": {
+      "Subzone": "The Oracle Glade",
+      "Mobs": "Name: Bloodfeather",
+      "Mode": "Wander"
+    },
+    "SideActivityRequirements": [
+      "PathDist <= 40"
+    ]
   }
 ]

--- a/README.md
+++ b/README.md
@@ -1863,6 +1863,28 @@ e.g.
 }
 ```
 
+#### Backing out of melee
+
+No dedicated action is needed for this - a plain `KeyAction` bound to the backpedal key does it. `PressDuration` holds the key, `Interrupt` is a *keep-going* condition rather than a stop one, so the press is cut short as soon as it stops holding. `BaseAction` keeps it out of the spell/cast-time machinery, and `BeforeCastFaceTarget` aims first, since backpedalling is relative to facing.
+
+```json
+{
+    "Name": "Stepback",
+    "Key": "S",
+    "PressDuration": 3000,
+    "BaseAction": true,
+    "BeforeCastFaceTarget": true,
+    "Requirements": [
+        "Has Pet",
+        "TargetsPet",
+        "InMeleeRange"
+    ],
+    "Interrupt": "InMeleeRange && TargetAlive"
+}
+```
+
+That one only fires while the pet holds the mob - backing away from something chasing you just drags it along. A mage kiting off a root uses the same shape with `"Frostbite"` and `"TargetsMe"` instead.
+
 ### Adhoc Goals
 
 **Why Adhoc Goals?** These handle "between fight" activities - things you do when you're not actively killing something. Buffs that expired, health/mana that needs restoring, pet summoning, etc. The bot checks these when out of combat and performs them if conditions are met.
@@ -3118,6 +3140,7 @@ Allow requirements about what buffs/debuffs you have or the target has or in gen
 | `"Has Pet"` | The player's pet is alive |
 | `"Pet HasTarget"` | Players pet has target |
 | `"Pet Happy"` | Pet happiness is green |
+| `"PetCanPull"` | The pet is alive and at least one of its spells is castable right now. False once the pet runs out of power - an Imp with no mana for Firebolt stands still instead of closing to melee, so a pull handed to the pet never happens. |
 | `"Mounted"` | Player riding on a mount (druid form excluded) |
 | `"BagFull"` | Inventory is full |
 | `"BagGreyItem"` | Indicates that there are at least one Grey Quality level item. |


### PR DESCRIPTION
## Problem

A pet-led pull did not register. After the pet landed its opener the player was still not flagged as being in combat, so the bot sat on the target doing nothing until the mob walked over and swung — often 6-8 seconds later, and frequently long enough for `PullTargetGoal`'s `MAX_PULL_DURATION` to expire, clear the target and turn away.

A second failure sat behind it: once the pet ran out of power it stopped attacking entirely. A pet with nothing to cast stands where it is rather than closing to melee, so the pull never happened at all and the bot waited out the full pull timer every time.

## Root cause

Two independent bugs, both in the addon's combat log handling and both invisible from outside.

**Pet damage never reached the bot.** `EventHandlers.lua` gated the damage-*done* branch on `playerPetSummons[sourceGUID]`. That table is only ever filled by a live `SPELL_SUMMON` row and is emptied on every reinit, so a pet that was already out when the addon loaded — login, `/reload`, a loading screen, or attaching the bot to a running session — was not in it and every point of its damage was discarded. The damage-*taken* branch immediately above already had the `petGUID` fallback; the done branch did not.

Measured on a live pull:

```
00:14:34:138  New Plan= Pull Target
00:14:35..41  !PetEngaged ... dmgDone=0 dmgTaken=0 targetCombat=False playerCombat=False   (x7s)
00:14:37:110  StuckDetector Unstuck attempt 1: jump
00:14:42:072  DamageDone += guid=45150 | playerCombat=False    <- pet regened and fired
```

**The player's combat flag is the wrong question.** From Wrath on, `UnitAffectingCombat("player")` only turns true once the mob reaches the player and swings. `GoapKey.incombat` and `.pulled` both came from it, so `CombatGoal` could not run while the pet was already fighting.

## Changes

### Addon — `Addons/DataToColor` (version `1.12.0` → `1.12.1`)

- `EventHandlers.lua`: the pet damage-done branch now falls back to `DataToColor.petGUID`, mirroring the damage-taken branch. Kill credit is registered there too — without it a mob the pet killed on its own was never queued by `unitDied` and its corpse was never reported lootable.
- `Query.lua` / `BitCache.lua`: new `bits3` bit 18, "the pet can still afford a costed attack". Slot costs are cached on `PET_BAR_UPDATE`; only the `UnitPower` comparison is polled, and with no pet it costs nothing.

### Core

- `CombatLog.PetEngaged` — the pet holds a live mob that blows have already been traded with. `GoapKey.incombat` and `.pulled` now come from `PlayerOrPetCombat()`.
- Damage recording widened from the player's combat flag to "a pet is out". Not a floodgate: the addon only pushes rows whose source or destination is the player or one of its summons.
- New `PetCanPull` requirement over the new bit.
- The user-facing `InCombat` requirement deliberately stays bound to the raw player flag, so no existing profile changes meaning.

### Profiles

- **Warlock 1-10** — the pet pull is gated on `PetCanPull`, and Immolate / Shadow Bolt take the opener back with `"!Has Pet || !PetCanPull"`.
- **Hunter 1-10** — gains the same `PetCanPull`-gated pet pull, shaped after `Hunter_66_farm_pet_pull`. Also two backpedal entries built entirely from existing `KeyAction` machinery: with a pet, back out of melee while the pet tanks; without one, kite between shots.

### Paths

- `1-8_NightElf_Teldrassil.json` — a night-elf Bloodfeather wander route in The Oracle Glade, capped at level 11 like the other blocks in the file. Unrelated to the pet work, included here for convenience.

## Design notes

**Why cost, and not the two obvious alternatives.** Both were measured on 3.4.x and both are dead ends. `GetPetActionSlotUsable` returns `true` for *every* slot including `PET_ACTION_FOLLOW` and `PET_MODE_PASSIVE`, and stays `true` for Firebolt while the Imp is far too dry to cast it. `autoCastAllowed` does not separate them either — Blood Pact (6307) reports it exactly like Firebolt (3110). What actually differs is that Blood Pact is free. This is written up in `Query.lua:GetPetActionSpellCost` so it is not rediscovered the hard way.

**Focus and mana share one path.** Costs resolve through the existing `GetSpellPowerCost` abstraction and compare against `UnitPower(pet, type)`, so a hunter pet's focus needs no special casing.

**`Target_Combat` was tried and rejected.** It looks like the natural signal — the mob's own combat flag, event-driven off `UNIT_FLAGS` — but it stayed `false` for every second of a live pet pull and never once beat the combat log to the answer. Noted in the `PetEngaged` doc comment.

**Merged `Approach` entry in the hunter Pull.** `PullTargetGoal` keeps a single Approach key per sequence (`PullTargetGoal.cs:82-86`, last-wins) and skips every Approach-named key in the cast loop, so a second entry of that name is silently shadowed. Both jobs live in one entry's requirements instead.

**No new C# for the backpedals.** `PressDuration` holds the key and `Interrupt` is a keep-going condition, so the press is cut short the moment it stops applying. `BeforeCastFaceTarget` aims first where the retreat direction matters.

## Testing

Warlock 1-10 and Hunter 1-10 in Coldridge Valley / Northshire on Wrath 3.4.x. Pet pulls now register on the pet's first landed hit rather than on the mob's first melee swing; the player takes the opener back when the pet runs dry. Full solution builds clean in Release; `luac -p` clean on every touched Lua file.

## Upgrade note

**The in-game addon must be updated** — the Core changes depend on `bits3` bit 18 and on the repaired pet damage rows. An out-of-date addon reports bit 18 as `0`, which reads as "the pet cannot pull" and disables the pet-pull branch in any profile using it. Both `Warlock_1_10` and `Hunter_1-10` fall back to the player's own opener in that case rather than stalling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
